### PR TITLE
dock: Add `visible` method to Panel trait to control panel visible.

### DIFF
--- a/crates/story/src/button_story.rs
+++ b/crates/story/src/button_story.rs
@@ -50,7 +50,7 @@ impl super::Story for ButtonStory {
         "Displays a button or a component that looks like a button."
     }
 
-    fn closeable() -> bool {
+    fn closable() -> bool {
         false
     }
 

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -55,7 +55,7 @@ impl super::Story for InputStory {
         "Input"
     }
 
-    fn closeable() -> bool {
+    fn closable() -> bool {
         false
     }
 

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -304,6 +304,10 @@ impl Panel for StoryContainer {
         self.zoomable
     }
 
+    fn visible(&self, _: &AppContext) -> bool {
+        !matches!(self.name.as_ref(), "Accordion" | "Image" | "Sidebar")
+    }
+
     fn set_zoomed(&self, zoomed: bool, _cx: &ViewContext<Self>) {
         println!("panel: {} zoomed: {}", self.name, zoomed);
     }

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -100,7 +100,7 @@ pub fn init(cx: &mut AppContext) {
         };
 
         let view = cx.new_view(|cx| {
-            let (title, description, closeable, zoomable, story) = story_state.to_story(cx);
+            let (title, description, closable, zoomable, story) = story_state.to_story(cx);
             let mut container = StoryContainer::new(cx).story(story, story_state.story_klass);
 
             cx.on_focus_in(&container.focus_handle, |this: &mut StoryContainer, _| {
@@ -110,7 +110,7 @@ pub fn init(cx: &mut AppContext) {
 
             container.name = title.into();
             container.description = description.into();
-            container.closeable = closeable;
+            container.closable = closable;
             container.zoomable = zoomable;
             container
         });
@@ -146,7 +146,7 @@ pub struct StoryContainer {
     height: Option<gpui::Pixels>,
     story: Option<AnyView>,
     story_klass: Option<SharedString>,
-    closeable: bool,
+    closable: bool,
     zoomable: bool,
 }
 
@@ -164,7 +164,7 @@ pub trait Story: FocusableView {
     fn description() -> &'static str {
         ""
     }
-    fn closeable() -> bool {
+    fn closable() -> bool {
         true
     }
     fn zoomable() -> bool {
@@ -191,7 +191,7 @@ impl StoryContainer {
             height: None,
             story: None,
             story_klass: None,
-            closeable: true,
+            closable: true,
             zoomable: true,
         }
     }
@@ -206,7 +206,7 @@ impl StoryContainer {
         let view = cx.new_view(|cx| {
             let mut story = Self::new(cx).story(story.into(), story_klass);
             story.focus_handle = focus_handle;
-            story.closeable = S::closeable();
+            story.closable = S::closable();
             story.zoomable = S::zoomable();
             story.name = name.into();
             story.description = description.into();
@@ -266,7 +266,7 @@ impl StoryState {
                 (
                     $klass::title(),
                     $klass::description(),
-                    $klass::closeable(),
+                    $klass::closable(),
                     $klass::zoomable(),
                     $klass::view(cx).into(),
                 )
@@ -320,8 +320,8 @@ impl Panel for StoryContainer {
         }
     }
 
-    fn closeable(&self, _cx: &AppContext) -> bool {
-        self.closeable
+    fn closable(&self, _cx: &AppContext) -> bool {
+        self.closable
     }
 
     fn zoomable(&self, _cx: &AppContext) -> bool {

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -305,7 +305,10 @@ impl Panel for StoryContainer {
     }
 
     fn visible(&self, _: &AppContext) -> bool {
-        !matches!(self.name.as_ref(), "Accordion" | "Image" | "Sidebar")
+        !matches!(
+            self.name.as_ref(),
+            "Scrollable" | "Table" | "Image" | "Sidebar"
+        )
     }
 
     fn set_zoomed(&self, zoomed: bool, _cx: &ViewContext<Self>) {

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -285,7 +285,7 @@ impl Panel for StoryContainer {
         self.name.clone().into_any_element()
     }
 
-    fn title_style(&self, cx: &WindowContext) -> Option<TitleStyle> {
+    fn title_style(&self, cx: &AppContext) -> Option<TitleStyle> {
         if let Some(bg) = self.title_bg {
             Some(TitleStyle {
                 background: bg,
@@ -296,11 +296,11 @@ impl Panel for StoryContainer {
         }
     }
 
-    fn closeable(&self, _cx: &WindowContext) -> bool {
+    fn closeable(&self, _cx: &AppContext) -> bool {
         self.closeable
     }
 
-    fn zoomable(&self, _cx: &WindowContext) -> bool {
+    fn zoomable(&self, _cx: &AppContext) -> bool {
         self.zoomable
     }
 

--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -412,8 +412,8 @@ impl StoryWorkspace {
         cx: &mut ViewContext<Self>,
     ) {
         let panel_name = action.0.clone();
-        let invisble_panels = AppState::global(cx).invisible_panels.clone();
-        invisble_panels.update(cx, |names, cx| {
+        let invisible_panels = AppState::global(cx).invisible_panels.clone();
+        invisible_panels.update(cx, |names, cx| {
             if names.contains(&panel_name) {
                 names.retain(|id| id != &panel_name);
             } else {
@@ -445,7 +445,7 @@ impl Render for StoryWorkspace {
         let modal_layer = Root::render_modal_layer(cx);
         let notification_layer = Root::render_notification_layer(cx);
         let notifications_count = cx.notifications().len();
-        let invisble_panels = AppState::global(cx).invisible_panels.clone();
+        let invisible_panels = AppState::global(cx).invisible_panels.clone();
 
         div()
             .id("story-workspace")
@@ -493,7 +493,7 @@ impl Render for StoryWorkspace {
                                         .separator()
                                         .menu_with_check(
                                             "Sidebar",
-                                            !invisble_panels
+                                            !invisible_panels
                                                 .read(cx)
                                                 .contains(&SharedString::from("Sidebar")),
                                             Box::new(TogglePanelVisible(SharedString::from(
@@ -502,7 +502,7 @@ impl Render for StoryWorkspace {
                                         )
                                         .menu_with_check(
                                             "Modal",
-                                            !invisble_panels
+                                            !invisible_panels
                                                 .read(cx)
                                                 .contains(&SharedString::from("SidebModalar")),
                                             Box::new(TogglePanelVisible(SharedString::from(
@@ -511,7 +511,7 @@ impl Render for StoryWorkspace {
                                         )
                                         .menu_with_check(
                                             "Accordion",
-                                            !invisble_panels
+                                            !invisible_panels
                                                 .read(cx)
                                                 .contains(&SharedString::from("Accordion")),
                                             Box::new(TogglePanelVisible(SharedString::from(
@@ -520,7 +520,7 @@ impl Render for StoryWorkspace {
                                         )
                                         .menu_with_check(
                                             "List",
-                                            !invisble_panels
+                                            !invisible_panels
                                                 .read(cx)
                                                 .contains(&SharedString::from("List")),
                                             Box::new(TogglePanelVisible(SharedString::from(

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -505,7 +505,7 @@ impl super::Story for TableStory {
         Self::view(cx)
     }
 
-    fn closeable() -> bool {
+    fn closable() -> bool {
         false
     }
 }

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -81,7 +81,7 @@ impl Dock {
     ) -> Self {
         let panel = cx.new_view(|cx| {
             let mut tab = TabPanel::new(None, dock_area.clone(), cx);
-            tab.closeable = false;
+            tab.closable = false;
             tab
         });
 

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -50,16 +50,22 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
     }
 
     /// Whether the panel can be closed, default is `true`.
+    ///
+    /// This method called in Panel render, we should make sure it is fast.
     fn closeable(&self, cx: &AppContext) -> bool {
         true
     }
 
     /// Return true if the panel is zoomable, default is `false`.
+    ///
+    /// This method called in Panel render, we should make sure it is fast.
     fn zoomable(&self, cx: &AppContext) -> bool {
         true
     }
 
     /// Return false to hide panel, true to show panel, default is `true`.
+    ///
+    /// This method called in Panel render, we should make sure it is fast.
     fn visible(&self, cx: &AppContext) -> bool {
         true
     }

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -52,7 +52,7 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
     /// Whether the panel can be closed, default is `true`.
     ///
     /// This method called in Panel render, we should make sure it is fast.
-    fn closeable(&self, cx: &AppContext) -> bool {
+    fn closable(&self, cx: &AppContext) -> bool {
         true
     }
 
@@ -107,7 +107,7 @@ pub trait PanelView: 'static + Send + Sync {
     fn panel_name(&self, cx: &AppContext) -> &'static str;
     fn title(&self, cx: &WindowContext) -> AnyElement;
     fn title_style(&self, cx: &AppContext) -> Option<TitleStyle>;
-    fn closeable(&self, cx: &AppContext) -> bool;
+    fn closable(&self, cx: &AppContext) -> bool;
     fn zoomable(&self, cx: &AppContext) -> bool;
     fn visible(&self, cx: &AppContext) -> bool;
     fn set_active(&self, active: bool, cx: &mut WindowContext);
@@ -132,8 +132,8 @@ impl<T: Panel> PanelView for View<T> {
         self.read(cx).title_style(cx)
     }
 
-    fn closeable(&self, cx: &AppContext) -> bool {
-        self.read(cx).closeable(cx)
+    fn closable(&self, cx: &AppContext) -> bool {
+        self.read(cx).closable(cx)
     }
 
     fn zoomable(&self, cx: &AppContext) -> bool {

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -45,17 +45,22 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
     }
 
     /// The theme of the panel title, default is `None`.
-    fn title_style(&self, cx: &WindowContext) -> Option<TitleStyle> {
+    fn title_style(&self, cx: &AppContext) -> Option<TitleStyle> {
         None
     }
 
     /// Whether the panel can be closed, default is `true`.
-    fn closeable(&self, cx: &WindowContext) -> bool {
+    fn closeable(&self, cx: &AppContext) -> bool {
         true
     }
 
     /// Return true if the panel is zoomable, default is `false`.
-    fn zoomable(&self, cx: &WindowContext) -> bool {
+    fn zoomable(&self, cx: &AppContext) -> bool {
+        true
+    }
+
+    /// Return false to hide panel, true to show panel, default is `true`.
+    fn visible(&self, cx: &AppContext) -> bool {
         true
     }
 
@@ -95,9 +100,10 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
 pub trait PanelView: 'static + Send + Sync {
     fn panel_name(&self, cx: &AppContext) -> &'static str;
     fn title(&self, cx: &WindowContext) -> AnyElement;
-    fn title_style(&self, cx: &WindowContext) -> Option<TitleStyle>;
-    fn closeable(&self, cx: &WindowContext) -> bool;
-    fn zoomable(&self, cx: &WindowContext) -> bool;
+    fn title_style(&self, cx: &AppContext) -> Option<TitleStyle>;
+    fn closeable(&self, cx: &AppContext) -> bool;
+    fn zoomable(&self, cx: &AppContext) -> bool;
+    fn visible(&self, cx: &AppContext) -> bool;
     fn set_active(&self, active: bool, cx: &mut WindowContext);
     fn set_zoomed(&self, zoomed: bool, cx: &mut WindowContext);
     fn popup_menu(&self, menu: PopupMenu, cx: &WindowContext) -> PopupMenu;
@@ -116,16 +122,20 @@ impl<T: Panel> PanelView for View<T> {
         self.read(cx).title(cx)
     }
 
-    fn title_style(&self, cx: &WindowContext) -> Option<TitleStyle> {
+    fn title_style(&self, cx: &AppContext) -> Option<TitleStyle> {
         self.read(cx).title_style(cx)
     }
 
-    fn closeable(&self, cx: &WindowContext) -> bool {
+    fn closeable(&self, cx: &AppContext) -> bool {
         self.read(cx).closeable(cx)
     }
 
-    fn zoomable(&self, cx: &WindowContext) -> bool {
+    fn zoomable(&self, cx: &AppContext) -> bool {
         self.read(cx).zoomable(cx)
+    }
+
+    fn visible(&self, cx: &AppContext) -> bool {
+        self.read(cx).visible(cx)
     }
 
     fn set_active(&self, active: bool, cx: &mut WindowContext) {

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -172,6 +172,7 @@ impl StackPanel {
     fn new_resizable_panel(panel: Arc<dyn PanelView>, size: Option<Pixels>) -> ResizablePanel {
         resizable_panel()
             .content_view(panel.view())
+            .content_visible(move |cx| panel.visible(cx))
             .when_some(size, |this, size| this.size(size))
     }
 

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -109,6 +109,10 @@ impl Panel for TabPanel {
             .unwrap_or(false)
     }
 
+    fn visible(&self, cx: &AppContext) -> bool {
+        self.visible_panels(cx).next().is_some()
+    }
+
     fn popup_menu(&self, menu: PopupMenu, cx: &WindowContext) -> PopupMenu {
         if let Some(panel) = self.active_panel(cx) {
             panel.popup_menu(menu, cx)

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -26,7 +26,7 @@ use super::{
 
 #[derive(Clone, Copy)]
 struct TabState {
-    closeable: bool,
+    closable: bool,
     zoomable: bool,
     draggable: bool,
     droppable: bool,
@@ -71,9 +71,9 @@ pub struct TabPanel {
     stack_panel: Option<WeakView<StackPanel>>,
     pub(crate) panels: Vec<Arc<dyn PanelView>>,
     pub(crate) active_ix: usize,
-    /// If this is true, the Panel closeable will follow the active panel's closeable,
+    /// If this is true, the Panel closable will follow the active panel's closable,
     /// otherwise this TabPanel will not able to close
-    pub(crate) closeable: bool,
+    pub(crate) closable: bool,
 
     tab_bar_scroll_handle: ScrollHandle,
     is_zoomed: bool,
@@ -93,13 +93,13 @@ impl Panel for TabPanel {
             .unwrap_or("Empty Tab".into_any_element())
     }
 
-    fn closeable(&self, cx: &AppContext) -> bool {
-        if !self.closeable {
+    fn closable(&self, cx: &AppContext) -> bool {
+        if !self.closable {
             return false;
         }
 
         self.active_panel(cx)
-            .map(|panel| panel.closeable(cx))
+            .map(|panel| panel.closable(cx))
             .unwrap_or(false)
     }
 
@@ -155,7 +155,7 @@ impl TabPanel {
             will_split_placement: None,
             is_zoomed: false,
             is_collapsed: false,
-            closeable: true,
+            closable: true,
         }
     }
 
@@ -421,7 +421,7 @@ impl TabPanel {
                                 };
                                 this.separator().menu(name, Box::new(ToggleZoom))
                             })
-                            .when(state.closeable, |this| {
+                            .when(state.closable, |this| {
                                 this.separator()
                                     .menu(t!("Dock.Close"), Box::new(ClosePanel))
                             })
@@ -977,13 +977,13 @@ impl Render for TabPanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl gpui::IntoElement {
         let focus_handle = self.focus_handle(cx);
         let mut state = TabState {
-            closeable: self.closeable(cx),
+            closable: self.closable(cx),
             draggable: self.draggable(cx),
             droppable: self.droppable(cx),
             zoomable: self.zoomable(cx),
         };
         if !state.draggable {
-            state.closeable = false;
+            state.closable = false;
         }
 
         v_flex()

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -93,7 +93,7 @@ impl Panel for TabPanel {
             .unwrap_or("Empty Tab".into_any_element())
     }
 
-    fn closeable(&self, cx: &WindowContext) -> bool {
+    fn closeable(&self, cx: &AppContext) -> bool {
         if !self.closeable {
             return false;
         }
@@ -103,7 +103,7 @@ impl Panel for TabPanel {
             .unwrap_or(false)
     }
 
-    fn zoomable(&self, cx: &WindowContext) -> bool {
+    fn zoomable(&self, cx: &AppContext) -> bool {
         self.active_panel()
             .map(|panel| panel.zoomable(cx))
             .unwrap_or(false)


### PR DESCRIPTION
Closes #502 #499 

## Added

- Add `visible` method to `Panel` trait, if return false this panel will disappear.

## Break changes

- Renamed `closeable` to `closable`.
- The `title_style`, `closable`, `zoomable` in `Panel` trait have been change `cx: &WindowContext` to `cx: &AppContext`.