### PR TITLE
dropdown : Modularize creation

### DIFF
--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -156,6 +156,13 @@ impl DropdownStory {
                     Dropdown::new("string-list3", cx)
                         .set_delegate(Vec::<SharedString>::new(), cx)
                         .small()
+                        .empty(|cx| {
+                            h_flex()
+                                .h_24()
+                                .justify_center()
+                                .text_color(cx.theme().muted_foreground)
+                                .child("No Data")
+                        })
                 }),
                 disabled_dropdown: cx.new_view(|cx| {
                     Dropdown::new("disabled-dropdown", cx)

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -97,8 +97,8 @@ impl DropdownStory {
         ];
         let country_dropdown = cx.new_view(|cx| {
             Dropdown::new("dropdown-country", cx)
-                .set_delegate(countries, cx)
-                .set_selected_index(Some(6), cx)
+                .delegate(countries, cx)
+                .index(Some(6), cx)
                 .cleanable()
         });
 
@@ -114,7 +114,7 @@ impl DropdownStory {
 
         let fruit_dropdown = cx.new_view(|cx| {
             Dropdown::new("dropdown-fruits", cx)
-                .set_delegate(fruits, cx)
+                .delegate(fruits, cx)
                 .icon(IconName::Search)
                 .width(px(200.))
                 .menu_width(px(320.))
@@ -131,18 +131,18 @@ impl DropdownStory {
                 country_dropdown_ftl_on: false,
                 simple_dropdown1: cx.new_view(|cx| {
                     Dropdown::new("string-list1", cx)
-                        .set_delegate(
+                        .delegate(
                             vec!["QPUI".into(), "Iced".into(), "QT".into(), "Cocoa".into()],
                             cx,
                         )
-                        .set_selected_index(Some(0), cx)
+                        .index(Some(0), cx)
                         .small()
                         .placeholder("UI")
                         .title_prefix("UI: ")
                 }),
                 simple_dropdown2: cx.new_view(|cx| {
                     Dropdown::new("string-list2", cx)
-                        .set_delegate(
+                        .delegate(
                             SearchableVec::new(vec![
                                 "Rust".into(),
                                 "Go".into(),
@@ -151,7 +151,7 @@ impl DropdownStory {
                             ]),
                             cx,
                         )
-                        .set_selected_index(None, cx)
+                        .index(None, cx)
                         .small()
                         .placeholder("Language")
                         .title_prefix("Language: ")
@@ -167,7 +167,7 @@ impl DropdownStory {
                 }),
                 disabled_dropdown: cx.new_view(|cx| {
                     Dropdown::new("disabled-dropdown", cx)
-                        .set_delegate(Vec::<SharedString>::new(), cx)
+                        .delegate(Vec::<SharedString>::new(), cx)
                         .small()
                         .disabled(true)
                 }),
@@ -282,8 +282,8 @@ impl Render for DropdownStory {
                         view.country_dropdown_ftl_on = !view.country_dropdown_ftl_on;
                         view.country_dropdown.update(cx, |this, cx| {
                             match view.country_dropdown_ftl_on {
-                                true => this.set_delegate(countries_mock_ftl, cx),
-                                false => this.set_delegate(countries, cx),
+                                true => this.delegate(countries_mock_ftl, cx),
+                                false => this.delegate(countries, cx),
                             }
                         });
                         cx.notify();

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -21,6 +21,7 @@ pub fn init(cx: &mut AppContext) {
     ])
 }
 
+#[derive(Clone)]
 struct Country {
     name: SharedString,
     code: SharedString,
@@ -92,9 +93,12 @@ impl DropdownStory {
             Country::new("Venezuela", "VE"),
             Country::new("Ecuador", "EC"),
         ];
-
-        let country_dropdown =
-            cx.new_view(|cx| Dropdown::new("dropdown-country", countries, Some(6), cx).cleanable());
+        let country_dropdown = cx.new_view(|cx| {
+            Dropdown::new("dropdown-country", cx)
+                .set_delegate(countries, cx)
+                .set_selected_index(Some(6), cx)
+                .cleanable()
+        });
 
         let fruits = SearchableVec::new(vec![
             "Apple".into(),
@@ -106,7 +110,8 @@ impl DropdownStory {
             "Avocado".into(),
         ]);
         let fruit_dropdown = cx.new_view(|cx| {
-            Dropdown::new("dropdown-fruits", fruits, None, cx)
+            Dropdown::new("dropdown-fruits", cx)
+                .set_delegate(fruits, cx)
                 .icon(IconName::Search)
                 .width(px(200.))
                 .menu_width(px(320.))
@@ -121,45 +126,40 @@ impl DropdownStory {
                 country_dropdown,
                 fruit_dropdown,
                 simple_dropdown1: cx.new_view(|cx| {
-                    Dropdown::new(
-                        "string-list1",
-                        vec!["QPUI".into(), "Iced".into(), "QT".into(), "Cocoa".into()],
-                        Some(0),
-                        cx,
-                    )
-                    .small()
-                    .placeholder("UI")
-                    .title_prefix("UI: ")
+                    Dropdown::new("string-list1", cx)
+                        .set_delegate(
+                            vec!["QPUI".into(), "Iced".into(), "QT".into(), "Cocoa".into()],
+                            cx,
+                        )
+                        .set_selected_index(Some(0), cx)
+                        .small()
+                        .placeholder("UI")
+                        .title_prefix("UI: ")
                 }),
                 simple_dropdown2: cx.new_view(|cx| {
-                    Dropdown::new(
-                        "string-list2",
-                        SearchableVec::new(vec![
-                            "Rust".into(),
-                            "Go".into(),
-                            "C++".into(),
-                            "JavaScript".into(),
-                        ]),
-                        None,
-                        cx,
-                    )
-                    .small()
-                    .placeholder("Language")
-                    .title_prefix("Language: ")
+                    Dropdown::new("string-list2", cx)
+                        .set_delegate(
+                            SearchableVec::new(vec![
+                                "Rust".into(),
+                                "Go".into(),
+                                "C++".into(),
+                                "JavaScript".into(),
+                            ]),
+                            cx,
+                        )
+                        .set_selected_index(None, cx)
+                        .small()
+                        .placeholder("Language")
+                        .title_prefix("Language: ")
                 }),
                 simple_dropdown3: cx.new_view(|cx| {
-                    Dropdown::new("string-list3", Vec::<SharedString>::new(), None, cx)
+                    Dropdown::new("string-list3", cx)
+                        .set_delegate(Vec::<SharedString>::new(), cx)
                         .small()
-                        .empty(|cx| {
-                            h_flex()
-                                .h_24()
-                                .justify_center()
-                                .text_color(cx.theme().muted_foreground)
-                                .child("No Data")
-                        })
                 }),
                 disabled_dropdown: cx.new_view(|cx| {
-                    Dropdown::new("disabled-dropdown", Vec::<SharedString>::new(), None, cx)
+                    Dropdown::new("disabled-dropdown", cx)
+                        .set_delegate(Vec::<SharedString>::new(), cx)
                         .small()
                         .disabled(true)
                 }),

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -52,10 +52,12 @@ pub struct DropdownStory {
     disabled: bool,
     country_dropdown: View<Dropdown<Vec<Country>>>,
     fruit_dropdown: View<Dropdown<SearchableVec<SharedString>>>,
+    ftl_on: bool,
     simple_dropdown1: View<Dropdown<Vec<SharedString>>>,
     simple_dropdown2: View<Dropdown<SearchableVec<SharedString>>>,
     simple_dropdown3: View<Dropdown<Vec<SharedString>>>,
     disabled_dropdown: View<Dropdown<Vec<SharedString>>>,
+    changing_dropdown: View<Dropdown<Vec<SharedString>>>,
 }
 
 impl super::Story for DropdownStory {
@@ -109,6 +111,7 @@ impl DropdownStory {
             "Watermelon & This is a longlonglonglonglonglonglonglonglong title".into(),
             "Avocado".into(),
         ]);
+
         let fruit_dropdown = cx.new_view(|cx| {
             Dropdown::new("dropdown-fruits", cx)
                 .set_delegate(fruits, cx)
@@ -125,6 +128,7 @@ impl DropdownStory {
                 disabled: false,
                 country_dropdown,
                 fruit_dropdown,
+                ftl_on: false,
                 simple_dropdown1: cx.new_view(|cx| {
                     Dropdown::new("string-list1", cx)
                         .set_delegate(
@@ -153,16 +157,13 @@ impl DropdownStory {
                         .title_prefix("Language: ")
                 }),
                 simple_dropdown3: cx.new_view(|cx| {
-                    Dropdown::new("string-list3", cx)
-                        .set_delegate(Vec::<SharedString>::new(), cx)
-                        .small()
-                        .empty(|cx| {
-                            h_flex()
-                                .h_24()
-                                .justify_center()
-                                .text_color(cx.theme().muted_foreground)
-                                .child("No Data")
-                        })
+                    Dropdown::new("string-list3", cx).small().empty(|cx| {
+                        h_flex()
+                            .h_24()
+                            .justify_center()
+                            .text_color(cx.theme().muted_foreground)
+                            .child("No Data")
+                    })
                 }),
                 disabled_dropdown: cx.new_view(|cx| {
                     Dropdown::new("disabled-dropdown", cx)
@@ -170,6 +171,7 @@ impl DropdownStory {
                         .small()
                         .disabled(true)
                 }),
+                changing_dropdown: cx.new_view(|cx| Dropdown::new("string-list4", cx).small()),
             }
         })
     }
@@ -246,6 +248,47 @@ impl Render for DropdownStory {
                     })),
             )
             .child(
+                Checkbox::new("mock-ftl-countries")
+                    .label("Country ftl")
+                    .checked(self.ftl_on)
+                    .on_click(cx.listener(|view, _, cx| {
+                        let countries = vec![
+                            Country::new("United States", "US"),
+                            Country::new("Canada", "CA"),
+                            Country::new("Mexico", "MX"),
+                            Country::new("Brazil", "BR"),
+                            Country::new("Argentina", "AR"),
+                            Country::new("Chile", "CL"),
+                            Country::new("China", "CN"),
+                            Country::new("Peru", "PE"),
+                            Country::new("Colombia", "CO"),
+                            Country::new("Venezuela", "VE"),
+                            Country::new("Ecuador", "EC"),
+                        ];
+                        // sorry, this is ai generated
+                        let countries_mock_ftl = vec![
+                            Country::new("美国", "US"),
+                            Country::new("加拿大", "CA"),
+                            Country::new("墨西哥", "MX"),
+                            Country::new("巴西", "BR"),
+                            Country::new("阿根廷", "AR"),
+                            Country::new("智利", "CL"),
+                            Country::new("中国", "CN"),
+                            Country::new("秘鲁", "PE"),
+                            Country::new("哥伦比亚", "CO"),
+                            Country::new("委内瑞拉", "VE"),
+                            Country::new("厄瓜多尔", "EC"),
+                        ];
+                        view.ftl_on = !view.ftl_on;
+                        view.country_dropdown
+                            .update(cx, |this, cx| match view.ftl_on {
+                                true => this.set_delegate(countries_mock_ftl, cx),
+                                false => this.set_delegate(countries, cx),
+                            });
+                        cx.notify();
+                    })),
+            )
+            .child(
                 h_flex()
                     .w_full()
                     .items_center()
@@ -289,6 +332,7 @@ impl Render for DropdownStory {
                     .child(self.simple_dropdown1.clone())
                     .child(self.simple_dropdown2.clone())
                     .child(self.simple_dropdown3.clone())
+                    .child(self.changing_dropdown.clone())
                     .child(self.disabled_dropdown.clone()),
             )
     }

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -51,8 +51,8 @@ impl DropdownItem for Country {
 pub struct DropdownStory {
     disabled: bool,
     country_dropdown: View<Dropdown<Vec<Country>>>,
+    country_dropdown_ftl_on: bool,
     fruit_dropdown: View<Dropdown<SearchableVec<SharedString>>>,
-    ftl_on: bool,
     simple_dropdown1: View<Dropdown<Vec<SharedString>>>,
     simple_dropdown2: View<Dropdown<SearchableVec<SharedString>>>,
     simple_dropdown3: View<Dropdown<Vec<SharedString>>>,
@@ -128,7 +128,7 @@ impl DropdownStory {
                 disabled: false,
                 country_dropdown,
                 fruit_dropdown,
-                ftl_on: false,
+                country_dropdown_ftl_on: false,
                 simple_dropdown1: cx.new_view(|cx| {
                     Dropdown::new("string-list1", cx)
                         .set_delegate(
@@ -250,7 +250,7 @@ impl Render for DropdownStory {
             .child(
                 Checkbox::new("mock-ftl-countries")
                     .label("Country ftl")
-                    .checked(self.ftl_on)
+                    .checked(self.country_dropdown_ftl_on)
                     .on_click(cx.listener(|view, _, cx| {
                         let countries = vec![
                             Country::new("United States", "US"),
@@ -279,12 +279,13 @@ impl Render for DropdownStory {
                             Country::new("委内瑞拉", "VE"),
                             Country::new("厄瓜多尔", "EC"),
                         ];
-                        view.ftl_on = !view.ftl_on;
-                        view.country_dropdown
-                            .update(cx, |this, cx| match view.ftl_on {
+                        view.country_dropdown_ftl_on = !view.country_dropdown_ftl_on;
+                        view.country_dropdown.update(cx, |this, cx| {
+                            match view.country_dropdown_ftl_on {
                                 true => this.set_delegate(countries_mock_ftl, cx),
                                 false => this.set_delegate(countries, cx),
-                            });
+                            }
+                        });
                         cx.notify();
                     })),
             )

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -253,16 +253,9 @@ impl ModalStory {
         let date_picker =
             cx.new_view(|cx| DatePicker::new("birthday-picker", cx).placeholder("Date of Birth"));
         let dropdown = cx.new_view(|cx| {
-            Dropdown::new(
-                "dropdown1",
-                vec![
-                    "Option 1".to_string(),
-                    "Option 2".to_string(),
-                    "Option 3".to_string(),
-                ],
-                None,
-                cx,
-            )
+            Dropdown::new("dropdown1", cx)
+                .set_delegate(delegate, cx)
+                .set_selected_index(Some(0), cx)
         });
 
         Self {

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -255,7 +255,7 @@ impl ModalStory {
             cx.new_view(|cx| DatePicker::new("birthday-picker", cx).placeholder("Date of Birth"));
         let dropdown = cx.new_view(|cx| {
             Dropdown::new("dropdown1", cx)
-                .set_delegate(
+                .delegate(
                     vec![
                         "Option 1".to_string(),
                         "Option 2".to_string(),
@@ -263,7 +263,7 @@ impl ModalStory {
                     ],
                     cx,
                 )
-                .set_selected_index(None, cx)
+                .index(None, cx)
         });
 
         Self {

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -24,6 +24,7 @@ use ui::{
 
 actions!(modal_story, [TestAction]);
 
+#[derive(Clone)]
 pub struct ListItemDeletegate {
     story: WeakView<ModalStory>,
     confirmed_index: Option<usize>,
@@ -254,8 +255,15 @@ impl ModalStory {
             cx.new_view(|cx| DatePicker::new("birthday-picker", cx).placeholder("Date of Birth"));
         let dropdown = cx.new_view(|cx| {
             Dropdown::new("dropdown1", cx)
-                .set_delegate(delegate, cx)
-                .set_selected_index(Some(0), cx)
+                .set_delegate(
+                    vec![
+                        "Option 1".to_string(),
+                        "Option 2".to_string(),
+                        "Option 3".to_string(),
+                    ],
+                    cx,
+                )
+                .set_selected_index(None, cx)
         });
 
         Self {

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -61,7 +61,7 @@ impl DropdownItem for SharedString {
 
 pub trait DropdownDelegate: Sized + Clone {
     type Item: DropdownItem + Clone;
-
+    /// Returns an empty Vec
     fn empty() -> Self;
 
     fn len(&self) -> usize;

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -353,11 +353,11 @@ where
             bounds: Bounds::default(),
             disabled: false,
         };
-        this.set_selected_index(None, cx);
+        this.index(None, cx);
         this
     }
 
-    pub fn set_delegate(&mut self, delegate: D, cx: &mut ViewContext<Self>) -> Self {
+    pub fn delegate(&mut self, delegate: D, cx: &mut ViewContext<Self>) -> Self {
         let current_value = self.selected_value.clone();
 
         self.list.update(cx, |list, _cx| {
@@ -369,22 +369,18 @@ where
             let current_index = self.selected_index(cx);
 
             if current_index != new_index {
-                self.set_selected_index(new_index, cx);
+                self.index(new_index, cx);
             }
         } else {
             if self.selected_index(cx).is_some() {
-                self.set_selected_index(None, cx);
+                self.index(None, cx);
             }
         }
 
         self.clone()
     }
 
-    pub fn set_selected_index(
-        &mut self,
-        selected_index: Option<usize>,
-        cx: &mut ViewContext<Self>,
-    ) -> Self {
+    pub fn index(&mut self, selected_index: Option<usize>, cx: &mut ViewContext<Self>) -> Self {
         self.list.update(cx, |list, cx| {
             list.set_selected_index(selected_index, cx);
         });
@@ -460,7 +456,7 @@ where
     {
         let delegate = self.list.read(cx).delegate();
         let selected_index = delegate.delegate.position(selected_value);
-        self.set_selected_index(selected_index, cx);
+        self.index(selected_index, cx);
     }
 
     pub fn selected_index(&self, cx: &WindowContext) -> Option<usize> {
@@ -541,7 +537,7 @@ where
     }
 
     fn clean(&mut self, _: &ClickEvent, cx: &mut ViewContext<Self>) {
-        self.set_selected_index(None, cx);
+        self.index(None, cx);
         cx.emit(DropdownEvent::Confirm(None));
     }
 


### PR DESCRIPTION
Makes `new()` simpler and implements the following setters:
- ~~`set_delegate`~~ `delegate`
- ~~`set_selected_index`~~ `index`

old:
```rust
Dropdown::new("dropdown-country", countries, Some(6), cx).cleanable()
```

new:
```rust
Dropdown::new("dropdown-country", cx)
                .delegate(countries, cx)
                .index(Some(6), cx)
                .cleanable()
```

Good use case for this change would be something like the ftl example on `crates/story/src/dropdown_story.rs`