### PR TITLE
input: Update Input `text` method to return `&SharedString` type.

### DIFF
--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -82,7 +82,7 @@ impl WebViewStory {
             input
         });
 
-        let url = address_input.read(cx).text();
+        let url = address_input.read(cx).text().clone();
         webview.update(cx, |view, _| {
             view.load_url(&url);
         });
@@ -98,7 +98,7 @@ impl WebViewStory {
                 &address_input,
                 |this: &mut Self, input, event: &InputEvent, cx| match event {
                     InputEvent::PressEnter { .. } => {
-                        let url = input.read(cx).text();
+                        let url = input.read(cx).text().clone();
                         this.webview.update(cx, |view, _| {
                             view.load_url(&url);
                         });

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -699,8 +699,8 @@ impl TextInput {
     }
 
     /// Return the text of the input field.
-    pub fn text(&self) -> SharedString {
-        self.text.clone()
+    pub fn text(&self) -> &SharedString {
+        &self.text
     }
 
     pub fn disabled(&self) -> bool {

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -11,8 +11,7 @@ use crate::{
 use gpui::{
     div, prelude::FluentBuilder, uniform_list, AnyElement, AppContext, Entity, FocusHandle,
     Focusable, InteractiveElement, IntoElement, KeyBinding, Length, ListSizingBehavior,
-    MouseButton, ParentElement, Render, SharedString, Styled, Task, UniformListScrollHandle,
-    Window,
+    MouseButton, ParentElement, Render, Styled, Task, UniformListScrollHandle, Window,
 };
 use gpui::{px, App, Context, EventEmitter, MouseDownEvent, ScrollStrategy, Subscription};
 use rust_i18n::t;
@@ -276,19 +275,6 @@ where
 
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
-    }
-
-    /// Set the query_input text
-    pub fn set_query(&mut self, query: &str, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(query_input) = &self.query_input {
-            let query = query.to_owned();
-            query_input.update(cx, |input, cx| input.set_text(query, window, cx))
-        }
-    }
-
-    /// Get the query_input text
-    pub fn query(&self, _: &mut Window, cx: &mut Context<Self>) -> Option<SharedString> {
-        self.query_input.as_ref().map(|input| input.read(cx).text())
     }
 
     fn render_scrollbar(&self, _: &mut Window, cx: &mut Context<Self>) -> Option<impl IntoElement> {


### PR DESCRIPTION
## Break Changes

- input: Now the `text` method `Input` changed return type from `SharedString` to `&SharedString`.
- list: Remove `set_query` and `query` method from `List`, you can use `query_input` to instead.