### PR TITLE
text_view: Remove last paragraph bottom margin.

### DIFF
--- a/crates/story/src/switch_story.rs
+++ b/crates/story/src/switch_story.rs
@@ -218,7 +218,6 @@ impl Render for SwitchStory {
                                             "The [long long label](https://github.com) text used markdown, \
                                              it should wrap when the text is too long.",
                                         )
-                                        .inline(),
                                     ),
                             ),
                     ),

--- a/crates/ui/src/text/html.rs
+++ b/crates/ui/src/text/html.rs
@@ -160,7 +160,7 @@ impl Element for HtmlElement {
 
             let mut el = div()
                 .map(|this| match root {
-                    Ok(node) => this.child(node.render(None, &self.style, window, cx)),
+                    Ok(node) => this.child(node.render(None, true, &self.style, window, cx)),
                     Err(err) => this.child(
                         v_flex()
                             .gap_1()

--- a/crates/ui/src/text/markdown.rs
+++ b/crates/ui/src/text/markdown.rs
@@ -116,7 +116,7 @@ impl Element for MarkdownElement {
 
             let mut el = div()
                 .map(|this| match root {
-                    Ok(node) => this.child(node.render(None, &self.style, window, cx)),
+                    Ok(node) => this.child(node.render(None, true, &self.style, window, cx)),
                     Err(err) => this.child(
                         v_flex()
                             .gap_1()

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -64,15 +64,6 @@ impl Default for TextViewStyle {
 }
 
 impl TextViewStyle {
-    /// Default style for inline text.
-    ///
-    /// This style has no paragraph gap.
-    pub fn inline() -> Self {
-        Self {
-            paragraph_gap: rems(0.),
-        }
-    }
-
     /// Set paragraph gap, default is 1 rem.
     pub fn paragraph_gap(mut self, gap: Rems) -> Self {
         self.paragraph_gap = gap;
@@ -105,11 +96,6 @@ impl TextView {
             Self::Markdown(el) => Self::Markdown(el.style(style)),
             Self::Html(el) => Self::Html(el.style(style)),
         }
-    }
-
-    /// Set to use [`TextViewStyle::inline`].
-    pub fn inline(self) -> Self {
-        self.style(TextViewStyle::inline())
     }
 }
 


### PR DESCRIPTION
Now, we can be easy to use TextView for 1 line text.


## Break Changes

- Removed `inline` method by previous #649 added, this is not needed.