### PR TITLE
description_list: Wrap description value if it’s too long

### DIFF
--- a/crates/ui/src/description_list.rs
+++ b/crates/ui/src/description_list.rs
@@ -293,6 +293,7 @@ impl RenderOnce for DescriptionList {
                                     };
 
                                     el.flex_1()
+                                        .overflow_x_hidden()
                                         .child(
                                             div()
                                                 .when(self.layout.is_horizontal(), |this| {


### PR DESCRIPTION
| Before | After |
| - | - |
|  <img width="752" alt="SCR-20250408-nfvl" src="https://github.com/user-attachments/assets/5ed558af-869a-4634-bbb5-80fc1481a15c" /> | <img width="752" alt="SCR-20250408-ngcy" src="https://github.com/user-attachments/assets/a5871af5-978b-421d-b608-12fa940a884c" /> |