### PR TITLE
description_list: Fix incorrect align items for horizontal layout

### DIFF
--- a/crates/story/examples/description_list.rs
+++ b/crates/story/examples/description_list.rs
@@ -52,7 +52,7 @@ impl Example {
                 1,
             ),
             (
-                "Platform",
+                "This is a long label for Platform",
                 "macOS, Windows, Linux",
                 1,
             ),

--- a/crates/ui/src/description_list.rs
+++ b/crates/ui/src/description_list.rs
@@ -289,7 +289,7 @@ impl RenderOnce for DescriptionList {
                                     let el = if self.layout.is_vertical() {
                                         v_flex()
                                     } else {
-                                        h_flex().h_full()
+                                        div().flex().flex_row().h_full()
                                     };
 
                                     el.flex_1()


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="539" alt="image" src="https://github.com/user-attachments/assets/ecd997b5-1f59-4c41-83a3-dfdee6b1be8a" /> | <img width="556" alt="image" src="https://github.com/user-attachments/assets/1088d466-1635-45c3-b578-9ada1c960d66" /> |