### PR TITLE
tab: Add new `pill` style, renamed old `pill` tab to `outline`.

### DIFF
--- a/crates/story/src/accordion_story.rs
+++ b/crates/story/src/accordion_story.rs
@@ -4,7 +4,7 @@ use gpui::{
 };
 use gpui_component::{
     accordion::Accordion,
-    button::{Button, ButtonGroup},
+    button::{Button, ButtonGroup, ButtonVariants as _},
     checkbox::Checkbox,
     h_flex,
     switch::Switch,
@@ -72,6 +72,8 @@ impl Render for AccordionStory {
                     .gap_2()
                     .child(
                         ButtonGroup::new("toggle-size")
+                            .outline()
+                            .compact()
                             .child(
                                 Button::new("xsmall")
                                     .label("XSmall")

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -6,7 +6,7 @@ use gpui::{
     ParentElement, Pixels, Render, ScrollHandle, SharedString, Size, Styled, Window,
 };
 use gpui_component::{
-    button::{Button, ButtonGroup},
+    button::{Button, ButtonGroup, ButtonVariants as _},
     divider::Divider,
     gray_100, gray_800, h_flex,
     label::Label,
@@ -103,6 +103,8 @@ impl ScrollableStory {
                     .gap_2()
                     .child(
                         ButtonGroup::new("test-cases")
+                            .outline()
+                            .compact()
                             .child(
                                 Button::new("test-0")
                                     .label("Size 0")
@@ -138,6 +140,8 @@ impl ScrollableStory {
                     .child(Divider::vertical().px_2())
                     .child(
                         ButtonGroup::new("scrollbars")
+                            .outline()
+                            .compact()
                             .child(
                                 Button::new("test-axis-both")
                                     .label("Both Scrollbar")

--- a/crates/story/src/tabs_story.rs
+++ b/crates/story/src/tabs_story.rs
@@ -145,10 +145,52 @@ impl Render for TabsStory {
                 ),
             )
             .child(
+                section("Underline Tabs", cx).child(
+                    TabBar::new("underline")
+                        .w_full()
+                        .px_2()
+                        .mx_3()
+                        .underline()
+                        .with_size(self.size)
+                        .selected_index(self.active_tab_ix)
+                        .on_click(cx.listener(|this, ix: &usize, window, cx| {
+                            this.set_active_tab(*ix, window, cx);
+                        }))
+                        .child("Account")
+                        .child("Profile")
+                        .child("Documents")
+                        .child("Mail")
+                        .child("Appearance")
+                        .child("Settings")
+                        .child("About")
+                        .child("License"),
+                ),
+            )
+            .child(
                 section("Pill Tabs", cx).child(
                     TabBar::new("pill")
                         .w_full()
                         .pill()
+                        .with_size(self.size)
+                        .selected_index(self.active_tab_ix)
+                        .on_click(cx.listener(|this, ix: &usize, window, cx| {
+                            this.set_active_tab(*ix, window, cx);
+                        }))
+                        .child(Tab::new("Account"))
+                        .child(Tab::new("Profile").disabled(true))
+                        .child(Tab::new("Documents & Files"))
+                        .child(Tab::new("Mail"))
+                        .child(Tab::new("Appearance"))
+                        .child(Tab::new("Settings"))
+                        .child(Tab::new("About"))
+                        .child(Tab::new("License")),
+                ),
+            )
+            .child(
+                section("Outline Tabs", cx).child(
+                    TabBar::new("outline")
+                        .w_full()
+                        .outline()
                         .with_size(self.size)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
@@ -178,28 +220,6 @@ impl Render for TabsStory {
                         .child(IconName::Calendar)
                         .child(IconName::Map)
                         .children(vec!["Appearance", "Settings", "About", "License"]),
-                ),
-            )
-            .child(
-                section("Underline Tabs", cx).child(
-                    TabBar::new("underline")
-                        .w_full()
-                        .px_2()
-                        .mx_3()
-                        .underline()
-                        .with_size(self.size)
-                        .selected_index(self.active_tab_ix)
-                        .on_click(cx.listener(|this, ix: &usize, window, cx| {
-                            this.set_active_tab(*ix, window, cx);
-                        }))
-                        .child("Account")
-                        .child("Profile")
-                        .child("Documents")
-                        .child("Mail")
-                        .child("Appearance")
-                        .child("Settings")
-                        .child("About")
-                        .child("License"),
                 ),
             )
     }

--- a/crates/story/src/tabs_story.rs
+++ b/crates/story/src/tabs_story.rs
@@ -67,6 +67,8 @@ impl Render for TabsStory {
             .gap_6()
             .child(
                 ButtonGroup::new("toggle-size")
+                    .outline()
+                    .compact()
                     .child(
                         Button::new("xsmall")
                             .label("XSmall")

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -12,6 +12,7 @@ use gpui::{
 pub enum TabVariant {
     #[default]
     Tab,
+    Outline,
     Pill,
     Segmented,
     Underline,
@@ -66,23 +67,23 @@ impl TabVariant {
     fn inner_height(&self, size: Size) -> Pixels {
         match size {
             Size::XSmall => match self {
-                TabVariant::Tab | TabVariant::Pill => px(20.),
+                TabVariant::Tab | TabVariant::Outline | TabVariant::Pill => px(20.),
                 TabVariant::Segmented => px(16.),
                 TabVariant::Underline => px(20.),
             },
             Size::Small => match self {
-                TabVariant::Tab | TabVariant::Pill => px(24.),
+                TabVariant::Tab | TabVariant::Outline | TabVariant::Pill => px(24.),
                 TabVariant::Segmented => px(20.),
                 TabVariant::Underline => px(22.),
             },
             Size::Large => match self {
-                TabVariant::Tab | TabVariant::Pill => px(36.),
+                TabVariant::Tab | TabVariant::Outline | TabVariant::Pill => px(36.),
                 TabVariant::Segmented => px(28.),
                 TabVariant::Underline => px(30.),
             },
             _ => match self {
                 TabVariant::Tab => px(30.),
-                TabVariant::Pill => px(26.),
+                TabVariant::Outline | TabVariant::Pill => px(26.),
                 TabVariant::Segmented => px(24.),
                 TabVariant::Underline => px(24.),
             },
@@ -143,11 +144,17 @@ impl TabVariant {
                 border_color: cx.theme().transparent,
                 ..Default::default()
             },
-            TabVariant::Pill => TabStyle {
+            TabVariant::Outline => TabStyle {
                 fg: cx.theme().tab_foreground,
                 bg: cx.theme().transparent,
                 borders: Edges::all(px(1.)),
                 border_color: cx.theme().border,
+                radius: px(99.),
+                ..Default::default()
+            },
+            TabVariant::Pill => TabStyle {
+                fg: cx.theme().foreground,
+                bg: cx.theme().transparent,
                 radius: px(99.),
                 ..Default::default()
             },
@@ -187,11 +194,17 @@ impl TabVariant {
                 border_color: cx.theme().transparent,
                 ..Default::default()
             },
-            TabVariant::Pill => TabStyle {
+            TabVariant::Outline => TabStyle {
                 fg: cx.theme().secondary_foreground,
                 bg: cx.theme().secondary_hover,
                 borders: Edges::all(px(1.)),
                 border_color: cx.theme().border,
+                radius: px(99.),
+                ..Default::default()
+            },
+            TabVariant::Pill => TabStyle {
+                fg: cx.theme().secondary_foreground,
+                bg: cx.theme().secondary_hover,
                 radius: px(99.),
                 ..Default::default()
             },
@@ -236,11 +249,17 @@ impl TabVariant {
                 border_color: cx.theme().border,
                 ..Default::default()
             },
-            TabVariant::Pill => TabStyle {
+            TabVariant::Outline => TabStyle {
                 fg: cx.theme().primary,
                 bg: cx.theme().transparent,
                 borders: Edges::all(px(1.)),
                 border_color: cx.theme().primary,
+                radius: px(99.),
+                ..Default::default()
+            },
+            TabVariant::Pill => TabStyle {
+                fg: cx.theme().primary_foreground,
+                bg: cx.theme().primary,
                 radius: px(99.),
                 ..Default::default()
             },
@@ -283,7 +302,7 @@ impl TabVariant {
                 },
                 ..Default::default()
             },
-            TabVariant::Pill => TabStyle {
+            TabVariant::Outline => TabStyle {
                 fg: cx.theme().muted_foreground,
                 bg: cx.theme().transparent,
                 borders: Edges::all(px(1.)),
@@ -291,6 +310,20 @@ impl TabVariant {
                     cx.theme().primary
                 } else {
                     cx.theme().border
+                },
+                radius: px(99.),
+                ..Default::default()
+            },
+            TabVariant::Pill => TabStyle {
+                fg: if selected {
+                    cx.theme().primary_foreground.opacity(0.5)
+                } else {
+                    cx.theme().muted_foreground
+                },
+                bg: if selected {
+                    cx.theme().primary.opacity(0.5)
+                } else {
+                    cx.theme().transparent
                 },
                 radius: px(99.),
                 ..Default::default()
@@ -422,6 +455,12 @@ impl Tab {
     /// Use Pill variant.
     pub fn pill(mut self) -> Self {
         self.variant = TabVariant::Pill;
+        self
+    }
+
+    /// Use outline variant.
+    pub fn outline(mut self) -> Self {
+        self.variant = TabVariant::Outline;
         self
     }
 

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -54,6 +54,12 @@ impl TabBar {
         self
     }
 
+    /// Set the Tab variant to Outline, all children will inherit the variant.
+    pub fn outline(mut self) -> Self {
+        self.variant = TabVariant::Outline;
+        self
+    }
+
     /// Set the Tab variant to Segmented, all children will inherit the variant.
     pub fn segmented(mut self) -> Self {
         self.variant = TabVariant::Segmented;
@@ -143,9 +149,13 @@ impl RenderOnce for TabBar {
                 let padding = Edges::all(px(0.));
                 (cx.theme().tab_bar, padding, px(0.))
             }
-            TabVariant::Pill => {
+            TabVariant::Outline => {
                 let padding = Edges::all(px(0.));
                 (cx.theme().transparent, padding, default_gap)
+            }
+            TabVariant::Pill => {
+                let padding = Edges::all(px(0.));
+                (cx.theme().transparent, padding, px(4.))
             }
             TabVariant::Segmented => {
                 let padding_x = match self.size {


### PR DESCRIPTION
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/4800a737-4e57-405b-b083-bf57ae3038ad" />

## Break Changes

- As you see on the above screenshot, the old `pill` style has been renamed to `outline`.