### PR TITLE
ci: Temporarily skip machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ on:
   pull_request:
   push:
     branches:
-      - "*"
+      - '*'
     tags:
-      - "*"
+      - '*'
 
 jobs:
   test:
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system dependencies
         run: script/bootstrap
-      - name: Machete
-        uses: bnjbvr/cargo-machete@main
+      # - name: Machete
+      #   uses: bnjbvr/cargo-machete@main
       - name: Setup | Cache Cargo
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
https://github.com/actions/runner-images/pull/11661

`cargo-machete` needs edition 2024, reopen after this PR is merged.