### PR TITLE
dock: Refactor to use ratio for dock, panel size.

### DIFF
--- a/crates/story/examples/dock.rs
+++ b/crates/story/examples/dock.rs
@@ -279,7 +279,7 @@ impl StoryWorkspace {
                     cx,
                 ),
             ],
-            vec![None, Some(px(360.))],
+            vec![None, Some(0.2)],
             &dock_area,
             window,
             cx,
@@ -328,9 +328,9 @@ impl StoryWorkspace {
         _ = dock_area.update(cx, |view, cx| {
             view.set_version(MAIN_DOCK_AREA.version, window, cx);
             view.set_center(dock_item, window, cx);
-            view.set_left_dock(left_panels, Some(px(350.)), true, window, cx);
-            view.set_bottom_dock(bottom_panels, Some(px(200.)), true, window, cx);
-            view.set_right_dock(right_panels, Some(px(320.)), true, window, cx);
+            view.set_left_dock(left_panels, 0.3, true, window, cx);
+            view.set_bottom_dock(bottom_panels, 0.2, true, window, cx);
+            view.set_right_dock(right_panels, 0.3, true, window, cx);
 
             Self::save_state(&view.dump(cx)).unwrap();
         });

--- a/crates/story/src/resizable_story.rs
+++ b/crates/story/src/resizable_story.rs
@@ -53,10 +53,10 @@ impl ResizableStory {
             v_resizable()
                 .group(
                     h_resizable()
-                        .flex(0.1)
+                        .ratio(0.1)
                         .child(
                             resizable_panel()
-                                .flex(0.3)
+                                .ratio(0.3)
                                 .content(|_, cx| panel_box("Left 1 (Min 120px)", cx)),
                             cx,
                         )
@@ -66,7 +66,7 @@ impl ResizableStory {
                         )
                         .child(
                             resizable_panel()
-                                .flex(0.4)
+                                .ratio(0.4)
                                 .content(|_, cx| panel_box("Right (Grow)", cx)),
                             cx,
                         ),
@@ -78,7 +78,7 @@ impl ResizableStory {
                 )
                 .child(
                     resizable_panel()
-                        .flex(0.5)
+                        .ratio(0.5)
                         .content(|_, cx| panel_box("Bottom", cx)),
                     cx,
                 )
@@ -88,7 +88,7 @@ impl ResizableStory {
             h_resizable()
                 .child(
                     resizable_panel()
-                        .flex(0.3)
+                        .ratio(0.3)
                         .content(|_, cx| panel_box("Left 2", cx)),
                     cx,
                 )

--- a/crates/story/src/resizable_story.rs
+++ b/crates/story/src/resizable_story.rs
@@ -53,36 +53,32 @@ impl ResizableStory {
             v_resizable()
                 .group(
                     h_resizable()
-                        .size(px(150.))
+                        .flex(0.1)
                         .child(
                             resizable_panel()
-                                .size(px(300.))
+                                .flex(0.3)
                                 .content(|_, cx| panel_box("Left 1 (Min 120px)", cx)),
                             cx,
                         )
                         .child(
-                            resizable_panel()
-                                .size(px(400.))
-                                .content(|_, cx| panel_box("Center 1", cx)),
+                            resizable_panel().content(|_, cx| panel_box("Center 1", cx)),
                             cx,
                         )
                         .child(
                             resizable_panel()
-                                .size(px(300.))
+                                .flex(0.4)
                                 .content(|_, cx| panel_box("Right (Grow)", cx)),
                             cx,
                         ),
                     cx,
                 )
                 .child(
-                    resizable_panel()
-                        .size(px(150.))
-                        .content(|_, cx| panel_box("Center (Grow)", cx)),
+                    resizable_panel().content(|_, cx| panel_box("Center (Grow)", cx)),
                     cx,
                 )
                 .child(
                     resizable_panel()
-                        .size(px(210.))
+                        .flex(0.5)
                         .content(|_, cx| panel_box("Bottom", cx)),
                     cx,
                 )
@@ -92,14 +88,12 @@ impl ResizableStory {
             h_resizable()
                 .child(
                     resizable_panel()
-                        .size(px(300.))
+                        .flex(0.3)
                         .content(|_, cx| panel_box("Left 2", cx)),
                     cx,
                 )
                 .child(
-                    resizable_panel()
-                        .size(px(400.))
-                        .content(|_, cx| panel_box("Right (Grow)", cx)),
+                    resizable_panel().content(|_, cx| panel_box("Right (Grow)", cx)),
                     cx,
                 )
         });
@@ -114,8 +108,9 @@ impl ResizableStory {
 impl Render for ResizableStory {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
+            .h_full()
             .gap_6()
-            .child(self.group1.clone())
+            .child(div().h(px(800.)).child(self.group1.clone()))
             .child(self.group2.clone())
     }
 }

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -41,11 +41,11 @@ impl Panel for StackPanel {
         }
     }
     fn dump(&self, cx: &App) -> PanelState {
-        let sizes = self.panel_group.read(cx).sizes();
+        let flexes = self.panel_group.read(cx).flexes();
         let mut state = PanelState::new(self);
         for panel in &self.panels {
             state.add_child(panel.dump(cx));
-            state.info = PanelInfo::stack(sizes.clone(), self.axis);
+            state.info = PanelInfo::stack(flexes.clone(), self.axis);
         }
 
         state

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -13,8 +13,8 @@ use crate::{
 use super::{DockArea, Panel, PanelEvent, PanelState, PanelView, TabPanel};
 use gpui::{
     prelude::FluentBuilder as _, App, AppContext, Axis, Context, DismissEvent, Entity,
-    EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Pixels, Render, Styled,
-    Subscription, WeakEntity, Window,
+    EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Render, Styled, Subscription,
+    WeakEntity, Window,
 };
 use smallvec::SmallVec;
 
@@ -41,7 +41,7 @@ impl Panel for StackPanel {
         }
     }
     fn dump(&self, cx: &App) -> PanelState {
-        let flexes = self.panel_group.read(cx).flexes();
+        let flexes = self.panel_group.read(cx).ratios();
         let mut state = PanelState::new(self);
         for panel in &self.panels {
             state.add_child(panel.dump(cx));
@@ -111,19 +111,19 @@ impl StackPanel {
     pub fn add_panel(
         &mut self,
         panel: Arc<dyn PanelView>,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.insert_panel(panel, self.panels.len(), size, dock_area, window, cx);
+        self.insert_panel(panel, self.panels.len(), ratio, dock_area, window, cx);
     }
 
     pub fn add_panel_at(
         &mut self,
         panel: Arc<dyn PanelView>,
         placement: Placement,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -132,7 +132,7 @@ impl StackPanel {
             panel,
             self.panels_len(),
             placement,
-            size,
+            ratio,
             dock_area,
             window,
             cx,
@@ -145,17 +145,17 @@ impl StackPanel {
         panel: Arc<dyn PanelView>,
         ix: usize,
         placement: Placement,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         match placement {
             Placement::Top | Placement::Left => {
-                self.insert_panel_before(panel, ix, size, dock_area, window, cx)
+                self.insert_panel_before(panel, ix, ratio, dock_area, window, cx)
             }
             Placement::Right | Placement::Bottom => {
-                self.insert_panel_after(panel, ix, size, dock_area, window, cx)
+                self.insert_panel_after(panel, ix, ratio, dock_area, window, cx)
             }
         }
     }
@@ -165,12 +165,12 @@ impl StackPanel {
         &mut self,
         panel: Arc<dyn PanelView>,
         ix: usize,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.insert_panel(panel, ix, size, dock_area, window, cx);
+        self.insert_panel(panel, ix, ratio, dock_area, window, cx);
     }
 
     /// Insert a panel after the index.
@@ -178,26 +178,26 @@ impl StackPanel {
         &mut self,
         panel: Arc<dyn PanelView>,
         ix: usize,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.insert_panel(panel, ix + 1, size, dock_area, window, cx);
+        self.insert_panel(panel, ix + 1, ratio, dock_area, window, cx);
     }
 
     fn new_resizable_panel(panel: Arc<dyn PanelView>, ratio: Option<f32>) -> ResizablePanel {
         resizable_panel()
             .content_view(panel.view())
             .content_visible(move |_, cx| panel.visible(cx))
-            .when_some(ratio, |this, ratio| this.flex(ratio))
+            .when_some(ratio, |this, ratio| this.ratio(ratio))
     }
 
     fn insert_panel(
         &mut self,
         panel: Arc<dyn PanelView>,
         ix: usize,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         dock_area: WeakEntity<DockArea>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -240,12 +240,8 @@ impl StackPanel {
 
         self.panels.insert(ix, panel.clone());
         self.panel_group.update(cx, |view, cx| {
-            let total_size = view.total_size();
             view.insert_child(
-                Self::new_resizable_panel(
-                    panel.clone(),
-                    size.and_then(|size| Some(size / total_size)),
-                ),
+                Self::new_resizable_panel(panel.clone(), ratio),
                 ix,
                 window,
                 cx,

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -186,11 +186,11 @@ impl StackPanel {
         self.insert_panel(panel, ix + 1, size, dock_area, window, cx);
     }
 
-    fn new_resizable_panel(panel: Arc<dyn PanelView>, size: Option<Pixels>) -> ResizablePanel {
+    fn new_resizable_panel(panel: Arc<dyn PanelView>, ratio: Option<f32>) -> ResizablePanel {
         resizable_panel()
             .content_view(panel.view())
             .content_visible(move |_, cx| panel.visible(cx))
-            .when_some(size, |this, size| this.size(size))
+            .when_some(ratio, |this, ratio| this.flex(ratio))
     }
 
     fn insert_panel(
@@ -240,8 +240,12 @@ impl StackPanel {
 
         self.panels.insert(ix, panel.clone());
         self.panel_group.update(cx, |view, cx| {
+            let total_size = view.total_size();
             view.insert_child(
-                Self::new_resizable_panel(panel.clone(), size),
+                Self::new_resizable_panel(
+                    panel.clone(),
+                    size.and_then(|size| Some(size / total_size)),
+                ),
                 ix,
                 window,
                 cx,

--- a/crates/ui/src/dock/state.rs
+++ b/crates/ui/src/dock/state.rs
@@ -206,7 +206,7 @@ impl PanelState {
                 } else {
                     Axis::Vertical
                 };
-                let ratios = ratios.iter().map(|&ratio| Some(ratio as f32)).collect();
+                let ratios = ratios.iter().map(|&ratio| Some(ratio)).collect();
                 DockItem::split_with_sizes(axis, items, ratios, &dock_area, window, cx)
             }
             PanelInfo::Tabs { active_index } => {

--- a/crates/ui/src/dock/state.rs
+++ b/crates/ui/src/dock/state.rs
@@ -100,7 +100,7 @@ impl From<Bounds<Pixels>> for TileMeta {
 pub enum PanelInfo {
     #[serde(rename = "stack")]
     Stack {
-        sizes: Vec<Pixels>,
+        flexes: Vec<f32>,
         axis: usize, // 0 for horizontal, 1 for vertical
     },
     #[serde(rename = "tabs")]
@@ -112,9 +112,9 @@ pub enum PanelInfo {
 }
 
 impl PanelInfo {
-    pub fn stack(sizes: Vec<Pixels>, axis: Axis) -> Self {
+    pub fn stack(flexes: Vec<f32>, axis: Axis) -> Self {
         Self::Stack {
-            sizes,
+            flexes,
             axis: if axis == Axis::Horizontal { 0 } else { 1 },
         }
     }
@@ -142,9 +142,9 @@ impl PanelInfo {
         }
     }
 
-    pub fn sizes(&self) -> Option<&Vec<Pixels>> {
+    pub fn flexes(&self) -> Option<&Vec<f32>> {
         match self {
-            Self::Stack { sizes, .. } => Some(sizes),
+            Self::Stack { flexes, .. } => Some(flexes),
             _ => None,
         }
     }
@@ -194,14 +194,15 @@ impl PanelState {
             .collect();
 
         match info {
-            PanelInfo::Stack { sizes, axis } => {
+            PanelInfo::Stack { flexes, axis } => {
                 let axis = if axis == 0 {
                     Axis::Horizontal
                 } else {
                     Axis::Vertical
                 };
-                let sizes = sizes.iter().map(|s| Some(*s)).collect_vec();
-                DockItem::split_with_sizes(axis, items, sizes, &dock_area, window, cx)
+                let flexes = flexes.iter().map(|s| Some(*s)).collect_vec();
+                // FIXME: Set sizes from flexes.
+                DockItem::split_with_sizes(axis, items, vec![], &dock_area, window, cx)
             }
             PanelInfo::Tabs { active_index } => {
                 if items.len() == 1 {

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use gpui::{
     div, prelude::FluentBuilder, px, rems, App, AppContext, Context, Corner, DefiniteLength,
     DismissEvent, DragMoveEvent, Empty, Entity, EventEmitter, FocusHandle, Focusable,
-    InteractiveElement as _, IntoElement, ParentElement, Pixels, Render, ScrollHandle,
-    SharedString, StatefulInteractiveElement, StyleRefinement, Styled, WeakEntity, Window,
+    InteractiveElement as _, IntoElement, ParentElement, Render, ScrollHandle, SharedString,
+    StatefulInteractiveElement, StyleRefinement, Styled, WeakEntity, Window,
 };
 use rust_i18n::t;
 
@@ -264,7 +264,7 @@ impl TabPanel {
         &mut self,
         panel: Arc<dyn PanelView>,
         placement: Placement,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -272,7 +272,7 @@ impl TabPanel {
             cx.update(|window, cx| {
                 view.update(cx, |view, cx| {
                     view.will_split_placement = Some(placement);
-                    view.split_panel(panel, placement, size, window, cx)
+                    view.split_panel(panel, placement, ratio, window, cx)
                 })
                 .ok()
             })
@@ -930,7 +930,7 @@ impl TabPanel {
         &self,
         panel: Arc<dyn PanelView>,
         placement: Placement,
-        size: Option<Pixels>,
+        ratio: Option<f32>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -959,7 +959,7 @@ impl TabPanel {
                     Arc::new(new_tab_panel),
                     ix,
                     placement,
-                    size,
+                    ratio,
                     dock_area.clone(),
                     window,
                     cx,
@@ -971,7 +971,7 @@ impl TabPanel {
                     Arc::new(new_tab_panel),
                     ix,
                     placement,
-                    size,
+                    ratio,
                     dock_area.clone(),
                     window,
                     cx,
@@ -1001,7 +1001,13 @@ impl TabPanel {
 
             new_stack_panel.update(cx, |view, cx| match placement {
                 Placement::Left | Placement::Top => {
-                    view.add_panel(Arc::new(new_tab_panel), size, dock_area.clone(), window, cx);
+                    view.add_panel(
+                        Arc::new(new_tab_panel),
+                        ratio,
+                        dock_area.clone(),
+                        window,
+                        cx,
+                    );
                     view.add_panel(
                         Arc::new(tab_panel.clone()),
                         None,
@@ -1018,7 +1024,13 @@ impl TabPanel {
                         window,
                         cx,
                     );
-                    view.add_panel(Arc::new(new_tab_panel), size, dock_area.clone(), window, cx);
+                    view.add_panel(
+                        Arc::new(new_tab_panel),
+                        ratio,
+                        dock_area.clone(),
+                        window,
+                        cx,
+                    );
                 }
             });
 

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -2,7 +2,7 @@ use std::{ops::Deref, rc::Rc};
 
 use gpui::{
     canvas, div, prelude::FluentBuilder, px, relative, Along, AnyElement, AnyView, App, AppContext,
-    Axis, Bounds, Context, Element, Empty, Entity, EntityId, EventEmitter, IntoElement, IsZero,
+    Axis, Bounds, Context, Element, Empty, Entity, EntityId, EventEmitter, IntoElement,
     MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, Style, Styled, WeakEntity, Window,
 };
 
@@ -28,9 +28,9 @@ impl Render for DragPanel {
 #[derive(Clone)]
 pub struct ResizablePanelGroup {
     panels: Vec<Entity<ResizablePanel>>,
-    flexes: Vec<f32>,
+    ratios: Vec<f32>,
     axis: Axis,
-    size_ratio: Option<f32>,
+    ratio: Option<f32>,
     bounds: Bounds<Pixels>,
     resizing_panel_ix: Option<usize>,
 }
@@ -39,16 +39,16 @@ impl ResizablePanelGroup {
     pub(super) fn new() -> Self {
         Self {
             axis: Axis::Horizontal,
-            flexes: Vec::new(),
+            ratios: Vec::new(),
             panels: Vec::new(),
-            size_ratio: None,
+            ratio: None,
             bounds: Bounds::default(),
             resizing_panel_ix: None,
         }
     }
 
-    pub fn load(&mut self, flexes: Vec<f32>, panels: Vec<Entity<ResizablePanel>>) {
-        self.flexes = flexes;
+    pub fn load(&mut self, ratios: Vec<f32>, panels: Vec<Entity<ResizablePanel>>) {
+        self.ratios = ratios;
         self.panels = panels;
     }
 
@@ -72,10 +72,10 @@ impl ResizablePanelGroup {
     /// Add a ResizablePanelGroup as a child to the group.
     pub fn group(self, group: ResizablePanelGroup, cx: &mut Context<Self>) -> Self {
         let group: ResizablePanelGroup = group;
-        let size_ratio = group.size_ratio;
+        let ratio = group.ratio;
         let panel = ResizablePanel::new()
             .content_view(cx.new(|_| group).into())
-            .when_some(size_ratio, |this, ratio| this.flex(ratio));
+            .when_some(ratio, |this, ratio| this.ratio(ratio));
         self.child(panel, cx)
     }
 
@@ -83,14 +83,14 @@ impl ResizablePanelGroup {
     ///
     /// - When the axis is horizontal, the size is the height of the group.
     /// - When the axis is vertical, the size is the width of the group.
-    pub fn flex(mut self, ratio: f32) -> Self {
-        self.size_ratio = Some(ratio);
+    pub fn ratio(mut self, ratio: f32) -> Self {
+        self.ratio = Some(ratio);
         self
     }
 
-    /// Returns the sizes of the resizable panels.
-    pub(crate) fn flexes(&self) -> &Vec<f32> {
-        &self.flexes
+    /// Returns the ratios of the panels.
+    pub(crate) fn ratios(&self) -> &Vec<f32> {
+        &self.ratios
     }
 
     /// Calculates the sum of all panel sizes within the group.
@@ -102,12 +102,12 @@ impl ResizablePanelGroup {
         let mut panel = panel;
         panel.axis = self.axis;
         panel.group = Some(cx.entity().downgrade());
-        let flex = match panel.size_ratio {
+        let ratio = match panel.ratio {
             Some(ratio) => ratio,
             None => panel.initial_radio.unwrap_or_default(),
         };
 
-        self.flexes.push(flex);
+        self.ratios.push(ratio);
         self.panels.push(cx.new(|_| panel));
     }
 
@@ -121,11 +121,11 @@ impl ResizablePanelGroup {
         let mut panel = panel;
         panel.axis = self.axis;
         panel.group = Some(cx.entity().downgrade());
-        let flex = match panel.size_ratio {
+        let ratio = match panel.ratio {
             Some(ratio) => ratio,
             None => panel.initial_radio.unwrap_or_default(),
         };
-        self.flexes.insert(ix, flex);
+        self.ratios.insert(ix, ratio);
         self.panels.insert(ix, cx.new(|_| panel));
         cx.notify()
     }
@@ -142,31 +142,31 @@ impl ResizablePanelGroup {
 
         let old_panel = self.panels[ix].clone();
         let old_panel_initial_ratio = old_panel.read(cx).initial_radio;
-        let old_panel_size_ratio = old_panel.read(cx).size_ratio;
+        let old_panel_ratio = old_panel.read(cx).ratio;
 
         panel.initial_radio = old_panel_initial_ratio;
-        panel.size_ratio = old_panel_size_ratio;
+        panel.ratio = old_panel_ratio;
         panel.axis = self.axis;
         panel.group = Some(cx.entity().downgrade());
 
-        let flex = match panel.size_ratio {
+        let ratio = match panel.ratio {
             Some(ratio) => ratio,
             None => panel.initial_radio.unwrap_or_default(),
         };
 
-        self.flexes[ix] = flex;
+        self.ratios[ix] = ratio;
         self.panels[ix] = cx.new(|_| panel);
         cx.notify()
     }
 
     pub fn remove_child(&mut self, ix: usize, _: &mut Window, cx: &mut Context<Self>) {
-        self.flexes.remove(ix);
+        self.ratios.remove(ix);
         self.panels.remove(ix);
         cx.notify()
     }
 
     pub(crate) fn remove_all_children(&mut self, _: &mut Window, cx: &mut Context<Self>) {
-        self.flexes.clear();
+        self.ratios.clear();
         self.panels.clear();
         cx.notify()
     }
@@ -199,7 +199,7 @@ impl ResizablePanelGroup {
     fn sync_real_panel_sizes(&mut self, _: &Window, cx: &mut App) {
         let total_size = self.total_size();
         for (i, panel) in self.panels.iter().enumerate() {
-            self.flexes[i] = panel.read(cx).bounds.size.along(self.axis) / total_size;
+            self.ratios[i] = panel.read(cx).bounds.size.along(self.axis) / total_size;
         }
     }
 
@@ -222,54 +222,54 @@ impl ResizablePanelGroup {
 
         self.sync_real_panel_sizes(window, cx);
 
-        let new_flex = size / container_size;
-        let mut changed = new_flex - self.flexes[ix];
+        let new_ratio = size / container_size;
+        let mut changed = new_ratio - self.ratios[ix];
         let is_expand = changed > 0.;
 
         let main_ix = ix;
-        let mut new_flexes = self.flexes.clone();
-        let min_flex = PANEL_MIN_SIZE / container_size;
+        let mut new_ratios = self.ratios.clone();
+        let min_ratio = PANEL_MIN_SIZE / container_size;
 
         if is_expand {
-            new_flexes[ix] = new_flex;
+            new_ratios[ix] = new_ratio;
 
             // Now to expand logic is correct.
             while changed > 0. && ix < self.panels.len() - 1 {
                 ix += 1;
-                let available_flex = (new_flexes[ix] - min_flex).max(0.);
-                let to_reduce = changed.min(available_flex);
-                new_flexes[ix] -= to_reduce;
+                let available_ratio = (new_ratios[ix] - min_ratio).max(0.);
+                let to_reduce = changed.min(available_ratio);
+                new_ratios[ix] -= to_reduce;
                 changed -= to_reduce;
             }
         } else {
-            let new_size = new_flex.max(min_flex);
-            new_flexes[ix] = new_size;
-            changed = new_flex - min_flex;
-            new_flexes[ix + 1] += self.flexes[ix] - new_size;
+            let new_size = new_ratio.max(min_ratio);
+            new_ratios[ix] = new_size;
+            changed = new_ratio - min_ratio;
+            new_ratios[ix + 1] += self.ratios[ix] - new_size;
 
             while changed < 0. && ix > 0 {
                 ix -= 1;
-                let available_flex = self.flexes[ix] - min_flex;
-                let to_increase = (changed).min(available_flex);
-                new_flexes[ix] += to_increase;
+                let available_ratio = self.ratios[ix] - min_ratio;
+                let to_increase = (changed).min(available_ratio);
+                new_ratios[ix] += to_increase;
                 changed += to_increase;
             }
         }
 
         // If total size exceeds container size, adjust the main panel
-        let total_flex: f32 = new_flexes.iter().sum();
-        if total_flex > 1. {
-            let overflow = 1.0 - total_flex;
-            new_flexes[main_ix] = (new_flexes[main_ix] - overflow).max(min_flex);
+        let total_ratio: f32 = new_ratios.iter().sum();
+        if total_ratio > 1. {
+            let overflow = 1.0 - total_ratio;
+            new_ratios[main_ix] = (new_ratios[main_ix] - overflow).max(min_ratio);
         }
 
-        self.flexes = new_flexes;
+        self.ratios = new_ratios;
         for (i, panel) in self.panels.iter().enumerate() {
-            let flex = self.flexes[i];
-            if flex > 0. {
+            let ratio = self.ratios[i];
+            if ratio > 0. {
                 panel.update(cx, |this, _| {
-                    this.size = Some(container_size * flex);
-                    this.size_ratio = Some(flex);
+                    this.size = Some(container_size * ratio);
+                    this.ratio = Some(ratio);
                 });
             }
         }
@@ -319,7 +319,7 @@ pub struct ResizablePanel {
     /// size is the size that the panel has when it is resized or adjusted by flex layout.
     size: Option<Pixels>,
     /// the size ratio that the panel has relative to its group
-    size_ratio: Option<f32>,
+    ratio: Option<f32>,
     axis: Axis,
     content_builder: Option<Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>>,
     content_view: Option<AnyView>,
@@ -335,7 +335,7 @@ impl ResizablePanel {
             group: None,
             initial_radio: None,
             size: None,
-            size_ratio: None,
+            ratio: None,
             axis: Axis::Horizontal,
             content_builder: None,
             content_view: None,
@@ -375,9 +375,9 @@ impl ResizablePanel {
     /// Set the flex ratio of the panel, the ratio is relative to the total size of the group.
     ///
     /// The `ratio` is 0.0 to 1.0.
-    pub fn flex(mut self, ratio: f32) -> Self {
+    pub fn ratio(mut self, ratio: f32) -> Self {
         self.initial_radio = Some(ratio);
-        self.size_ratio = Some(ratio);
+        self.ratio = Some(ratio);
         self
     }
 
@@ -385,7 +385,7 @@ impl ResizablePanel {
     fn update_size(&mut self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut Context<Self>) {
         let new_size = bounds.size.along(self.axis);
         self.bounds = bounds;
-        self.size_ratio = None;
+        self.ratio = None;
         self.size = Some(new_size);
         cx.notify();
 
@@ -405,7 +405,7 @@ impl Render for ResizablePanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if !(self.content_visible)(window, cx) {
             // To keep size as initial size, to make sure the size will not be changed.
-            self.initial_radio = self.size_ratio;
+            self.initial_radio = self.ratio;
             self.size = None;
             return div();
         }
@@ -437,8 +437,8 @@ impl Render for ResizablePanel {
                     .flex_basis(relative(radio))
                 }
             })
-            .map(|this| match (self.size_ratio, self.size, total_size) {
-                (Some(size_ratio), _, _) => this.flex_basis(relative(size_ratio)),
+            .map(|this| match (self.ratio, self.size, total_size) {
+                (Some(ratio), _, _) => this.flex_basis(relative(ratio)),
                 (None, Some(size), Some(total_size)) => {
                     this.flex_basis(relative(size / total_size))
                 }

--- a/crates/ui/tests/fixtures/layout.json
+++ b/crates/ui/tests/fixtures/layout.json
@@ -255,6 +255,7 @@
     },
     "placement": "bottom",
     "size": 200.0,
+    "ratio": 0.32,
     "open": true,
     "resizeable": true
   }


### PR DESCRIPTION
## Break Changes

- The `Dock`, `DockItem` has changed the `size`, `sizes` to `ratio` and `ratios`, to use relative ratio instead of absolute size.