### PR TITLE
scrollbar: Fix Scrollbar not clickable when it is always showing.

### DIFF
--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::ActiveTheme;
+use crate::{ActiveTheme, Theme};
 use gpui::{
     fill, point, px, relative, App, Bounds, ContentMask, CursorStyle, Edges, Element, EntityId,
     Hitbox, Hsla, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels,
@@ -632,7 +632,11 @@ impl Element for Scrollbar {
         cx: &mut App,
     ) {
         let hitbox_bounds = prepaint.hitbox.bounds;
-        let is_visible = self.state.get().is_scrollbar_visible();
+        let is_visible = self.state.get().is_scrollbar_visible()
+           // always visible if enabled by `Theme` settings
+           || cx.global_mut::<Theme>().scrollbar_show.is_always()
+           // `Theme` settings could be still overriden at `platform` level (e.g. on `Linux`)
+           || !cx.should_auto_hide_scrollbars();
         let is_hover_to_show = cx.theme().scrollbar_show.is_hover();
 
         // Update last_scroll_time when offset is changed.

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -635,7 +635,7 @@ impl Element for Scrollbar {
         let is_visible = self.state.get().is_scrollbar_visible()
            // always visible if enabled by `Theme` settings
            || cx.global_mut::<Theme>().scrollbar_show.is_always()
-           // `Theme` settings could be still overriden at `platform` level (e.g. on `Linux`)
+           // `Theme` settings could be still overridden at `platform` level (e.g. on `Linux`)
            || !cx.should_auto_hide_scrollbars();
         let is_hover_to_show = cx.theme().scrollbar_show.is_hover();
 

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{ActiveTheme, Theme};
+use crate::ActiveTheme;
 use gpui::{
     fill, point, px, relative, App, Bounds, ContentMask, CursorStyle, Edges, Element, EntityId,
     Hitbox, Hsla, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels,
@@ -632,11 +632,7 @@ impl Element for Scrollbar {
         cx: &mut App,
     ) {
         let hitbox_bounds = prepaint.hitbox.bounds;
-        let is_visible = self.state.get().is_scrollbar_visible()
-           // always visible if enabled by `Theme` settings
-           || cx.global_mut::<Theme>().scrollbar_show.is_always()
-           // `Theme` settings could be still overridden at `platform` level (e.g. on `Linux`)
-           || !cx.should_auto_hide_scrollbars();
+        let is_visible = self.state.get().is_scrollbar_visible() || cx.theme().scrollbar_show.is_always();
         let is_hover_to_show = cx.theme().scrollbar_show.is_hover();
 
         // Update last_scroll_time when offset is changed.


### PR DESCRIPTION
On `platform` level,  [should_auto_hide_scrollbars()](https://github.com/zed-industries/zed/blob/76a81607deec5b9093237cd3e98506dccc9f9565/crates/gpui/src/platform.rs#L205) might be `false` for some `platform`s, e.g. for `Linux`. 

That's why another check is needed to make scrollbars work properly on Linux.

Fixes #685