### PR TITLE
chore: Remove reexport prelude.

### DIFF
--- a/crates/story/src/button_story.rs
+++ b/crates/story/src/button_story.rs
@@ -1,14 +1,13 @@
 use gpui::{
-    actions, px, App, AppContext as _, ClickEvent, Context, Entity, Focusable, InteractiveElement,
-    IntoElement, ParentElement as _, Render, Styled as _, Window,
+    actions, prelude::FluentBuilder, px, App, AppContext as _, ClickEvent, Context, Entity,
+    Focusable, InteractiveElement, IntoElement, ParentElement as _, Render, Styled as _, Window,
 };
 
 use ui::{
     button::{Button, ButtonCustomVariant, ButtonGroup, ButtonVariants as _, DropdownButton},
     checkbox::Checkbox,
-    h_flex,
-    prelude::FluentBuilder,
-    v_flex, ActiveTheme, Disableable as _, Icon, IconName, Selectable as _, Sizable as _, Theme,
+    h_flex, v_flex, ActiveTheme, Disableable as _, Icon, IconName, Selectable as _, Sizable as _,
+    Theme,
 };
 
 use crate::section;

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    actions, div, App, AppContext, Axis, Context, Entity, Focusable, InteractiveElement,
-    IntoElement, ParentElement as _, Render, Styled, Window,
+    actions, div, prelude::FluentBuilder as _, App, AppContext, Axis, Context, Entity, Focusable,
+    InteractiveElement, IntoElement, ParentElement as _, Render, Styled, Window,
 };
 use ui::{
     button::{Button, ButtonGroup},
@@ -10,7 +10,6 @@ use ui::{
     form::{form_field, v_form},
     h_flex,
     input::TextInput,
-    prelude::FluentBuilder as _,
     switch::Switch,
     v_flex, AxisExt, FocusableCycle, Selectable, Sizable, Size,
 };

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    actions, div, px, App, AppContext as _, Context, Entity, FocusHandle, Focusable,
-    InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Render, SharedString, Styled,
-    Window,
+    actions, div, prelude::FluentBuilder as _, px, App, AppContext as _, Context, Entity,
+    FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding, ParentElement as _,
+    Render, SharedString, Styled, Window,
 };
 use regex::Regex;
 
@@ -11,7 +11,6 @@ use ui::{
     checkbox::Checkbox,
     h_flex,
     input::{InputEvent, NumberInput, NumberInputEvent, OtpInput, TextInput},
-    prelude::FluentBuilder as _,
     v_flex, FocusableCycle, IconName, Sizable,
 };
 

--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, impl_internal_actions, relative, App, AppContext, ClickEvent, Context, Entity, Focusable,
-    ParentElement, Render, SharedString, Styled, Window,
+    div, impl_internal_actions, prelude::FluentBuilder, relative, App, AppContext, ClickEvent,
+    Context, Entity, Focusable, ParentElement, Render, SharedString, Styled, Window,
 };
 
 use serde::Deserialize;
@@ -9,7 +9,6 @@ use ui::{
     divider::Divider,
     h_flex,
     popup_menu::PopupMenuExt,
-    prelude::FluentBuilder,
     sidebar::{
         Sidebar, SidebarFooter, SidebarGroup, SidebarHeader, SidebarMenu, SidebarToggleButton,
     },

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -5,9 +5,9 @@ use std::{
 
 use fake::{Fake, Faker};
 use gpui::{
-    div, impl_internal_actions, px, AnyElement, App, AppContext, Context, Edges, Entity, Focusable,
-    InteractiveElement, IntoElement, ParentElement, Pixels, Render, SharedString, Styled, Timer,
-    Window,
+    div, impl_internal_actions, prelude::FluentBuilder as _, px, AnyElement, App, AppContext,
+    Context, Edges, Entity, Focusable, InteractiveElement, IntoElement, ParentElement, Pixels,
+    Render, SharedString, Styled, Timer, Window,
 };
 use serde::Deserialize;
 use ui::{
@@ -18,7 +18,6 @@ use ui::{
     input::{InputEvent, TextInput},
     label::Label,
     popup_menu::{PopupMenu, PopupMenuExt},
-    prelude::FluentBuilder as _,
     table::{ColFixed, ColSort, Table, TableDelegate, TableEvent},
     v_flex, ActiveTheme as _, Selectable, Sizable as _, Size, StyleSized as _,
 };

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -1,16 +1,15 @@
 use std::rc::Rc;
 
 use gpui::{
-    div, px, AnyElement, App, AppContext, ClickEvent, Context, Corner, Entity, FocusHandle, Hsla,
-    InteractiveElement as _, IntoElement, MouseButton, ParentElement as _, Render, SharedString,
-    Styled as _, Subscription, Window,
+    div, prelude::FluentBuilder as _, px, AnyElement, App, AppContext, ClickEvent, Context, Corner,
+    Entity, FocusHandle, Hsla, InteractiveElement as _, IntoElement, MouseButton,
+    ParentElement as _, Render, SharedString, Styled as _, Subscription, Window,
 };
 use ui::{
     badge::Badge,
     button::{Button, ButtonVariants as _},
     color_picker::{ColorPicker, ColorPickerEvent},
     popup_menu::PopupMenuExt as _,
-    prelude::FluentBuilder as _,
     scroll::ScrollbarShow,
     ActiveTheme as _, ContextModal as _, IconName, Sizable as _, Theme, TitleBar,
 };

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    actions, px, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle, Focusable,
-    InteractiveElement, IntoElement, KeyBinding, ParentElement, Pixels, Render, SharedString,
-    Styled, Subscription, Window,
+    actions, prelude::FluentBuilder as _, px, App, AppContext as _, Context, Entity, EventEmitter,
+    FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding, ParentElement, Pixels,
+    Render, SharedString, Styled, Subscription, Window,
 };
 use regex::Regex;
 
@@ -9,7 +9,6 @@ use crate::{
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{InputEvent, TextInput},
-    prelude::FluentBuilder,
     ActiveTheme, IconName, Sizable, Size, StyleSized, StyledExt,
 };
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -34,7 +34,6 @@ pub mod modal;
 pub mod notification;
 pub mod popover;
 pub mod popup_menu;
-pub mod prelude;
 pub mod progress;
 pub mod radio;
 pub mod resizable;

--- a/crates/ui/src/prelude.rs
+++ b/crates/ui/src/prelude.rs
@@ -1,9 +1,0 @@
-//! The prelude of this crate. When building UI in Zed you almost always want to import this.
-
-pub use gpui::prelude::*;
-#[allow(unused_imports)]
-pub use gpui::{
-    div, px, relative, rems, AbsoluteLength, App, Context, DefiniteLength, Div, Element, ElementId,
-    Entity, InteractiveElement, ParentElement, Pixels, Rems, RenderOnce, SharedString, Styled,
-    Window,
-};


### PR DESCRIPTION
This is useless, we can just use `gpui::prelude`, so I removed it.

## Break changes

- The `ui::prelude` has been removed, you can replace by use `gpui::prelude`.