### PR TITLE
calendar: Differentiate text color of disabled and non-current month

### DIFF
--- a/crates/story/src/calendar_story.rs
+++ b/crates/story/src/calendar_story.rs
@@ -96,7 +96,11 @@ impl CalendarStory {
                 window,
                 cx,
             );
-            picker.set_date(now, window, cx);
+            picker.set_date(
+                now.checked_sub_days(Days::new(1)).unwrap_or_default(),
+                window,
+                cx,
+            );
             picker
         });
         let date_picker_small = cx.new(|cx| {

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -161,7 +161,7 @@ pub enum Matcher {
     /// Match declare days of the week.
     ///
     /// Matcher::DayOfWeek(vec![0, 6])
-    /// @ill match the days of the week that are Sunday and Saturday.
+    /// Will match the days of the week that are Sunday and Saturday.
     DayOfWeek(Vec<u32>),
     /// Match the included days, except for those before and after the interval.
     ///
@@ -481,7 +481,11 @@ impl Calendar {
                 }
             })
             .when(muted, |this| {
-                this.text_color(cx.theme().muted_foreground.opacity(0.3))
+                this.text_color(if disabled {
+                    cx.theme().muted_foreground.opacity(0.3)
+                } else {
+                    cx.theme().muted_foreground
+                })
             })
             .when(secondary_active, |this| {
                 this.bg(if muted {


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="341" alt="image" src="https://github.com/user-attachments/assets/452d57b1-5ec6-4ad3-bc30-ed8a966d12e5" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/9f664cea-aa55-479a-8d5b-61570101a66f" /> |