### PR TITLE
list: Export `query_input` for support update the default Query Input.

### DIFF
--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -257,6 +257,11 @@ impl ModalStory {
         let list = cx.new(|cx| {
             let mut list = List::new(delegate, window, cx);
             list.focus(window, cx);
+            if let Some(query_input) = list.query_input() {
+                query_input.update(cx, |input, cx| {
+                    input.set_placeholder("Pickup your country...", window, cx);
+                })
+            }
             list
         });
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -646,8 +646,14 @@ impl TextInput {
     }
 
     /// Set the placeholder text of the input field with reference.
-    pub fn set_placeholder(&mut self, placeholder: impl Into<SharedString>) {
+    pub fn set_placeholder(
+        &mut self,
+        placeholder: impl Into<SharedString>,
+        _: &Window,
+        cx: &mut Context<Self>,
+    ) {
         self.placeholder = placeholder.into();
+        cx.notify();
     }
 
     /// Set true to show the clear button when the input field is not empty.

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -677,7 +677,12 @@ impl TextInput {
     }
 
     /// Set the regular expression pattern of the input field with reference.
-    pub fn set_pattern(&mut self, pattern: regex::Regex) {
+    pub fn set_pattern(
+        &mut self,
+        pattern: regex::Regex,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
         self.pattern = Some(pattern);
     }
 

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -57,11 +57,12 @@ impl NumberInput {
     pub fn placeholder(
         self,
         placeholder: impl Into<SharedString>,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        self.input
-            .update(cx, |input, _| input.set_placeholder(placeholder));
+        self.input.update(cx, |input, cx| {
+            input.set_placeholder(placeholder, window, cx)
+        });
         self
     }
 
@@ -73,11 +74,11 @@ impl NumberInput {
     pub fn set_placeholder(
         &self,
         text: impl Into<SharedString>,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.input.update(cx, |input, _| {
-            input.set_placeholder(text);
+        self.input.update(cx, |input, cx| {
+            input.set_placeholder(text, window, cx);
         });
     }
 

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -82,8 +82,14 @@ impl NumberInput {
         });
     }
 
-    pub fn pattern(self, pattern: regex::Regex, _: &mut Window, cx: &mut Context<Self>) -> Self {
-        self.input.update(cx, |input, _| input.set_pattern(pattern));
+    pub fn pattern(
+        self,
+        pattern: regex::Regex,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        self.input
+            .update(cx, |input, cx| input.set_pattern(pattern, window, cx));
         self
     }
 

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -245,6 +245,11 @@ where
         self.query_input = Some(query_input);
     }
 
+    /// Get the query input entity.
+    pub fn query_input(&self) -> Option<&Entity<TextInput>> {
+        self.query_input.as_ref()
+    }
+
     pub fn delegate(&self) -> &D {
         &self.delegate
     }


### PR DESCRIPTION
## Break Change

- Updated `set_placeholder` and `set_pattern` method to add `window` and `cx` argument.

    ```diff
    - fn set_placeholder(&mut self, placeholder: impl Into<SharedString>)
    + fn set_placeholder(&mut self, placeholder: impl Into<SharedString>, _: &Window, cx: &mut Context<Self>)

    - fn set_pattern(&mut self, pattern: regex::Regex)
    + fn set_pattern(&mut self, pattern: regex::Regex, window: &mut Window, cx: &mut Context<Self>)
    ```