### PR TITLE
label: Avoid String alloc and remove custom text-align.

### DIFF
--- a/crates/story/examples/text.rs
+++ b/crates/story/examples/text.rs
@@ -1,0 +1,35 @@
+use gpui::*;
+use story::{Assets, TextStory};
+
+pub struct Example {
+    root: Entity<TextStory>,
+}
+
+impl Example {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let root = TextStory::view(window, cx);
+
+        Self { root }
+    }
+
+    fn view(window: &mut Window, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| Self::new(window, cx))
+    }
+}
+
+impl Render for Example {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div().p_4().size_full().child(self.root.clone())
+    }
+}
+
+fn main() {
+    let app = Application::new().with_assets(Assets);
+
+    app.run(move |cx| {
+        story::init(cx);
+        cx.activate(true);
+
+        story::create_new_window("List Example", Example::view, cx);
+    });
+}

--- a/crates/ui/src/label.rs
+++ b/crates/ui/src/label.rs
@@ -19,38 +19,22 @@ pub enum TextAlign {
 pub struct Label {
     base: Div,
     label: SharedString,
+    chars_count: usize,
     align: TextAlign,
     marked: bool,
 }
 
 impl Label {
     pub fn new(label: impl Into<SharedString>) -> Self {
+        let label: SharedString = label.into();
+        let chars_count = label.chars().count();
         Self {
             base: h_flex().line_height(rems(1.25)),
-            label: label.into(),
+            label,
+            chars_count,
             align: TextAlign::default(),
             marked: false,
         }
-    }
-
-    pub fn text_align(mut self, align: TextAlign) -> Self {
-        self.align = align;
-        self
-    }
-
-    pub fn text_left(mut self) -> Self {
-        self.align = TextAlign::Left;
-        self
-    }
-
-    pub fn text_center(mut self) -> Self {
-        self.align = TextAlign::Center;
-        self
-    }
-
-    pub fn text_right(mut self) -> Self {
-        self.align = TextAlign::Right;
-        self
     }
 
     pub fn masked(mut self, masked: bool) -> Self {
@@ -67,28 +51,20 @@ impl Styled for Label {
 
 impl RenderOnce for Label {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
-        let text = self.label;
-
-        let text_display = if self.marked {
-            MASKED.repeat(text.chars().count())
+        let text = if self.marked {
+            SharedString::from(MASKED.repeat(self.chars_count))
         } else {
-            text.to_string()
+            self.label
         };
 
-        div().text_color(cx.theme().foreground).child(
-            self.base
-                .map(|this| match self.align {
-                    TextAlign::Left => this.justify_start(),
-                    TextAlign::Center => this.justify_center(),
-                    TextAlign::Right => this.justify_end(),
-                })
-                .map(|this| {
-                    if self.align == TextAlign::Left {
-                        this.child(div().size_full().child(text_display))
-                    } else {
-                        this.child(text_display)
-                    }
-                }),
-        )
+        div()
+            .text_color(cx.theme().foreground)
+            .child(self.base.map(|this| {
+                if self.align == TextAlign::Left {
+                    this.child(div().size_full().child(text))
+                } else {
+                    this.child(text)
+                }
+            }))
     }
 }

--- a/crates/ui/src/label.rs
+++ b/crates/ui/src/label.rs
@@ -1,26 +1,16 @@
 use gpui::{
-    div, prelude::FluentBuilder, rems, App, Div, IntoElement, ParentElement, RenderOnce,
-    SharedString, Styled, Window,
+    div, rems, App, Div, IntoElement, ParentElement, RenderOnce, SharedString, Styled, Window,
 };
 
-use crate::{h_flex, ActiveTheme};
+use crate::ActiveTheme;
 
 const MASKED: &'static str = "•";
-
-#[derive(Default, PartialEq, Eq)]
-pub enum TextAlign {
-    #[default]
-    Left,
-    Center,
-    Right,
-}
 
 #[derive(IntoElement)]
 pub struct Label {
     base: Div,
     label: SharedString,
     chars_count: usize,
-    align: TextAlign,
     marked: bool,
 }
 
@@ -29,10 +19,9 @@ impl Label {
         let label: SharedString = label.into();
         let chars_count = label.chars().count();
         Self {
-            base: h_flex().line_height(rems(1.25)),
+            base: div().line_height(rems(1.25)),
             label,
             chars_count,
-            align: TextAlign::default(),
             marked: false,
         }
     }
@@ -59,12 +48,6 @@ impl RenderOnce for Label {
 
         div()
             .text_color(cx.theme().foreground)
-            .child(self.base.map(|this| {
-                if self.align == TextAlign::Left {
-                    this.child(div().size_full().child(text))
-                } else {
-                    this.child(text)
-                }
-            }))
+            .child(self.base.child(text))
     }
 }


### PR DESCRIPTION
Reverted #615 and recreate again.

## Break changes

- Remove `TextAlign` and `text_left`, `text_right` ... method from label, we can use same things from GPUI.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/95e9066a-e58d-47a8-9acf-b483b0203b1b" />
