### PR TITLE
Revert "dock: Revert `AnyView` cached (#607)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GPUI and GPUI Component still in development, so we need add dependency by git.
 And GPUI Component depends on `gpui` by special version (It keep updated to upstream) for including WebView support.
 
 ```toml
-gpui = { git = "https://github.com/huacnlee/zed.git", branch = "webview" }
+gpui = { git = "https://github.com/huacnlee/zed.git", branch = "export-platform-window" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component.git" }
 ```
 

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -3,9 +3,10 @@
 use std::sync::Arc;
 
 use gpui::{
-    div, prelude::FluentBuilder as _, px, App, AppContext, Axis, Context, Element, Empty, Entity,
-    InteractiveElement as _, IntoElement, MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels,
-    Point, Render, StatefulInteractiveElement, Style, Styled as _, WeakEntity, Window,
+    div, prelude::FluentBuilder as _, px, AnyView, App, AppContext, Axis, Context, Element, Empty,
+    Entity, InteractiveElement as _, IntoElement, MouseMoveEvent, MouseUpEvent, ParentElement as _,
+    Pixels, Point, Render, StatefulInteractiveElement, Style, StyleRefinement, Styled as _,
+    WeakEntity, Window,
 };
 use serde::{Deserialize, Serialize};
 
@@ -394,6 +395,8 @@ impl Render for Dock {
             return div();
         }
 
+        let cache_style = StyleRefinement::default().v_flex().size_full();
+
         div()
             .relative()
             .overflow_hidden()
@@ -408,8 +411,10 @@ impl Render for Dock {
             })
             .map(|this| match &self.panel {
                 DockItem::Split { view, .. } => this.child(view.clone()),
-                DockItem::Tabs { view, .. } => this.child(view.clone()),
-                DockItem::Panel { view, .. } => this.child(view.clone().view()),
+                DockItem::Tabs { view, .. } => {
+                    this.child(AnyView::from(view.clone()).cached(cache_style))
+                }
+                DockItem::Panel { view, .. } => this.child(view.clone().view().cached(cache_style)),
                 // Not support to render Tiles and Tile into Dock
                 DockItem::Tiles { .. } => this,
             })

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -4,7 +4,7 @@ use gpui::{
     div, prelude::FluentBuilder, px, rems, App, AppContext, Context, Corner, DefiniteLength,
     DismissEvent, DragMoveEvent, Empty, Entity, EventEmitter, FocusHandle, Focusable,
     InteractiveElement as _, IntoElement, ParentElement, Pixels, Render, ScrollHandle,
-    SharedString, StatefulInteractiveElement, Styled, WeakEntity, Window,
+    SharedString, StatefulInteractiveElement, StyleRefinement, Styled, WeakEntity, Window,
 };
 use rust_i18n::t;
 
@@ -14,7 +14,7 @@ use crate::{
     h_flex,
     popup_menu::{PopupMenu, PopupMenuExt},
     tab::{Tab, TabBar},
-    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable,
+    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable, StyledExt as _,
 };
 
 use super::{
@@ -767,7 +767,11 @@ impl TabPanel {
             .overflow_y_scroll()
             .overflow_x_hidden()
             .flex_1()
-            .child(active_panel.view())
+            .child(
+                active_panel
+                    .view()
+                    .cached(StyleRefinement::default().v_flex().size_full()),
+            )
             .when(state.droppable, |this| {
                 this.on_drag_move(cx.listener(Self::on_panel_drag_move))
                     .child(


### PR DESCRIPTION
This reverts commit 2479fc34182ddd989a6e0dc6358df18428c3d714.

> NOTE: When we enabled this, we need make sure call `cx.nofity()` when the data has been updated.

In real world application, this may reduce about 3% CPU cost.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/9188cde9-3402-4860-9e03-328aa74a74e7" />

> I watched this data about 5 minutes, the CPU cost is always like this.

