### PR TITLE
table: Fix Table subtract with overflow error.

### DIFF
--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -1559,7 +1559,7 @@ where
                                         }
 
                                         let mut items = Vec::with_capacity(
-                                            visible_range.end - visible_range.start,
+                                            visible_range.end.saturating_sub(visible_range.start),
                                         );
 
                                         // Render fake rows to fill the table


### PR DESCRIPTION
```
thread 'main' panicked at gpui-component-f2cfc37a601d48ab/dffb419/crates/ui/src/[table.rs:1562](http://table.rs:1562/):45:
attempt to subtract with overflow
stack backtrace:
```