### PR TITLE
colors: Add `mix` method and merge ColorExt to Colorize.

### DIFF
--- a/crates/story/examples/tiles.rs
+++ b/crates/story/examples/tiles.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 use story::{Assets, ButtonStory, IconStory, StoryContainer};
 use ui::{
     dock::{DockArea, DockAreaState, DockEvent, DockItem},
-    theme::ActiveTheme,
-    Root, TitleBar,
+    ActiveTheme, Root, TitleBar,
 };
 
 actions!(main_menu, [Quit]);

--- a/crates/story/src/button_story.rs
+++ b/crates/story/src/button_story.rs
@@ -8,8 +8,7 @@ use ui::{
     checkbox::Checkbox,
     h_flex,
     prelude::FluentBuilder,
-    theme::{ActiveTheme, Theme},
-    v_flex, Disableable as _, Icon, IconName, Selectable as _, Sizable as _,
+    v_flex, ActiveTheme, Disableable as _, Icon, IconName, Selectable as _, Sizable as _, Theme,
 };
 
 use crate::section;

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -6,9 +6,7 @@ use gpui::{
 use ui::{
     checkbox::Checkbox,
     dropdown::{Dropdown, DropdownEvent, DropdownItem, SearchableVec},
-    h_flex,
-    theme::ActiveTheme,
-    v_flex, FocusableCycle, IconName, Sizable,
+    h_flex, v_flex, ActiveTheme, FocusableCycle, IconName, Sizable,
 };
 
 actions!(dropdown_story, [Tab, TabPrev]);

--- a/crates/story/src/icon_story.rs
+++ b/crates/story/src/icon_story.rs
@@ -4,9 +4,7 @@ use gpui::{
 use ui::{
     button::{Button, ButtonVariant, ButtonVariants},
     dock::PanelControl,
-    h_flex,
-    theme::ActiveTheme as _,
-    v_flex, Icon, IconName,
+    h_flex, v_flex, ActiveTheme as _, Icon, IconName,
 };
 
 pub struct IconStory {

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -57,8 +57,7 @@ use ui::{
     label::Label,
     notification::Notification,
     popup_menu::PopupMenu,
-    theme::ActiveTheme,
-    v_flex, ContextModal, IconName,
+    v_flex, ActiveTheme, ContextModal, IconName,
 };
 
 const PANEL_NAME: &str = "StoryContainer";
@@ -121,7 +120,7 @@ pub fn init(cx: &mut AppContext) {
 actions!(story, [ShowPanelInfo]);
 
 pub fn section(title: impl IntoElement, cx: &WindowContext) -> Div {
-    use ui::theme::ActiveTheme;
+    use ui::ActiveTheme;
     let theme = cx.theme();
 
     h_flex()

--- a/crates/story/src/list_story.rs
+++ b/crates/story/src/list_story.rs
@@ -11,11 +11,10 @@ use gpui::{
 use ui::{
     button::Button,
     checkbox::Checkbox,
-    h_flex,
+    h_flex, hsl,
     label::Label,
     list::{List, ListDelegate, ListEvent, ListItem},
-    theme::{hsl, ActiveTheme},
-    v_flex, Sizable,
+    v_flex, ActiveTheme, Sizable,
 };
 
 actions!(list_story, [SelectedCompany]);

--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -16,8 +16,7 @@ use ui::{
     dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement},
     popup_menu::PopupMenuExt,
     scroll::ScrollbarShow,
-    theme::{ActiveTheme, Theme},
-    ContextModal, IconName, Root, Sizable, TitleBar,
+    ActiveTheme, ContextModal, IconName, Root, Sizable, Theme, TitleBar,
 };
 
 const MAIN_DOCK_AREA: DockAreaTab = DockAreaTab {
@@ -162,8 +161,8 @@ impl StoryWorkspace {
 
     fn change_color_mode(&mut self, _: &ClickEvent, cx: &mut ViewContext<Self>) {
         let mode = match cx.theme().mode.is_dark() {
-            true => ui::theme::ThemeMode::Light,
-            false => ui::theme::ThemeMode::Dark,
+            true => ui::ThemeMode::Light,
+            false => ui::ThemeMode::Dark,
         };
 
         Theme::change(mode, cx);

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -17,10 +17,9 @@ use ui::{
     list::{List, ListDelegate, ListItem},
     modal::ModalButtonProps,
     notification::{Notification, NotificationType},
-    theme::ActiveTheme as _,
     v_flex,
     webview::WebView,
-    ContextModal as _, Icon, IconName, Placement,
+    ActiveTheme as _, ContextModal as _, Icon, IconName, Placement,
 };
 
 actions!(modal_story, [TestAction]);

--- a/crates/story/src/popup_story.rs
+++ b/crates/story/src/popup_story.rs
@@ -14,8 +14,7 @@ use ui::{
     popover::{Popover, PopoverContent},
     popup_menu::PopupMenuExt,
     switch::Switch,
-    theme::ActiveTheme as _,
-    v_flex, ContextModal, IconName, Sizable,
+    v_flex, ActiveTheme as _, ContextModal, IconName, Sizable,
 };
 
 #[derive(Clone, PartialEq, Deserialize)]

--- a/crates/story/src/progress_story.rs
+++ b/crates/story/src/progress_story.rs
@@ -11,8 +11,7 @@ use ui::{
     progress::Progress,
     skeleton::Skeleton,
     slider::{Slider, SliderEvent},
-    theme::Colorize,
-    v_flex, ColorExt as _, ContextModal, IconName, Sizable,
+    v_flex, Colorize as _, ContextModal, IconName, Sizable,
 };
 
 pub struct ProgressStory {
@@ -147,7 +146,7 @@ impl gpui::FocusableView for ProgressStory {
 
 impl Render for ProgressStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let rgb = SharedString::from(self.slider_hsl_value.to_hex_string());
+        let rgb = SharedString::from(self.slider_hsl_value.to_hex());
 
         v_flex()
             .items_center()

--- a/crates/story/src/resizable_story.rs
+++ b/crates/story/src/resizable_story.rs
@@ -2,7 +2,7 @@ use gpui::{
     div, px, AnyElement, IntoElement, ParentElement as _, Render, SharedString, Styled, View,
     ViewContext, VisualContext, WindowContext,
 };
-use ui::theme::ActiveTheme;
+use ui::ActiveTheme;
 use ui::{
     resizable::{h_resizable, resizable_panel, v_resizable, ResizablePanelGroup},
     v_flex,

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -9,7 +9,7 @@ use ui::button::Button;
 use ui::divider::Divider;
 use ui::label::Label;
 use ui::scroll::{Scrollbar, ScrollbarAxis, ScrollbarState};
-use ui::theme::ActiveTheme;
+use ui::ActiveTheme;
 use ui::{h_flex, v_flex, v_virtual_list, StyledExt as _};
 
 pub struct ScrollableStory {

--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -13,8 +13,7 @@ use ui::{
     sidebar::{
         Sidebar, SidebarFooter, SidebarGroup, SidebarHeader, SidebarMenu, SidebarToggleButton,
     },
-    theme::ActiveTheme,
-    v_flex, Collapsible, Icon, IconName,
+    v_flex, ActiveTheme, Collapsible, Icon, IconName,
 };
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]

--- a/crates/story/src/switch_story.rs
+++ b/crates/story/src/switch_story.rs
@@ -4,8 +4,8 @@ use gpui::{
 };
 
 use ui::{
-    checkbox::Checkbox, h_flex, label::Label, radio::Radio, switch::Switch, theme::ActiveTheme,
-    v_flex, Disableable as _, Side, Sizable, StyledExt,
+    checkbox::Checkbox, h_flex, label::Label, radio::Radio, switch::Switch, v_flex, ActiveTheme,
+    Disableable as _, Side, Sizable, StyledExt,
 };
 
 use crate::section;

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -20,8 +20,7 @@ use ui::{
     popup_menu::{PopupMenu, PopupMenuExt},
     prelude::FluentBuilder as _,
     table::{ColFixed, ColSort, Table, TableDelegate, TableEvent},
-    theme::ActiveTheme as _,
-    v_flex, Selectable, Sizable as _, Size, StyleSized as _,
+    v_flex, ActiveTheme as _, Selectable, Sizable as _, Size, StyleSized as _,
 };
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]

--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -5,9 +5,9 @@ use gpui::{
 use ui::{
     h_flex,
     input::{InputEvent, TextInput},
-    theme::ActiveTheme,
     v_flex,
     webview::WebView,
+    ActiveTheme,
 };
 
 pub struct WebViewStory {

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -6,7 +6,7 @@ use gpui::{
     WindowContext,
 };
 
-use crate::{h_flex, theme::ActiveTheme as _, v_flex, Icon, IconName, Sizable, Size};
+use crate::{h_flex, v_flex, ActiveTheme as _, Icon, IconName, Sizable, Size};
 
 /// An AccordionGroup is a container for multiple Accordion elements.
 #[derive(IntoElement)]

--- a/crates/ui/src/breadcrumb.rs
+++ b/crates/ui/src/breadcrumb.rs
@@ -5,7 +5,7 @@ use gpui::{
     ParentElement, RenderOnce, SharedString, StatefulInteractiveElement, Styled, WindowContext,
 };
 
-use crate::{h_flex, theme::ActiveTheme, Icon, IconName};
+use crate::{h_flex, ActiveTheme, Icon, IconName};
 
 #[derive(IntoElement)]
 pub struct Breadcrumb {

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -1,6 +1,6 @@
 use crate::{
-    h_flex, indicator::Indicator, theme::ActiveTheme, tooltip::Tooltip, Colorize as _, Disableable,
-    Icon, Selectable, Sizable, Size,
+    h_flex, indicator::Indicator, tooltip::Tooltip, ActiveTheme, Colorize as _, Disableable, Icon,
+    Selectable, Sizable, Size,
 };
 use gpui::{
     div, prelude::FluentBuilder as _, px, relative, AnyElement, ClickEvent, Corners, Div, Edges,

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -1,9 +1,6 @@
 use crate::{
-    h_flex,
-    indicator::Indicator,
-    theme::{ActiveTheme, Colorize as _},
-    tooltip::Tooltip,
-    Disableable, Icon, Selectable, Sizable, Size,
+    h_flex, indicator::Indicator, theme::ActiveTheme, tooltip::Tooltip, Colorize as _, Disableable,
+    Icon, Selectable, Sizable, Size,
 };
 use gpui::{
     div, prelude::FluentBuilder as _, px, relative, AnyElement, ClickEvent, Corners, Div, Edges,

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme, v_flex, Disableable, IconName, Selectable};
+use crate::{h_flex, v_flex, ActiveTheme, Disableable, IconName, Selectable};
 use gpui::{
     div, prelude::FluentBuilder as _, relative, svg, ElementId, InteractiveElement, IntoElement,
     ParentElement, RenderOnce, SharedString, StatefulInteractiveElement as _, Styled as _,

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -10,9 +10,8 @@ use crate::{
     h_flex,
     input::{InputEvent, TextInput},
     popover::Escape,
-    theme::ActiveTheme as _,
     tooltip::Tooltip,
-    v_flex, Colorize as _, Sizable, Size, StyleSized,
+    v_flex, ActiveTheme as _, Colorize as _, Sizable, Size, StyleSized,
 };
 
 const KEY_CONTEXT: &'static str = "ColorPicker";

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -10,9 +10,9 @@ use crate::{
     h_flex,
     input::{InputEvent, TextInput},
     popover::Escape,
-    theme::{ActiveTheme as _, Colorize},
+    theme::ActiveTheme as _,
     tooltip::Tooltip,
-    v_flex, ColorExt as _, Sizable, Size, StyleSized,
+    v_flex, Colorize as _, Sizable, Size, StyleSized,
 };
 
 const KEY_CONTEXT: &'static str = "ColorPicker";
@@ -75,14 +75,14 @@ impl ColorPicker {
 
         cx.subscribe(&color_input, |this, _, ev: &InputEvent, cx| match ev {
             InputEvent::Change(value) => {
-                if let Ok(color) = Hsla::parse_hex_string(value) {
+                if let Ok(color) = Hsla::parse_hex(value) {
                     this.value = Some(color);
                     this.hovered_color = Some(color);
                 }
             }
             InputEvent::PressEnter => {
                 let val = this.color_input.read(cx).text();
-                if let Ok(color) = Hsla::parse_hex_string(&val) {
+                if let Ok(color) = Hsla::parse_hex(&val) {
                     this.open = false;
                     this.update_value(Some(color), true, cx);
                 }
@@ -171,7 +171,7 @@ impl ColorPicker {
         self.hovered_color = value;
         self.color_input.update(cx, |view, cx| {
             if let Some(value) = value {
-                view.set_text(value.to_hex_string(), cx);
+                view.set_text(value.to_hex(), cx);
             } else {
                 view.set_text("", cx);
             }
@@ -189,10 +189,7 @@ impl ColorPicker {
         cx: &mut ViewContext<Self>,
     ) -> impl IntoElement {
         div()
-            .id(SharedString::from(format!(
-                "color-{}",
-                color.to_hex_string()
-            )))
+            .id(SharedString::from(format!("color-{}", color.to_hex())))
             .h_5()
             .w_5()
             .bg(color)
@@ -286,7 +283,7 @@ impl FocusableView for ColorPicker {
 impl Render for ColorPicker {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let display_title: SharedString = if let Some(value) = self.value {
-            value.to_hex_string()
+            value.to_hex()
         } else {
             "".to_string()
         }

--- a/crates/ui/src/colors.rs
+++ b/crates/ui/src/colors.rs
@@ -6,16 +6,112 @@ use serde::{de::Error, Deserialize, Deserializer};
 use crate::theme::hsl;
 use anyhow::Result;
 
-/// Extension methods for Hsla.
-pub trait ColorExt {
+pub trait Colorize: Sized {
+    /// Returns a new color with the given opacity.
+    ///
+    /// The opacity is a value between 0.0 and 1.0, where 0.0 is fully transparent and 1.0 is fully opaque.
+    fn opacity(&self, opacity: f32) -> Self;
+    /// Returns a new color with each channel divided by the given divisor.
+    ///
+    /// The divisor in range of 0.0 .. 1.0
+    fn divide(&self, divisor: f32) -> Self;
+    /// Return inverted color
+    fn invert(&self) -> Self;
+    /// Return inverted lightness
+    fn invert_l(&self) -> Self;
+    /// Return a new color with the lightness increased by the given factor.
+    ///
+    /// factor range: 0.0 .. 1.0
+    fn lighten(&self, amount: f32) -> Self;
+    /// Return a new color with the darkness increased by the given factor.
+    ///
+    /// factor range: 0.0 .. 1.0
+    fn darken(&self, amount: f32) -> Self;
+    /// Return a new color with the same lightness and alpha but different hue and saturation.
+    fn apply(&self, base_color: Self) -> Self;
+
+    /// Mix two colors together, the `factor` is a value between 0.0 and 1.0 for first color.
+    fn mix(&self, other: Self, factor: f32) -> Self;
+
     /// Convert the color to a hex string. For example, "#F8FAFC".
-    fn to_hex_string(&self) -> String;
+    fn to_hex(&self) -> String;
     /// Parse a hex string to a color.
-    fn parse_hex_string(hex: &str) -> Result<Hsla>;
+    fn parse_hex(hex: &str) -> Result<Self>;
 }
 
-impl ColorExt for Hsla {
-    fn to_hex_string(&self) -> String {
+impl Colorize for Hsla {
+    fn opacity(&self, factor: f32) -> Self {
+        Self {
+            a: self.a * factor.clamp(0.0, 1.0),
+            ..*self
+        }
+    }
+
+    fn divide(&self, divisor: f32) -> Self {
+        Self {
+            a: divisor,
+            ..*self
+        }
+    }
+
+    fn invert(&self) -> Self {
+        Self {
+            h: 1.0 - self.h,
+            s: 1.0 - self.s,
+            l: 1.0 - self.l,
+            a: self.a,
+        }
+    }
+
+    fn invert_l(&self) -> Self {
+        Self {
+            l: 1.0 - self.l,
+            ..*self
+        }
+    }
+
+    fn lighten(&self, factor: f32) -> Self {
+        let l = self.l * (1.0 + factor.clamp(0.0, 1.0));
+
+        Hsla { l, ..*self }
+    }
+
+    fn darken(&self, factor: f32) -> Self {
+        let l = self.l * (1.0 - factor.clamp(0.0, 1.0));
+
+        Self { l, ..*self }
+    }
+
+    fn apply(&self, new_color: Self) -> Self {
+        Hsla {
+            h: new_color.h,
+            s: new_color.s,
+            l: self.l,
+            a: self.a,
+        }
+    }
+
+    /// Reference:
+    /// https://github.com/bevyengine/bevy/blob/85eceb022da0326b47ac2b0d9202c9c9f01835bb/crates/bevy_color/src/hsla.rs#L112
+    fn mix(&self, other: Self, factor: f32) -> Self {
+        let factor = factor.clamp(0.0, 1.0);
+        let inv = 1.0 - factor;
+
+        #[inline]
+        fn lerp_hue(a: f32, b: f32, t: f32) -> f32 {
+            let diff = (b - a + 180.0).rem_euclid(360.) - 180.;
+            (a + diff * t).rem_euclid(360.0)
+        }
+
+        Hsla {
+            h: lerp_hue(self.h * 360., other.h * 360., factor) / 360.,
+            s: self.s * factor + other.s * inv,
+            l: self.l * factor + other.l * inv,
+            a: self.a * factor + other.a * inv,
+        }
+    }
+
+    fn to_hex(&self) -> String {
         let rgb = self.to_rgb();
 
         if rgb.a < 1. {
@@ -36,7 +132,7 @@ impl ColorExt for Hsla {
         )
     }
 
-    fn parse_hex_string(hex: &str) -> Result<Hsla> {
+    fn parse_hex(hex: &str) -> Result<Self> {
         let hex = hex.trim_start_matches('#');
         let len = hex.len();
         if len != 6 && len != 8 {
@@ -278,24 +374,56 @@ mod tests {
     #[test]
     fn test_to_hex_string() {
         let color: Hsla = rgb(0xf8fafc).into();
-        assert_eq!(color.to_hex_string(), "#F8FAFC");
+        assert_eq!(color.to_hex(), "#F8FAFC");
 
         let color: Hsla = rgb(0xfef2f2).into();
-        assert_eq!(color.to_hex_string(), "#FEF2F2");
+        assert_eq!(color.to_hex(), "#FEF2F2");
 
         let color: Hsla = rgba(0x0413fcaa).into();
-        assert_eq!(color.to_hex_string(), "#0413FCAA");
+        assert_eq!(color.to_hex(), "#0413FCAA");
     }
 
     #[test]
     fn test_from_hex_string() {
-        let color: Hsla = Hsla::parse_hex_string("#F8FAFC").unwrap();
+        let color: Hsla = Hsla::parse_hex("#F8FAFC").unwrap();
         assert_eq!(color, rgb(0xf8fafc).into());
 
-        let color: Hsla = Hsla::parse_hex_string("#FEF2F2").unwrap();
+        let color: Hsla = Hsla::parse_hex("#FEF2F2").unwrap();
         assert_eq!(color, rgb(0xfef2f2).into());
 
-        let color: Hsla = Hsla::parse_hex_string("#0413FCAA").unwrap();
+        let color: Hsla = Hsla::parse_hex("#0413FCAA").unwrap();
         assert_eq!(color, rgba(0x0413fcaa).into());
+    }
+
+    #[test]
+    fn test_lighten() {
+        let color = super::hsl(240.0, 5.0, 30.0);
+        let color = color.lighten(0.5);
+        assert_eq!(color.l, 0.45000002);
+        let color = color.lighten(0.5);
+        assert_eq!(color.l, 0.675);
+        let color = color.lighten(0.1);
+        assert_eq!(color.l, 0.7425);
+    }
+
+    #[test]
+    fn test_darken() {
+        let color = super::hsl(240.0, 5.0, 96.0);
+        let color = color.darken(0.5);
+        assert_eq!(color.l, 0.48);
+        let color = color.darken(0.5);
+        assert_eq!(color.l, 0.24);
+    }
+
+    #[test]
+    fn test_mix() {
+        let red = Hsla::parse_hex("#FF0000").unwrap();
+        let blue = Hsla::parse_hex("#0000FF").unwrap();
+        let green = Hsla::parse_hex("#00FF00").unwrap();
+        let yellow = Hsla::parse_hex("#FFFF00").unwrap();
+
+        assert_eq!(red.mix(blue, 0.5).to_hex(), "#FF00FF");
+        assert_eq!(green.mix(red, 0.5).to_hex(), "#FFFF00");
+        assert_eq!(blue.mix(yellow, 0.2).to_hex(), "#0098FF");
     }
 }

--- a/crates/ui/src/colors.rs
+++ b/crates/ui/src/colors.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use gpui::Hsla;
 use serde::{de::Error, Deserialize, Deserializer};
 
-use crate::theme::hsl;
+use crate::hsl;
 use anyhow::Result;
 
 pub trait Colorize: Sized {

--- a/crates/ui/src/divider.rs
+++ b/crates/ui/src/divider.rs
@@ -3,7 +3,7 @@ use gpui::{
     SharedString, Styled,
 };
 
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 
 /// A divider that can be either vertical or horizontal.
 #[derive(IntoElement)]

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -12,8 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     resizable::{HANDLE_PADDING, HANDLE_SIZE, PANEL_MIN_SIZE},
-    theme::ActiveTheme as _,
-    AxisExt as _, StyledExt,
+    ActiveTheme as _, AxisExt as _, StyledExt,
 };
 
 use super::{DockArea, DockItem, PanelView, TabPanel};

--- a/crates/ui/src/dock/invalid_panel.rs
+++ b/crates/ui/src/dock/invalid_panel.rs
@@ -3,7 +3,7 @@ use gpui::{
     Styled as _, WindowContext,
 };
 
-use crate::theme::ActiveTheme as _;
+use crate::ActiveTheme as _;
 
 use super::{Panel, PanelEvent, PanelState};
 

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -7,8 +7,7 @@ use crate::{
         h_resizable, resizable_panel, v_resizable, ResizablePanel, ResizablePanelEvent,
         ResizablePanelGroup,
     },
-    theme::ActiveTheme,
-    AxisExt as _, Placement,
+    ActiveTheme, AxisExt as _, Placement,
 };
 
 use super::{DockArea, Panel, PanelEvent, PanelState, PanelView, TabPanel};

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -15,8 +15,7 @@ use crate::{
     h_flex,
     popup_menu::{PopupMenu, PopupMenuExt},
     tab::{Tab, TabBar},
-    theme::ActiveTheme,
-    v_flex, AxisExt, IconName, Placement, Selectable, Sizable,
+    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable,
 };
 
 use super::{

--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -9,8 +9,7 @@ use crate::{
     h_flex,
     history::{History, HistoryItem},
     scroll::{Scrollbar, ScrollbarState},
-    theme::ActiveTheme,
-    v_flex, Icon, IconName,
+    v_flex, ActiveTheme, Icon, IconName,
 };
 
 use super::{DockArea, Panel, PanelEvent, PanelInfo, PanelState, PanelView, TabPanel, TileMeta};

--- a/crates/ui/src/drawer.rs
+++ b/crates/ui/src/drawer.rs
@@ -13,9 +13,8 @@ use crate::{
     modal::overlay_color,
     root::ContextModal as _,
     scroll::ScrollbarAxis,
-    theme::ActiveTheme,
     title_bar::TITLE_BAR_HEIGHT,
-    v_flex, IconName, Placement, Sizable, StyledExt as _,
+    v_flex, ActiveTheme, IconName, Placement, Sizable, StyledExt as _,
 };
 
 actions!(drawer, [Escape]);

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -11,8 +11,7 @@ use crate::{
     h_flex,
     input::ClearButton,
     list::{self, List, ListDelegate, ListItem},
-    theme::ActiveTheme,
-    v_flex, Disableable, Icon, IconName, Sizable, Size, StyleSized, StyledExt,
+    v_flex, ActiveTheme, Disableable, Icon, IconName, Sizable, Size, StyleSized, StyledExt,
 };
 
 actions!(dropdown, [Up, Down, Enter, Escape]);

--- a/crates/ui/src/icon.rs
+++ b/crates/ui/src/icon.rs
@@ -1,4 +1,4 @@
-use crate::{theme::ActiveTheme, Sizable, Size};
+use crate::{ActiveTheme, Sizable, Size};
 use gpui::{
     prelude::FluentBuilder as _, svg, AnyElement, Hsla, IntoElement, Radians, Render, RenderOnce,
     SharedString, StyleRefinement, Styled, Svg, Transformation, View, VisualContext, WindowContext,

--- a/crates/ui/src/input/clear_button.rs
+++ b/crates/ui/src/input/clear_button.rs
@@ -2,8 +2,7 @@ use gpui::{Styled, WindowContext};
 
 use crate::{
     button::{Button, ButtonVariants as _},
-    theme::ActiveTheme as _,
-    Icon, IconName, Sizable as _,
+    ActiveTheme as _, Icon, IconName, Sizable as _,
 };
 
 pub(crate) struct ClearButton {}

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use smallvec::SmallVec;
 
-use crate::theme::ActiveTheme as _;
+use crate::ActiveTheme as _;
 
 use super::TextInput;
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -31,7 +31,7 @@ use super::{number_input, ClearButton};
 use crate::history::History;
 use crate::indicator::Indicator;
 use crate::scroll::{Scrollbar, ScrollbarAxis, ScrollbarState};
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 use crate::Size;
 use crate::StyledExt;
 use crate::{Sizable, StyleSized};

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -10,8 +10,7 @@ use crate::{
     h_flex,
     input::{InputEvent, TextInput},
     prelude::FluentBuilder,
-    theme::ActiveTheme,
-    IconName, Sizable, Size, StyledExt,
+    ActiveTheme, IconName, Sizable, Size, StyledExt,
 };
 
 actions!(number_input, [Increment, Decrement]);

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -4,7 +4,7 @@ use gpui::{
     ParentElement as _, Render, SharedString, Styled as _, ViewContext,
 };
 
-use crate::{h_flex, theme::ActiveTheme, v_flex, Icon, IconName, Sizable, Size};
+use crate::{h_flex, v_flex, ActiveTheme, Icon, IconName, Sizable, Size};
 
 use super::{blink_cursor::BlinkCursor, InputEvent};
 

--- a/crates/ui/src/label.rs
+++ b/crates/ui/src/label.rs
@@ -3,7 +3,7 @@ use gpui::{
     Styled, WindowContext,
 };
 
-use crate::{h_flex, theme::ActiveTheme};
+use crate::{h_flex, ActiveTheme};
 
 const MASKED: &'static str = "•";
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -7,6 +7,7 @@ mod styled;
 mod svg_img;
 mod time;
 mod title_bar;
+mod virtual_list;
 mod window_border;
 
 pub mod accordion;
@@ -46,7 +47,6 @@ pub mod table;
 pub mod tag;
 pub mod theme;
 pub mod tooltip;
-pub mod virtual_list;
 pub mod webview;
 
 // re-export
@@ -65,6 +65,7 @@ pub use window_border::{window_border, WindowBorder};
 pub use colors::*;
 pub use icon::*;
 pub use svg_img::*;
+pub use theme::*;
 
 use std::ops::Deref;
 

--- a/crates/ui/src/link.rs
+++ b/crates/ui/src/link.rs
@@ -3,7 +3,7 @@ use gpui::{
     RenderOnce, SharedString, Stateful, StatefulInteractiveElement, Styled,
 };
 
-use crate::theme::ActiveTheme as _;
+use crate::ActiveTheme as _;
 
 /// A Link element like a `<a>` tag in HTML.
 #[derive(IntoElement)]

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -5,8 +5,7 @@ use crate::Icon;
 use crate::{
     input::{InputEvent, TextInput},
     scroll::{Scrollbar, ScrollbarState},
-    theme::ActiveTheme,
-    v_flex, IconName, Size,
+    v_flex, ActiveTheme, IconName, Size,
 };
 use gpui::{
     actions, div, prelude::FluentBuilder, uniform_list, AnyElement, AppContext, Entity,

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme, Disableable, Icon, IconName, Selectable, Sizable as _};
+use crate::{h_flex, ActiveTheme, Disableable, Icon, IconName, Selectable, Sizable as _};
 use gpui::{
     div, prelude::FluentBuilder as _, AnyElement, ClickEvent, Div, ElementId, InteractiveElement,
     IntoElement, MouseButton, MouseMoveEvent, ParentElement, RenderOnce, Stateful,

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -11,9 +11,7 @@ use rust_i18n::t;
 use crate::{
     animation::cubic_bezier,
     button::{Button, ButtonVariant, ButtonVariants as _},
-    h_flex,
-    theme::ActiveTheme as _,
-    v_flex, ContextModal, IconName, Sizable as _,
+    h_flex, v_flex, ActiveTheme as _, ContextModal, IconName, Sizable as _,
 };
 
 actions!(modal, [Escape, Enter]);

--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -10,9 +10,7 @@ use smol::Timer;
 use crate::{
     animation::cubic_bezier,
     button::{Button, ButtonVariants as _},
-    h_flex,
-    theme::ActiveTheme as _,
-    v_flex, Icon, IconName, Sizable as _, StyledExt,
+    h_flex, v_flex, ActiveTheme as _, Icon, IconName, Sizable as _, StyledExt,
 };
 
 pub enum NotificationType {

--- a/crates/ui/src/popup_menu.rs
+++ b/crates/ui/src/popup_menu.rs
@@ -15,8 +15,8 @@ use gpui::{
 use crate::scroll::{Scrollbar, ScrollbarState};
 use crate::StyledExt;
 use crate::{
-    button::Button, h_flex, list::ListItem, popover::Popover, theme::ActiveTheme, v_flex, Icon,
-    IconName, Selectable, Sizable as _,
+    button::Button, h_flex, list::ListItem, popover::Popover, v_flex, ActiveTheme, Icon, IconName,
+    Selectable, Sizable as _,
 };
 
 actions!(menu, [Confirm, Dismiss, SelectNext, SelectPrev]);

--- a/crates/ui/src/progress.rs
+++ b/crates/ui/src/progress.rs
@@ -1,4 +1,4 @@
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 use gpui::{
     div, prelude::FluentBuilder, px, relative, IntoElement, ParentElement, RenderOnce, Styled,
     WindowContext,

--- a/crates/ui/src/radio.rs
+++ b/crates/ui/src/radio.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme, IconName};
+use crate::{h_flex, ActiveTheme, IconName};
 use gpui::{
     div, prelude::FluentBuilder, relative, svg, ElementId, InteractiveElement, IntoElement,
     ParentElement, RenderOnce, SharedString, StatefulInteractiveElement, Styled, WindowContext,

--- a/crates/ui/src/resizable/resize_handle.rs
+++ b/crates/ui/src/resizable/resize_handle.rs
@@ -4,7 +4,7 @@ use gpui::{
     WindowContext,
 };
 
-use crate::{theme::ActiveTheme as _, AxisExt as _};
+use crate::{ActiveTheme as _, AxisExt as _};
 
 pub(crate) const HANDLE_PADDING: Pixels = px(4.);
 pub(crate) const HANDLE_SIZE: Pixels = px(1.);

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -2,8 +2,7 @@ use crate::{
     drawer::Drawer,
     modal::Modal,
     notification::{Notification, NotificationList},
-    theme::ActiveTheme,
-    window_border, Placement,
+    window_border, ActiveTheme, Placement,
 };
 use gpui::{
     canvas, div, prelude::FluentBuilder as _, AnyView, DefiniteLength, FocusHandle,

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -1,6 +1,6 @@
 use std::{cell::Cell, rc::Rc, time::Instant};
 
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 use gpui::{
     fill, point, px, relative, AppContext, Bounds, ContentMask, CursorStyle, Edges, Element,
     EntityId, Hitbox, Hsla, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,

--- a/crates/ui/src/sidebar/footer.rs
+++ b/crates/ui/src/sidebar/footer.rs
@@ -3,7 +3,7 @@ use gpui::{
     RenderOnce, SharedString, Styled,
 };
 
-use crate::{h_flex, popup_menu::PopupMenuExt, theme::ActiveTheme as _, Collapsible, Selectable};
+use crate::{h_flex, popup_menu::PopupMenuExt, ActiveTheme as _, Collapsible, Selectable};
 
 #[derive(IntoElement)]
 pub struct SidebarFooter {

--- a/crates/ui/src/sidebar/group.rs
+++ b/crates/ui/src/sidebar/group.rs
@@ -1,4 +1,4 @@
-use crate::{theme::ActiveTheme, v_flex, Collapsible};
+use crate::{v_flex, ActiveTheme, Collapsible};
 use gpui::{
     div, prelude::FluentBuilder as _, Div, IntoElement, ParentElement, RenderOnce, SharedString,
     Styled as _, WindowContext,

--- a/crates/ui/src/sidebar/header.rs
+++ b/crates/ui/src/sidebar/header.rs
@@ -3,7 +3,7 @@ use gpui::{
     RenderOnce, SharedString, Styled,
 };
 
-use crate::{h_flex, popup_menu::PopupMenuExt, theme::ActiveTheme as _, Collapsible, Selectable};
+use crate::{h_flex, popup_menu::PopupMenuExt, ActiveTheme as _, Collapsible, Selectable};
 
 #[derive(IntoElement)]
 pub struct SidebarHeader {

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme as _, v_flex, Collapsible, Icon, IconName, StyledExt};
+use crate::{h_flex, v_flex, ActiveTheme as _, Collapsible, Icon, IconName, StyledExt};
 use gpui::{
     div, percentage, prelude::FluentBuilder as _, ClickEvent, InteractiveElement as _, IntoElement,
     ParentElement as _, RenderOnce, SharedString, StatefulInteractiveElement as _, Styled as _,

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -2,8 +2,7 @@ use crate::{
     button::{Button, ButtonVariants},
     h_flex,
     scroll::ScrollbarAxis,
-    theme::ActiveTheme,
-    v_flex, Collapsible, Icon, IconName, Side, Sizable, StyledExt,
+    v_flex, ActiveTheme, Collapsible, Icon, IconName, Side, Sizable, StyledExt,
 };
 use gpui::{
     div, prelude::FluentBuilder, px, AnyElement, ClickEvent, Entity, EntityId,

--- a/crates/ui/src/skeleton.rs
+++ b/crates/ui/src/skeleton.rs
@@ -1,4 +1,4 @@
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 use gpui::{
     bounce, div, ease_in_out, Animation, AnimationExt, Div, IntoElement, RenderOnce, Styled,
 };

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme, tooltip::Tooltip, AxisExt};
+use crate::{h_flex, tooltip::Tooltip, ActiveTheme, AxisExt};
 use gpui::{
     canvas, div, prelude::FluentBuilder as _, px, Axis, Bounds, DragMoveEvent, EntityId,
     EventEmitter, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement as _,

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::{
     scroll::{Scrollable, ScrollbarAxis},
-    theme::ActiveTheme,
+    ActiveTheme,
 };
 use gpui::{
     div, px, Axis, Div, Edges, Element, ElementId, EntityId, FocusHandle, Pixels, Styled,

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, theme::ActiveTheme, Disableable, Side, Sizable, Size};
+use crate::{h_flex, ActiveTheme, Disableable, Side, Sizable, Size};
 use gpui::{
     div, prelude::FluentBuilder as _, px, Animation, AnimationExt as _, AnyElement, Element,
     ElementId, GlobalElementId, InteractiveElement, IntoElement, LayoutId, ParentElement as _,

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -1,5 +1,4 @@
-use crate::theme::ActiveTheme;
-use crate::Selectable;
+use crate::{ActiveTheme, Selectable};
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     div, px, AnyElement, Div, ElementId, InteractiveElement, IntoElement, ParentElement as _,

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -1,5 +1,4 @@
-use crate::h_flex;
-use crate::theme::ActiveTheme;
+use crate::{h_flex, ActiveTheme};
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     div, AnyElement, Div, ElementId, IntoElement, ParentElement, RenderOnce, ScrollHandle,

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -5,10 +5,7 @@ use crate::{
     h_flex,
     popup_menu::PopupMenu,
     scroll::{ScrollableMask, Scrollbar, ScrollbarState},
-    theme::ActiveTheme,
-    v_flex,
-    virtual_list::virtual_list,
-    Icon, IconName, Sizable, Size, StyleSized as _,
+    v_flex, ActiveTheme, Icon, IconName, Sizable, Size, StyleSized as _,
 };
 use gpui::{
     actions, canvas, div, prelude::FluentBuilder, px, uniform_list, AppContext, Axis, Bounds, Div,
@@ -1169,26 +1166,34 @@ where
                         .overflow_hidden()
                         .relative()
                         .child(
-                            virtual_list(view, row_ix, Axis::Horizontal, col_sizes, {
-                                move |table, visible_range: Range<usize>, _, cx| {
-                                    table.update_visible_range_if_need(
-                                        visible_range.clone(),
-                                        Axis::Horizontal,
-                                        cx,
-                                    );
+                            crate::virtual_list::virtual_list(
+                                view,
+                                row_ix,
+                                Axis::Horizontal,
+                                col_sizes,
+                                {
+                                    move |table, visible_range: Range<usize>, _, cx| {
+                                        table.update_visible_range_if_need(
+                                            visible_range.clone(),
+                                            Axis::Horizontal,
+                                            cx,
+                                        );
 
-                                    visible_range
-                                        .map(|col_ix| {
-                                            let col_ix = col_ix + left_cols_count;
-                                            table.render_col_wrap(col_ix, cx).child(
-                                                table.render_cell(col_ix, cx).child(
-                                                    table.delegate.render_td(row_ix, col_ix, cx),
-                                                ),
-                                            )
-                                        })
-                                        .collect::<Vec<_>>()
-                                }
-                            })
+                                        visible_range
+                                            .map(|col_ix| {
+                                                let col_ix = col_ix + left_cols_count;
+                                                table.render_col_wrap(col_ix, cx).child(
+                                                    table.render_cell(col_ix, cx).child(
+                                                        table
+                                                            .delegate
+                                                            .render_td(row_ix, col_ix, cx),
+                                                    ),
+                                                )
+                                            })
+                                            .collect::<Vec<_>>()
+                                    }
+                                },
+                            )
                             .with_scroll_handle(&self.horizontal_scroll_handle),
                         )
                         .child(self.delegate.render_last_empty_col(cx)),

--- a/crates/ui/src/table/loading.rs
+++ b/crates/ui/src/table/loading.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, skeleton::Skeleton, theme::ActiveTheme, v_flex, Size};
+use crate::{h_flex, skeleton::Skeleton, v_flex, ActiveTheme, Size};
 use gpui::{prelude::FluentBuilder as _, IntoElement, ParentElement as _, RenderOnce, Styled};
 
 #[derive(IntoElement)]

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -5,7 +5,7 @@ use gpui::{
     ViewContext, WindowAppearance, WindowContext,
 };
 
-use crate::scroll::ScrollbarShow;
+use crate::{scroll::ScrollbarShow, Colorize as _};
 
 pub fn init(cx: &mut AppContext) {
     Theme::sync_system_appearance(cx)
@@ -69,83 +69,7 @@ pub fn box_shadow(
         color,
     }
 }
-pub trait Colorize {
-    /// Returns a new color with the given opacity.
-    ///
-    /// The opacity is a value between 0.0 and 1.0, where 0.0 is fully transparent and 1.0 is fully opaque.
-    fn opacity(&self, opacity: f32) -> Hsla;
-    /// Returns a new color with each channel divided by the given divisor.
-    ///
-    /// The divisor in range of 0.0 .. 1.0
-    fn divide(&self, divisor: f32) -> Hsla;
-    /// Return inverted color
-    fn invert(&self) -> Hsla;
-    /// Return inverted lightness
-    fn invert_l(&self) -> Hsla;
-    /// Return a new color with the lightness increased by the given factor.
-    ///
-    /// factor range: 0.0 .. 1.0
-    fn lighten(&self, amount: f32) -> Hsla;
-    /// Return a new color with the darkness increased by the given factor.
-    ///
-    /// factor range: 0.0 .. 1.0
-    fn darken(&self, amount: f32) -> Hsla;
-    /// Return a new color with the same lightness and alpha but different hue and saturation.
-    fn apply(&self, base_color: Hsla) -> Hsla;
-}
 
-impl Colorize for Hsla {
-    fn opacity(&self, factor: f32) -> Hsla {
-        Hsla {
-            a: self.a * factor.clamp(0.0, 1.0),
-            ..*self
-        }
-    }
-
-    fn divide(&self, divisor: f32) -> Hsla {
-        Hsla {
-            a: divisor,
-            ..*self
-        }
-    }
-
-    fn invert(&self) -> Hsla {
-        Hsla {
-            h: 1.0 - self.h,
-            s: 1.0 - self.s,
-            l: 1.0 - self.l,
-            a: self.a,
-        }
-    }
-
-    fn invert_l(&self) -> Hsla {
-        Hsla {
-            l: 1.0 - self.l,
-            ..*self
-        }
-    }
-
-    fn lighten(&self, factor: f32) -> Hsla {
-        let l = self.l * (1.0 + factor.clamp(0.0, 1.0));
-
-        Hsla { l, ..*self }
-    }
-
-    fn darken(&self, factor: f32) -> Hsla {
-        let l = self.l * (1.0 - factor.clamp(0.0, 1.0));
-
-        Hsla { l, ..*self }
-    }
-
-    fn apply(&self, new_color: Hsla) -> Hsla {
-        Hsla {
-            h: new_color.h,
-            s: new_color.s,
-            l: self.l,
-            a: self.a,
-        }
-    }
-}
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ThemeColor {
     pub accent: Hsla,
@@ -549,30 +473,5 @@ pub enum ThemeMode {
 impl ThemeMode {
     pub fn is_dark(&self) -> bool {
         matches!(self, Self::Dark)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::theme::Colorize as _;
-
-    #[test]
-    fn test_lighten() {
-        let color = super::hsl(240.0, 5.0, 30.0);
-        let color = color.lighten(0.5);
-        assert_eq!(color.l, 0.45000002);
-        let color = color.lighten(0.5);
-        assert_eq!(color.l, 0.675);
-        let color = color.lighten(0.1);
-        assert_eq!(color.l, 0.7425);
-    }
-
-    #[test]
-    fn test_darken() {
-        let color = super::hsl(240.0, 5.0, 96.0);
-        let color = color.darken(0.5);
-        assert_eq!(color.l, 0.48);
-        let color = color.darken(0.5);
-        assert_eq!(color.l, 0.24);
     }
 }

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -10,9 +10,7 @@ use rust_i18n::t;
 
 use crate::{
     button::{Button, ButtonVariants as _},
-    h_flex,
-    theme::ActiveTheme,
-    v_flex, Disableable as _, IconName, Selectable, Sizable, Size,
+    h_flex, v_flex, ActiveTheme, Disableable as _, IconName, Selectable, Sizable, Size,
 };
 
 use super::utils::days_in_month;

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -12,8 +12,7 @@ use crate::{
     dropdown::Escape,
     h_flex,
     input::ClearButton,
-    theme::ActiveTheme,
-    v_flex, Icon, IconName, Sizable, Size, StyleSized as _, StyledExt as _,
+    v_flex, ActiveTheme, Icon, IconName, Sizable, Size, StyleSized as _, StyledExt as _,
 };
 
 use super::calendar::{Calendar, CalendarEvent, Date};

--- a/crates/ui/src/title_bar.rs
+++ b/crates/ui/src/title_bar.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{h_flex, theme::ActiveTheme, Icon, IconName, InteractiveElementExt as _, Sizable as _};
+use crate::{h_flex, ActiveTheme, Icon, IconName, InteractiveElementExt as _, Sizable as _};
 use gpui::{
     div, prelude::FluentBuilder as _, px, relative, AnyElement, ClickEvent, Div, Element, Hsla,
     InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels, RenderOnce, Stateful,

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -3,7 +3,7 @@ use gpui::{
     VisualContext, WindowContext,
 };
 
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 
 pub struct Tooltip {
     text: SharedString,

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -6,7 +6,7 @@ use gpui::{
     Pixels, Point, RenderOnce, ResizeEdge, Size, Styled as _, WindowContext,
 };
 
-use crate::theme::ActiveTheme;
+use crate::ActiveTheme;
 
 #[cfg(not(target_os = "linux"))]
 const SHADOW_SIZE: Pixels = Pixels(0.0);


### PR DESCRIPTION
- Add `mix` method to mix two color.
- Export `ui::theme::*` to crate root, before `use ui:theme::ActiveTheme` to `use ui::ActiveTheme`.

## Break Changes

- Moved `ui::theme::Colorize` to `ui::Colorize`.
- Merged `ColorExt` to `Colorize`.
- Renamed `to_hex_string` to `to_hex`, `parse_hex_string` to `parse_hex`.