### PR TITLE
tabs: Add menu to TabBar to display more items.

### DIFF
--- a/crates/story/src/tabs_story.rs
+++ b/crates/story/src/tabs_story.rs
@@ -4,6 +4,7 @@ use gpui::{
 
 use gpui_component::{
     button::{Button, ButtonGroup, ButtonVariants},
+    checkbox::Checkbox,
     h_flex,
     tab::{Tab, TabBar},
     v_flex, IconName, Selectable as _, Sizable, Size,
@@ -15,6 +16,7 @@ pub struct TabsStory {
     focus_handle: gpui::FocusHandle,
     active_tab_ix: usize,
     size: Size,
+    menu: bool,
 }
 
 impl super::Story for TabsStory {
@@ -41,6 +43,7 @@ impl TabsStory {
             focus_handle: cx.focus_handle(),
             active_tab_ix: 0,
             size: Size::default(),
+            menu: false,
         }
     }
 
@@ -66,45 +69,59 @@ impl Render for TabsStory {
         v_flex()
             .gap_6()
             .child(
-                ButtonGroup::new("toggle-size")
-                    .outline()
-                    .compact()
+                h_flex()
+                    .gap_3()
                     .child(
-                        Button::new("xsmall")
-                            .label("XSmall")
-                            .selected(self.size == Size::XSmall),
+                        ButtonGroup::new("toggle-size")
+                            .outline()
+                            .compact()
+                            .child(
+                                Button::new("xsmall")
+                                    .label("XSmall")
+                                    .selected(self.size == Size::XSmall),
+                            )
+                            .child(
+                                Button::new("small")
+                                    .label("Small")
+                                    .selected(self.size == Size::Small),
+                            )
+                            .child(
+                                Button::new("medium")
+                                    .label("Medium")
+                                    .selected(self.size == Size::Medium),
+                            )
+                            .child(
+                                Button::new("large")
+                                    .label("Large")
+                                    .selected(self.size == Size::Large),
+                            )
+                            .on_click(cx.listener(|this, selecteds: &Vec<usize>, window, cx| {
+                                let size = match selecteds[0] {
+                                    0 => Size::XSmall,
+                                    1 => Size::Small,
+                                    2 => Size::Medium,
+                                    3 => Size::Large,
+                                    _ => unreachable!(),
+                                };
+                                this.set_size(size, window, cx);
+                            })),
                     )
                     .child(
-                        Button::new("small")
-                            .label("Small")
-                            .selected(self.size == Size::Small),
-                    )
-                    .child(
-                        Button::new("medium")
-                            .label("Medium")
-                            .selected(self.size == Size::Medium),
-                    )
-                    .child(
-                        Button::new("large")
-                            .label("Large")
-                            .selected(self.size == Size::Large),
-                    )
-                    .on_click(cx.listener(|this, selecteds: &Vec<usize>, window, cx| {
-                        let size = match selecteds[0] {
-                            0 => Size::XSmall,
-                            1 => Size::Small,
-                            2 => Size::Medium,
-                            3 => Size::Large,
-                            _ => unreachable!(),
-                        };
-                        this.set_size(size, window, cx);
-                    })),
+                        Checkbox::new("show-menu")
+                            .label("More menu")
+                            .checked(self.menu)
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.menu = !this.menu;
+                                cx.notify();
+                            })),
+                    ),
             )
             .child(
                 section("Tabs", cx).child(
                     TabBar::new("tabs")
                         .w_full()
                         .with_size(self.size)
+                        .with_menu(self.menu)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -152,6 +169,7 @@ impl Render for TabsStory {
                         .w_full()
                         .underline()
                         .with_size(self.size)
+                        .with_menu(self.menu)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -172,6 +190,7 @@ impl Render for TabsStory {
                         .w_full()
                         .pill()
                         .with_size(self.size)
+                        .with_menu(self.menu)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -192,6 +211,7 @@ impl Render for TabsStory {
                         .w_full()
                         .outline()
                         .with_size(self.size)
+                        .with_menu(self.menu)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -212,6 +232,7 @@ impl Render for TabsStory {
                         .w_full()
                         .segmented()
                         .with_size(self.size)
+                        .with_menu(self.menu)
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -143,6 +143,10 @@ impl RenderOnce for ListItem {
                     this.hover(|this| this.bg(cx.theme().list_hover))
                 })
             })
+            .when(self.disabled, |this| {
+                this.cursor_not_allowed()
+                    .text_color(cx.theme().muted_foreground)
+            })
             .child(
                 h_flex()
                     .w_full()

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -583,7 +583,7 @@ impl RenderOnce for Tab {
             .flex_wrap()
             .items_center()
             .flex_shrink_0()
-            .cursor_pointer()
+            .when(!self.disabled, |this| this.cursor_pointer())
             .overflow_hidden()
             .h(height)
             .overflow_hidden()

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -379,15 +379,15 @@ impl TabVariant {
 pub struct Tab {
     id: ElementId,
     base: Div,
-    label: SharedString,
+    pub(super) label: SharedString,
     icon: Option<Icon>,
     prefix: Option<AnyElement>,
     suffix: Option<AnyElement>,
     children: Vec<AnyElement>,
     variant: TabVariant,
     size: Size,
-    disabled: bool,
-    selected: bool,
+    pub(super) disabled: bool,
+    pub(super) selected: bool,
     on_click: Option<Arc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
 }
 

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -1,15 +1,23 @@
 use std::sync::Arc;
 
-use crate::{h_flex, ActiveTheme, Selectable, Sizable, Size, StyledExt};
+use crate::button::{Button, ButtonVariants as _};
+use crate::popup_menu::PopupMenuExt as _;
+use crate::{h_flex, ActiveTheme, IconName, Selectable, Sizable, Size, StyledExt};
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    div, AnyElement, App, Div, Edges, ElementId, IntoElement, ParentElement, RenderOnce,
-    ScrollHandle, Stateful, StatefulInteractiveElement as _, Styled, Window,
+    div, impl_internal_actions, AnyElement, App, Corner, Div, Edges, ElementId, IntoElement,
+    ParentElement, RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement as _, Styled,
+    Window,
 };
 use gpui::{px, InteractiveElement};
 use smallvec::SmallVec;
 
 use super::{Tab, TabVariant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectTab(usize);
+
+impl_internal_actions!(tab_bar, [SelectTab]);
 
 #[derive(IntoElement)]
 pub struct TabBar {
@@ -22,6 +30,7 @@ pub struct TabBar {
     selected_index: Option<usize>,
     variant: TabVariant,
     size: Size,
+    menu: bool,
     on_click: Option<Arc<dyn Fn(&usize, &mut Window, &mut App) + 'static>>,
 }
 
@@ -39,6 +48,7 @@ impl TabBar {
             last_empty_space: div().w_3().into_any_element(),
             selected_index: None,
             on_click: None,
+            menu: false,
         }
     }
 
@@ -69,6 +79,12 @@ impl TabBar {
     /// Set the Tab variant to Underline, all children will inherit the variant.
     pub fn underline(mut self) -> Self {
         self.variant = TabVariant::Underline;
+        self
+    }
+
+    /// Enable or disable the popup menu for the TabBar
+    pub fn with_menu(mut self, menu: bool) -> Self {
+        self.menu = menu;
         self
     }
 
@@ -190,8 +206,19 @@ impl RenderOnce for TabBar {
             }
         };
 
+        let mut item_labels = Vec::new();
+        let selected_index = self.selected_index;
+
         self.base
             .group("tab-bar")
+            .on_action({
+                let on_click = self.on_click.clone();
+                move |action: &SelectTab, window: &mut Window, cx: &mut App| {
+                    if let Some(on_click) = on_click.clone() {
+                        on_click(&action.0, window, cx);
+                    }
+                }
+            })
             .relative()
             .flex()
             .items_center()
@@ -216,6 +243,7 @@ impl RenderOnce for TabBar {
                 self.variant == TabVariant::Pill || self.variant == TabVariant::Segmented,
                 |this| this.rounded(cx.theme().radius),
             )
+            .paddings(paddings)
             .when_some(self.prefix, |this, prefix| this.child(prefix))
             .child(
                 h_flex()
@@ -226,30 +254,45 @@ impl RenderOnce for TabBar {
                         this.track_scroll(&scroll_handle)
                     })
                     .gap(gap)
-                    .paddings(paddings)
-                    .children(
-                        self.children
-                            .into_iter()
-                            .enumerate()
-                            .map(move |(ix, child)| {
-                                child
-                                    .id(ix)
-                                    .variant(self.variant)
-                                    .with_size(self.size)
-                                    .when_some(self.selected_index, |this, selected_ix| {
-                                        this.selected(selected_ix == ix)
-                                    })
-                                    .when_some(self.on_click.clone(), move |this, on_click| {
-                                        this.on_click(move |_, window, cx| {
-                                            on_click(&ix, window, cx)
-                                        })
-                                    })
-                            }),
-                    )
-                    .when(self.suffix.is_some(), |this| {
+                    .children(self.children.into_iter().enumerate().map(|(ix, child)| {
+                        item_labels.push((child.label.clone(), child.disabled));
+                        child
+                            .id(ix)
+                            .variant(self.variant)
+                            .with_size(self.size)
+                            .when_some(self.selected_index, |this, selected_ix| {
+                                this.selected(selected_ix == ix)
+                            })
+                            .when_some(self.on_click.clone(), move |this, on_click| {
+                                this.on_click(move |_, window, cx| on_click(&ix, window, cx))
+                            })
+                    }))
+                    .when(self.suffix.is_some() || self.menu, |this| {
                         this.child(self.last_empty_space)
                     }),
             )
+            .when(self.menu, |this| {
+                this.child(
+                    Button::new("more")
+                        .xsmall()
+                        .ghost()
+                        .icon(IconName::ChevronDown)
+                        .popup_menu(move |mut this, _, _| {
+                            this = this.scrollable();
+                            for (ix, (label, disabled)) in item_labels.iter().enumerate() {
+                                this = this.menu_with_check_and_disabled(
+                                    label.clone(),
+                                    selected_index == Some(ix),
+                                    Box::new(SelectTab(ix)),
+                                    *disabled,
+                                );
+                            }
+
+                            this
+                        })
+                        .anchor(Corner::TopRight),
+                )
+            })
             .when_some(self.suffix, |this, suffix| this.child(suffix))
     }
 }

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -6,8 +6,8 @@ use crate::{h_flex, ActiveTheme, IconName, Selectable, Sizable, Size, StyledExt}
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     div, impl_internal_actions, AnyElement, App, Corner, Div, Edges, ElementId, IntoElement,
-    ParentElement, RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement as _, Styled,
-    Window,
+    ParentElement, RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement as _,
+    StyleRefinement, Styled, Window,
 };
 use gpui::{px, InteractiveElement};
 use smallvec::SmallVec;
@@ -141,7 +141,7 @@ impl TabBar {
 }
 
 impl Styled for TabBar {
-    fn style(&mut self) -> &mut gpui::StyleRefinement {
+    fn style(&mut self) -> &mut StyleRefinement {
         self.base.style()
     }
 }


### PR DESCRIPTION
<img width="752" alt="image" src="https://github.com/user-attachments/assets/a7efb600-553a-4b78-a8f4-aaba504d44f0" />

- tabs: Use default cursor when Tab is disabled.
- popup_menu: Add to support add menu item with disabled state.