### PR TITLE
panel: Update Panel `toolbar_buttons` method to use ViewContext<Self>.

### DIFF
--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -348,8 +348,8 @@ impl Panel for StoryContainer {
             .menu("Info", Box::new(ShowPanelInfo))
     }
 
-    fn toolbar_buttons(&self, _cx: &WindowContext) -> Vec<Button> {
-        vec![
+    fn toolbar_buttons(&self, _cx: &mut ViewContext<Self>) -> Option<Vec<Button>> {
+        Some(vec![
             Button::new("info").icon(IconName::Info).on_click(|_, cx| {
                 cx.push_notification("You have clicked info button");
             }),
@@ -358,7 +358,7 @@ impl Panel for StoryContainer {
                 .on_click(|_, cx| {
                     cx.push_notification("You have clicked search button");
                 }),
-        ]
+        ])
     }
 
     fn dump(&self, _cx: &AppContext) -> PanelState {

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -91,8 +91,8 @@ pub trait Panel: EventEmitter<PanelEvent> + FocusableView {
     }
 
     /// The addition toolbar buttons of the panel used to show in the right of the title bar, default is `None`.
-    fn toolbar_buttons(&self, cx: &WindowContext) -> Vec<Button> {
-        vec![]
+    fn toolbar_buttons(&self, cx: &mut ViewContext<Self>) -> Option<Vec<Button>> {
+        None
     }
 
     /// Dump the panel, used to serialize the panel.
@@ -113,7 +113,7 @@ pub trait PanelView: 'static + Send + Sync {
     fn set_active(&self, active: bool, cx: &mut WindowContext);
     fn set_zoomed(&self, zoomed: bool, cx: &mut WindowContext);
     fn popup_menu(&self, menu: PopupMenu, cx: &WindowContext) -> PopupMenu;
-    fn toolbar_buttons(&self, cx: &WindowContext) -> Vec<Button>;
+    fn toolbar_buttons(&self, cx: &mut WindowContext) -> Option<Vec<Button>>;
     fn view(&self) -> AnyView;
     fn focus_handle(&self, cx: &AppContext) -> FocusHandle;
     fn dump(&self, cx: &AppContext) -> PanelState;
@@ -160,8 +160,8 @@ impl<T: Panel> PanelView for View<T> {
         self.read(cx).popup_menu(menu, cx)
     }
 
-    fn toolbar_buttons(&self, cx: &WindowContext) -> Vec<Button> {
-        self.read(cx).toolbar_buttons(cx)
+    fn toolbar_buttons(&self, cx: &mut WindowContext) -> Option<Vec<Button>> {
+        self.update(cx, |this, cx| this.toolbar_buttons(cx))
     }
 
     fn view(&self) -> AnyView {

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -122,12 +122,9 @@ impl Panel for TabPanel {
         }
     }
 
-    fn toolbar_buttons(&self, cx: &WindowContext) -> Vec<Button> {
-        if let Some(panel) = self.active_panel(cx) {
-            panel.toolbar_buttons(cx)
-        } else {
-            vec![]
-        }
+    fn toolbar_buttons(&self, cx: &mut ViewContext<Self>) -> Option<Vec<Button>> {
+        self.active_panel(cx)
+            .and_then(|panel| panel.toolbar_buttons(cx))
     }
 
     fn dump(&self, cx: &AppContext) -> PanelState {
@@ -390,11 +387,9 @@ impl TabPanel {
             .gap_2()
             .occlude()
             .items_center()
-            .children(
-                self.toolbar_buttons(cx)
-                    .into_iter()
-                    .map(|btn| btn.xsmall().ghost()),
-            )
+            .when_some(self.toolbar_buttons(cx), |this, buttons| {
+                this.children(buttons.into_iter().map(|btn| btn.xsmall().ghost()))
+            })
             .when(self.is_zoomed, |this| {
                 this.child(
                     Button::new("zoom")


### PR DESCRIPTION
## Break changes

The `toolbar_buttons` trait method in Panel has been changed:

```diff
- fn toolbar_buttons(&self, cx: &WindowContext) -> Vec<Button>
+ fn toolbar_buttons(&self, cx: &mut ViewContext<Self>) -> Option<Vec<Button>>
```