### PR TITLE
input: Fix Input escape to propagate to parent element.

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -1079,8 +1079,10 @@ impl TextInput {
         }
 
         if self.clean_on_escape {
-            self.clean(window, cx);
+            return self.clean(window, cx);
         }
+
+        cx.propagate();
     }
 
     fn on_mouse_down(


### PR DESCRIPTION
Fix #803 changes broke Escape to dismiss dropdown menu.