### PR TITLE
virtual_list: Add VirtualList

### DIFF
--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -61,7 +61,9 @@ impl ScrollableStory {
             self.items = (0..100).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
             self.test_width = px(10000.);
         } else if n == 2 {
-            self.items = (0..500).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
+            self.items = (0..500000)
+                .map(|i| format!("Item {}", i))
+                .collect::<Vec<_>>();
             self.test_width = px(10000.);
         } else {
             self.items = (0..5).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
@@ -188,18 +190,37 @@ impl Render for ScrollableStory {
                                         story.scroll_size = content_size;
                                         visible_range
                                             .map(|ix| {
-                                                let item = story.items.get(ix).unwrap();
-                                                div()
+                                                h_flex()
                                                     .h(ITEM_HEIGHT)
                                                     .px_3()
-                                                    .w(px(100.))
+                                                    .gap_1()
+                                                    .children(
+                                                        (0..(story.test_width.0 as i32 / 100))
+                                                            .map(|i| {
+                                                                div()
+                                                                    .flex()
+                                                                    .h_full()
+                                                                    .items_center()
+                                                                    .justify_center()
+                                                                    .text_sm()
+                                                                    .w(px(100.))
+                                                                    .bg(
+                                                                        if cx.theme().mode.is_dark()
+                                                                        {
+                                                                            ui::gray_800()
+                                                                        } else {
+                                                                            ui::gray_100()
+                                                                        },
+                                                                    )
+                                                                    .child(if i == 0 {
+                                                                        format!("{}", ix)
+                                                                    } else {
+                                                                        format!("{}", i)
+                                                                    })
+                                                            })
+                                                            .collect::<Vec<_>>(),
+                                                    )
                                                     .items_center()
-                                                    .bg(if cx.theme().mode.is_dark() {
-                                                        ui::gray_800()
-                                                    } else {
-                                                        ui::gray_100()
-                                                    })
-                                                    .child(item.clone())
                                             })
                                             .collect::<Vec<_>>()
                                     },
@@ -232,9 +253,6 @@ impl Render for ScrollableStory {
                 ),
             )
             .child({
-                let items = self.items.clone();
-                let test_width = self.test_width;
-
                 div()
                     .relative()
                     .border_1()
@@ -248,14 +266,18 @@ impl Render for ScrollableStory {
                             .scrollable(cx.view().entity_id(), ScrollbarAxis::Vertical)
                             .focusable()
                             .p_3()
-                            .w(test_width)
+                            .w(self.test_width)
                             .gap_1()
                             .child("Hello world")
-                            .children(
-                                items
-                                    .iter()
-                                    .map(|s| div().bg(cx.theme().card).child(s.clone())),
-                            ),
+                            .children(self.items.iter().take(500).map(|item| {
+                                div()
+                                    .h(ITEM_HEIGHT)
+                                    .bg(cx.theme().background)
+                                    .items_center()
+                                    .justify_center()
+                                    .text_sm()
+                                    .child(item.to_string())
+                            })),
                     )
             })
     }

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use gpui::{
-    canvas, div, px, size, Entity, InteractiveElement, ParentElement, Pixels, Render, ScrollHandle,
+    div, px, size, Entity, InteractiveElement, ParentElement, Pixels, Render, ScrollHandle,
     SharedString, Size, StatefulInteractiveElement as _, Styled, View, ViewContext, VisualContext,
     WindowContext,
 };
