### PR TITLE
color_picker Fix popup does not close by clicking color button again.

### DIFF
--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -160,7 +160,6 @@ impl ColorPicker {
 
     fn on_escape(&mut self, _: &Escape, _: &mut Window, cx: &mut Context<Self>) {
         cx.propagate();
-
         self.open = false;
         cx.notify();
     }
@@ -335,6 +334,10 @@ impl Render for ColorPicker {
                     )
                     .when_some(self.label.clone(), |this, label| this.child(label))
                     .on_click(cx.listener(Self::toggle_picker))
+                    .on_mouse_up_out(
+                        MouseButton::Left,
+                        cx.listener(|view, _, window, cx| view.on_escape(&Escape, window, cx)),
+                    )
                     .child(
                         canvas(
                             move |bounds, _, cx| view.update(cx, |r, _| r.bounds = bounds),
@@ -367,12 +370,6 @@ impl Render for ColorPicker {
                                     .shadow_lg()
                                     .rounded(cx.theme().radius)
                                     .bg(cx.theme().background)
-                                    .on_mouse_up_out(
-                                        MouseButton::Left,
-                                        cx.listener(|view, _, window, cx| {
-                                            view.on_escape(&Escape, window, cx)
-                                        }),
-                                    )
                                     .child(self.render_colors(window, cx)),
                             ),
                     )


### PR DESCRIPTION
## How to reproduce

1. `cargo run` to run dashboard
2. Click `color-picker` button to open its layer and try to click same button again, to close the layer. The layer won't close. It will close only by clicking outside or selecting a color.

![click-cp](https://github.com/user-attachments/assets/b986c4b1-c996-4a99-957f-5c99addf8121)

## Fix

Move `on_mouse_up_out` handler from inner to upper child to **avoid** a race condition by changing value of `self.open` twice in `on_escape` AND `toggle_picker`.