### PR TITLE
table: Add `scrollbar_visible` to Table for control the scrollbar visibility.

### DIFF
--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -157,6 +157,7 @@ impl Size {
             _ => px(32.),
         }
     }
+
     /// Returns the padding for a table cell.
     pub fn table_cell_padding(&self) -> Edges<Pixels> {
         match self {

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -155,7 +155,7 @@ pub struct Table<D: TableDelegate> {
     pub horizontal_scroll_handle: ScrollHandle,
     pub horizontal_scrollbar_state: Rc<Cell<ScrollbarState>>,
 
-    scrollbar_visibles: Edges<bool>,
+    scrollbar_visible: Edges<bool>,
     selected_row: Option<usize>,
     selection_state: SelectionState,
     right_clicked_row: Option<usize>,
@@ -357,7 +357,7 @@ where
             stripe: false,
             border: true,
             size: Size::default(),
-            scrollbar_visibles: Edges::all(true),
+            scrollbar_visible: Edges::all(true),
             visible_range: VisibleRangeState::default(),
         };
 
@@ -396,12 +396,13 @@ where
         cx.notify();
     }
 
-    /// Set scrollbar visibility, the `visibles` is a `Edges` struct, only `right` and `bottom` are used.
-    ///
-    /// - `right` that is the vertical scrollbar visibility.
-    /// - `bottom` that is the horizontal scrollbar visibility.
-    pub fn scrollbar_visibles(mut self, visibles: Edges<bool>) -> Self {
-        self.scrollbar_visibles = visibles;
+    /// Set scrollbar visibility.
+    pub fn scrollbar_visible(mut self, vertical: bool, horizontal: bool) -> Self {
+        self.scrollbar_visible = Edges {
+            right: vertical,
+            bottom: horizontal,
+            ..Default::default()
+        };
         self
     }
 
@@ -1378,10 +1379,10 @@ where
                     .absolute()
                     .top_0()
                     .size_full()
-                    .when(self.scrollbar_visibles.right && rows_count > 0, |this| {
+                    .when(self.scrollbar_visible.right && rows_count > 0, |this| {
                         this.children(self.render_vertical_scrollbar(cx))
                     })
-                    .when(self.scrollbar_visibles.bottom, |this| {
+                    .when(self.scrollbar_visible.bottom, |this| {
                         this.child(self.render_horizontal_scrollbar(cx))
                     }),
             )

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -400,9 +400,9 @@ where
     ///
     /// - `right` that is the vertical scrollbar visibility.
     /// - `bottom` that is the horizontal scrollbar visibility.
-    pub fn set_scrollbar_visibles(&mut self, visibles: Edges<bool>, cx: &mut ViewContext<Self>) {
+    pub fn scrollbar_visibles(mut self, visibles: Edges<bool>) -> Self {
         self.scrollbar_visibles = visibles;
-        cx.notify();
+        self
     }
 
     /// When we update columns or rows, we need to refresh the table.

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -396,6 +396,11 @@ where
         cx.notify();
     }
 
+    /// Get the size of the table.
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
     /// Set scrollbar visibility.
     pub fn scrollbar_visible(mut self, vertical: bool, horizontal: bool) -> Self {
         self.scrollbar_visible = Edges {

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -11,8 +11,8 @@ use crate::{
     Icon, IconName, Sizable, Size, StyleSized as _,
 };
 use gpui::{
-    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AnyElement, AppContext, Axis,
-    Bounds, Div, DragMoveEvent, Edges, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
+    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AppContext, Axis, Bounds, Div,
+    DragMoveEvent, Edges, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
     InteractiveElement, IntoElement, KeyBinding, ListSizingBehavior, MouseButton, MouseDownEvent,
     ParentElement, Pixels, Point, Render, ScrollHandle, ScrollStrategy, SharedString, Stateful,
     StatefulInteractiveElement as _, Styled, UniformListScrollHandle, ViewContext,

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -151,11 +151,11 @@ pub struct Table<D: TableDelegate> {
     fixed_cols: FixedCols,
 
     pub vertical_scroll_handle: UniformListScrollHandle,
-    pub scrollbar_state: Rc<Cell<ScrollbarState>>,
+    pub vertical_scrollbar_state: Rc<Cell<ScrollbarState>>,
     pub horizontal_scroll_handle: ScrollHandle,
     pub horizontal_scrollbar_state: Rc<Cell<ScrollbarState>>,
-    scrollbar_visibles: Edges<bool>,
 
+    scrollbar_visibles: Edges<bool>,
     selected_row: Option<usize>,
     selection_state: SelectionState,
     right_clicked_row: Option<usize>,
@@ -344,7 +344,7 @@ where
             fixed_cols: FixedCols::default(),
             horizontal_scroll_handle: ScrollHandle::new(),
             vertical_scroll_handle: UniformListScrollHandle::new(),
-            scrollbar_state: Rc::new(Cell::new(ScrollbarState::new())),
+            vertical_scrollbar_state: Rc::new(Cell::new(ScrollbarState::new())),
             horizontal_scrollbar_state: Rc::new(Cell::new(ScrollbarState::new())),
             selection_state: SelectionState::Row,
             selected_row: None,
@@ -441,16 +441,6 @@ where
     //     self.horizontal_scroll_handle.scroll_to_item(col_ix);
     //     cx.notify();
     // }
-
-    /// Get scroll handle
-    pub fn scroll_handle(&self) -> &UniformListScrollHandle {
-        &self.vertical_scroll_handle
-    }
-
-    /// Get horizontal scroll handle
-    pub fn horizontal_scroll_handle(&self) -> &ScrollHandle {
-        &self.horizontal_scroll_handle
-    }
 
     /// Returns the selected row index.
     pub fn selected_row(&self) -> Option<usize> {
@@ -776,8 +766,8 @@ where
         }
     }
 
-    fn render_scrollbar(&self, cx: &mut ViewContext<Self>) -> Option<impl IntoElement> {
-        let state = self.scrollbar_state.clone();
+    fn render_vertical_scrollbar(&self, cx: &mut ViewContext<Self>) -> Option<impl IntoElement> {
+        let state = self.vertical_scrollbar_state.clone();
 
         Some(
             div()
@@ -1389,7 +1379,7 @@ where
                     .top_0()
                     .size_full()
                     .when(self.scrollbar_visibles.right && rows_count > 0, |this| {
-                        this.children(self.render_scrollbar(cx))
+                        this.children(self.render_vertical_scrollbar(cx))
                     })
                     .when(self.scrollbar_visibles.bottom, |this| {
                         this.child(self.render_horizontal_scrollbar(cx))

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -11,8 +11,8 @@ use crate::{
     Icon, IconName, Sizable, Size, StyleSized as _,
 };
 use gpui::{
-    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AppContext, Axis, Bounds, Div,
-    DragMoveEvent, Edges, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
+    actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AnyElement, AppContext, Axis,
+    Bounds, Div, DragMoveEvent, Edges, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
     InteractiveElement, IntoElement, KeyBinding, ListSizingBehavior, MouseButton, MouseDownEvent,
     ParentElement, Pixels, Point, Render, ScrollHandle, ScrollStrategy, SharedString, Stateful,
     StatefulInteractiveElement as _, Styled, UniformListScrollHandle, ViewContext,
@@ -274,6 +274,13 @@ pub trait TableDelegate: Sized + 'static {
             .text_color(cx.theme().muted_foreground.opacity(0.6))
             .child(Icon::new(IconName::Inbox).size_12())
             .into_any_element()
+    }
+
+    /// Render a element overlay on the table if needed, default to None.
+    ///
+    /// The overlay will be rendered on top of the table, but below the scrollbar.
+    fn render_overlay(&self, cx: &mut ViewContext<Table<Self>>) -> Option<AnyElement> {
+        None
     }
 
     /// Return true to enable load more data when scrolling to the bottom.
@@ -1240,7 +1247,6 @@ where
         self.focus_handle.clone()
     }
 }
-
 impl<D> EventEmitter<TableEvent> for Table<D> where D: TableDelegate {}
 
 impl<D> Render for Table<D>
@@ -1373,6 +1379,7 @@ where
                 move |bounds, cx| view.update(cx, |r, _| r.bounds = bounds),
                 |_, _, _| {},
             ))
+            .children(self.delegate().render_overlay(cx))
             .child(
                 div()
                     .absolute()


### PR DESCRIPTION
Ref #513 #542 

Add this to ability to render some custom view on top of the table, but below of the scrollbar.

## Break changes

- table: Renamed `scrollbar_state` to `vertical_scrollbar_state`.
- table: Removed `scroll_handle` and `horizontal_scroll_handle` method, there have a pub `vertical_scroll_handle` and `horizontal_scroll_handle` prop.