### PR TITLE
dock: Fix the tab panel cannot fill the entire height

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -725,7 +725,7 @@ impl TabPanel {
             return Empty {}.into_any_element();
         };
 
-        div()
+        v_flex()
             .id("tab-content")
             .group("")
             .overflow_y_scroll()


### PR DESCRIPTION
## Before
<img width="411" alt="image" src="https://github.com/user-attachments/assets/8801361d-20fd-4ba5-8b9e-bb18f6e8cc5a" />

## After
<img width="410" alt="image" src="https://github.com/user-attachments/assets/91975382-5ed1-45a4-acd2-a131d2a162f5" />
