### PR TITLE
sidebar: Fix menu item click handler

### DIFF
--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -1,6 +1,7 @@
 use gpui::{
     div, impl_internal_actions, prelude::FluentBuilder, relative, App, AppContext, ClickEvent,
-    Context, Entity, Focusable, IntoElement, ParentElement, Render, SharedString, Styled, Window,
+    Context, ElementId, Entity, Focusable, IntoElement, ParentElement, Render, SharedString,
+    Styled, Window,
 };
 
 use gpui_component::{
@@ -310,23 +311,35 @@ impl Render for SidebarStory {
                     .child(
                         SidebarGroup::new("Platform").child(SidebarMenu::new().children({
                             let mut items = Vec::with_capacity(groups[0].len());
-                            for item in groups[0].iter() {
+                            for (ix, item) in groups[0].iter().enumerate() {
                                 let item = *item;
+                                let id =
+                                    ElementId::Name(SharedString::new(format!("item-{}", ix,)));
+
                                 items.push(
-                                    SidebarMenuItem::new(item.label(), item.label())
+                                    SidebarMenuItem::new(item.label())
+                                        .id(id)
                                         .icon(item.icon().into())
                                         .active(self.active_item == item)
                                         .children({
                                             let mut sub_items =
                                                 Vec::with_capacity(item.items().len());
-                                            for sub_item in item.items() {
+                                            for (ix, sub_item) in
+                                                item.items().into_iter().enumerate()
+                                            {
+                                                let id = ElementId::Name(SharedString::new(
+                                                    format!("sub-item-{}", ix),
+                                                ));
+
                                                 sub_items.push(
-                                                    SidebarMenuItem::new(
-                                                        sub_item.label(),
-                                                        sub_item.label(),
-                                                    )
-                                                    .active(self.active_subitem == Some(sub_item))
-                                                    .on_click(cx.listener(sub_item.handler(&item))),
+                                                    SidebarMenuItem::new(sub_item.label())
+                                                        .id(id)
+                                                        .active(
+                                                            self.active_subitem == Some(sub_item),
+                                                        )
+                                                        .on_click(
+                                                            cx.listener(sub_item.handler(&item)),
+                                                        ),
                                                 );
                                             }
                                             sub_items
@@ -340,9 +353,13 @@ impl Render for SidebarStory {
                     .child(
                         SidebarGroup::new("Projects").child(SidebarMenu::new().children({
                             let mut items = Vec::with_capacity(groups[1].len());
-                            for item in groups[1].iter() {
+                            for (ix, item) in groups[1].iter().enumerate() {
+                                let id =
+                                    ElementId::Name(SharedString::new(format!("project-{}", ix)));
+
                                 items.push(
-                                    SidebarMenuItem::new(item.label(), item.label())
+                                    SidebarMenuItem::new(item.label())
+                                        .id(id)
                                         .icon(item.icon().into())
                                         .active(self.active_item == *item)
                                         .on_click(cx.listener(item.handler())),

--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -319,7 +319,7 @@ impl Render for SidebarStory {
                                         .children({
                                             let mut sub_items =
                                                 Vec::with_capacity(item.items().len());
-                                            for sub_item in item.items().into_iter() {
+                                            for sub_item in item.items() {
                                                 sub_items.push(
                                                     SidebarMenuItem::new(sub_item.label())
                                                         .active(

--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -313,7 +313,7 @@ impl Render for SidebarStory {
                             for item in groups[0].iter() {
                                 let item = *item;
                                 items.push(
-                                    SidebarMenuItem::new(item.label())
+                                    SidebarMenuItem::new(item.label(), item.label())
                                         .icon(item.icon().into())
                                         .active(self.active_item == item)
                                         .children({
@@ -321,13 +321,12 @@ impl Render for SidebarStory {
                                                 Vec::with_capacity(item.items().len());
                                             for sub_item in item.items() {
                                                 sub_items.push(
-                                                    SidebarMenuItem::new(sub_item.label())
-                                                        .active(
-                                                            self.active_subitem == Some(sub_item),
-                                                        )
-                                                        .on_click(
-                                                            cx.listener(sub_item.handler(&item)),
-                                                        ),
+                                                    SidebarMenuItem::new(
+                                                        sub_item.label(),
+                                                        sub_item.label(),
+                                                    )
+                                                    .active(self.active_subitem == Some(sub_item))
+                                                    .on_click(cx.listener(sub_item.handler(&item))),
                                                 );
                                             }
                                             sub_items
@@ -343,7 +342,7 @@ impl Render for SidebarStory {
                             let mut items = Vec::with_capacity(groups[1].len());
                             for item in groups[1].iter() {
                                 items.push(
-                                    SidebarMenuItem::new(item.label())
+                                    SidebarMenuItem::new(item.label(), item.label())
                                         .icon(item.icon().into())
                                         .active(self.active_item == *item)
                                         .on_click(cx.listener(item.handler())),

--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -1,7 +1,6 @@
 use gpui::{
     div, impl_internal_actions, prelude::FluentBuilder, relative, App, AppContext, ClickEvent,
-    Context, ElementId, Entity, Focusable, IntoElement, ParentElement, Render, SharedString,
-    Styled, Window,
+    Context, Entity, Focusable, IntoElement, ParentElement, Render, SharedString, Styled, Window,
 };
 
 use gpui_component::{
@@ -311,29 +310,18 @@ impl Render for SidebarStory {
                     .child(
                         SidebarGroup::new("Platform").child(SidebarMenu::new().children({
                             let mut items = Vec::with_capacity(groups[0].len());
-                            for (ix, item) in groups[0].iter().enumerate() {
+                            for item in groups[0].iter() {
                                 let item = *item;
-                                let id =
-                                    ElementId::Name(SharedString::new(format!("item-{}", ix,)));
-
                                 items.push(
                                     SidebarMenuItem::new(item.label())
-                                        .id(id)
                                         .icon(item.icon().into())
                                         .active(self.active_item == item)
                                         .children({
                                             let mut sub_items =
                                                 Vec::with_capacity(item.items().len());
-                                            for (ix, sub_item) in
-                                                item.items().into_iter().enumerate()
-                                            {
-                                                let id = ElementId::Name(SharedString::new(
-                                                    format!("sub-item-{}", ix),
-                                                ));
-
+                                            for sub_item in item.items().into_iter() {
                                                 sub_items.push(
                                                     SidebarMenuItem::new(sub_item.label())
-                                                        .id(id)
                                                         .active(
                                                             self.active_subitem == Some(sub_item),
                                                         )
@@ -353,13 +341,9 @@ impl Render for SidebarStory {
                     .child(
                         SidebarGroup::new("Projects").child(SidebarMenu::new().children({
                             let mut items = Vec::with_capacity(groups[1].len());
-                            for (ix, item) in groups[1].iter().enumerate() {
-                                let id =
-                                    ElementId::Name(SharedString::new(format!("project-{}", ix)));
-
+                            for item in groups[1].iter() {
                                 items.push(
                                     SidebarMenuItem::new(item.label())
-                                        .id(id)
                                         .icon(item.icon().into())
                                         .active(self.active_item == *item)
                                         .on_click(cx.listener(item.handler())),

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,8 +1,8 @@
 use crate::{h_flex, v_flex, ActiveTheme as _, Collapsible, Icon, IconName, StyledExt};
 use gpui::{
-    div, percentage, prelude::FluentBuilder as _, App, ClickEvent, InteractiveElement as _,
-    IntoElement, ParentElement as _, RenderOnce, SharedString, StatefulInteractiveElement as _,
-    Styled as _, Window,
+    div, percentage, prelude::FluentBuilder as _, App, ClickEvent, ElementId,
+    InteractiveElement as _, IntoElement, ParentElement as _, RenderOnce, SharedString,
+    StatefulInteractiveElement as _, Styled as _, Window,
 };
 use std::rc::Rc;
 
@@ -56,6 +56,7 @@ impl RenderOnce for SidebarMenu {
 /// A sidebar menu item
 #[derive(IntoElement)]
 pub struct SidebarMenuItem {
+    id: ElementId,
     icon: Option<Icon>,
     label: SharedString,
     handler: Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>,
@@ -66,8 +67,9 @@ pub struct SidebarMenuItem {
 
 impl SidebarMenuItem {
     /// Create a new SidebarMenuItem with a label
-    pub fn new(label: impl Into<SharedString>) -> Self {
+    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
         Self {
+            id: id.into(),
             icon: None,
             label: label.into(),
             handler: Rc::new(|_, _, _| {}),
@@ -129,7 +131,7 @@ impl SidebarMenuItem {
         let is_submenu = self.is_submenu();
 
         h_flex()
-            .id("sidebar-menu-item")
+            .id(self.id.clone())
             .overflow_hidden()
             .flex_shrink_0()
             .p_2()

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -67,9 +67,9 @@ pub struct SidebarMenuItem {
 
 impl SidebarMenuItem {
     /// Create a new SidebarMenuItem with a label
-    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+    pub fn new(label: impl Into<SharedString>) -> Self {
         Self {
-            id: id.into(),
+            id: ElementId::Integer(0),
             icon: None,
             label: label.into(),
             handler: Rc::new(|_, _, _| {}),
@@ -82,6 +82,12 @@ impl SidebarMenuItem {
     /// Set the icon for the menu item
     pub fn icon(mut self, icon: Icon) -> Self {
         self.icon = Some(icon);
+        self
+    }
+
+    /// Set id to the menu item.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.id = id.into();
         self
     }
 

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -48,7 +48,8 @@ impl RenderOnce for SidebarMenu {
         v_flex().gap_2().children(
             self.items
                 .into_iter()
-                .map(|item| item.collapsed(self.collapsed)),
+                .enumerate()
+                .map(|(ix, item)| item.id(ix).collapsed(self.collapsed)),
         )
     }
 }
@@ -86,7 +87,7 @@ impl SidebarMenuItem {
     }
 
     /// Set id to the menu item.
-    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+    fn id(mut self, id: impl Into<ElementId>) -> Self {
         self.id = id.into();
         self
     }
@@ -186,13 +187,19 @@ impl RenderOnce for SidebarMenuItem {
             .when(is_submenu && is_open && !is_collapsed, |this| {
                 this.child(
                     v_flex()
+                        .id("submenu")
                         .border_l_1()
                         .border_color(cx.theme().sidebar_border)
                         .gap_1()
                         .mx_3p5()
                         .px_2p5()
                         .py_0p5()
-                        .children(self.children),
+                        .children(
+                            self.children
+                                .into_iter()
+                                .enumerate()
+                                .map(|(ix, item)| item.id(ix)),
+                        ),
                 )
             })
     }

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -206,7 +206,8 @@ impl<E: Collapsible + IntoElement> RenderOnce for Sidebar<E> {
                         .children(
                             self.content
                                 .into_iter()
-                                .map(|c| c.collapsed(self.collapsed)),
+                                .enumerate()
+                                .map(|(ix, c)| div().id(ix).child(c.collapsed(self.collapsed))),
                         )
                         .gap_2()
                         .scrollable(self.view_id, ScrollbarAxis::Vertical),


### PR DESCRIPTION
The sidebar stopped working properly. Only one item was handling the click, by giving the ID to the `SidebarMenuItem` the issue seems to be resolved. I guess something changed within `gpui` itself that it broke.

**Before**


https://github.com/user-attachments/assets/e4fd21a9-e16d-4be6-b687-64a8a040eee7

**After**


https://github.com/user-attachments/assets/aed91762-c8ae-49f3-aaa8-77df2155f0c6

