### PR TITLE
modal: Fix close Modal by clicking overlay to support closing layer by layer.

### DIFF
--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -420,6 +420,11 @@ impl ModalStory {
                                             .title("Other Modal")
                                             .child("This is another modal.")
                                             .min_h(px(300.))
+                                            .overlay(overlay)
+                                            .keyboard(keyboard)
+                                            .show_close(modal_show_close)
+                                            .overlay_closable(overlay_closable)
+                                            .when(!modal_padding, |this| this.p(px(0.)))
                                     });
                                 },
                             ),

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -362,7 +362,8 @@ impl RenderOnce for Modal {
                         this.occlude().bg(overlay_color(self.overlay, window, cx))
                     })
                     .when(self.overlay_closable, |this| {
-                        if !self.overlay_visible {
+                        // Only the last modal owns the `mouse down - close modal` event.
+                        if (self.layer_ix + 1) != window.active_modal_counts(cx) {
                             return this;
                         }
 

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -362,6 +362,10 @@ impl RenderOnce for Modal {
                         this.occlude().bg(overlay_color(self.overlay, window, cx))
                     })
                     .when(self.overlay_closable, |this| {
+                        if !self.overlay_visible {
+                            return this;
+                        }
+
                         this.on_mouse_down(MouseButton::Left, {
                             let on_cancel = on_cancel.clone();
                             let on_close = on_close.clone();

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -12,7 +12,7 @@ use crate::{
     actions::{Cancel, Confirm},
     animation::cubic_bezier,
     button::{Button, ButtonVariant, ButtonVariants as _},
-    h_flex, v_flex, ActiveTheme as _, ContextModal, IconName, Sizable as _, StyledExt,
+    h_flex, v_flex, ActiveTheme as _, ContextModal, IconName, Root, Sizable as _, StyledExt,
 };
 
 const CONTEXT: &str = "Modal";
@@ -363,7 +363,7 @@ impl RenderOnce for Modal {
                     })
                     .when(self.overlay_closable, |this| {
                         // Only the last modal owns the `mouse down - close modal` event.
-                        if (self.layer_ix + 1) != window.active_modal_counts(cx) {
+                        if (self.layer_ix + 1) != Root::read(window, cx).active_modals.len() {
                             return this;
                         }
 

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -35,9 +35,6 @@ pub trait ContextModal: Sized {
     where
         F: Fn(Modal, &mut Window, &mut App) -> Modal + 'static;
 
-    /// Return active modal counts.
-    fn active_modal_counts(&mut self, cx: &mut App) -> usize;
-
     /// Return true, if there is an active Modal.
     fn has_active_modal(&mut self, cx: &mut App) -> bool;
 
@@ -122,12 +119,8 @@ impl ContextModal for Window {
         })
     }
 
-    fn active_modal_counts(&mut self, cx: &mut App) -> usize {
-        Root::read(self, cx).active_modals.len()
-    }
-
     fn has_active_modal(&mut self, cx: &mut App) -> bool {
-        self.active_modal_counts(cx) > 0
+        Root::read(self, cx).active_modals.len() > 0
     }
 
     fn close_modal(&mut self, cx: &mut App) {
@@ -249,7 +242,7 @@ pub struct Root {
     /// When the Modal, Drawer closes, we will focus back to the previous view.
     previous_focus_handle: Option<FocusHandle>,
     active_drawer: Option<ActiveDrawer>,
-    active_modals: Vec<ActiveModal>,
+    pub(crate) active_modals: Vec<ActiveModal>,
     pub(super) focused_input: Option<Entity<TextInput>>,
     pub notification: Entity<NotificationList>,
     drawer_size: Option<DefiniteLength>,
@@ -264,7 +257,7 @@ struct ActiveDrawer {
 }
 
 #[derive(Clone)]
-struct ActiveModal {
+pub(crate) struct ActiveModal {
     focus_handle: FocusHandle,
     builder: Rc<dyn Fn(Modal, &mut Window, &mut App) -> Modal + 'static>,
 }

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -34,6 +34,10 @@ pub trait ContextModal: Sized {
     fn open_modal<F>(&mut self, cx: &mut App, build: F)
     where
         F: Fn(Modal, &mut Window, &mut App) -> Modal + 'static;
+
+    /// Return active modal counts.
+    fn active_modal_counts(&mut self, cx: &mut App) -> usize;
+
     /// Return true, if there is an active Modal.
     fn has_active_modal(&mut self, cx: &mut App) -> bool;
 
@@ -118,8 +122,12 @@ impl ContextModal for Window {
         })
     }
 
+    fn active_modal_counts(&mut self, cx: &mut App) -> usize {
+        Root::read(self, cx).active_modals.len()
+    }
+
     fn has_active_modal(&mut self, cx: &mut App) -> bool {
-        Root::read(self, cx).active_modals.len() > 0
+        self.active_modal_counts(cx) > 0
     }
 
     fn close_modal(&mut self, cx: &mut App) {


### PR DESCRIPTION
Fix the issue that wrongly trigger `overlay` click event for the layer-stacked `modals`.

Fix #772 

I.E. When clicking the `overlay`, only the last modal will possibly be hide(If the last modal is not `overlayClosable`, click the overlay, all the modals will not be hide).

![gif](https://github.com/user-attachments/assets/96ac97fc-6b6d-463d-bce9-393e6236c5df)

I had tried another solution:
![image](https://github.com/user-attachments/assets/d9882d70-c82c-4397-a5ff-65cd49dc08ab)
![image](https://github.com/user-attachments/assets/3855fb6b-4aac-4c7c-9581-3b0843ef78dc)

If this one is better than prev, I will commit it~
