### PR TITLE
input: Fix Input to vertical center the mask chars.

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -506,7 +506,11 @@ impl Element for TextElement {
         let mut offset_y = px(0.);
         if self.input.read(cx).masked {
             // Move down offset for vertical centering the *****
-            offset_y = px(2.5);
+            if cfg!(target_os = "macos") {
+                offset_y = px(3.);
+            } else {
+                offset_y = px(2.5);
+            }
         }
         for line in prepaint.lines.iter() {
             let p = point(origin.x, origin.y + offset_y);

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -504,6 +504,10 @@ impl Element for TextElement {
         let origin = bounds.origin;
 
         let mut offset_y = px(0.);
+        if self.input.read(cx).masked {
+            // Move down offset for vertical centering the *****
+            offset_y = px(2.5);
+        }
         for line in prepaint.lines.iter() {
             let p = point(origin.x, origin.y + offset_y);
             _ = line.paint(p, line_height, window, cx);


### PR DESCRIPTION
Close #467

Windows:

<img width="397" alt="image" src="https://github.com/user-attachments/assets/0a185b42-1432-404a-b889-da1143706035" />

macOS:

<img width="510" alt="image" src="https://github.com/user-attachments/assets/ed186552-862b-404e-96dc-b0f3a0b552d6" />



