### PR TITLE
scrollbar: Improve scrollbar behaviour.

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -1249,7 +1249,7 @@ impl Render for TextInput {
                             .absolute()
                             .top_0()
                             .left_0()
-                            .right_0()
+                            .right(px(1.))
                             .bottom_0()
                             .child(
                                 Scrollbar::vertical(

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -94,7 +94,7 @@ impl ScrollbarState {
     fn with_hovered(&self, axis: Option<ScrollbarAxis>) -> Self {
         let mut state = *self;
         state.hovered_axis = axis;
-        if self.is_scrollbar_visiable() {
+        if self.is_scrollbar_visible() {
             state.last_scroll_time = Some(Instant::now());
         }
         state
@@ -123,7 +123,7 @@ impl ScrollbarState {
         state
     }
 
-    fn is_scrollbar_visiable(&self) -> bool {
+    fn is_scrollbar_visible(&self) -> bool {
         if let Some(last_time) = self.last_scroll_time {
             let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
             elapsed < FADE_OUT_DURATION
@@ -519,7 +519,7 @@ impl Element for Scrollbar {
         cx: &mut gpui::WindowContext,
     ) {
         let hitbox_bounds = prepaint.hitbox.bounds;
-        let is_visiable = self.state.get().is_scrollbar_visiable();
+        let is_visible = self.state.get().is_scrollbar_visible();
 
         for state in prepaint.states.iter() {
             let axis = state.axis;
@@ -583,7 +583,7 @@ impl Element for Scrollbar {
 
             let safe_range = (-scroll_area_size + container_size)..px(0.);
 
-            if is_visiable {
+            if is_visible {
                 cx.on_mouse_event({
                     let state = self.state.clone();
                     let view_id = self.view_id;

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -10,6 +10,8 @@ use gpui::{
 const MIN_THUMB_SIZE: f32 = 80.;
 const THUMB_RADIUS: Pixels = Pixels(3.0);
 const THUMB_INSET: Pixels = Pixels(4.);
+const FADE_OUT_DURATION: f32 = 3.0;
+const FADE_OUT_DELAY: f32 = 2.0;
 
 pub trait ScrollHandleOffsetable {
     fn offset(&self) -> Point<Pixels>;
@@ -92,6 +94,9 @@ impl ScrollbarState {
     fn with_hovered(&self, axis: Option<ScrollbarAxis>) -> Self {
         let mut state = *self;
         state.hovered_axis = axis;
+        if self.is_scrollbar_visiable() {
+            state.last_scroll_time = Some(Instant::now());
+        }
         state
     }
 
@@ -110,6 +115,21 @@ impl ScrollbarState {
         state.last_scroll_offset = last_scroll_offset;
         state.last_scroll_time = last_scroll_time;
         state
+    }
+
+    fn with_last_scroll_time(&self, t: Option<Instant>) -> Self {
+        let mut state = *self;
+        state.last_scroll_time = t;
+        state
+    }
+
+    fn is_scrollbar_visiable(&self) -> bool {
+        if let Some(last_time) = self.last_scroll_time {
+            let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
+            elapsed < FADE_OUT_DURATION
+        } else {
+            false
+        }
     }
 }
 
@@ -390,51 +410,56 @@ impl Element for Scrollbar {
             };
 
             let state = self.state.clone();
-            let (thumb_bg, bar_bg, bar_border, inset, radius) =
-                if state.get().dragged_axis == Some(axis) {
-                    (
-                        cx.theme().scrollbar_thumb,
-                        cx.theme().scrollbar,
-                        cx.theme().border,
-                        THUMB_INSET - px(1.),
-                        THUMB_RADIUS,
-                    )
-                } else if state.get().hovered_axis == Some(axis) {
-                    if state.get().hovered_on_thumb == Some(axis) {
-                        (
-                            cx.theme().scrollbar_thumb,
-                            cx.theme().scrollbar,
-                            cx.theme().border,
-                            THUMB_INSET - px(1.),
-                            THUMB_RADIUS,
-                        )
-                    } else {
-                        (
-                            cx.theme().scrollbar_thumb.opacity(NORMAL_OPACITY),
-                            gpui::transparent_black(),
-                            gpui::transparent_black(),
-                            THUMB_INSET,
-                            THUMB_RADIUS,
-                        )
-                    }
-                } else {
-                    let mut idle_state = (
-                        gpui::transparent_black(),
-                        gpui::transparent_black(),
-                        gpui::transparent_black(),
-                        THUMB_INSET,
-                        THUMB_RADIUS - px(1.),
-                    );
-                    if let Some(last_time) = state.get().last_scroll_time {
-                        let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
-                        if elapsed < 1.0 {
-                            let y_value = NORMAL_OPACITY - elapsed.powi(10); // y = 1 - x^10
+            let is_hovered_on_bar = state.get().hovered_axis == Some(axis);
+            let is_hovered_on_thumb = state.get().hovered_on_thumb == Some(axis);
+
+            let (thumb_bg, bar_bg, bar_border, inset, radius) = if state.get().dragged_axis
+                == Some(axis)
+            {
+                (
+                    cx.theme().scrollbar_thumb,
+                    cx.theme().scrollbar,
+                    cx.theme().border,
+                    THUMB_INSET - px(1.),
+                    THUMB_RADIUS,
+                )
+            } else {
+                let mut idle_state = (
+                    gpui::transparent_black(),
+                    gpui::transparent_black(),
+                    gpui::transparent_black(),
+                    THUMB_INSET,
+                    THUMB_RADIUS - px(1.),
+                );
+
+                // Delay 2s to fade out the scrollbar thumb (in 1s)
+                if let Some(last_time) = state.get().last_scroll_time {
+                    let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
+                    if elapsed < FADE_OUT_DURATION {
+                        if is_hovered_on_bar {
+                            state.set(state.get().with_last_scroll_time(Some(Instant::now())));
+                            if is_hovered_on_thumb {
+                                idle_state.0 = cx.theme().scrollbar_thumb;
+                            } else {
+                                idle_state.0 = cx.theme().scrollbar_thumb.opacity(NORMAL_OPACITY);
+                            }
+                            idle_state.3 = THUMB_INSET - px(1.);
+                            idle_state.4 = THUMB_RADIUS;
+                        } else {
+                            let y_value = if elapsed < FADE_OUT_DELAY {
+                                NORMAL_OPACITY
+                            } else {
+                                // y = 1 - (x - 2)^10
+                                NORMAL_OPACITY - (elapsed - FADE_OUT_DELAY).powi(10)
+                            };
                             idle_state.0 = cx.theme().scrollbar_thumb.opacity(y_value);
                             cx.request_animation_frame();
                         }
                     }
-                    idle_state
-                };
+                }
+
+                idle_state
+            };
 
             let border_width = px(0.);
             let thumb_bounds = if is_vertical {
@@ -494,6 +519,7 @@ impl Element for Scrollbar {
         cx: &mut gpui::WindowContext,
     ) {
         let hitbox_bounds = prepaint.hitbox.bounds;
+        let is_visiable = self.state.get().is_scrollbar_visiable();
 
         for state in prepaint.states.iter() {
             let axis = state.axis;
@@ -557,52 +583,54 @@ impl Element for Scrollbar {
 
             let safe_range = (-scroll_area_size + container_size)..px(0.);
 
-            cx.on_mouse_event({
-                let state = self.state.clone();
-                let view_id = self.view_id;
-                let scroll_handle = self.scroll_handle.clone();
+            if is_visiable {
+                cx.on_mouse_event({
+                    let state = self.state.clone();
+                    let view_id = self.view_id;
+                    let scroll_handle = self.scroll_handle.clone();
 
-                move |event: &MouseDownEvent, phase, cx| {
-                    if phase.bubble() && bounds.contains(&event.position) {
-                        cx.stop_propagation();
+                    move |event: &MouseDownEvent, phase, cx| {
+                        if phase.bubble() && bounds.contains(&event.position) {
+                            cx.stop_propagation();
 
-                        if thumb_bounds.contains(&event.position) {
-                            // click on the thumb bar, set the drag position
-                            let pos = event.position - thumb_bounds.origin;
+                            if thumb_bounds.contains(&event.position) {
+                                // click on the thumb bar, set the drag position
+                                let pos = event.position - thumb_bounds.origin;
 
-                            state.set(state.get().with_drag_pos(axis, pos));
+                                state.set(state.get().with_drag_pos(axis, pos));
 
-                            cx.notify(Some(view_id));
-                        } else {
-                            // click on the scrollbar, jump to the position
-                            // Set the thumb bar center to the click position
-                            let offset = scroll_handle.offset();
-                            let percentage = if is_vertical {
-                                (event.position.y - thumb_size / 2. - bounds.origin.y)
-                                    / (bounds.size.height - thumb_size)
+                                cx.notify(Some(view_id));
                             } else {
-                                (event.position.x - thumb_size / 2. - bounds.origin.x)
-                                    / (bounds.size.width - thumb_size)
-                            }
-                            .min(1.);
+                                // click on the scrollbar, jump to the position
+                                // Set the thumb bar center to the click position
+                                let offset = scroll_handle.offset();
+                                let percentage = if is_vertical {
+                                    (event.position.y - thumb_size / 2. - bounds.origin.y)
+                                        / (bounds.size.height - thumb_size)
+                                } else {
+                                    (event.position.x - thumb_size / 2. - bounds.origin.x)
+                                        / (bounds.size.width - thumb_size)
+                                }
+                                .min(1.);
 
-                            if is_vertical {
-                                scroll_handle.set_offset(point(
-                                    offset.x,
-                                    (-scroll_area_size * percentage)
-                                        .clamp(safe_range.start, safe_range.end),
-                                ));
-                            } else {
-                                scroll_handle.set_offset(point(
-                                    (-scroll_area_size * percentage)
-                                        .clamp(safe_range.start, safe_range.end),
-                                    offset.y,
-                                ));
+                                if is_vertical {
+                                    scroll_handle.set_offset(point(
+                                        offset.x,
+                                        (-scroll_area_size * percentage)
+                                            .clamp(safe_range.start, safe_range.end),
+                                    ));
+                                } else {
+                                    scroll_handle.set_offset(point(
+                                        (-scroll_area_size * percentage)
+                                            .clamp(safe_range.start, safe_range.end),
+                                        offset.y,
+                                    ));
+                                }
                             }
                         }
                     }
-                }
-            });
+                });
+            }
 
             cx.on_mouse_event({
                 let scroll_handle = self.scroll_handle.clone();

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -2,16 +2,32 @@ use std::{cell::Cell, rc::Rc, time::Instant};
 
 use crate::theme::ActiveTheme;
 use gpui::{
-    fill, point, px, relative, Bounds, ContentMask, CursorStyle, Edges, Element, EntityId, Hitbox,
-    Hsla, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    Position, ScrollHandle, ScrollWheelEvent, Style, UniformListScrollHandle,
+    fill, point, px, relative, AppContext, Bounds, ContentMask, CursorStyle, Edges, Element,
+    EntityId, Hitbox, Hsla, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
+    Pixels, Point, Position, ScrollHandle, ScrollWheelEvent, Style, UniformListScrollHandle,
 };
+use serde::{Deserialize, Serialize};
+
+/// Scrollbar show mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+pub enum ScrollbarShow {
+    #[default]
+    Scrolling,
+    Hover,
+}
+
+impl ScrollbarShow {
+    fn is_hover(&self) -> bool {
+        matches!(self, Self::Hover)
+    }
+}
 
 const MIN_THUMB_SIZE: f32 = 80.;
 const THUMB_RADIUS: Pixels = Pixels(3.0);
 const THUMB_INSET: Pixels = Pixels(4.);
 const FADE_OUT_DURATION: f32 = 3.0;
 const FADE_OUT_DELAY: f32 = 2.0;
+const NORMAL_OPACITY: f32 = 0.6;
 
 pub trait ScrollHandleOffsetable {
     fn offset(&self) -> Point<Pixels>;
@@ -277,6 +293,52 @@ impl Scrollbar {
         self.axis = axis;
         self
     }
+
+    fn style_for_default(cx: &AppContext) -> (Hsla, Hsla, Hsla, Pixels, Pixels) {
+        (
+            cx.theme().scrollbar_thumb,
+            cx.theme().scrollbar,
+            cx.theme().border,
+            THUMB_INSET - px(1.),
+            THUMB_RADIUS,
+        )
+    }
+
+    fn style_for_hovered_thumb(cx: &AppContext) -> (Hsla, Hsla, Hsla, Pixels, Pixels) {
+        (
+            cx.theme().scrollbar_thumb,
+            cx.theme().scrollbar,
+            cx.theme().border,
+            THUMB_INSET - px(1.),
+            THUMB_RADIUS,
+        )
+    }
+
+    fn style_for_hovered_bar(cx: &AppContext) -> (Hsla, Hsla, Hsla, Pixels, Pixels) {
+        let (inset, radius) = if cx.theme().scrollbar_show.is_hover() {
+            (THUMB_INSET, THUMB_RADIUS - px(1.))
+        } else {
+            (THUMB_INSET - px(1.), THUMB_RADIUS)
+        };
+
+        (
+            cx.theme().scrollbar_thumb.opacity(NORMAL_OPACITY),
+            gpui::transparent_black(),
+            gpui::transparent_black(),
+            inset,
+            radius,
+        )
+    }
+
+    fn style_for_idle(_: &AppContext) -> (Hsla, Hsla, Hsla, Pixels, Pixels) {
+        (
+            gpui::transparent_black(),
+            gpui::transparent_black(),
+            gpui::transparent_black(),
+            THUMB_INSET,
+            THUMB_RADIUS - px(1.),
+        )
+    }
 }
 
 impl IntoElement for Scrollbar {
@@ -346,7 +408,6 @@ impl Element for Scrollbar {
         let mut states = vec![];
 
         let mut has_both = self.axis.is_both();
-        const NORMAL_OPACITY: f32 = 0.6;
 
         for axis in self.axis.all().into_iter() {
             let is_vertical = axis.is_vertical();
@@ -410,56 +471,47 @@ impl Element for Scrollbar {
             };
 
             let state = self.state.clone();
+            let is_hover_to_show = cx.theme().scrollbar_show.is_hover();
             let is_hovered_on_bar = state.get().hovered_axis == Some(axis);
             let is_hovered_on_thumb = state.get().hovered_on_thumb == Some(axis);
 
-            let (thumb_bg, bar_bg, bar_border, inset, radius) = if state.get().dragged_axis
-                == Some(axis)
-            {
-                (
-                    cx.theme().scrollbar_thumb,
-                    cx.theme().scrollbar,
-                    cx.theme().border,
-                    THUMB_INSET - px(1.),
-                    THUMB_RADIUS,
-                )
-            } else {
-                let mut idle_state = (
-                    gpui::transparent_black(),
-                    gpui::transparent_black(),
-                    gpui::transparent_black(),
-                    THUMB_INSET,
-                    THUMB_RADIUS - px(1.),
-                );
-
-                // Delay 2s to fade out the scrollbar thumb (in 1s)
-                if let Some(last_time) = state.get().last_scroll_time {
-                    let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
-                    if elapsed < FADE_OUT_DURATION {
-                        if is_hovered_on_bar {
-                            state.set(state.get().with_last_scroll_time(Some(Instant::now())));
-                            if is_hovered_on_thumb {
-                                idle_state.0 = cx.theme().scrollbar_thumb;
+            let (thumb_bg, bar_bg, bar_border, inset, radius) =
+                if state.get().dragged_axis == Some(axis) {
+                    Self::style_for_default(cx)
+                } else if is_hover_to_show && is_hovered_on_bar {
+                    if is_hovered_on_thumb {
+                        Self::style_for_hovered_thumb(cx)
+                    } else {
+                        Self::style_for_hovered_bar(cx)
+                    }
+                } else {
+                    let mut idle_state = Self::style_for_idle(cx);
+                    // Delay 2s to fade out the scrollbar thumb (in 1s)
+                    if let Some(last_time) = state.get().last_scroll_time {
+                        let elapsed = Instant::now().duration_since(last_time).as_secs_f32();
+                        if elapsed < FADE_OUT_DURATION {
+                            if is_hovered_on_bar {
+                                state.set(state.get().with_last_scroll_time(Some(Instant::now())));
+                                idle_state = if is_hovered_on_thumb {
+                                    Self::style_for_hovered_thumb(cx)
+                                } else {
+                                    Self::style_for_hovered_bar(cx)
+                                };
                             } else {
-                                idle_state.0 = cx.theme().scrollbar_thumb.opacity(NORMAL_OPACITY);
+                                let y_value = if elapsed < FADE_OUT_DELAY {
+                                    NORMAL_OPACITY
+                                } else {
+                                    // y = 1 - (x - 2)^10
+                                    NORMAL_OPACITY - (elapsed - FADE_OUT_DELAY).powi(10)
+                                };
+                                idle_state.0 = cx.theme().scrollbar_thumb.opacity(y_value);
+                                cx.request_animation_frame();
                             }
-                            idle_state.3 = THUMB_INSET - px(1.);
-                            idle_state.4 = THUMB_RADIUS;
-                        } else {
-                            let y_value = if elapsed < FADE_OUT_DELAY {
-                                NORMAL_OPACITY
-                            } else {
-                                // y = 1 - (x - 2)^10
-                                NORMAL_OPACITY - (elapsed - FADE_OUT_DELAY).powi(10)
-                            };
-                            idle_state.0 = cx.theme().scrollbar_thumb.opacity(y_value);
-                            cx.request_animation_frame();
                         }
                     }
-                }
 
-                idle_state
-            };
+                    idle_state
+                };
 
             let border_width = px(0.);
             let thumb_bounds = if is_vertical {
@@ -520,6 +572,7 @@ impl Element for Scrollbar {
     ) {
         let hitbox_bounds = prepaint.hitbox.bounds;
         let is_visible = self.state.get().is_scrollbar_visible();
+        let is_hover_to_show = cx.theme().scrollbar_show.is_hover();
 
         for state in prepaint.states.iter() {
             let axis = state.axis;
@@ -583,7 +636,7 @@ impl Element for Scrollbar {
 
             let safe_range = (-scroll_area_size + container_size)..px(0.);
 
-            if is_visible {
+            if is_hover_to_show || is_visible {
                 cx.on_mouse_event({
                     let state = self.state.clone();
                     let view_id = self.view_id;

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -5,6 +5,8 @@ use gpui::{
     ViewContext, WindowAppearance, WindowContext,
 };
 
+use crate::scroll::ScrollbarShow;
+
 pub fn init(cx: &mut AppContext) {
     Theme::sync_system_appearance(cx)
 }
@@ -373,6 +375,8 @@ pub struct Theme {
     pub radius: f32,
     pub shadow: bool,
     pub transparent: Hsla,
+    /// Show the scrollbar mode, default: Scrolling
+    pub scrollbar_show: ScrollbarShow,
 }
 
 impl Deref for Theme {
@@ -518,6 +522,7 @@ impl From<ThemeColor> for Theme {
             },
             radius: 4.0,
             shadow: true,
+            scrollbar_show: ScrollbarShow::default(),
             colors,
         }
     }


### PR DESCRIPTION
- Only show scroll when recent scrolled.
- Keep showing scrollbar when is visible and hovered on.
- Delay 3s to fade out.
- If not visible, do not handle mouse down event.
- Add `cx.theme().scrollbar_show` option to control scrollbar show `[Hover, Scrolling]`, default: `Scrolling`.

Close #472

![CleanShot 2024-12-10 at 15 43 43](https://github.com/user-attachments/assets/17e5f46a-5602-4544-9a5c-82ec68a24dd4)
