### PR TITLE
panel: Avoid render panel when TabPanel is collapsed.

### DIFF
--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -144,6 +144,11 @@ impl Dock {
                         panel.set_collapsed(true, cx);
                     });
                 }
+                DockItem::Split { items, .. } => {
+                    for item in items {
+                        item.set_collapsed(true, cx);
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -85,6 +85,29 @@ pub enum DockItem {
     Panel { view: Arc<dyn PanelView> },
 }
 
+impl std::fmt::Debug for DockItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DockItem::Split {
+                axis, items, sizes, ..
+            } => f
+                .debug_struct("Split")
+                .field("axis", axis)
+                .field("items", &items.len())
+                .field("sizes", sizes)
+                .finish(),
+            DockItem::Tabs {
+                items, active_ix, ..
+            } => f
+                .debug_struct("Tabs")
+                .field("items", &items.len())
+                .field("active_ix", active_ix)
+                .finish(),
+            DockItem::Panel { .. } => f.debug_struct("Panel").finish(),
+        }
+    }
+}
+
 impl DockItem {
     /// Create DockItem with split layout, each item of panel have equal size.
     pub fn split(

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -42,6 +42,12 @@ impl Tab {
         self.suffix = Some(suffix.into());
         self
     }
+
+    /// Set disabled state to the tab
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
 }
 
 impl Selectable for Tab {
@@ -72,9 +78,11 @@ impl Styled for Tab {
 impl RenderOnce for Tab {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         let (text_color, bg_color) = match (self.selected, self.disabled) {
-            (true, _) => (cx.theme().tab_active_foreground, cx.theme().tab_active),
-            (false, true) => (cx.theme().tab_foreground.opacity(0.5), cx.theme().tab),
+            (true, false) => (cx.theme().tab_active_foreground, cx.theme().tab_active),
             (false, false) => (cx.theme().muted_foreground, cx.theme().tab),
+            // disabled
+            (true, true) => (cx.theme().muted_foreground, cx.theme().tab_active),
+            (false, true) => (cx.theme().muted_foreground, cx.theme().tab),
         };
 
         self.base
@@ -89,7 +97,6 @@ impl RenderOnce for Tab {
             .border_color(cx.theme().transparent)
             .when(self.selected, |this| this.border_color(cx.theme().border))
             .text_sm()
-            .when(self.disabled, |this| this)
             .when_some(self.prefix, |this, prefix| {
                 this.child(prefix).text_color(text_color)
             })


### PR DESCRIPTION
Close #488

- Fix `collapsed` sync to `TabPanel` when load state.