@@ -169,78 +169,66 @@ impl Render for ScrollableStory {
                     .child(Label::new(self.message.clone())),
             )
             .child(
-                div()
-                    .w_full()
-                    .border_1()
-                    .border_color(cx.theme().border)
-                    .child(
-                        div().relative().w_full().h(px(350.)).child(
-                            v_flex()
-                                .relative()
-                                .p_4()
-                                .size_full()
-                                .child(
-                                    v_virtual_list(
-                                        cx.view().clone(),
-                                        "items",
-                                        self.item_sizes.clone(),
-                                        self.scroll_handle.clone(),
-                                        move |story, visible_range, cx| {
-                                            story.set_message(
-                                                &format!("visible_range: {:?}", visible_range),
-                                                cx,
-                                            );
-                                            visible_range
-                                                .map(|ix| {
-                                                    let item = story.items.get(ix).unwrap();
-                                                    div()
-                                                        .h(ITEM_HEIGHT)
-                                                        .px_3()
-                                                        // .w(story.test_width)
-                                                        .items_center()
-                                                        .bg(if cx.theme().mode.is_dark() {
-                                                            ui::gray_800()
-                                                        } else {
-                                                            ui::gray_100()
-                                                        })
-                                                        .child(item.clone())
-                                                })
-                                                .collect::<Vec<_>>()
-                                        },
-                                    )
-                                    .v_flex()
-                                    .gap_1(),
+                div().w_full().child(
+                    div().relative().w_full().h(px(350.)).child(
+                        v_flex()
+                            .relative()
+                            .size_full()
+                            .child(
+                                v_virtual_list(
+                                    cx.view().clone(),
+                                    "items",
+                                    self.item_sizes.clone(),
+                                    self.scroll_handle.clone(),
+                                    move |story, visible_range, content_size, cx| {
+                                        story.set_message(
+                                            &format!("visible_range: {:?}", visible_range),
+                                            cx,
+                                        );
+                                        story.scroll_size = content_size;
+                                        visible_range
+                                            .map(|ix| {
+                                                let item = story.items.get(ix).unwrap();
+                                                div()
+                                                    .h(ITEM_HEIGHT)
+                                                    .px_3()
+                                                    // .w(story.test_width)
+                                                    .items_center()
+                                                    .bg(if cx.theme().mode.is_dark() {
+                                                        ui::gray_800()
+                                                    } else {
+                                                        ui::gray_100()
+                                                    })
+                                                    .child(item.clone())
+                                            })
+                                            .collect::<Vec<_>>()
+                                    },
                                 )
-                                .child({
-                                    let view = cx.view().clone();
-                                    canvas(
-                                        move |bounds, cx| {
-                                            view.update(cx, |r, _| r.scroll_size = bounds.size)
-                                        },
-                                        |_, _, _| {},
-                                    )
+                                .p_4()
+                                .border_1()
+                                .border_color(cx.theme().border)
+                                .v_flex()
+                                .gap_1(),
+                            )
+                            .child({
+                                div()
                                     .absolute()
-                                    .size_full()
-                                })
-                                .child({
-                                    div()
-                                        .absolute()
-                                        .top_0()
-                                        .left_0()
-                                        .right_0()
-                                        .bottom_0()
-                                        .child(
-                                            Scrollbar::both(
-                                                view.entity_id(),
-                                                self.scroll_state.clone(),
-                                                self.scroll_handle.clone(),
-                                                self.scroll_size,
-                                            )
-                                            .axis(self.axis),
+                                    .top_0()
+                                    .left_0()
+                                    .right_0()
+                                    .bottom_0()
+                                    .child(
+                                        Scrollbar::both(
+                                            view.entity_id(),
+                                            self.scroll_state.clone(),
+                                            self.scroll_handle.clone(),
+                                            self.scroll_size,
                                         )
-                                }),
-                        ),
+                                        .axis(self.axis),
+                                    )
+                            }),
                     ),
+                ),
             )
             .child({
                 let items = self.items.clone();

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -180,7 +180,6 @@ impl Render for ScrollableStory {
                                     cx.view().clone(),
                                     "items",
                                     self.item_sizes.clone(),
-                                    self.scroll_handle.clone(),
                                     move |story, visible_range, content_size, cx| {
                                         story.set_message(
                                             &format!("visible_range: {:?}", visible_range),
@@ -193,7 +192,7 @@ impl Render for ScrollableStory {
                                                 div()
                                                     .h(ITEM_HEIGHT)
                                                     .px_3()
-                                                    .w(story.test_width)
+                                                    .w(px(100.))
                                                     .items_center()
                                                     .bg(if cx.theme().mode.is_dark() {
                                                         ui::gray_800()
@@ -205,6 +204,7 @@ impl Render for ScrollableStory {
                                             .collect::<Vec<_>>()
                                     },
                                 )
+                                .track_scroll(&self.scroll_handle)
                                 .p_4()
                                 .border_1()
                                 .border_color(cx.theme().border)

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -55,7 +55,7 @@ impl ScrollableStory {
 
     pub fn change_test_cases(&mut self, n: usize, cx: &mut ViewContext<Self>) {
         if n == 0 {
-            self.items = (0..500).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
+            self.items = (0..5000).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
             self.test_width = px(3000.);
         } else if n == 1 {
             self.items = (0..100).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
@@ -192,7 +192,7 @@ impl Render for ScrollableStory {
                                                 div()
                                                     .h(ITEM_HEIGHT)
                                                     .px_3()
-                                                    // .w(story.test_width)
+                                                    .w(story.test_width)
                                                     .items_center()
                                                     .bg(if cx.theme().mode.is_dark() {
                                                         ui::gray_800()

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -172,6 +172,7 @@ impl Render for ScrollableStory {
                 div().w_full().child(
                     div().relative().w_full().h(px(350.)).child(
                         v_flex()
+                            .id("test-0")
                             .relative()
                             .size_full()
                             .child(

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -192,7 +192,6 @@ impl Render for ScrollableStory {
                                             .map(|ix| {
                                                 h_flex()
                                                     .h(ITEM_HEIGHT)
-                                                    .px_3()
                                                     .gap_1()
                                                     .children(
                                                         (0..(story.test_width.0 as i32 / 100))

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -2,14 +2,16 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use gpui::{
-    canvas, div, px, Entity, InteractiveElement, ParentElement, Pixels, Render, ScrollHandle,
-    StatefulInteractiveElement as _, Styled, View, ViewContext, VisualContext, WindowContext,
+    canvas, div, px, size, Entity, InteractiveElement, ParentElement, Pixels, Render, ScrollHandle,
+    SharedString, Size, StatefulInteractiveElement as _, Styled, View, ViewContext, VisualContext,
+    WindowContext,
 };
 use ui::button::Button;
 use ui::divider::Divider;
+use ui::label::Label;
 use ui::scroll::{Scrollbar, ScrollbarAxis, ScrollbarState};
 use ui::theme::ActiveTheme;
-use ui::{h_flex, v_flex, StyledExt as _};
+use ui::{h_flex, v_flex, v_virtual_list, StyledExt as _};
 
 pub struct ScrollableStory {
     focus_handle: gpui::FocusHandle,
@@ -17,20 +19,33 @@ pub struct ScrollableStory {
     scroll_size: gpui::Size<Pixels>,
     scroll_state: Rc<Cell<ScrollbarState>>,
     items: Vec<String>,
+    item_sizes: Rc<Vec<Size<Pixels>>>,
     test_width: Pixels,
     axis: ScrollbarAxis,
+    message: SharedString,
 }
+
+const ITEM_HEIGHT: Pixels = px(30.);
 
 impl ScrollableStory {
     fn new(cx: &mut ViewContext<Self>) -> Self {
+        let items = (0..5000).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
+        let test_width = px(3000.);
+        let item_sizes = items
+            .iter()
+            .map(|_| size(test_width, ITEM_HEIGHT))
+            .collect::<Vec<_>>();
+
         Self {
             focus_handle: cx.focus_handle(),
             scroll_handle: ScrollHandle::new(),
             scroll_state: Rc::new(Cell::new(ScrollbarState::default())),
             scroll_size: gpui::Size::default(),
-            items: (0..500).map(|i| format!("Item {}", i)).collect::<Vec<_>>(),
-            test_width: px(3000.),
+            items,
+            item_sizes: Rc::new(item_sizes),
+            test_width,
             axis: ScrollbarAxis::Both,
+            message: SharedString::default(),
         }
     }
 
@@ -52,12 +67,24 @@ impl ScrollableStory {
             self.items = (0..5).map(|i| format!("Item {}", i)).collect::<Vec<_>>();
             self.test_width = px(10000.);
         }
+
+        self.item_sizes = self
+            .items
+            .iter()
+            .map(|_| size(self.test_width, ITEM_HEIGHT))
+            .collect::<Vec<_>>()
+            .into();
         self.scroll_state.set(ScrollbarState::default());
         cx.notify();
     }
 
     pub fn change_axis(&mut self, axis: ScrollbarAxis, cx: &mut ViewContext<Self>) {
         self.axis = axis;
+        cx.notify();
+    }
+
+    fn set_message(&mut self, msg: &str, cx: &mut ViewContext<Self>) {
+        self.message = SharedString::from(msg.to_string());
         cx.notify();
     }
 }
@@ -68,7 +95,7 @@ impl super::Story for ScrollableStory {
     }
 
     fn description() -> &'static str {
-        "Add vertical or horizontal, or both scrollbars to a container."
+        "Add vertical or horizontal, or both scrollbars to a container, and use `virtual_list` to render a large number of items."
     }
 
     fn new_view(cx: &mut WindowContext) -> View<impl gpui::FocusableView> {
@@ -92,50 +119,54 @@ impl Render for ScrollableStory {
             .child(
                 h_flex()
                     .gap_2()
-                    .child(Button::new("test-0").label("Size 0").on_click(cx.listener(
-                        |view, _, cx| {
-                            view.change_test_cases(0, cx);
-                        },
-                    )))
-                    .child(Button::new("test-1").label("Size 1").on_click(cx.listener(
-                        |view, _, cx| {
-                            view.change_test_cases(1, cx);
-                        },
-                    )))
-                    .child(Button::new("test-2").label("Size 2").on_click(cx.listener(
-                        |view, _, cx| {
-                            view.change_test_cases(2, cx);
-                        },
-                    )))
-                    .child(Button::new("test-3").label("Size 3").on_click(cx.listener(
-                        |view, _, cx| {
-                            view.change_test_cases(3, cx);
-                        },
-                    )))
-                    .child(Divider::vertical().px_2())
+                    .justify_between()
                     .child(
-                        Button::new("test-axis-both")
-                            .label("Both Scrollbar")
-                            .on_click(
-                                cx.listener(|view, _, cx| {
-                                    view.change_axis(ScrollbarAxis::Both, cx)
-                                }),
+                        h_flex()
+                            .gap_2()
+                            .child(Button::new("test-0").label("Size 0").on_click(cx.listener(
+                                |view, _, cx| {
+                                    view.change_test_cases(0, cx);
+                                },
+                            )))
+                            .child(Button::new("test-1").label("Size 1").on_click(cx.listener(
+                                |view, _, cx| {
+                                    view.change_test_cases(1, cx);
+                                },
+                            )))
+                            .child(Button::new("test-2").label("Size 2").on_click(cx.listener(
+                                |view, _, cx| {
+                                    view.change_test_cases(2, cx);
+                                },
+                            )))
+                            .child(Button::new("test-3").label("Size 3").on_click(cx.listener(
+                                |view, _, cx| {
+                                    view.change_test_cases(3, cx);
+                                },
+                            )))
+                            .child(Divider::vertical().px_2())
+                            .child(
+                                Button::new("test-axis-both")
+                                    .label("Both Scrollbar")
+                                    .on_click(cx.listener(|view, _, cx| {
+                                        view.change_axis(ScrollbarAxis::Both, cx)
+                                    })),
+                            )
+                            .child(
+                                Button::new("test-axis-vertical")
+                                    .label("Vertical")
+                                    .on_click(cx.listener(|view, _, cx| {
+                                        view.change_axis(ScrollbarAxis::Vertical, cx)
+                                    })),
+                            )
+                            .child(
+                                Button::new("test-axis-horizontal")
+                                    .label("Horizontal")
+                                    .on_click(cx.listener(|view, _, cx| {
+                                        view.change_axis(ScrollbarAxis::Horizontal, cx)
+                                    })),
                             ),
                     )
-                    .child(
-                        Button::new("test-axis-vertical")
-                            .label("Vertical")
-                            .on_click(cx.listener(|view, _, cx| {
-                                view.change_axis(ScrollbarAxis::Vertical, cx)
-                            })),
-                    )
-                    .child(
-                        Button::new("test-axis-horizontal")
-                            .label("Horizontal")
-                            .on_click(cx.listener(|view, _, cx| {
-                                view.change_axis(ScrollbarAxis::Horizontal, cx)
-                            })),
-                    ),
+                    .child(Label::new(self.message.clone())),
             )
             .child(
                 div()
@@ -143,56 +174,72 @@ impl Render for ScrollableStory {
                     .border_1()
                     .border_color(cx.theme().border)
                     .child(
-                        div()
-                            .relative()
-                            .w_full()
-                            .h(px(350.))
-                            .child(
-                                div()
-                                    .id("scroll-story")
-                                    .overflow_scroll()
-                                    .p_4()
-                                    .size_full()
-                                    .track_scroll(&self.scroll_handle)
-                                    .child(
-                                        v_flex()
-                                            .gap_1()
-                                            .w(self.test_width)
-                                            .children(self.items.iter().map(|s| {
-                                                div().bg(cx.theme().card).child(s.clone())
-                                            }))
-                                            .child({
-                                                let view = cx.view().clone();
-                                                canvas(
-                                                    move |bounds, cx| {
-                                                        view.update(cx, |r, _| {
-                                                            r.scroll_size = bounds.size
+                        div().relative().w_full().h(px(350.)).child(
+                            v_flex()
+                                .relative()
+                                .p_4()
+                                .size_full()
+                                .child(
+                                    v_virtual_list(
+                                        cx.view().clone(),
+                                        "items",
+                                        self.item_sizes.clone(),
+                                        self.scroll_handle.clone(),
+                                        move |story, visible_range, cx| {
+                                            story.set_message(
+                                                &format!("visible_range: {:?}", visible_range),
+                                                cx,
+                                            );
+                                            visible_range
+                                                .map(|ix| {
+                                                    let item = story.items.get(ix).unwrap();
+                                                    div()
+                                                        .h(ITEM_HEIGHT)
+                                                        .px_3()
+                                                        // .w(story.test_width)
+                                                        .items_center()
+                                                        .bg(if cx.theme().mode.is_dark() {
+                                                            ui::gray_800()
+                                                        } else {
+                                                            ui::gray_100()
                                                         })
-                                                    },
-                                                    |_, _, _| {},
-                                                )
-                                                .absolute()
-                                                .size_full()
-                                            }),
-                                    ),
-                            )
-                            .child(
-                                div()
+                                                        .child(item.clone())
+                                                })
+                                                .collect::<Vec<_>>()
+                                        },
+                                    )
+                                    .v_flex()
+                                    .gap_1(),
+                                )
+                                .child({
+                                    let view = cx.view().clone();
+                                    canvas(
+                                        move |bounds, cx| {
+                                            view.update(cx, |r, _| r.scroll_size = bounds.size)
+                                        },
+                                        |_, _, _| {},
+                                    )
                                     .absolute()
-                                    .top_0()
-                                    .left_0()
-                                    .right_0()
-                                    .bottom_0()
-                                    .child(
-                                        Scrollbar::both(
-                                            view.entity_id(),
-                                            self.scroll_state.clone(),
-                                            self.scroll_handle.clone(),
-                                            self.scroll_size,
+                                    .size_full()
+                                })
+                                .child({
+                                    div()
+                                        .absolute()
+                                        .top_0()
+                                        .left_0()
+                                        .right_0()
+                                        .bottom_0()
+                                        .child(
+                                            Scrollbar::both(
+                                                view.entity_id(),
+                                                self.scroll_state.clone(),
+                                                self.scroll_handle.clone(),
+                                                self.scroll_size,
+                                            )
+                                            .axis(self.axis),
                                         )
-                                        .axis(self.axis),
-                                    ),
-                            ),
+                                }),
+                        ),
                     ),
             )
             .child({

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -59,7 +59,7 @@ pub use root::{ContextModal, Root};
 pub use styled::*;
 pub use time::*;
 pub use title_bar::*;
-pub use virtual_list::{horizontal_virtual_list, vertical_virtual_list, VirtualItem};
+pub use virtual_list::{h_virtual_list, v_virtual_list, VirtualItem};
 
 pub use colors::*;
 pub use icon::*;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -7,7 +7,6 @@ mod styled;
 mod svg_img;
 mod time;
 mod title_bar;
-mod virtual_list;
 
 pub mod accordion;
 pub mod animation;
@@ -47,6 +46,7 @@ pub mod tab;
 pub mod table;
 pub mod theme;
 pub mod tooltip;
+pub mod virtual_list;
 pub mod webview;
 
 // re-export
@@ -59,7 +59,7 @@ pub use root::{ContextModal, Root};
 pub use styled::*;
 pub use time::*;
 pub use title_bar::*;
-pub use virtual_list::*;
+pub use virtual_list::{horizontal_virtual_list, vertical_virtual_list, VirtualItem};
 
 pub use colors::*;
 pub use icon::*;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -5,9 +5,9 @@ mod icon;
 mod root;
 mod styled;
 mod svg_img;
-mod table_row;
 mod time;
 mod title_bar;
+mod virtual_list;
 
 pub mod accordion;
 pub mod animation;
@@ -59,6 +59,7 @@ pub use root::{ContextModal, Root};
 pub use styled::*;
 pub use time::*;
 pub use title_bar::*;
+pub use virtual_list::*;
 
 pub use colors::*;
 pub use icon::*;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -59,7 +59,7 @@ pub use root::{ContextModal, Root};
 pub use styled::*;
 pub use time::*;
 pub use title_bar::*;
-pub use virtual_list::{h_virtual_list, v_virtual_list, VirtualItem};
+pub use virtual_list::{h_virtual_list, v_virtual_list, VirtualList};
 
 pub use colors::*;
 pub use icon::*;

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -1030,8 +1030,8 @@ where
                         .overflow_hidden()
                         .relative()
                         .child(horizontal_virtual_list(
-                            view,
                             row_ix,
+                            view,
                             col_sizes,
                             self.horizontal_scroll_handle.clone(),
                             {

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -1039,7 +1039,7 @@ where
                             self.horizontal_scroll_handle.clone(),
                             false,
                             {
-                                move |table, visible_range: Range<usize>, cx| {
+                                move |table, visible_range: Range<usize>, _, cx| {
                                     visible_range
                                         .map(|col_ix| {
                                             let col_ix = col_ix + left_cols_count;

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -2,14 +2,16 @@ use std::{cell::Cell, ops::Range, rc::Rc};
 
 use crate::{
     context_menu::ContextMenuExt,
-    h_flex, horizontal_virtual_list,
+    h_flex,
     popup_menu::PopupMenu,
     scroll::{ScrollableAxis, ScrollableMask, Scrollbar, ScrollbarState},
     theme::ActiveTheme,
-    v_flex, Icon, IconName, Sizable, Size, StyleSized as _,
+    v_flex,
+    virtual_list::virtual_list,
+    Icon, IconName, Sizable, Size, StyleSized as _,
 };
 use gpui::{
-    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AppContext, Bounds, Div,
+    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AppContext, Axis, Bounds, Div,
     DragMoveEvent, Edges, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
     InteractiveElement, IntoElement, KeyBinding, ListSizingBehavior, MouseButton, ParentElement,
     Pixels, Point, Render, ScrollHandle, ScrollStrategy, SharedString, Stateful,
@@ -1029,11 +1031,13 @@ where
                         .h_full()
                         .overflow_hidden()
                         .relative()
-                        .child(horizontal_virtual_list(
-                            row_ix,
+                        .child(virtual_list(
                             view,
+                            row_ix,
+                            Axis::Horizontal,
                             col_sizes,
                             self.horizontal_scroll_handle.clone(),
+                            false,
                             {
                                 move |table, visible_range: Range<usize>, cx| {
                                     visible_range

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -2,10 +2,9 @@ use std::{cell::Cell, ops::Range, rc::Rc};
 
 use crate::{
     context_menu::ContextMenuExt,
-    h_flex,
+    h_flex, horizontal_virtual_list,
     popup_menu::PopupMenu,
     scroll::{ScrollableAxis, ScrollableMask, Scrollbar, ScrollbarState},
-    table_row::table_row,
     theme::ActiveTheme,
     v_flex, Icon, IconName, Sizable, Size, StyleSized as _,
 };
@@ -975,11 +974,11 @@ where
         let is_stripe_row = self.stripe && row_ix % 2 != 0;
         let is_selected = self.selected_row == Some(row_ix);
         let view = cx.view().clone();
-        let col_groups: Rc<Vec<ColGroup>> = Rc::new(
+        let col_sizes: Rc<Vec<gpui::Size<Pixels>>> = Rc::new(
             self.col_groups
                 .iter()
                 .skip(left_cols_count)
-                .cloned()
+                .map(|col| col.bounds.size)
                 .collect(),
         );
 
@@ -1030,10 +1029,10 @@ where
                         .h_full()
                         .overflow_hidden()
                         .relative()
-                        .child(table_row(
+                        .child(horizontal_virtual_list(
                             view,
                             row_ix,
-                            col_groups,
+                            col_sizes,
                             self.horizontal_scroll_handle.clone(),
                             {
                                 move |table, visible_range: Range<usize>, cx| {

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -1031,14 +1031,8 @@ where
                         .h_full()
                         .overflow_hidden()
                         .relative()
-                        .child(virtual_list(
-                            view,
-                            row_ix,
-                            Axis::Horizontal,
-                            col_sizes,
-                            self.horizontal_scroll_handle.clone(),
-                            false,
-                            {
+                        .child(
+                            virtual_list(view, row_ix, Axis::Horizontal, col_sizes, {
                                 move |table, visible_range: Range<usize>, _, cx| {
                                     visible_range
                                         .map(|col_ix| {
@@ -1051,8 +1045,9 @@ where
                                         })
                                         .collect::<Vec<_>>()
                                 }
-                            },
-                        ))
+                            })
+                            .with_scroll_handle(&self.horizontal_scroll_handle),
+                        )
                         .child(self.delegate.render_last_empty_col(cx)),
                 )
                 // Row selected style

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -183,7 +183,7 @@ impl Element for VirtualList {
         .to_pixels(font_size.into(), cx.rem_size());
 
         // TODO: To cache the item_sizes, item_origins
-        // If there have 500,000 items, this methid will speed about 500~600µs
+        // If there have 500,000 items, this method will speed about 500~600µs
         // let start = std::time::Instant::now();
         // Prepare each item's size by axis
         let item_sizes = match self.axis {

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -1,11 +1,15 @@
 //! Vistual List for render a large number of differently sized rows/columns.
 //!
-//! NOTE: This must ensure each column width or row height.
+//! > NOTE: This must ensure each column width or row height.
 //!
 //! Only visible range are rendered for performance reasons.
 //!
 //! Inspired by `gpui::uniform_list`.
 //! https://github.com/zed-industries/zed/blob/0ae1603610ab6b265bdfbee7b8dbc23c5ab06edc/crates/gpui/src/elements/uniform_list.rs
+//!
+//! Unlike the `uniform_list`, the each item can have different size.
+//!
+//! This is useful for more complex layout, for example, a table with different row height.
 use std::{cmp, ops::Range, rc::Rc};
 
 use gpui::{

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -1,9 +1,10 @@
-//! Table row component for render a large number of differently sized columns (Must ensure each column width).
+//! Vistual List for render a large number of differently sized rows/columns.
 //!
-//! Only visible columns are rendered for performance reasons.
+//! NOTE: This must ensure each column width or row height.
 //!
-//! Inspired by uniform_list to rolate vertically to horizontally.
+//! Only visible range are rendered for performance reasons.
 //!
+//! Inspired by `gpui::uniform_list`.
 //! https://github.com/zed-industries/zed/blob/0ae1603610ab6b265bdfbee7b8dbc23c5ab06edc/crates/gpui/src/elements/uniform_list.rs
 use std::{cmp, ops::Range, rc::Rc};
 

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -21,8 +21,8 @@ use smallvec::SmallVec;
 ///
 /// The `item_sizes` is the size of each column.
 pub fn vertical_virtual_list<R, V>(
-    view: View<V>,
     id: impl Into<ElementId>,
+    view: View<V>,
     item_sizes: Rc<Vec<Size<Pixels>>>,
     scroll_handle: ScrollHandle,
     f: impl 'static + Fn(&mut V, Range<usize>, &mut ViewContext<V>) -> Vec<R>,
@@ -31,13 +31,13 @@ where
     R: IntoElement,
     V: Render,
 {
-    virtual_list(view, id, Axis::Vertical, item_sizes, scroll_handle, f)
+    virtual_list(id, view, Axis::Vertical, item_sizes, scroll_handle, f)
 }
 
 /// Create a virtual list in Horizontal direction.
 pub fn horizontal_virtual_list<R, V>(
-    view: View<V>,
     id: impl Into<ElementId>,
+    view: View<V>,
     item_sizes: Rc<Vec<Size<Pixels>>>,
     scroll_handle: ScrollHandle,
     f: impl 'static + Fn(&mut V, Range<usize>, &mut ViewContext<V>) -> Vec<R>,
@@ -46,12 +46,12 @@ where
     R: IntoElement,
     V: Render,
 {
-    virtual_list(view, id, Axis::Horizontal, item_sizes, scroll_handle, f)
+    virtual_list(id, view, Axis::Horizontal, item_sizes, scroll_handle, f)
 }
 
 fn virtual_list<R, V>(
-    view: View<V>,
     id: impl Into<ElementId>,
+    view: View<V>,
     axis: Axis,
     item_sizes: Rc<Vec<Size<Pixels>>>,
     scroll_handle: ScrollHandle,

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -13,10 +13,10 @@
 use std::{cmp, ops::Range, rc::Rc};
 
 use gpui::{
-    div, point, prelude::FluentBuilder as _, px, size, AnyElement, AvailableSpace, Axis, Bounds,
-    ContentMask, Div, Element, ElementId, GlobalElementId, Hitbox, InteractiveElement, IntoElement,
-    IsZero as _, Pixels, Render, ScrollHandle, Size, Stateful, StatefulInteractiveElement,
-    StyleRefinement, Styled, View, ViewContext, WindowContext,
+    div, point, px, size, AnyElement, AvailableSpace, Axis, Bounds, ContentMask, Div, Element,
+    ElementId, GlobalElementId, Hitbox, InteractiveElement, IntoElement, IsZero as _, Pixels,
+    Render, ScrollHandle, Size, Stateful, StatefulInteractiveElement, StyleRefinement, Styled,
+    View, ViewContext, WindowContext,
 };
 use smallvec::SmallVec;
 

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -183,6 +183,9 @@ impl Element for VirtualList {
         }
         .to_pixels(font_size.into(), cx.rem_size());
 
+        // TODO: To cache the item_sizes, item_origins
+        // If there have 500,000 items, this methid will speed about 500~600µs
+        // let start = std::time::Instant::now();
         // Prepare each item's size by axis
         let item_sizes = match self.axis {
             Axis::Horizontal => self
@@ -230,6 +233,7 @@ impl Element for VirtualList {
                 })
                 .collect::<Vec<_>>(),
         };
+        // println!("layout: {} {:?}", item_sizes.len(), start.elapsed());
 
         let (layout_id, _) = self.base.request_layout(global_id, cx);
 
@@ -402,7 +406,6 @@ impl Element for VirtualList {
                                         )
                                 }
                             };
-                            // dbg!(&item_origin);
 
                             let available_space = match self.axis {
                                 Axis::Horizontal => size(
@@ -438,8 +441,8 @@ impl Element for VirtualList {
         self.base
             .interactivity()
             .paint(global_id, bounds, hitbox.as_ref(), cx, |_, cx| {
-                for col in &mut layout.items {
-                    col.paint(cx);
+                for item in &mut layout.items {
+                    item.paint(cx);
                 }
             })
     }

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -80,8 +80,7 @@ where
         base: div()
             .id(id)
             .size_full()
-            .when(axis == Axis::Horizontal, |this| this.overflow_x_scroll())
-            .when(axis == Axis::Vertical, |this| this.overflow_y_scroll())
+            .overflow_scroll()
             .track_scroll(&scroll_handle),
         scroll_handle,
         items_count: item_sizes.len(),


### PR DESCRIPTION
Vistual List for render a large number of differently sized rows/columns.

> NOTE: This must ensure each column width or row height.

Unlike the `uniform_list`, the each item can have different size. This is useful for more complex layout, for example, a table with different row height.