### PR TITLE
fix: wrong size variant in sizable trait

### DIFF
--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -215,17 +215,22 @@ pub trait Sizable: Sized {
     /// Or a `Pixels` to set a custom size: `px(30.)`
     fn with_size(self, size: impl Into<Size>) -> Self;
 
-    /// Set to Size::Small
-    fn small(self) -> Self {
-        self.with_size(Size::Small)
-    }
-
     /// Set to Size::XSmall
     fn xsmall(self) -> Self {
         self.with_size(Size::XSmall)
     }
 
+    /// Set to Size::Small
+    fn small(self) -> Self {
+        self.with_size(Size::Small)
+    }
+
     /// Set to Size::Medium
+    fn medium(self) -> Self {
+        self.with_size(Size::Medium)
+    }
+
+    /// Set to Size::Large
     fn large(self) -> Self {
         self.with_size(Size::Large)
     }

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -208,6 +208,7 @@ pub trait Disableable {
 }
 
 /// A trait for setting the size of an element.
+/// Size::Medium is use by default.
 pub trait Sizable: Sized {
     /// Set the ui::Size of this element.
     ///
@@ -223,11 +224,6 @@ pub trait Sizable: Sized {
     /// Set to Size::Small
     fn small(self) -> Self {
         self.with_size(Size::Small)
-    }
-
-    /// Set to Size::Medium
-    fn medium(self) -> Self {
-        self.with_size(Size::Medium)
     }
 
     /// Set to Size::Large


### PR DESCRIPTION
### Changelog:
- Adjust `/// Set to Size::Medium` to `/// Set to Size::Large`
- Add size `.medium()`