### PR TITLE
switch: Fix switch label to vertical center.

### DIFF
--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -203,9 +203,11 @@ impl Element for Switch {
                                 ),
                         )
                         .when_some(self.label.take(), |this, label| {
-                            this.child(div().child(label).map(|this| match self.size {
-                                Size::XSmall | Size::Small => this.text_sm(),
-                                _ => this.text_base(),
+                            this.child(div().line_height(bg_height).child(label).map(|this| {
+                                match self.size {
+                                    Size::XSmall | Size::Small => this.text_sm(),
+                                    _ => this.text_base(),
+                                }
                             }))
                         })
                         .when_some(


### PR DESCRIPTION
<img width="775" alt="image" src="https://github.com/user-attachments/assets/c004e552-c161-4e09-9543-13727382204b" />
