### PR TITLE
svg_img: No longer use the global image loader.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,6 +2774,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "futures-util",
  "gpui",
  "html5ever 0.27.0",
  "image",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -42,6 +42,7 @@ minify-html = "0.15.0"
 chrono = "0.4.38"
 syntect = { version = "5.2", features = ["plist-load"] }
 schemars = "0.8.22"
+futures-util = "0.3.31"
 
 [dev-dependencies]
 indoc = "2"

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -252,11 +252,13 @@ impl Element for SvgImg {
 
                     let task = load_svg(source, window, cx);
 
+                    // If task is loaded, set the image
+                    if let Some(Ok(image)) = task.clone().now_or_never() {
+                        prev_image = Some(image);
+                    }
+
                     (
-                        (
-                            layout_id,
-                            task.clone().now_or_never().transpose().ok().flatten(),
-                        ),
+                        (layout_id, prev_image.clone()),
                         Some(SvgImgState {
                             hash: source_hash,
                             image: prev_image,

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -1,18 +1,18 @@
 use std::{
-    collections::HashSet,
     hash::Hash,
     ops::Deref,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{Arc, LazyLock},
 };
 
 use gpui::{
-    hash, px, App, Asset, Bounds, Element, ElementId, GlobalElementId, Hitbox, ImageCacheError,
-    InteractiveElement, Interactivity, IntoElement, Pixels, RenderImage, SharedString, Size,
-    StyleRefinement, Styled, Window,
+    hash, px, App, Asset, AssetLogger, Bounds, Element, ElementId, GlobalElementId, Hitbox,
+    ImageCacheError, InteractiveElement, Interactivity, IntoElement, Pixels, RenderImage,
+    SharedString, StyleRefinement, Styled, Task, Window,
 };
 use image::Frame;
 use smallvec::SmallVec;
 
+use futures_util::{future::Shared, FutureExt};
 use image::ImageBuffer;
 
 const SCALE: f32 = 2.;
@@ -79,43 +79,9 @@ impl Hash for ImageSource {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ImageData {
-    image: Arc<RenderImage>,
-    size: Size<Pixels>,
-    source: ImageSource,
-    uses: Arc<Mutex<HashSet<u64>>>,
-}
-
-impl ImageData {
-    fn new(source: ImageSource, image: Arc<RenderImage>, size: Size<Pixels>) -> Self {
-        Self {
-            source,
-            image,
-            size,
-            uses: Arc::new(Mutex::new(HashSet::new())),
-        }
-    }
-
-    fn use_image(&self, global_id: &GlobalElementId) -> Arc<RenderImage> {
-        self.uses.lock().unwrap().insert(hash(global_id));
-        self.image.clone()
-    }
-
-    fn remove_use(&mut self, global_id: &GlobalElementId, window: &mut Window, cx: &mut App) {
-        let mut uses = self.uses.lock().unwrap();
-        uses.remove(&hash(global_id));
-        if uses.len() == 0 {
-            // println!("dropping image: {:?}", self.image);
-            cx.remove_asset::<SvgImageLoader>(&self.source);
-            _ = window.drop_image(self.image.clone());
-        }
-    }
-}
-
 impl Asset for SvgImageLoader {
     type Source = ImageSource;
-    type Output = Result<ImageData, ImageCacheError>;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
 
     fn load(
         source: Self::Source,
@@ -149,7 +115,6 @@ impl Asset for SvgImageLoader {
             )
             .ok_or(usvg::Error::InvalidSize)?;
 
-            let img_size = gpui::size(px(pixmap.width() as f32), px(pixmap.height() as f32));
             let transform = resvg::tiny_skia::Transform::from_scale(SCALE, SCALE);
 
             resvg::render(&tree, transform, &mut pixmap.as_mut());
@@ -169,7 +134,7 @@ impl Asset for SvgImageLoader {
             }
 
             let image = Arc::new(RenderImage::new(SmallVec::from_elem(Frame::new(buffer), 1)));
-            Ok(ImageData::new(source, image, img_size))
+            Ok(image)
         }
     }
 }
@@ -208,11 +173,34 @@ impl IntoElement for SvgImg {
     }
 }
 
-struct SvgImgState(Option<(u64, ImageData)>);
+fn load_svg(
+    source: &ImageSource,
+    window: &mut Window,
+    cx: &mut App,
+) -> Shared<Task<Result<Arc<RenderImage>, ImageCacheError>>> {
+    let fut = AssetLogger::<SvgImageLoader>::load(source.clone(), cx);
+    let task = cx.background_executor().spawn(fut).shared();
+
+    let entity = window.current_view();
+    window
+        .spawn(cx, {
+            let task = task.clone();
+            async move |cx| {
+                _ = task.await;
+                cx.on_next_frame(move |_, cx| {
+                    cx.notify(entity);
+                });
+            }
+        })
+        .detach();
+    task
+}
+
+struct SvgImgState(Option<(u64, Shared<Task<Result<Arc<RenderImage>, ImageCacheError>>>)>);
 
 impl Element for SvgImg {
-    type RequestLayoutState = Option<ImageData>;
-    type PrepaintState = (Option<Hitbox>, Option<ImageData>);
+    type RequestLayoutState = Option<Arc<RenderImage>>;
+    type PrepaintState = (Option<Hitbox>, Option<Arc<RenderImage>>);
 
     fn id(&self) -> Option<ElementId> {
         Some(self.id.clone())
@@ -238,28 +226,31 @@ impl Element for SvgImg {
         window.with_element_state::<SvgImgState, _>(global_id, |state, window| {
             match state {
                 Some(mut state) => {
-                    if let Some((prev_hash, mut prev_image)) = state.0.take() {
+                    if let Some((prev_hash, prev_task)) = state.0.take() {
                         if source_hash == prev_hash {
                             return (
-                                (layout_id, Some(prev_image.clone())),
-                                SvgImgState(Some((prev_hash, prev_image))),
+                                (
+                                    layout_id,
+                                    prev_task.clone().now_or_never().transpose().ok().flatten(),
+                                ),
+                                SvgImgState(Some((prev_hash, prev_task))),
                             );
                         } else {
-                            // Drop the previous image from the cache.
-                            // Here can't remove directly, because same the image is being used by another element.
-                            prev_image.remove_use(global_id, window, cx);
+                            // Drop the texture of previous image.
+                            if let Some(Ok(prev_image)) = prev_task.now_or_never() {
+                                _ = window.drop_image(prev_image);
+                            }
                         }
                     }
 
-                    let image = window
-                        .use_asset::<SvgImageLoader>(&source, cx)
-                        .transpose()
-                        .ok()
-                        .flatten();
+                    let task = load_svg(source, window, cx);
 
                     (
-                        (layout_id, image.clone()),
-                        SvgImgState(image.map(|image| (source_hash, image))),
+                        (
+                            layout_id,
+                            task.clone().now_or_never().transpose().ok().flatten(),
+                        ),
+                        SvgImgState(Some((source_hash, task))),
                     )
                 }
                 None => ((layout_id, None), SvgImgState(None)),
@@ -297,10 +288,10 @@ impl Element for SvgImg {
         cx: &mut App,
     ) {
         let hitbox = state.0.as_ref();
-        let Some(image_data) = state.1.take() else {
+        let Some(image) = state.1.take() else {
             return;
         };
-        let size = image_data.size;
+        let size = image.size(0).map(|x| x.0 as f32);
 
         self.interactivity
             .paint(global_id, bounds, hitbox, window, cx, |_, window, _| {
@@ -313,7 +304,7 @@ impl Element for SvgImg {
                     bounds.size.height / size.height
                 };
 
-                let ratio = ratio.min(1.0);
+                let ratio = ratio.min(px(1.0));
                 let new_size = size.map(|dim| dim * ratio);
 
                 let new_origin = gpui::Point {
@@ -326,15 +317,8 @@ impl Element for SvgImg {
                     size: new_size.map(|size| size.ceil()),
                 };
 
-                match window.paint_image(
-                    img_bounds,
-                    px(0.).into(),
-                    image_data.use_image(&global_id.unwrap()),
-                    0,
-                    false,
-                ) {
-                    Ok(_) => {}
-                    Err(err) => eprintln!("failed to paint svg image: {:?}", err),
+                if let Err(err) = window.paint_image(img_bounds, px(0.).into(), image, 0, false) {
+                    eprintln!("failed to paint svg image: {:?}", err);
                 }
             })
     }

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -181,7 +181,6 @@ fn load_svg(
     let fut = AssetLogger::<SvgImageLoader>::load(source.clone(), cx);
     let task = cx.background_executor().spawn(fut).shared();
 
-    let entity = window.current_view();
     window
         .spawn(cx, {
             let task = task.clone();

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -250,9 +250,11 @@ impl Element for SvgImg {
                                 Some(state),
                             );
                         } else {
-                            // Drop the texture of previous image.
+                            // Drop the texture of previous image on next frame.
                             if let Some(Ok(old_image)) = state.task.now_or_never() {
-                                _ = window.drop_image(old_image);
+                                window.on_next_frame(|window, _| {
+                                    _ = window.drop_image(old_image);
+                                });
                             }
                         }
                     }

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -181,6 +181,7 @@ fn load_svg(
     let fut = AssetLogger::<SvgImageLoader>::load(source.clone(), cx);
     let task = cx.background_executor().spawn(fut).shared();
 
+    let entity = window.current_view();
     window
         .spawn(cx, {
             let task = task.clone();

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -238,7 +238,7 @@ impl Element for SvgImg {
                         } else {
                             // Drop the texture of previous image.
                             if let Some(Ok(prev_image)) = prev_task.now_or_never() {
-                                _ = window.drop_image(prev_image);
+                                // _ = window.drop_image(prev_image);
                             }
                         }
                     }

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -316,8 +316,8 @@ impl Element for SvgImg {
                     bounds.size.height / size.height
                 };
 
-                let ratio = ratio.min(px(1.0));
-                let new_size = size.map(|dim| dim * ratio);
+                let ratio = ratio.0.min(1.0);
+                let new_size = size.map(|dim| px(dim) * ratio);
 
                 let new_origin = gpui::Point {
                     x: bounds.origin.x + px(((bounds.size.width - new_size.width) / 2.).into()),

--- a/crates/ui/src/svg_img.rs
+++ b/crates/ui/src/svg_img.rs
@@ -238,7 +238,14 @@ impl Element for SvgImg {
                             return (
                                 (
                                     layout_id,
-                                    state.task.clone().now_or_never().transpose().ok().flatten(),
+                                    state
+                                        .task
+                                        .clone()
+                                        .now_or_never()
+                                        .transpose()
+                                        .ok()
+                                        .flatten()
+                                        .or(state.image.clone()),
                                 ),
                                 Some(state),
                             );
@@ -252,13 +259,16 @@ impl Element for SvgImg {
 
                     let task = load_svg(source, window, cx);
 
-                    // If task is loaded, set the image
-                    if let Some(Ok(image)) = task.clone().now_or_never() {
-                        prev_image = Some(image);
-                    }
-
                     (
-                        (layout_id, prev_image.clone()),
+                        (
+                            layout_id,
+                            task.clone()
+                                .now_or_never()
+                                .transpose()
+                                .ok()
+                                .flatten()
+                                .or(prev_image.clone()),
+                        ),
                         Some(SvgImgState {
                             hash: source_hash,
                             image: prev_image,


### PR DESCRIPTION
Update SvgImg load logic and try to drop image to fix VRAM leak issue.