### PR TITLE
chore: Unify icon parameter types in ListItem and Dropdown.

### DIFF
--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -161,7 +161,7 @@ where
 
         if let Some(item) = self.delegate.get(ix) {
             let list_item = ListItem::new(("list-item", ix))
-                .check_icon(Icon::new(IconName::Check))
+                .check_icon(IconName::Check)
                 .selected(selected)
                 .input_text_size(size)
                 .list_size(size)

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -161,7 +161,7 @@ where
 
         if let Some(item) = self.delegate.get(ix) {
             let list_item = ListItem::new(("list-item", ix))
-                .check_icon(IconName::Check)
+                .check_icon(Icon::new(IconName::Check))
                 .selected(selected)
                 .input_text_size(size)
                 .list_size(size)
@@ -247,7 +247,7 @@ pub struct Dropdown<D: DropdownDelegate + 'static> {
     focus_handle: FocusHandle,
     list: Entity<List<DropdownListDelegate<D>>>,
     size: Size,
-    icon: Option<IconName>,
+    icon: Option<Icon>,
     open: bool,
     cleanable: bool,
     placeholder: Option<SharedString>,
@@ -408,7 +408,7 @@ where
     }
 
     /// Set the right icon for the dropdown input, instead of the default arrow icon.
-    pub fn icon(mut self, icon: impl Into<IconName>) -> Self {
+    pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
         self.icon = Some(icon.into());
         self
     }
@@ -719,14 +719,14 @@ where
                                     Some(icon) => icon,
                                     None => {
                                         if self.open {
-                                            IconName::ChevronUp
+                                            Icon::new(IconName::ChevronUp)
                                         } else {
-                                            IconName::ChevronDown
+                                            Icon::new(IconName::ChevronDown)
                                         }
                                     }
                                 };
 
-                                this.child(Icon::new(icon).xsmall().text_color(
+                                this.child(icon.xsmall().text_color(
                                     match self.disabled {
                                         true => cx.theme().muted_foreground.opacity(0.5),
                                         false => cx.theme().muted_foreground,

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -1,4 +1,4 @@
-use crate::{h_flex, ActiveTheme, Disableable, Icon, IconName, Selectable, Sizable as _};
+use crate::{h_flex, ActiveTheme, Disableable, Icon, Selectable, Sizable as _};
 use gpui::{
     div, prelude::FluentBuilder as _, AnyElement, App, ClickEvent, Div, ElementId,
     InteractiveElement, IntoElement, MouseButton, MouseMoveEvent, ParentElement, RenderOnce,
@@ -38,8 +38,8 @@ impl ListItem {
     }
 
     /// Set to show check icon, default is None.
-    pub fn check_icon(mut self, icon: IconName) -> Self {
-        self.check_icon = Some(Icon::new(icon));
+    pub fn check_icon(mut self, icon: impl Into<Icon>) -> Self {
+        self.check_icon = Some(icon.into());
         self
     }
 


### PR DESCRIPTION
## Changes

This PR unifies icon parameter types in UI components:

- Changed `ListItem.check_icon` parameter type from `IconName` to `impl Into<Icon>`
- Changed `Dropdown.icon` parameter type from `impl Into<IconName>` to `impl Into<Icon>`
- Updated related rendering logic

## Impact

- **API Consistency**: All components now accept the same icon parameter type
- **Backward Compatible**: Existing code using `IconName` continues to work
- **Enhanced Flexibility**: Components can now accept custom `Icon` instances directly