### PR TITLE
dock: Fix to sync active state to panels when collapse dock.

### DIFF
--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -410,7 +410,7 @@ impl DockItem {
                 }
             }
             DockItem::Tiles { .. } => {}
-            DockItem::Panel { .. } => {}
+            DockItem::Panel { view } => view.set_active(!collapsed, window, cx),
         }
     }
 

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -35,7 +35,11 @@ impl Panel for StackPanel {
     fn title(&self, _window: &gpui::Window, _cx: &gpui::App) -> gpui::AnyElement {
         "StackPanel".into_any_element()
     }
-
+    fn set_active(&mut self, active: bool, window: &mut Window, cx: &mut App) {
+        for panel in &self.panels {
+            panel.set_active(active, window, cx);
+        }
+    }
     fn dump(&self, cx: &App) -> PanelState {
         let sizes = self.panel_group.read(cx).sizes();
         let mut state = PanelState::new(self);

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -347,10 +347,13 @@ impl TabPanel {
     pub(super) fn set_collapsed(
         &mut self,
         collapsed: bool,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.collapsed = collapsed;
+        if let Some(panel) = self.panels.get(self.active_ix) {
+            panel.set_active(!collapsed, window, cx);
+        }
         cx.notify();
     }
 


### PR DESCRIPTION
This is a continuation of #764
Without this, if we drag webview to sidebar and collapse, webview is not aware of itself being hidden
<img width="994" alt="image" src="https://github.com/user-attachments/assets/6d8d66d1-2a9b-472a-a42f-d04b47aefaac" />
