### PR TITLE
input: Fix to position cursor at correct offset on mouse down or select.

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -916,10 +916,11 @@ impl TextInput {
             }
         }
 
-        // To fix when line only have 1 char, the closest_index_for_x will always 1.
+        // HOTFIX:
+        //
+        // Wait https://github.com/zed-industries/zed/pull/23603
         if line.unwrapped_layout.len == 1 {
-            // Hardcoded if x > 4px (4px about half chat in most case), return 1
-            if x > px(4.) {
+            if x > line.width() / 2.0 {
                 return 1;
             }
             return 0;


### PR DESCRIPTION
Ref: https://github.com/zed-industries/zed/pull/23603

---

## TODO

Here still have a little bug in multiple lines and soft wrapped line.
Only the first line can get correct position, the wrapped line is always got the offset +1, so the first char of that soft wrapped line, we can't position the cursor at the first.