### PR TITLE
text_view: Stop propagation on click link in TextView.

### DIFF
--- a/crates/ui/src/text/element.rs
+++ b/crates/ui/src/text/element.rs
@@ -303,6 +303,10 @@ impl RenderOnce for Paragraph {
                         let links = links.clone();
                         move |ix, _, cx| {
                             if let Some((_, link)) = &links.get(ix) {
+                                // Stop propagation to prevent the parent element from handling the event.
+                                //
+                                // For example the text in a checkbox label, click link need avoid toggle check state.
+                                cx.stop_propagation();
                                 cx.open_url(&link.url);
                             }
                         }


### PR DESCRIPTION
To avoid trigger parent element, for example as a Label for checkbox.