### PR TITLE
panel: Reduce tool buttons gap from 8px to 4px.

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -410,7 +410,7 @@ impl TabPanel {
 
         // TODO: Do not show MenuButton if there is no menu items
         h_flex()
-            .gap_2()
+            .gap_1()
             .occlude()
             .items_center()
             .when_some(self.toolbar_buttons(window, cx), |this, buttons| {
@@ -432,6 +432,7 @@ impl TabPanel {
                             .xsmall()
                             .ghost()
                             .tooltip(tooltip)
+                            .when(zoomed, |this| this.selected(true))
                             .on_click(cx.listener(|view, _, window, cx| {
                                 view.on_action_toggle_zoom(&ToggleZoom, window, cx)
                             })),


### PR DESCRIPTION
<img width="314" alt="image" src="https://github.com/user-attachments/assets/eab5f4f8-b604-4c5c-bfd4-2535340b1d1e" />

And use `selected` style for zoom button when zoomed:

<img width="114" alt="image" src="https://github.com/user-attachments/assets/fa11ec81-a4db-42ea-8edc-39ed8ad40ba1" />
