### PR TITLE
dock: Leave some space between the tabs title and panel

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -761,12 +761,15 @@ impl TabPanel {
             return Empty {}.into_any_element();
         };
 
+        let is_render_in_tabs = self.panels.len() > 1;
+
         v_flex()
             .id("tab-content")
             .group("")
             .overflow_y_scroll()
             .overflow_x_hidden()
             .flex_1()
+            .when(is_render_in_tabs, |this| this.pt_2())
             .child(
                 active_panel
                     .view()


### PR DESCRIPTION
## Before
<img width="541" alt="image" src="https://github.com/user-attachments/assets/a41390ec-a86b-4ca2-bcf4-a2b368c1e2e0" />

## After
<img width="518" alt="image" src="https://github.com/user-attachments/assets/0896abe5-d499-4052-aa84-0864029c0346" />
