### PR TITLE
input: Refactor Input, Picker as stateless mode.

### DIFF
--- a/crates/story/examples/html.rs
+++ b/crates/story/examples/html.rs
@@ -1,9 +1,14 @@
 use gpui::*;
-use gpui_component::{h_flex, input::TextInput, text::TextView, ActiveTheme as _};
+use gpui_component::{
+    h_flex,
+    input::{InputState, TextInput},
+    text::TextView,
+    ActiveTheme as _,
+};
 use story::Assets;
 
 pub struct Example {
-    text_input: Entity<TextInput>,
+    input_state: Entity<InputState>,
     _subscribe: Subscription,
 }
 
@@ -11,27 +16,23 @@ const EXAMPLE: &str = include_str!("./html.html");
 
 impl Example {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let text_input = cx.new(|cx| {
-            TextInput::new(window, cx)
+        let input_state = cx.new(|cx| {
+            InputState::new(window, cx)
                 .multi_line()
-                .appearance(false)
                 .h_full()
+                .default_text(EXAMPLE)
                 .placeholder("Enter your HTML here...")
         });
 
         let _subscribe = cx.subscribe(
-            &text_input,
+            &input_state,
             |_, _, _: &gpui_component::input::InputEvent, cx| {
                 cx.notify();
             },
         );
 
-        _ = text_input.update(cx, |input, cx| {
-            input.set_text(EXAMPLE, window, cx);
-        });
-
         Self {
-            text_input,
+            input_state,
             _subscribe,
         }
     }
@@ -52,7 +53,7 @@ impl Render for Example {
                     .w_1_2()
                     .border_r_1()
                     .border_color(cx.theme().border)
-                    .child(self.text_input.clone()),
+                    .child(TextInput::new(self.input_state.clone()).appearance(false)),
             )
             .child(
                 div()
@@ -61,7 +62,7 @@ impl Render for Example {
                     .w_1_2()
                     .p_5()
                     .overflow_y_scroll()
-                    .child(TextView::html("preview", self.text_input.read(cx).text())),
+                    .child(TextView::html("preview", self.input_state.read(cx).text())),
             )
     }
 }

--- a/crates/story/examples/html.rs
+++ b/crates/story/examples/html.rs
@@ -20,7 +20,7 @@ impl Example {
             InputState::new(window, cx)
                 .multi_line()
                 .h_full()
-                .default_text(EXAMPLE)
+                .default_value(EXAMPLE)
                 .placeholder("Enter your HTML here...")
         });
 
@@ -62,7 +62,7 @@ impl Render for Example {
                     .w_1_2()
                     .p_5()
                     .overflow_y_scroll()
-                    .child(TextView::html("preview", self.input_state.read(cx).text())),
+                    .child(TextView::html("preview", self.input_state.read(cx).value())),
             )
     }
 }

--- a/crates/story/examples/html.rs
+++ b/crates/story/examples/html.rs
@@ -52,11 +52,7 @@ impl Render for Example {
                     .w_1_2()
                     .border_r_1()
                     .border_color(cx.theme().border)
-                    .child(
-                        TextInput::new(self.input_state.clone())
-                            .h_full()
-                            .appearance(false),
-                    ),
+                    .child(TextInput::new(&self.input_state).h_full().appearance(false)),
             )
             .child(
                 div()

--- a/crates/story/examples/html.rs
+++ b/crates/story/examples/html.rs
@@ -19,7 +19,6 @@ impl Example {
         let input_state = cx.new(|cx| {
             InputState::new(window, cx)
                 .multi_line()
-                .h_full()
                 .default_value(EXAMPLE)
                 .placeholder("Enter your HTML here...")
         });
@@ -53,7 +52,11 @@ impl Render for Example {
                     .w_1_2()
                     .border_r_1()
                     .border_color(cx.theme().border)
-                    .child(TextInput::new(self.input_state.clone()).appearance(false)),
+                    .child(
+                        TextInput::new(self.input_state.clone())
+                            .h_full()
+                            .appearance(false),
+                    ),
             )
             .child(
                 div()

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -22,7 +22,7 @@ impl Example {
                 .multi_line()
                 .h_full()
                 .placeholder("Enter your Markdown here...")
-                .default_text(EXAMPLE)
+                .default_value(EXAMPLE)
         });
 
         let _subscribe = cx.subscribe(
@@ -71,7 +71,7 @@ impl Render for Example {
                     .flex_1()
                     .overflow_y_scroll()
                     .child(
-                        TextView::markdown("preview", self.input_state.read(cx).text()).style(
+                        TextView::markdown("preview", self.input_state.read(cx).value()).style(
                             TextViewStyle {
                                 highlight_theme: Rc::new(theme),
                                 ..Default::default()

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -59,11 +59,7 @@ impl Render for Example {
                     .border_r_1()
                     .border_color(cx.theme().border)
                     .flex_1()
-                    .child(
-                        TextInput::new(self.input_state.clone())
-                            .h_full()
-                            .appearance(false),
-                    ),
+                    .child(TextInput::new(&self.input_state).h_full().appearance(false)),
             )
             .child(
                 div()

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -3,40 +3,36 @@ use std::rc::Rc;
 use gpui::*;
 use gpui_component::{
     highlighter::HighlightTheme,
-    input::TextInput,
+    input::{InputState, TextInput},
     text::{TextView, TextViewStyle},
     ActiveTheme as _,
 };
 use story::Assets;
 
 pub struct Example {
-    text_input: Entity<TextInput>,
+    input_state: Entity<InputState>,
 }
 
 const EXAMPLE: &str = include_str!("./markdown.md");
 
 impl Example {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let text_input = cx.new(|cx| {
-            TextInput::new(window, cx)
+        let input_state = cx.new(|cx| {
+            InputState::new(window, cx)
                 .multi_line()
-                .appearance(false)
                 .h_full()
                 .placeholder("Enter your Markdown here...")
+                .default_text(EXAMPLE)
         });
 
         let _subscribe = cx.subscribe(
-            &text_input,
+            &input_state,
             |_, _, _: &gpui_component::input::InputEvent, cx| {
                 cx.notify();
             },
         );
 
-        _ = text_input.update(cx, |input, cx| {
-            input.set_text(EXAMPLE, window, cx);
-        });
-
-        Self { text_input }
+        Self { input_state }
     }
 
     fn view(window: &mut Window, cx: &mut App) -> Entity<Self> {
@@ -64,7 +60,7 @@ impl Render for Example {
                     .border_r_1()
                     .border_color(cx.theme().border)
                     .flex_1()
-                    .child(self.text_input.clone()),
+                    .child(TextInput::new(self.input_state.clone()).appearance(false)),
             )
             .child(
                 div()
@@ -75,7 +71,7 @@ impl Render for Example {
                     .flex_1()
                     .overflow_y_scroll()
                     .child(
-                        TextView::markdown("preview", self.text_input.read(cx).text()).style(
+                        TextView::markdown("preview", self.input_state.read(cx).text()).style(
                             TextViewStyle {
                                 highlight_theme: Rc::new(theme),
                                 ..Default::default()

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -20,7 +20,6 @@ impl Example {
         let input_state = cx.new(|cx| {
             InputState::new(window, cx)
                 .multi_line()
-                .h_full()
                 .placeholder("Enter your Markdown here...")
                 .default_value(EXAMPLE)
         });
@@ -60,7 +59,11 @@ impl Render for Example {
                     .border_r_1()
                     .border_color(cx.theme().border)
                     .flex_1()
-                    .child(TextInput::new(self.input_state.clone()).appearance(false)),
+                    .child(
+                        TextInput::new(self.input_state.clone())
+                            .h_full()
+                            .appearance(false),
+                    ),
             )
             .child(
                 div()

--- a/crates/story/examples/tiles.rs
+++ b/crates/story/examples/tiles.rs
@@ -5,7 +5,7 @@ use gpui_component::{
         register_panel, DockArea, DockAreaState, DockEvent, DockItem, Panel, PanelEvent, PanelInfo,
         PanelRegistry, PanelState, PanelView,
     },
-    input::TextInput,
+    input::{InputState, TextInput},
     ActiveTheme, Root, Sizable, TitleBar,
 };
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ const TILES_DOCK_AREA: DockAreaTab = DockAreaTab {
 /// - Add a search bar to all panels.
 struct ContainerPanel {
     panel: Arc<dyn PanelView>,
-    search_input: Entity<TextInput>,
+    search_state: Entity<InputState>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -77,16 +77,11 @@ impl ContainerPanel {
 
     fn new(panel: Arc<dyn PanelView>, window: &mut Window, cx: &mut App) -> Entity<Self> {
         cx.new(|cx| {
-            let search_input = cx.new(|cx| {
-                TextInput::new(window, cx)
-                    .xsmall()
-                    .appearance(false)
-                    .placeholder("Search...")
-            });
+            let search_state = cx.new(|cx| InputState::new(window, cx).placeholder("Search..."));
 
             Self {
                 panel,
-                search_input,
+                search_state,
             }
         })
     }
@@ -110,7 +105,11 @@ impl Panel for ContainerPanel {
                 .rounded_lg()
                 .border_1()
                 .border_color(cx.theme().input)
-                .child(self.search_input.clone())
+                .child(
+                    TextInput::new(self.search_state.clone())
+                        .xsmall()
+                        .appearance(false),
+                )
                 .into_any_element(),
         )
     }

--- a/crates/story/examples/tiles.rs
+++ b/crates/story/examples/tiles.rs
@@ -106,7 +106,7 @@ impl Panel for ContainerPanel {
                 .border_1()
                 .border_color(cx.theme().input)
                 .child(
-                    TextInput::new(self.search_state.clone())
+                    TextInput::new(&self.search_state)
                         .xsmall()
                         .appearance(false),
                 )

--- a/crates/story/src/calendar_story.rs
+++ b/crates/story/src/calendar_story.rs
@@ -47,7 +47,7 @@ impl CalendarStory {
 }
 
 impl Focusable for CalendarStory {
-    fn focus_handle(&self, _: &App) -> gpui::FocusHandle {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
@@ -59,12 +59,12 @@ impl Render for CalendarStory {
             .child(
                 section("Normal")
                     .max_w_md()
-                    .child(Calendar::new(self.calendar.clone())),
+                    .child(Calendar::new(&self.calendar)),
             )
             .child(
                 section("With 3 Months")
                     .max_w_md()
-                    .child(Calendar::new(self.calendar_wide.clone()).number_of_months(3)),
+                    .child(Calendar::new(&self.calendar_wide).number_of_months(3)),
             )
     }
 }

--- a/crates/story/src/calendar_story.rs
+++ b/crates/story/src/calendar_story.rs
@@ -2,14 +2,17 @@ use gpui::{
     App, AppContext, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement as _,
     Render, Styled as _, Window,
 };
-use gpui_component::{calendar::Calendar, v_flex};
+use gpui_component::{
+    calendar::{Calendar, CalendarState},
+    v_flex,
+};
 
 use crate::section;
 
 pub struct CalendarStory {
     focus_handle: FocusHandle,
-    calendar: Entity<Calendar>,
-    calendar_wide: Entity<Calendar>,
+    calendar: Entity<CalendarState>,
+    calendar_wide: Entity<CalendarState>,
 }
 
 impl super::Story for CalendarStory {
@@ -32,8 +35,8 @@ impl CalendarStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let calendar = cx.new(|cx| Calendar::new(window, cx));
-        let calendar_wide = cx.new(|cx| Calendar::new(window, cx).number_of_months(3));
+        let calendar = cx.new(|cx| CalendarState::new(window, cx));
+        let calendar_wide = cx.new(|cx| CalendarState::new(window, cx));
 
         Self {
             calendar,
@@ -53,11 +56,15 @@ impl Render for CalendarStory {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .gap_3()
-            .child(section("Normal").max_w_md().child(self.calendar.clone()))
+            .child(
+                section("Normal")
+                    .max_w_md()
+                    .child(Calendar::new(self.calendar.clone())),
+            )
             .child(
                 section("With 3 Months")
                     .max_w_md()
-                    .child(self.calendar_wide.clone()),
+                    .child(Calendar::new(self.calendar_wide.clone()).number_of_months(3)),
             )
     }
 }

--- a/crates/story/src/color_picker_story.rs
+++ b/crates/story/src/color_picker_story.rs
@@ -65,14 +65,12 @@ impl Render for ColorPickerStory {
         v_flex().gap_3().child(
             section("Normal")
                 .max_w_md()
-                .child(
-                    ColorPicker::new("1", self.color.clone()).featured_colors(vec![
-                        red_500(),
-                        blue_500(),
-                        green_500(),
-                        yellow_500(),
-                    ]),
-                )
+                .child(ColorPicker::new(&self.color).featured_colors(vec![
+                    red_500(),
+                    blue_500(),
+                    green_500(),
+                    yellow_500(),
+                ]))
                 .when_some(self.selected_color, |this, color| {
                     this.child(color.to_hex())
                 }),

--- a/crates/story/src/color_picker_story.rs
+++ b/crates/story/src/color_picker_story.rs
@@ -4,14 +4,14 @@ use gpui::{
 };
 use gpui_component::{
     blue_500,
-    color_picker::{ColorPicker, ColorPickerEvent},
+    color_picker::{ColorPicker, ColorPickerEvent, ColorState},
     green_500, red_500, v_flex, yellow_500, Colorize,
 };
 
 use crate::section;
 
 pub struct ColorPickerStory {
-    color_picker: Entity<ColorPicker>,
+    color: Entity<ColorState>,
     selected_color: Option<Hsla>,
 
     _subscriptions: Vec<Subscription>,
@@ -37,13 +37,9 @@ impl ColorPickerStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let color_picker = cx.new(|cx| {
-            ColorPicker::new("1", window, cx)
-                .default_value(red_500())
-                .featured_colors(vec![red_500(), blue_500(), green_500(), yellow_500()])
-        });
+        let color = cx.new(|cx| ColorState::new(window, cx).default_value(red_500()));
 
-        let _subscriptions = vec![cx.subscribe(&color_picker, |this, _, ev, _| match ev {
+        let _subscriptions = vec![cx.subscribe(&color, |this, _, ev, _| match ev {
             ColorPickerEvent::Change(color) => {
                 this.selected_color = *color;
                 println!("Color changed to: {:?}", color);
@@ -51,7 +47,7 @@ impl ColorPickerStory {
         })];
 
         Self {
-            color_picker,
+            color,
             selected_color: Some(red_500()),
             _subscriptions,
         }
@@ -60,7 +56,7 @@ impl ColorPickerStory {
 
 impl Focusable for ColorPickerStory {
     fn focus_handle(&self, cx: &gpui::App) -> gpui::FocusHandle {
-        self.color_picker.focus_handle(cx)
+        self.color.read(cx).focus_handle(cx)
     }
 }
 
@@ -69,7 +65,14 @@ impl Render for ColorPickerStory {
         v_flex().gap_3().child(
             section("Normal")
                 .max_w_md()
-                .child(self.color_picker.clone())
+                .child(
+                    ColorPicker::new("1", self.color.clone()).featured_colors(vec![
+                        red_500(),
+                        blue_500(),
+                        green_500(),
+                        yellow_500(),
+                    ]),
+                )
                 .when_some(self.selected_color, |this, color| {
                     this.child(color.to_hex())
                 }),

--- a/crates/story/src/color_picker_story.rs
+++ b/crates/story/src/color_picker_story.rs
@@ -4,14 +4,14 @@ use gpui::{
 };
 use gpui_component::{
     blue_500,
-    color_picker::{ColorPicker, ColorPickerEvent, ColorState},
+    color_picker::{ColorPicker, ColorPickerEvent, ColorPickerState},
     green_500, red_500, v_flex, yellow_500, Colorize,
 };
 
 use crate::section;
 
 pub struct ColorPickerStory {
-    color: Entity<ColorState>,
+    color: Entity<ColorPickerState>,
     selected_color: Option<Hsla>,
 
     _subscriptions: Vec<Subscription>,
@@ -37,7 +37,7 @@ impl ColorPickerStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let color = cx.new(|cx| ColorState::new(window, cx).default_value(red_500()));
+        let color = cx.new(|cx| ColorPickerState::new(window, cx).default_value(red_500()));
 
         let _subscriptions = vec![cx.subscribe(&color, |this, _, ev, _| match ev {
             ColorPickerEvent::Change(color) => {

--- a/crates/story/src/date_picker_story.rs
+++ b/crates/story/src/date_picker_story.rs
@@ -5,19 +5,19 @@ use gpui::{
 };
 use gpui_component::{
     calendar,
-    date_picker::{DatePicker, DatePickerEvent, DateRangePreset, DateState},
+    date_picker::{DatePicker, DatePickerEvent, DatePickerState, DateRangePreset},
     v_flex, Sizable as _,
 };
 
 use crate::section;
 
 pub struct DatePickerStory {
-    date_picker: Entity<DateState>,
-    date_picker_small: Entity<DateState>,
-    date_picker_large: Entity<DateState>,
+    date_picker: Entity<DatePickerState>,
+    date_picker_small: Entity<DatePickerState>,
+    date_picker_large: Entity<DatePickerState>,
     date_picker_value: Option<String>,
-    date_range_picker: Entity<DateState>,
-    default_range_mode_picker: Entity<DateState>,
+    date_range_picker: Entity<DatePickerState>,
+    default_range_mode_picker: Entity<DatePickerState>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -44,13 +44,13 @@ impl DatePickerStory {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let now = chrono::Local::now().naive_local().date();
         let date_picker = cx.new(|cx| {
-            let mut picker = DateState::new(window, cx);
+            let mut picker = DatePickerState::new(window, cx);
             picker.set_date(now, window, cx);
             picker.set_disabled(vec![0, 6], window, cx);
             picker
         });
         let date_picker_large = cx.new(|cx| {
-            let mut picker = DateState::new(window, cx).date_format("%Y-%m-%d");
+            let mut picker = DatePickerState::new(window, cx).date_format("%Y-%m-%d");
             picker.set_disabled(
                 calendar::Matcher::range(Some(now), now.checked_add_days(Days::new(7))),
                 window,
@@ -64,7 +64,7 @@ impl DatePickerStory {
             picker
         });
         let date_picker_small = cx.new(|cx| {
-            let mut picker = DateState::new(window, cx);
+            let mut picker = DatePickerState::new(window, cx);
             picker.set_disabled(
                 calendar::Matcher::interval(Some(now), now.checked_add_days(Days::new(5))),
                 window,
@@ -74,7 +74,7 @@ impl DatePickerStory {
             picker
         });
         let date_range_picker = cx.new(|cx| {
-            let mut picker = DateState::new(window, cx);
+            let mut picker = DatePickerState::new(window, cx);
             picker.set_date(
                 (now, now.checked_add_days(Days::new(4)).unwrap()),
                 window,
@@ -83,7 +83,7 @@ impl DatePickerStory {
             picker
         });
 
-        let default_range_mode_picker = cx.new(|cx| DateState::range(window, cx));
+        let default_range_mode_picker = cx.new(|cx| DatePickerState::range(window, cx));
 
         let _subscriptions = vec![
             cx.subscribe(&date_picker, |this, _, ev, _| match ev {

--- a/crates/story/src/date_picker_story.rs
+++ b/crates/story/src/date_picker_story.rs
@@ -5,19 +5,19 @@ use gpui::{
 };
 use gpui_component::{
     calendar,
-    date_picker::{DatePicker, DatePickerEvent, DateRangePreset},
+    date_picker::{DatePicker, DatePickerEvent, DateRangePreset, DateState},
     v_flex, Sizable as _,
 };
 
 use crate::section;
 
 pub struct DatePickerStory {
-    date_picker: Entity<DatePicker>,
-    date_picker_small: Entity<DatePicker>,
-    date_picker_large: Entity<DatePicker>,
+    date_picker: Entity<DateState>,
+    date_picker_small: Entity<DateState>,
+    date_picker_large: Entity<DateState>,
     date_picker_value: Option<String>,
-    date_range_picker: Entity<DatePicker>,
-    default_range_mode_picker: Entity<DatePicker>,
+    date_range_picker: Entity<DateState>,
+    default_range_mode_picker: Entity<DateState>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -42,53 +42,15 @@ impl DatePickerStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let presets = vec![
-            DateRangePreset::single(
-                "Yesterday",
-                (Utc::now() - Duration::days(1)).naive_local().date(),
-            ),
-            DateRangePreset::single(
-                "Last Week",
-                (Utc::now() - Duration::weeks(1)).naive_local().date(),
-            ),
-            DateRangePreset::single(
-                "Last Month",
-                (Utc::now() - Duration::days(30)).naive_local().date(),
-            ),
-        ];
-        let range_presets = vec![
-            DateRangePreset::range(
-                "Last 7 Days",
-                (Utc::now() - Duration::days(7)).naive_local().date(),
-                Utc::now().naive_local().date(),
-            ),
-            DateRangePreset::range(
-                "Last 14 Days",
-                (Utc::now() - Duration::days(14)).naive_local().date(),
-                Utc::now().naive_local().date(),
-            ),
-            DateRangePreset::range(
-                "Last 30 Days",
-                (Utc::now() - Duration::days(30)).naive_local().date(),
-                Utc::now().naive_local().date(),
-            ),
-            DateRangePreset::range(
-                "Last 90 Days",
-                (Utc::now() - Duration::days(90)).naive_local().date(),
-                Utc::now().naive_local().date(),
-            ),
-        ];
         let now = chrono::Local::now().naive_local().date();
         let date_picker = cx.new(|cx| {
-            let mut picker = DatePicker::new("date_picker_medium", window, cx)
-                .cleanable()
-                .presets(presets);
+            let mut picker = DateState::new(window, cx);
             picker.set_date(now, window, cx);
             picker.set_disabled(vec![0, 6], window, cx);
             picker
         });
         let date_picker_large = cx.new(|cx| {
-            let mut picker = DatePicker::new("date_picker_large", window, cx)
+            let mut picker = DateState::new(window, cx)
                 .large()
                 .date_format("%Y-%m-%d")
                 .width(px(300.));
@@ -174,9 +136,52 @@ impl Focusable for DatePickerStory {
 
 impl Render for DatePickerStory {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        let presets = vec![
+            DateRangePreset::single(
+                "Yesterday",
+                (Utc::now() - Duration::days(1)).naive_local().date(),
+            ),
+            DateRangePreset::single(
+                "Last Week",
+                (Utc::now() - Duration::weeks(1)).naive_local().date(),
+            ),
+            DateRangePreset::single(
+                "Last Month",
+                (Utc::now() - Duration::days(30)).naive_local().date(),
+            ),
+        ];
+        let range_presets = vec![
+            DateRangePreset::range(
+                "Last 7 Days",
+                (Utc::now() - Duration::days(7)).naive_local().date(),
+                Utc::now().naive_local().date(),
+            ),
+            DateRangePreset::range(
+                "Last 14 Days",
+                (Utc::now() - Duration::days(14)).naive_local().date(),
+                Utc::now().naive_local().date(),
+            ),
+            DateRangePreset::range(
+                "Last 30 Days",
+                (Utc::now() - Duration::days(30)).naive_local().date(),
+                Utc::now().naive_local().date(),
+            ),
+            DateRangePreset::range(
+                "Last 90 Days",
+                (Utc::now() - Duration::days(90)).naive_local().date(),
+                Utc::now().naive_local().date(),
+            ),
+        ];
+
         v_flex()
             .gap_3()
-            .child(section("Normal").max_w_md().child(self.date_picker.clone()))
+            .child(
+                section("Normal").max_w_md().child(
+                    DatePicker::new("date-picker1", self.date_picker.clone())
+                        .cleanable()
+                        .presets(presets),
+                ),
+            )
             .child(
                 section("Small with 180px width")
                     .max_w_md()

--- a/crates/story/src/date_picker_story.rs
+++ b/crates/story/src/date_picker_story.rs
@@ -164,28 +164,28 @@ impl Render for DatePickerStory {
             .gap_3()
             .child(
                 section("Normal").max_w_md().child(
-                    DatePicker::new("date-picker1", self.date_picker.clone())
+                    DatePicker::new(&self.date_picker)
                         .cleanable()
                         .presets(presets),
                 ),
             )
             .child(
                 section("Small with 180px width").max_w_md().child(
-                    DatePicker::new("date-picker-small", self.date_picker_small.clone())
+                    DatePicker::new(&self.date_picker_small)
                         .small()
                         .width(px(180.)),
                 ),
             )
             .child(
                 section("Large").max_w_md().child(
-                    DatePicker::new("date-picker-large", self.date_picker_large.clone())
+                    DatePicker::new(&self.date_picker_large)
                         .large()
                         .width(px(300.)),
                 ),
             )
             .child(
                 section("Date Range").max_w_md().child(
-                    DatePicker::new("date-range-picker", self.date_range_picker.clone())
+                    DatePicker::new(&self.date_range_picker)
                         .number_of_months(2)
                         .cleanable()
                         .presets(range_presets.clone()),
@@ -193,13 +193,10 @@ impl Render for DatePickerStory {
             )
             .child(
                 section("Default Range Mode").max_w_md().child(
-                    DatePicker::new(
-                        "default-range-mode-picker",
-                        self.default_range_mode_picker.clone(),
-                    )
-                    .placeholder("Range mode picker")
-                    .cleanable()
-                    .presets(range_presets.clone()),
+                    DatePicker::new(&self.default_range_mode_picker)
+                        .placeholder("Range mode picker")
+                        .cleanable()
+                        .presets(range_presets.clone()),
                 ),
             )
             .child(

--- a/crates/story/src/date_picker_story.rs
+++ b/crates/story/src/date_picker_story.rs
@@ -50,10 +50,7 @@ impl DatePickerStory {
             picker
         });
         let date_picker_large = cx.new(|cx| {
-            let mut picker = DateState::new(window, cx)
-                .large()
-                .date_format("%Y-%m-%d")
-                .width(px(300.));
+            let mut picker = DateState::new(window, cx).date_format("%Y-%m-%d");
             picker.set_disabled(
                 calendar::Matcher::range(Some(now), now.checked_add_days(Days::new(7))),
                 window,
@@ -67,9 +64,7 @@ impl DatePickerStory {
             picker
         });
         let date_picker_small = cx.new(|cx| {
-            let mut picker = DatePicker::new("date_picker_small", window, cx)
-                .small()
-                .width(px(180.));
+            let mut picker = DateState::new(window, cx);
             picker.set_disabled(
                 calendar::Matcher::interval(Some(now), now.checked_add_days(Days::new(5))),
                 window,
@@ -79,10 +74,7 @@ impl DatePickerStory {
             picker
         });
         let date_range_picker = cx.new(|cx| {
-            let mut picker = DatePicker::new("date_range_picker", window, cx)
-                .number_of_months(2)
-                .cleanable()
-                .presets(range_presets.clone());
+            let mut picker = DateState::new(window, cx);
             picker.set_date(
                 (now, now.checked_add_days(Days::new(4)).unwrap()),
                 window,
@@ -91,12 +83,7 @@ impl DatePickerStory {
             picker
         });
 
-        let default_range_mode_picker = cx.new(|cx| {
-            DatePicker::range_picker("default_range_mode_picker", window, cx)
-                .placeholder("Range mode picker")
-                .cleanable()
-                .presets(range_presets.clone())
-        });
+        let default_range_mode_picker = cx.new(|cx| DateState::range(window, cx));
 
         let _subscriptions = vec![
             cx.subscribe(&date_picker, |this, _, ev, _| match ev {
@@ -183,24 +170,37 @@ impl Render for DatePickerStory {
                 ),
             )
             .child(
-                section("Small with 180px width")
-                    .max_w_md()
-                    .child(self.date_picker_small.clone()),
+                section("Small with 180px width").max_w_md().child(
+                    DatePicker::new("date-picker-small", self.date_picker_small.clone())
+                        .small()
+                        .width(px(180.)),
+                ),
             )
             .child(
-                section("Large")
-                    .max_w_md()
-                    .child(self.date_picker_large.clone()),
+                section("Large").max_w_md().child(
+                    DatePicker::new("date-picker-large", self.date_picker_large.clone())
+                        .large()
+                        .width(px(300.)),
+                ),
             )
             .child(
-                section("Date Range")
-                    .max_w_md()
-                    .child(self.date_range_picker.clone()),
+                section("Date Range").max_w_md().child(
+                    DatePicker::new("date-range-picker", self.date_range_picker.clone())
+                        .number_of_months(2)
+                        .cleanable()
+                        .presets(range_presets.clone()),
+                ),
             )
             .child(
-                section("Default Range Mode")
-                    .max_w_md()
-                    .child(self.default_range_mode_picker.clone()),
+                section("Default Range Mode").max_w_md().child(
+                    DatePicker::new(
+                        "default-range-mode-picker",
+                        self.default_range_mode_picker.clone(),
+                    )
+                    .placeholder("Range mode picker")
+                    .cleanable()
+                    .presets(range_presets.clone()),
+                ),
             )
             .child(
                 section("Date Picker Value").max_w_md().child(

--- a/crates/story/src/drawer_story.rs
+++ b/crates/story/src/drawer_story.rs
@@ -11,7 +11,7 @@ use raw_window_handle::HasWindowHandle;
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     checkbox::Checkbox,
-    date_picker::DatePicker,
+    date_picker::{DatePicker, DateState},
     h_flex,
     input::{InputState, TextInput},
     list::{List, ListDelegate, ListItem},
@@ -161,7 +161,7 @@ pub struct DrawerStory {
     list: Entity<List<ListItemDeletegate>>,
     input1: Entity<InputState>,
     input2: Entity<InputState>,
-    date_picker: Entity<DatePicker>,
+    date: Entity<DateState>,
     modal_overlay: bool,
     model_show_close: bool,
     model_padding: bool,
@@ -267,8 +267,7 @@ impl DrawerStory {
         let input2 = cx.new(|cx| {
             InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
-        let date_picker = cx
-            .new(|cx| DatePicker::new("birthday-picker", window, cx).placeholder("Date of Birth"));
+        let date = cx.new(|cx| DateState::new(window, cx));
 
         Self {
             focus_handle: cx.focus_handle(),
@@ -277,7 +276,7 @@ impl DrawerStory {
             list,
             input1,
             input2,
-            date_picker,
+            date,
             modal_overlay: true,
             model_show_close: true,
             model_padding: true,
@@ -293,7 +292,7 @@ impl DrawerStory {
         cx: &mut Context<Self>,
     ) {
         let input = self.input1.clone();
-        let date_picker = self.date_picker.clone();
+        let date = self.date.clone();
         let list = self.list.clone();
 
         let list_h = match placement {
@@ -308,7 +307,9 @@ impl DrawerStory {
                 .title("Drawer Title")
                 .gap_4()
                 .child(TextInput::new(input.clone()))
-                .child(date_picker.clone())
+                .child(
+                    DatePicker::new("birthday-picker", date.clone()).placeholder("Date of Birth"),
+                )
                 .child(
                     Button::new("send-notification")
                         .child("Test Notification")

--- a/crates/story/src/drawer_story.rs
+++ b/crates/story/src/drawer_story.rs
@@ -11,7 +11,7 @@ use raw_window_handle::HasWindowHandle;
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     checkbox::Checkbox,
-    date_picker::{DatePicker, DateState},
+    date_picker::{DatePicker, DatePickerState},
     h_flex,
     input::{InputState, TextInput},
     list::{List, ListDelegate, ListItem},
@@ -161,7 +161,7 @@ pub struct DrawerStory {
     list: Entity<List<ListItemDeletegate>>,
     input1: Entity<InputState>,
     input2: Entity<InputState>,
-    date: Entity<DateState>,
+    date: Entity<DatePickerState>,
     modal_overlay: bool,
     model_show_close: bool,
     model_padding: bool,
@@ -267,7 +267,7 @@ impl DrawerStory {
         let input2 = cx.new(|cx| {
             InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
-        let date = cx.new(|cx| DateState::new(window, cx));
+        let date = cx.new(|cx| DatePickerState::new(window, cx));
 
         Self {
             focus_handle: cx.focus_handle(),

--- a/crates/story/src/drawer_story.rs
+++ b/crates/story/src/drawer_story.rs
@@ -291,8 +291,6 @@ impl DrawerStory {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let input = self.input1.clone();
-        let date = self.date.clone();
         let list = self.list.clone();
 
         let list_h = match placement {
@@ -301,15 +299,15 @@ impl DrawerStory {
         };
 
         let overlay = self.modal_overlay;
+        let input1 = self.input1.clone();
+        let date = self.date.clone();
         window.open_drawer_at(placement, cx, move |this, _, cx| {
             this.overlay(overlay)
                 .size(px(400.))
                 .title("Drawer Title")
                 .gap_4()
-                .child(TextInput::new(input.clone()))
-                .child(
-                    DatePicker::new("birthday-picker", date.clone()).placeholder("Date of Birth"),
-                )
+                .child(TextInput::new(&input1))
+                .child(DatePicker::new(&date).placeholder("Date of Birth"))
                 .child(
                     Button::new("send-notification")
                         .child("Test Notification")
@@ -463,7 +461,7 @@ impl Render for DrawerStory {
                     .child(
                         section("Focus back test")
                             .max_w_md()
-                            .child(TextInput::new(self.input2.clone()))
+                            .child(TextInput::new(&self.input2))
                             .child(
                                 Button::new("test-action")
                                     .label("Test Action")

--- a/crates/story/src/drawer_story.rs
+++ b/crates/story/src/drawer_story.rs
@@ -13,7 +13,7 @@ use gpui_component::{
     checkbox::Checkbox,
     date_picker::DatePicker,
     h_flex,
-    input::TextInput,
+    input::{InputState, TextInput},
     list::{List, ListDelegate, ListItem},
     v_flex,
     webview::WebView,
@@ -159,8 +159,8 @@ pub struct DrawerStory {
     drawer_placement: Option<Placement>,
     selected_value: Option<SharedString>,
     list: Entity<List<ListItemDeletegate>>,
-    input1: Entity<TextInput>,
-    input2: Entity<TextInput>,
+    input1: Entity<InputState>,
+    input2: Entity<InputState>,
     date_picker: Entity<DatePicker>,
     modal_overlay: bool,
     model_show_close: bool,
@@ -263,9 +263,9 @@ impl DrawerStory {
             list
         });
 
-        let input1 = cx.new(|cx| TextInput::new(window, cx).placeholder("Your Name"));
+        let input1 = cx.new(|cx| InputState::new(window, cx).placeholder("Your Name"));
         let input2 = cx.new(|cx| {
-            TextInput::new(window, cx).placeholder("For test focus back on modal close.")
+            InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
         let date_picker = cx
             .new(|cx| DatePicker::new("birthday-picker", window, cx).placeholder("Date of Birth"));
@@ -307,7 +307,7 @@ impl DrawerStory {
                 .size(px(400.))
                 .title("Drawer Title")
                 .gap_4()
-                .child(input.clone())
+                .child(TextInput::new(input.clone()))
                 .child(date_picker.clone())
                 .child(
                     Button::new("send-notification")
@@ -462,7 +462,7 @@ impl Render for DrawerStory {
                     .child(
                         section("Focus back test")
                             .max_w_md()
-                            .child(self.input2.clone())
+                            .child(TextInput::new(self.input2.clone()))
                             .child(
                                 Button::new("test-action")
                                     .label("Test Action")

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -5,7 +5,7 @@ use gpui::{
 
 use gpui_component::{
     checkbox::Checkbox,
-    dropdown::{Dropdown, DropdownEvent, DropdownItem, SearchableVec},
+    dropdown::{Dropdown, DropdownEvent, DropdownItem, DropdownState, SearchableVec},
     h_flex, v_flex, ActiveTheme, FocusableCycle, IconName, Sizable,
 };
 
@@ -53,12 +53,12 @@ impl DropdownItem for Country {
 
 pub struct DropdownStory {
     disabled: bool,
-    country_dropdown: Entity<Dropdown<Vec<Country>>>,
-    fruit_dropdown: Entity<Dropdown<SearchableVec<SharedString>>>,
-    simple_dropdown1: Entity<Dropdown<Vec<SharedString>>>,
-    simple_dropdown2: Entity<Dropdown<SearchableVec<SharedString>>>,
-    simple_dropdown3: Entity<Dropdown<Vec<SharedString>>>,
-    disabled_dropdown: Entity<Dropdown<Vec<SharedString>>>,
+    country_dropdown: Entity<DropdownState<Vec<Country>>>,
+    fruit_dropdown: Entity<DropdownState<SearchableVec<SharedString>>>,
+    simple_dropdown1: Entity<DropdownState<Vec<SharedString>>>,
+    simple_dropdown2: Entity<DropdownState<SearchableVec<SharedString>>>,
+    simple_dropdown3: Entity<DropdownState<Vec<SharedString>>>,
+    disabled_dropdown: Entity<DropdownState<Vec<SharedString>>>,
 }
 
 impl super::Story for DropdownStory {
@@ -97,9 +97,7 @@ impl DropdownStory {
             Country::new("Ecuador", "EC"),
         ];
 
-        let country_dropdown = cx.new(|cx| {
-            Dropdown::new("dropdown-country", countries, Some(6), window, cx).cleanable()
-        });
+        let country_dropdown = cx.new(|cx| DropdownState::new(countries, Some(6), window, cx));
 
         let fruits = SearchableVec::new(vec![
             "Apple".into(),
@@ -110,12 +108,7 @@ impl DropdownStory {
             "Watermelon & This is a long long long long long long long long long title".into(),
             "Avocado".into(),
         ]);
-        let fruit_dropdown = cx.new(|cx| {
-            Dropdown::new("dropdown-fruits", fruits, None, window, cx)
-                .icon(IconName::Search)
-                .width(px(320.))
-                .menu_width(px(400.))
-        });
+        let fruit_dropdown = cx.new(|cx| DropdownState::new(fruits, None, window, cx));
 
         cx.new(|cx| {
             cx.subscribe_in(&country_dropdown, window, Self::on_dropdown_event)
@@ -126,23 +119,16 @@ impl DropdownStory {
                 country_dropdown,
                 fruit_dropdown,
                 simple_dropdown1: cx.new(|cx| {
-                    Dropdown::new(
-                        "string-list1",
+                    DropdownState::new(
                         vec!["QPUI".into(), "Iced".into(), "QT".into(), "Cocoa".into()],
                         Some(0),
                         window,
                         cx,
                     )
-                    .small()
-                    .placeholder("UI")
-                    .title_prefix("UI: ")
                 }),
                 simple_dropdown2: cx.new(|cx| {
                     let mut dropdown =
-                        Dropdown::new("string-list2", SearchableVec::new(vec![]), None, window, cx)
-                            .small()
-                            .placeholder("Language")
-                            .title_prefix("Language: ");
+                        DropdownState::new(SearchableVec::new(vec![]), None, window, cx);
 
                     dropdown.set_items(
                         SearchableVec::new(vec![
@@ -157,28 +143,10 @@ impl DropdownStory {
 
                     dropdown
                 }),
-                simple_dropdown3: cx.new(|cx| {
-                    Dropdown::new("string-list3", Vec::<SharedString>::new(), None, window, cx)
-                        .small()
-                        .empty(|_, cx| {
-                            h_flex()
-                                .h_24()
-                                .justify_center()
-                                .text_color(cx.theme().muted_foreground)
-                                .child("No Data")
-                        })
-                }),
-                disabled_dropdown: cx.new(|cx| {
-                    Dropdown::new(
-                        "disabled-dropdown",
-                        Vec::<SharedString>::new(),
-                        None,
-                        window,
-                        cx,
-                    )
-                    .small()
-                    .disabled(true)
-                }),
+                simple_dropdown3: cx
+                    .new(|cx| DropdownState::new(Vec::<SharedString>::new(), None, window, cx)),
+                disabled_dropdown: cx
+                    .new(|cx| DropdownState::new(Vec::<SharedString>::new(), None, window, cx)),
             }
         })
     }
@@ -189,7 +157,7 @@ impl DropdownStory {
 
     fn on_dropdown_event(
         &mut self,
-        _: &Entity<Dropdown<Vec<Country>>>,
+        _: &Entity<DropdownState<Vec<Country>>>,
         event: &DropdownEvent<Vec<Country>>,
         _window: &mut Window,
         _cx: &mut Context<Self>,
@@ -211,16 +179,7 @@ impl DropdownStory {
 
     fn toggle_disabled(&mut self, disabled: bool, _: &mut Window, cx: &mut Context<Self>) {
         self.disabled = disabled;
-        self.country_dropdown
-            .update(cx, |this, _| this.set_disabled(disabled));
-        self.fruit_dropdown
-            .update(cx, |this, _| this.set_disabled(disabled));
-        self.simple_dropdown1
-            .update(cx, |this, _| this.set_disabled(disabled));
-        self.simple_dropdown2
-            .update(cx, |this, _| this.set_disabled(disabled));
-        self.simple_dropdown3
-            .update(cx, |this, _| this.set_disabled(disabled));
+        cx.notify();
     }
 }
 
@@ -256,34 +215,55 @@ impl Render for DropdownStory {
                     })),
             )
             .child(
-                section("Dropdown")
-                    .max_w_128()
-                    .child(self.country_dropdown.clone()),
+                section("Dropdown").max_w_128().child(
+                    Dropdown::new("country", self.country_dropdown.clone())
+                        .cleanable()
+                        .disabled(self.disabled),
+                ),
             )
             .child(
-                section("Searchable")
-                    .max_w_128()
-                    .child(self.fruit_dropdown.clone()),
+                section("Searchable").max_w_128().child(
+                    Dropdown::new("fruits", self.fruit_dropdown.clone())
+                        .disabled(self.disabled)
+                        .icon(IconName::Search)
+                        .width(px(320.))
+                        .menu_width(px(400.)),
+                ),
+            )
+            .child(section("Disabled").max_w_128().child(
+                Dropdown::new("disabled-dropdown", self.disabled_dropdown.clone()).disabled(true),
+            ))
+            .child(
+                section("With preview label").max_w_128().child(
+                    Dropdown::new("simple-dropdown1", self.simple_dropdown1.clone())
+                        .disabled(self.disabled)
+                        .small()
+                        .placeholder("UI")
+                        .title_prefix("UI: "),
+                ),
             )
             .child(
-                section("Disabled")
-                    .max_w_128()
-                    .child(self.disabled_dropdown.clone()),
+                section("Searchable Dropdown").max_w_128().child(
+                    Dropdown::new("simple-dropdown2", self.simple_dropdown2.clone())
+                        .disabled(self.disabled)
+                        .small()
+                        .placeholder("Language")
+                        .title_prefix("Language: "),
+                ),
             )
             .child(
-                section("With preview label")
-                    .max_w_128()
-                    .child(self.simple_dropdown1.clone()),
-            )
-            .child(
-                section("Searchable Dropdown")
-                    .max_w_128()
-                    .child(self.simple_dropdown2.clone()),
-            )
-            .child(
-                section("Empty Items")
-                    .max_w_128()
-                    .child(self.simple_dropdown3.clone()),
+                section("Empty Items").max_w_128().child(
+                    Dropdown::new("simple-dropdown3", self.simple_dropdown3.clone())
+                        .disabled(self.disabled)
+                        .small()
+                        .empty(
+                            h_flex()
+                                .h_24()
+                                .justify_center()
+                                .text_color(cx.theme().muted_foreground)
+                                .child("No Data"),
+                        ),
+                ),
             )
             .child(
                 section("Selected Values").max_w_lg().child(

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -120,7 +120,17 @@ impl DropdownStory {
                 fruit_dropdown,
                 simple_dropdown1: cx.new(|cx| {
                     DropdownState::new(
-                        vec!["QPUI".into(), "Iced".into(), "QT".into(), "Cocoa".into()],
+                        vec![
+                            "GPUI".into(),
+                            "Iced".into(),
+                            "egui".into(),
+                            "Makepad".into(),
+                            "Slint".into(),
+                            "QT".into(),
+                            "ImGui".into(),
+                            "Cocoa".into(),
+                            "WinUI".into(),
+                        ],
                         Some(0),
                         window,
                         cx,

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -216,26 +216,28 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Dropdown").max_w_128().child(
-                    Dropdown::new("country", self.country_dropdown.clone())
+                    Dropdown::new(self.country_dropdown.clone())
                         .cleanable()
                         .disabled(self.disabled),
                 ),
             )
             .child(
                 section("Searchable").max_w_128().child(
-                    Dropdown::new("fruits", self.fruit_dropdown.clone())
+                    Dropdown::new(self.fruit_dropdown.clone())
                         .disabled(self.disabled)
                         .icon(IconName::Search)
                         .width(px(320.))
                         .menu_width(px(400.)),
                 ),
             )
-            .child(section("Disabled").max_w_128().child(
-                Dropdown::new("disabled-dropdown", self.disabled_dropdown.clone()).disabled(true),
-            ))
+            .child(
+                section("Disabled")
+                    .max_w_128()
+                    .child(Dropdown::new(self.disabled_dropdown.clone()).disabled(true)),
+            )
             .child(
                 section("With preview label").max_w_128().child(
-                    Dropdown::new("simple-dropdown1", self.simple_dropdown1.clone())
+                    Dropdown::new(self.simple_dropdown1.clone())
                         .disabled(self.disabled)
                         .small()
                         .placeholder("UI")
@@ -244,7 +246,7 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Searchable Dropdown").max_w_128().child(
-                    Dropdown::new("simple-dropdown2", self.simple_dropdown2.clone())
+                    Dropdown::new(self.simple_dropdown2.clone())
                         .disabled(self.disabled)
                         .small()
                         .placeholder("Language")
@@ -253,7 +255,7 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Empty Items").max_w_128().child(
-                    Dropdown::new("simple-dropdown3", self.simple_dropdown3.clone())
+                    Dropdown::new(self.simple_dropdown3.clone())
                         .disabled(self.disabled)
                         .small()
                         .empty(

--- a/crates/story/src/dropdown_story.rs
+++ b/crates/story/src/dropdown_story.rs
@@ -216,14 +216,14 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Dropdown").max_w_128().child(
-                    Dropdown::new(self.country_dropdown.clone())
+                    Dropdown::new(&self.country_dropdown)
                         .cleanable()
                         .disabled(self.disabled),
                 ),
             )
             .child(
                 section("Searchable").max_w_128().child(
-                    Dropdown::new(self.fruit_dropdown.clone())
+                    Dropdown::new(&self.fruit_dropdown)
                         .disabled(self.disabled)
                         .icon(IconName::Search)
                         .width(px(320.))
@@ -233,11 +233,11 @@ impl Render for DropdownStory {
             .child(
                 section("Disabled")
                     .max_w_128()
-                    .child(Dropdown::new(self.disabled_dropdown.clone()).disabled(true)),
+                    .child(Dropdown::new(&self.disabled_dropdown).disabled(true)),
             )
             .child(
                 section("With preview label").max_w_128().child(
-                    Dropdown::new(self.simple_dropdown1.clone())
+                    Dropdown::new(&self.simple_dropdown1)
                         .disabled(self.disabled)
                         .small()
                         .placeholder("UI")
@@ -246,7 +246,7 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Searchable Dropdown").max_w_128().child(
-                    Dropdown::new(self.simple_dropdown2.clone())
+                    Dropdown::new(&self.simple_dropdown2)
                         .disabled(self.disabled)
                         .small()
                         .placeholder("Language")
@@ -255,7 +255,7 @@ impl Render for DropdownStory {
             )
             .child(
                 section("Empty Items").max_w_128().child(
-                    Dropdown::new(self.simple_dropdown3.clone())
+                    Dropdown::new(&self.simple_dropdown3)
                         .disabled(self.disabled)
                         .small()
                         .empty(

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -10,7 +10,7 @@ use gpui_component::{
     divider::Divider,
     form::{form_field, v_form},
     h_flex,
-    input::TextInput,
+    input::{InputState, TextInput},
     switch::Switch,
     v_flex, AxisExt, FocusableCycle, Selectable, Sizable, Size,
 };
@@ -18,9 +18,9 @@ use gpui_component::{
 actions!(input_story, [Tab, TabPrev]);
 
 pub struct FormStory {
-    name_input: Entity<TextInput>,
-    email_input: Entity<TextInput>,
-    bio_input: Entity<TextInput>,
+    name_input: Entity<InputState>,
+    email_input: Entity<InputState>,
+    bio_input: Entity<InputState>,
     color_picker: Entity<ColorPicker>,
     subscribe_email: bool,
     date_picker: Entity<DatePicker>,
@@ -52,26 +52,22 @@ impl FormStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let name_input = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx).cleanable();
-            input.set_text("Jason Lee", window, cx);
-            input
-        });
+        let name_input = cx.new(|cx| InputState::new(window, cx).default_text("Jason Lee"));
         let color_picker = cx.new(|cx| {
             ColorPicker::new("color-picker-1", window, cx)
                 .small()
                 .label("Theme color")
         });
 
-        let email_input = cx.new(|cx| TextInput::new(window, cx).placeholder("Enter text here..."));
+        let email_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
         let bio_input = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx)
+            InputState::new(window, cx)
                 .multi_line()
                 .rows(5)
                 .max_rows(20)
-                .placeholder("Enter text here...");
-            input.set_text("Hello 世界，this is GPUI component.", window, cx);
-            input
+                .placeholder("Enter text here...")
+                .default_text("Hello 世界，this is GPUI component.")
         });
         let date_picker = cx.new(|cx| DatePicker::new("birthday", window, cx));
 
@@ -171,19 +167,19 @@ impl Render for FormStory {
                     .child(
                         form_field()
                             .label_fn(|_, _| "Name")
-                            .child(self.name_input.clone()),
+                            .child(TextInput::new(self.name_input.clone())),
                     )
                     .child(
                         form_field()
                             .label("Email")
-                            .child(self.email_input.clone())
+                            .child(TextInput::new(self.email_input.clone()))
                             .required(true),
                     )
                     .child(
                         form_field()
                             .label("Bio")
                             .when(self.layout.is_vertical(), |this| this.items_start())
-                            .child(self.bio_input.clone())
+                            .child(TextInput::new(self.bio_input.clone()))
                             .description_fn(|_, _| {
                                 div().child("Use at most 100 words to describe yourself.")
                             }),

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -5,8 +5,8 @@ use gpui::{
 use gpui_component::{
     button::{Button, ButtonGroup},
     checkbox::Checkbox,
-    color_picker::{ColorPicker, ColorState},
-    date_picker::{DatePicker, DateState},
+    color_picker::{ColorPicker, ColorPickerState},
+    date_picker::{DatePicker, DatePickerState},
     divider::Divider,
     form::{form_field, v_form},
     h_flex,
@@ -21,9 +21,9 @@ pub struct FormStory {
     name_input: Entity<InputState>,
     email_input: Entity<InputState>,
     bio_input: Entity<InputState>,
-    color_state: Entity<ColorState>,
+    color_state: Entity<ColorPickerState>,
     subscribe_email: bool,
-    date: Entity<DateState>,
+    date: Entity<DatePickerState>,
     layout: Axis,
     size: Size,
 }
@@ -53,7 +53,7 @@ impl FormStory {
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let name_input = cx.new(|cx| InputState::new(window, cx).default_value("Jason Lee"));
-        let color_state = cx.new(|cx| ColorState::new(window, cx));
+        let color_state = cx.new(|cx| ColorPickerState::new(window, cx));
 
         let email_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
@@ -65,7 +65,7 @@ impl FormStory {
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")
         });
-        let date = cx.new(|cx| DateState::new(window, cx));
+        let date = cx.new(|cx| DatePickerState::new(window, cx));
 
         Self {
             name_input,

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -67,7 +67,7 @@ impl FormStory {
                 .rows(5)
                 .max_rows(20)
                 .placeholder("Enter text here...")
-                .default_text("Hello 世界，this is GPUI component.")
+                .default_value("Hello 世界，this is GPUI component.")
         });
         let date_picker = cx.new(|cx| DatePicker::new("birthday", window, cx));
 

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -6,7 +6,7 @@ use gpui_component::{
     button::{Button, ButtonGroup},
     checkbox::Checkbox,
     color_picker::{ColorPicker, ColorState},
-    date_picker::DatePicker,
+    date_picker::{DatePicker, DateState},
     divider::Divider,
     form::{form_field, v_form},
     h_flex,
@@ -23,7 +23,7 @@ pub struct FormStory {
     bio_input: Entity<InputState>,
     color_state: Entity<ColorState>,
     subscribe_email: bool,
-    date_picker: Entity<DatePicker>,
+    date: Entity<DateState>,
     layout: Axis,
     size: Size,
 }
@@ -65,13 +65,13 @@ impl FormStory {
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")
         });
-        let date_picker = cx.new(|cx| DatePicker::new("birthday", window, cx));
+        let date = cx.new(|cx| DateState::new(window, cx));
 
         Self {
             name_input,
             email_input,
             bio_input,
-            date_picker,
+            date,
             color_state,
             subscribe_email: false,
             layout: Axis::Vertical,
@@ -188,7 +188,7 @@ impl Render for FormStory {
                     .child(
                         form_field()
                             .label("Birthday")
-                            .child(self.date_picker.clone())
+                            .child(DatePicker::new("date-picker", self.date.clone()))
                             .description("Select your birthday, we will send you a gift."),
                     )
                     .child(

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -5,7 +5,7 @@ use gpui::{
 use gpui_component::{
     button::{Button, ButtonGroup},
     checkbox::Checkbox,
-    color_picker::ColorPicker,
+    color_picker::{ColorPicker, ColorState},
     date_picker::DatePicker,
     divider::Divider,
     form::{form_field, v_form},
@@ -21,7 +21,7 @@ pub struct FormStory {
     name_input: Entity<InputState>,
     email_input: Entity<InputState>,
     bio_input: Entity<InputState>,
-    color_picker: Entity<ColorPicker>,
+    color_state: Entity<ColorState>,
     subscribe_email: bool,
     date_picker: Entity<DatePicker>,
     layout: Axis,
@@ -53,11 +53,7 @@ impl FormStory {
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let name_input = cx.new(|cx| InputState::new(window, cx).default_value("Jason Lee"));
-        let color_picker = cx.new(|cx| {
-            ColorPicker::new("color-picker-1", window, cx)
-                .small()
-                .label("Theme color")
-        });
+        let color_state = cx.new(|cx| ColorState::new(window, cx));
 
         let email_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
@@ -76,7 +72,7 @@ impl FormStory {
             email_input,
             bio_input,
             date_picker,
-            color_picker,
+            color_state,
             subscribe_email: false,
             layout: Axis::Vertical,
             size: Size::default(),
@@ -206,7 +202,13 @@ impl Render for FormStory {
                                 })),
                         ),
                     )
-                    .child(form_field().child(self.color_picker.clone()))
+                    .child(
+                        form_field().child(
+                            ColorPicker::new("color-picker-1", self.color_state.clone())
+                                .small()
+                                .label("Theme color"),
+                        ),
+                    )
                     .child(
                         form_field().child(
                             Checkbox::new("use-vertical-layout")

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -163,19 +163,19 @@ impl Render for FormStory {
                     .child(
                         form_field()
                             .label_fn(|_, _| "Name")
-                            .child(TextInput::new(self.name_input.clone())),
+                            .child(TextInput::new(&self.name_input)),
                     )
                     .child(
                         form_field()
                             .label("Email")
-                            .child(TextInput::new(self.email_input.clone()))
+                            .child(TextInput::new(&self.email_input))
                             .required(true),
                     )
                     .child(
                         form_field()
                             .label("Bio")
                             .when(self.layout.is_vertical(), |this| this.items_start())
-                            .child(TextInput::new(self.bio_input.clone()))
+                            .child(TextInput::new(&self.bio_input))
                             .description_fn(|_, _| {
                                 div().child("Use at most 100 words to describe yourself.")
                             }),
@@ -188,7 +188,7 @@ impl Render for FormStory {
                     .child(
                         form_field()
                             .label("Birthday")
-                            .child(DatePicker::new("date-picker", self.date.clone()))
+                            .child(DatePicker::new(&self.date))
                             .description("Select your birthday, we will send you a gift."),
                     )
                     .child(
@@ -204,7 +204,7 @@ impl Render for FormStory {
                     )
                     .child(
                         form_field().child(
-                            ColorPicker::new("color-picker-1", self.color_state.clone())
+                            ColorPicker::new(&self.color_state)
                                 .small()
                                 .label("Theme color"),
                         ),

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -52,7 +52,7 @@ impl FormStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let name_input = cx.new(|cx| InputState::new(window, cx).default_text("Jason Lee"));
+        let name_input = cx.new(|cx| InputState::new(window, cx).default_value("Jason Lee"));
         let color_picker = cx.new(|cx| {
             ColorPicker::new("color-picker-1", window, cx)
                 .small()

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -188,29 +188,25 @@ impl Render for InputStory {
             .child(
                 section("Normal Input")
                     .max_w_md()
-                    .child(TextInput::new(self.input1.clone()).cleanable())
+                    .child(TextInput::new(&self.input1).cleanable())
                     .child(self.input2.clone()),
             )
             .child(
                 section("Input State")
                     .max_w_md()
-                    .child(TextInput::new(self.disabled_input.clone()).disabled(true))
-                    .child(
-                        TextInput::new(self.mask_input.clone())
-                            .mask_toggle()
-                            .cleanable(),
-                    ),
+                    .child(TextInput::new(&self.disabled_input).disabled(true))
+                    .child(TextInput::new(&self.mask_input).mask_toggle().cleanable()),
             )
             .child(
                 section("Prefix and Suffix")
                     .max_w_md()
                     .child(
-                        TextInput::new(self.prefix_input1.clone())
+                        TextInput::new(&self.prefix_input1)
                             .cleanable()
                             .prefix(Icon::new(IconName::Search).small().ml_3()),
                     )
                     .child(
-                        TextInput::new(self.both_input1.clone())
+                        TextInput::new(&self.both_input1)
                             .cleanable()
                             .prefix(div().child(Icon::new(IconName::Search).small()).ml_3())
                             .suffix(
@@ -222,21 +218,19 @@ impl Render for InputStory {
                             ),
                     )
                     .child(
-                        TextInput::new(self.suffix_input1.clone())
-                            .cleanable()
-                            .suffix(
-                                Button::new("info")
-                                    .ghost()
-                                    .icon(IconName::Info)
-                                    .xsmall()
-                                    .mr_3(),
-                            ),
+                        TextInput::new(&self.suffix_input1).cleanable().suffix(
+                            Button::new("info")
+                                .ghost()
+                                .icon(IconName::Info)
+                                .xsmall()
+                                .mr_3(),
+                        ),
                     ),
             )
             .child(
                 section("Currency Input with thousands separator")
                     .max_w_md()
-                    .child(TextInput::new(self.currency_input.clone()))
+                    .child(TextInput::new(&self.currency_input))
                     .child(
                         div().child(format!("Value: {:?}", self.currency_input.read(cx).value())),
                     ),
@@ -244,7 +238,7 @@ impl Render for InputStory {
             .child(
                 section("Input with mask pattern: (999)-999-9999")
                     .max_w_md()
-                    .child(TextInput::new(self.phone_input.clone()))
+                    .child(TextInput::new(&self.phone_input))
                     .child(
                         v_flex()
                             .child(format!("Value: {:?}", self.phone_input.read(cx).value()))
@@ -257,7 +251,7 @@ impl Render for InputStory {
             .child(
                 section("Input with mask pattern: AAA-###-AAA")
                     .max_w_md()
-                    .child(TextInput::new(self.mask_input2.clone()))
+                    .child(TextInput::new(&self.mask_input2))
                     .child(
                         v_flex()
                             .child(format!("Value: {:?}", self.mask_input2.read(cx).value()))
@@ -270,13 +264,13 @@ impl Render for InputStory {
             .child(
                 section("Input Size")
                     .max_w_md()
-                    .child(TextInput::new(self.large_input.clone()).large())
-                    .child(TextInput::new(self.small_input.clone()).small()),
+                    .child(TextInput::new(&self.large_input).large())
+                    .child(TextInput::new(&self.small_input).small()),
             )
             .child(
                 section("Cleanable and ESC to clean")
                     .max_w_md()
-                    .child(TextInput::new(self.input_esc.clone()).cleanable()),
+                    .child(TextInput::new(&self.input_esc).cleanable()),
             )
             .child(
                 section("Focused Input")

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -8,7 +8,7 @@ use crate::section;
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     h_flex,
-    input::{InputEvent, MaskPattern, TextInput},
+    input::{InputEvent, InputState, MaskPattern, TextInput},
     v_flex, ContextModal, FocusableCycle, Icon, IconName, Sizable,
 };
 
@@ -24,19 +24,19 @@ pub fn init(cx: &mut App) {
 }
 
 pub struct InputStory {
-    input1: Entity<TextInput>,
-    input2: Entity<TextInput>,
-    input_esc: Entity<TextInput>,
-    mask_input: Entity<TextInput>,
-    disabled_input: Entity<TextInput>,
-    prefix_input1: Entity<TextInput>,
-    suffix_input1: Entity<TextInput>,
-    both_input1: Entity<TextInput>,
-    large_input: Entity<TextInput>,
-    small_input: Entity<TextInput>,
-    phone_input: Entity<TextInput>,
-    mask_input2: Entity<TextInput>,
-    currency_input: Entity<TextInput>,
+    input1: Entity<InputState>,
+    input2: Entity<InputState>,
+    input_esc: Entity<InputState>,
+    mask_input: Entity<InputState>,
+    disabled_input: Entity<InputState>,
+    prefix_input1: Entity<InputState>,
+    suffix_input1: Entity<InputState>,
+    both_input1: Entity<InputState>,
+    large_input: Entity<InputState>,
+    small_input: Entity<InputState>,
+    phone_input: Entity<InputState>,
+    mask_input2: Entity<InputState>,
+    currency_input: Entity<InputState>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -62,7 +62,7 @@ impl InputStory {
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let input1 = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx).cleanable().h_full();
+            let mut input = InputState::new(window, cx).h_full();
             input.set_text(
                 "Hello 世界，this is GPUI component, this is a long text.",
                 window,
@@ -71,60 +71,34 @@ impl InputStory {
             input
         });
 
-        let input2 = cx.new(|cx| TextInput::new(window, cx).placeholder("Enter text here..."));
+        let input2 = cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
         let input_esc = cx.new(|cx| {
-            TextInput::new(window, cx)
+            InputState::new(window, cx)
                 .placeholder("Enter text and clear it by pressing ESC")
-                .cleanable()
                 .clean_on_escape()
         });
 
         let mask_input = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx)
-                .masked(true)
-                .mask_toggle()
-                .cleanable();
+            let mut input = InputState::new(window, cx).masked(true);
             input.set_text("this-is-password", window, cx);
             input
         });
 
-        let prefix_input1 = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .prefix(|_, _| div().child(Icon::new(IconName::Search).small()).ml_3())
-                .placeholder("Search some thing...")
-                .cleanable()
-        });
+        let prefix_input1 =
+            cx.new(|cx| InputState::new(window, cx).placeholder("Search some thing..."));
         let suffix_input1 = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .suffix(|_, _| {
-                    Button::new("info")
-                        .ghost()
-                        .icon(IconName::Info)
-                        .xsmall()
-                        .mr_3()
-                })
+            InputState::new(window, cx)
                 .placeholder("This input only support [a-zA-Z0-9] characters.")
                 .pattern(regex::Regex::new(r"^[a-zA-Z0-9]*$").unwrap())
-                .cleanable()
         });
         let both_input1 = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .prefix(|_, _| div().child(Icon::new(IconName::Search).small()).ml_3())
-                .suffix(|_, _| {
-                    Button::new("info")
-                        .ghost()
-                        .icon(IconName::Info)
-                        .xsmall()
-                        .mr_3()
-                })
-                .cleanable()
-                .placeholder("This input have prefix and suffix.")
+            InputState::new(window, cx).placeholder("This input have prefix and suffix.")
         });
 
-        let phone_input = cx.new(|cx| TextInput::new(window, cx).mask_pattern("(999)-999-9999"));
-        let mask_input2 = cx.new(|cx| TextInput::new(window, cx).mask_pattern("AAA-###-AAA"));
+        let phone_input = cx.new(|cx| InputState::new(window, cx).mask_pattern("(999)-999-9999"));
+        let mask_input2 = cx.new(|cx| InputState::new(window, cx).mask_pattern("AAA-###-AAA"));
         let currency_input = cx.new(|cx| {
-            TextInput::new(window, cx).mask_pattern(MaskPattern::Number {
+            InputState::new(window, cx).mask_pattern(MaskPattern::Number {
                 separator: Some(','),
                 fraction: Some(3),
             })
@@ -142,19 +116,14 @@ impl InputStory {
             input_esc,
             mask_input,
             disabled_input: cx.new(|cx| {
-                let mut input = TextInput::new(window, cx);
+                let mut input = InputState::new(window, cx);
                 input.set_text("This is disabled input", window, cx);
                 input.set_disabled(true, window, cx);
                 input
             }),
-            large_input: cx.new(|cx| {
-                TextInput::new(window, cx)
-                    .large()
-                    .placeholder("Large input")
-            }),
+            large_input: cx.new(|cx| InputState::new(window, cx).placeholder("Large input")),
             small_input: cx.new(|cx| {
-                TextInput::new(window, cx)
-                    .small()
+                InputState::new(window, cx)
                     .validate(|s| s.parse::<f32>().is_ok())
                     .placeholder("validate to limit float number.")
             }),
@@ -178,7 +147,7 @@ impl InputStory {
 
     fn on_input_event(
         &mut self,
-        _: &Entity<TextInput>,
+        _: &Entity<InputState>,
         event: &InputEvent,
         _window: &mut Window,
         _cx: &mut Context<Self>,
@@ -228,26 +197,55 @@ impl Render for InputStory {
             .child(
                 section("Normal Input")
                     .max_w_md()
-                    .child(self.input1.clone())
+                    .child(TextInput::new(self.input1.clone()).cleanable())
                     .child(self.input2.clone()),
             )
             .child(
                 section("Input State")
                     .max_w_md()
-                    .child(self.disabled_input.clone())
-                    .child(self.mask_input.clone()),
+                    .child(TextInput::new(self.disabled_input.clone()))
+                    .child(
+                        TextInput::new(self.mask_input.clone())
+                            .mask_toggle()
+                            .cleanable(),
+                    ),
             )
             .child(
                 section("Prefix and Suffix")
                     .max_w_md()
-                    .child(self.prefix_input1.clone())
-                    .child(self.both_input1.clone())
-                    .child(self.suffix_input1.clone()),
+                    .child(
+                        TextInput::new(self.prefix_input1.clone())
+                            .cleanable()
+                            .prefix(Icon::new(IconName::Search).small().ml_3()),
+                    )
+                    .child(
+                        TextInput::new(self.both_input1.clone())
+                            .cleanable()
+                            .prefix(div().child(Icon::new(IconName::Search).small()).ml_3())
+                            .suffix(
+                                Button::new("info")
+                                    .ghost()
+                                    .icon(IconName::Info)
+                                    .xsmall()
+                                    .mr_3(),
+                            ),
+                    )
+                    .child(
+                        TextInput::new(self.suffix_input1.clone())
+                            .cleanable()
+                            .suffix(
+                                Button::new("info")
+                                    .ghost()
+                                    .icon(IconName::Info)
+                                    .xsmall()
+                                    .mr_3(),
+                            ),
+                    ),
             )
             .child(
                 section("Currency Input with thousands separator")
                     .max_w_md()
-                    .child(self.currency_input.clone())
+                    .child(TextInput::new(self.currency_input.clone()))
                     .child(
                         div().child(format!("Value: {:?}", self.currency_input.read(cx).text())),
                     ),
@@ -255,7 +253,7 @@ impl Render for InputStory {
             .child(
                 section("Input with mask pattern: (999)-999-9999")
                     .max_w_md()
-                    .child(self.phone_input.clone())
+                    .child(TextInput::new(self.phone_input.clone()))
                     .child(
                         v_flex()
                             .child(format!("Value: {:?}", self.phone_input.read(cx).text()))
@@ -268,7 +266,7 @@ impl Render for InputStory {
             .child(
                 section("Input with mask pattern: AAA-###-AAA")
                     .max_w_md()
-                    .child(self.mask_input2.clone())
+                    .child(TextInput::new(self.mask_input2.clone()))
                     .child(
                         v_flex()
                             .child(format!("Value: {:?}", self.mask_input2.read(cx).text()))
@@ -281,13 +279,13 @@ impl Render for InputStory {
             .child(
                 section("Input Size")
                     .max_w_md()
-                    .child(self.large_input.clone())
-                    .child(self.small_input.clone()),
+                    .child(TextInput::new(self.large_input.clone()).large())
+                    .child(TextInput::new(self.small_input.clone()).small()),
             )
             .child(
                 section("Cleanable and ESC to clean")
                     .max_w_md()
-                    .child(self.input_esc.clone()),
+                    .child(TextInput::new(self.input_esc.clone()).cleanable()),
             )
             .child(
                 section("Focused Input")

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -247,7 +247,7 @@ impl Render for InputStory {
                     .max_w_md()
                     .child(TextInput::new(self.currency_input.clone()))
                     .child(
-                        div().child(format!("Value: {:?}", self.currency_input.read(cx).text())),
+                        div().child(format!("Value: {:?}", self.currency_input.read(cx).value())),
                     ),
             )
             .child(
@@ -256,10 +256,10 @@ impl Render for InputStory {
                     .child(TextInput::new(self.phone_input.clone()))
                     .child(
                         v_flex()
-                            .child(format!("Value: {:?}", self.phone_input.read(cx).text()))
+                            .child(format!("Value: {:?}", self.phone_input.read(cx).value()))
                             .child(format!(
                                 "Unmask Value: {:?}",
-                                self.phone_input.read(cx).unmask_text()
+                                self.phone_input.read(cx).unmask_value()
                             )),
                     ),
             )
@@ -269,10 +269,10 @@ impl Render for InputStory {
                     .child(TextInput::new(self.mask_input2.clone()))
                     .child(
                         v_flex()
-                            .child(format!("Value: {:?}", self.mask_input2.read(cx).text()))
+                            .child(format!("Value: {:?}", self.mask_input2.read(cx).value()))
                             .child(format!(
                                 "Unmask Value: {:?}",
-                                self.mask_input2.read(cx).unmask_text()
+                                self.mask_input2.read(cx).unmask_value()
                             )),
                     ),
             )
@@ -294,7 +294,7 @@ impl Render for InputStory {
                     .overflow_hidden()
                     .child(div().child(format!(
                         "Value: {:?}",
-                        window.focused_input(cx).map(|input| input.read(cx).text())
+                        window.focused_input(cx).map(|input| input.read(cx).value())
                     ))),
             )
             .child(

--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -62,13 +62,8 @@ impl InputStory {
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let input1 = cx.new(|cx| {
-            let mut input = InputState::new(window, cx).h_full();
-            input.set_text(
-                "Hello 世界，this is GPUI component, this is a long text.",
-                window,
-                cx,
-            );
-            input
+            InputState::new(window, cx)
+                .default_value("Hello 世界，this is GPUI component, this is a long text.")
         });
 
         let input2 = cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
@@ -79,9 +74,9 @@ impl InputStory {
         });
 
         let mask_input = cx.new(|cx| {
-            let mut input = InputState::new(window, cx).masked(true);
-            input.set_text("this-is-password", window, cx);
-            input
+            InputState::new(window, cx)
+                .masked(true)
+                .default_value("this-is-password")
         });
 
         let prefix_input1 =
@@ -115,12 +110,8 @@ impl InputStory {
             input2,
             input_esc,
             mask_input,
-            disabled_input: cx.new(|cx| {
-                let mut input = InputState::new(window, cx);
-                input.set_text("This is disabled input", window, cx);
-                input.set_disabled(true, window, cx);
-                input
-            }),
+            disabled_input: cx
+                .new(|cx| InputState::new(window, cx).default_value("This is disabled input")),
             large_input: cx.new(|cx| InputState::new(window, cx).placeholder("Large input")),
             small_input: cx.new(|cx| {
                 InputState::new(window, cx)
@@ -203,7 +194,7 @@ impl Render for InputStory {
             .child(
                 section("Input State")
                     .max_w_md()
-                    .child(TextInput::new(self.disabled_input.clone()))
+                    .child(TextInput::new(self.disabled_input.clone()).disabled(true))
                     .child(
                         TextInput::new(self.mask_input.clone())
                             .mask_toggle()

--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -218,7 +218,7 @@ impl Render for Gallery {
                                             .flex_1()
                                             .mx_1()
                                             .child(
-                                                TextInput::new(self.search_input.clone())
+                                                TextInput::new(&self.search_input)
                                                     .appearance(false)
                                                     .cleanable(),
                                             ),

--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -115,7 +115,7 @@ impl Gallery {
 
 impl Render for Gallery {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let query = self.search_input.read(cx).text().trim().to_lowercase();
+        let query = self.search_input.read(cx).value().trim().to_lowercase();
 
         let stories: Vec<_> = self
             .stories

--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -1,7 +1,7 @@
 use gpui::{prelude::*, *};
 use gpui_component::{
     h_flex,
-    input::{InputEvent, TextInput},
+    input::{InputEvent, InputState, TextInput},
     resizable::{h_resizable, resizable_panel, ResizableState},
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarMenu, SidebarMenuItem},
     v_flex, ActiveTheme as _, Icon, IconName,
@@ -13,19 +13,14 @@ pub struct Gallery {
     active_group_index: Option<usize>,
     active_index: Option<usize>,
     collapsed: bool,
-    search_input: Entity<TextInput>,
+    search_input: Entity<InputState>,
     sidebar_state: Entity<ResizableState>,
     _subscriptions: Vec<Subscription>,
 }
 
 impl Gallery {
     pub fn new(init_story: Option<&str>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let search_input = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .appearance(false)
-                .cleanable()
-                .placeholder("Search...")
-        });
+        let search_input = cx.new(|cx| InputState::new(window, cx).placeholder("Search..."));
         let _subscriptions = vec![cx.subscribe(&search_input, |this, _, e, cx| match e {
             InputEvent::Change(_) => {
                 this.active_group_index = Some(0);
@@ -222,7 +217,11 @@ impl Render for Gallery {
                                             .rounded_full()
                                             .flex_1()
                                             .mx_1()
-                                            .child(self.search_input.clone()),
+                                            .child(
+                                                TextInput::new(self.search_input.clone())
+                                                    .appearance(false)
+                                                    .cleanable(),
+                                            ),
                                     ),
                             )
                             .children(stories.clone().into_iter().enumerate().map(

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -8,7 +8,7 @@ use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     checkbox::Checkbox,
     date_picker::{DatePicker, DateState},
-    dropdown::Dropdown,
+    dropdown::{Dropdown, DropdownState},
     h_flex,
     input::{InputState, TextInput},
     modal::ModalButtonProps,
@@ -24,7 +24,7 @@ pub struct ModalStory {
     input1: Entity<InputState>,
     input2: Entity<InputState>,
     date: Entity<DateState>,
-    dropdown: Entity<Dropdown<Vec<String>>>,
+    dropdown: Entity<DropdownState<Vec<String>>>,
     modal_overlay: bool,
     model_show_close: bool,
     model_padding: bool,
@@ -58,8 +58,7 @@ impl ModalStory {
         });
         let date = cx.new(|cx| DateState::new(window, cx));
         let dropdown = cx.new(|cx| {
-            Dropdown::new(
-                "dropdown1",
+            DropdownState::new(
                 vec![
                     "Option 1".to_string(),
                     "Option 2".to_string(),
@@ -111,7 +110,7 @@ impl ModalStory {
                         .child("This is a modal dialog.")
                         .child("You can put anything here.")
                         .child(TextInput::new(input1.clone()))
-                        .child(dropdown.clone())
+                        .child(Dropdown::new("dropdown1", dropdown.clone()))
                         .child(
                             DatePicker::new("birthday-picker", date.clone())
                                 .placeholder("Date of Birth"),

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -109,12 +109,9 @@ impl ModalStory {
                         .gap_3()
                         .child("This is a modal dialog.")
                         .child("You can put anything here.")
-                        .child(TextInput::new(input1.clone()))
-                        .child(Dropdown::new(dropdown.clone()))
-                        .child(
-                            DatePicker::new("birthday-picker", date.clone())
-                                .placeholder("Date of Birth"),
-                        ),
+                        .child(TextInput::new(&input1))
+                        .child(Dropdown::new(&dropdown))
+                        .child(DatePicker::new(&date).placeholder("Date of Birth")),
                 )
                 .footer({
                     let view = view.clone();
@@ -253,7 +250,7 @@ impl Render for ModalStory {
                     .child(
                         section("Focus back test")
                             .max_w_md()
-                            .child(TextInput::new(self.input2.clone()))
+                            .child(TextInput::new(&self.input2))
                             .child(
                                 Button::new("test-action")
                                     .label("Test Action")

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -7,7 +7,7 @@ use gpui::{
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     checkbox::Checkbox,
-    date_picker::{DatePicker, DateState},
+    date_picker::{DatePicker, DatePickerState},
     dropdown::{Dropdown, DropdownState},
     h_flex,
     input::{InputState, TextInput},
@@ -23,7 +23,7 @@ pub struct ModalStory {
     selected_value: Option<SharedString>,
     input1: Entity<InputState>,
     input2: Entity<InputState>,
-    date: Entity<DateState>,
+    date: Entity<DatePickerState>,
     dropdown: Entity<DropdownState<Vec<String>>>,
     modal_overlay: bool,
     model_show_close: bool,
@@ -56,7 +56,7 @@ impl ModalStory {
         let input2 = cx.new(|cx| {
             InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
-        let date = cx.new(|cx| DateState::new(window, cx));
+        let date = cx.new(|cx| DatePickerState::new(window, cx));
         let dropdown = cx.new(|cx| {
             DropdownState::new(
                 vec![

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -110,7 +110,7 @@ impl ModalStory {
                         .child("This is a modal dialog.")
                         .child("You can put anything here.")
                         .child(TextInput::new(input1.clone()))
-                        .child(Dropdown::new("dropdown1", dropdown.clone()))
+                        .child(Dropdown::new(dropdown.clone()))
                         .child(
                             DatePicker::new("birthday-picker", date.clone())
                                 .placeholder("Date of Birth"),

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -10,7 +10,7 @@ use gpui_component::{
     date_picker::DatePicker,
     dropdown::Dropdown,
     h_flex,
-    input::TextInput,
+    input::{InputState, TextInput},
     modal::ModalButtonProps,
     v_flex, ContextModal as _,
 };
@@ -21,8 +21,8 @@ actions!(modal_story, [TestAction]);
 pub struct ModalStory {
     focus_handle: FocusHandle,
     selected_value: Option<SharedString>,
-    input1: Entity<TextInput>,
-    input2: Entity<TextInput>,
+    input1: Entity<InputState>,
+    input2: Entity<InputState>,
     date_picker: Entity<DatePicker>,
     dropdown: Entity<Dropdown<Vec<String>>>,
     modal_overlay: bool,
@@ -52,9 +52,9 @@ impl ModalStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let input1 = cx.new(|cx| TextInput::new(window, cx).placeholder("Your Name"));
+        let input1 = cx.new(|cx| InputState::new(window, cx).placeholder("Your Name"));
         let input2 = cx.new(|cx| {
-            TextInput::new(window, cx).placeholder("For test focus back on modal close.")
+            InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
         let date_picker = cx
             .new(|cx| DatePicker::new("birthday-picker", window, cx).placeholder("Date of Birth"));
@@ -111,7 +111,7 @@ impl ModalStory {
                         .gap_3()
                         .child("This is a modal dialog.")
                         .child("You can put anything here.")
-                        .child(input1.clone())
+                        .child(TextInput::new(input1.clone()))
                         .child(dropdown.clone())
                         .child(date_picker.clone()),
                 )
@@ -252,7 +252,7 @@ impl Render for ModalStory {
                     .child(
                         section("Focus back test")
                             .max_w_md()
-                            .child(self.input2.clone())
+                            .child(TextInput::new(self.input2.clone()))
                             .child(
                                 Button::new("test-action")
                                     .label("Test Action")

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -132,7 +132,7 @@ impl ModalStory {
                                         view.selected_value = Some(
                                             format!(
                                                 "Hello, {}, date: {}",
-                                                input1.read(cx).text(),
+                                                input1.read(cx).value(),
                                                 date_picker.read(cx).date()
                                             )
                                             .into(),

--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -7,7 +7,7 @@ use gpui::{
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     checkbox::Checkbox,
-    date_picker::DatePicker,
+    date_picker::{DatePicker, DateState},
     dropdown::Dropdown,
     h_flex,
     input::{InputState, TextInput},
@@ -23,7 +23,7 @@ pub struct ModalStory {
     selected_value: Option<SharedString>,
     input1: Entity<InputState>,
     input2: Entity<InputState>,
-    date_picker: Entity<DatePicker>,
+    date: Entity<DateState>,
     dropdown: Entity<Dropdown<Vec<String>>>,
     modal_overlay: bool,
     model_show_close: bool,
@@ -56,8 +56,7 @@ impl ModalStory {
         let input2 = cx.new(|cx| {
             InputState::new(window, cx).placeholder("For test focus back on modal close.")
         });
-        let date_picker = cx
-            .new(|cx| DatePicker::new("birthday-picker", window, cx).placeholder("Date of Birth"));
+        let date = cx.new(|cx| DateState::new(window, cx));
         let dropdown = cx.new(|cx| {
             Dropdown::new(
                 "dropdown1",
@@ -77,7 +76,7 @@ impl ModalStory {
             selected_value: None,
             input1,
             input2,
-            date_picker,
+            date,
             dropdown,
             modal_overlay: true,
             model_show_close: true,
@@ -93,7 +92,7 @@ impl ModalStory {
         let modal_padding = self.model_padding;
         let overlay_closable = self.overlay_closable;
         let input1 = self.input1.clone();
-        let date_picker = self.date_picker.clone();
+        let date = self.date.clone();
         let dropdown = self.dropdown.clone();
         let view = cx.entity().clone();
         let keyboard = self.model_keyboard;
@@ -113,18 +112,21 @@ impl ModalStory {
                         .child("You can put anything here.")
                         .child(TextInput::new(input1.clone()))
                         .child(dropdown.clone())
-                        .child(date_picker.clone()),
+                        .child(
+                            DatePicker::new("birthday-picker", date.clone())
+                                .placeholder("Date of Birth"),
+                        ),
                 )
                 .footer({
                     let view = view.clone();
                     let input1 = input1.clone();
-                    let date_picker = date_picker.clone();
+                    let date = date.clone();
                     move |_, _, _, _cx| {
                         vec![
                             Button::new("confirm").primary().label("Confirm").on_click({
                                 let view = view.clone();
                                 let input1 = input1.clone();
-                                let date_picker = date_picker.clone();
+                                let date = date.clone();
                                 move |_, window, cx| {
                                     window.close_modal(cx);
 
@@ -133,7 +135,7 @@ impl ModalStory {
                                             format!(
                                                 "Hello, {}, date: {}",
                                                 input1.read(cx).value(),
-                                                date_picker.read(cx).date()
+                                                date.read(cx).date()
                                             )
                                             .into(),
                                         )

--- a/crates/story/src/number_input_story.rs
+++ b/crates/story/src/number_input_story.rs
@@ -200,17 +200,17 @@ impl Render for NumberInputStory {
             .child(
                 section("Normal Size")
                     .max_w_md()
-                    .child(NumberInput::new(self.number_input1.clone())),
+                    .child(NumberInput::new(&self.number_input1)),
             )
             .child(
                 section("Small Size")
                     .max_w_md()
-                    .child(NumberInput::new(self.number_input2.clone()).small()),
+                    .child(NumberInput::new(&self.number_input2).small()),
             )
             .child(
                 section("With mask pattern")
                     .max_w_md()
-                    .child(NumberInput::new(self.number_input3.clone())),
+                    .child(NumberInput::new(&self.number_input3)),
             )
     }
 }

--- a/crates/story/src/number_input_story.rs
+++ b/crates/story/src/number_input_story.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 
 use crate::section;
 use gpui_component::{
-    input::{InputEvent, MaskPattern, NumberInput, NumberInputEvent, StepAction},
+    input::{InputEvent, InputState, MaskPattern, NumberInput, NumberInputEvent, StepAction},
     v_flex, FocusableCycle, Sizable,
 };
 
@@ -23,10 +23,10 @@ pub fn init(cx: &mut App) {
 
 pub struct NumberInputStory {
     number_input1_value: i64,
-    number_input1: Entity<NumberInput>,
-    number_input2: Entity<NumberInput>,
+    number_input1: Entity<InputState>,
+    number_input2: Entity<InputState>,
     number_input2_value: u64,
-    number_input3: Entity<NumberInput>,
+    number_input3: Entity<InputState>,
     number_input3_value: f64,
 
     _subscriptions: Vec<Subscription>,
@@ -58,29 +58,24 @@ impl NumberInputStory {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let number_input1_value = 1;
         let number_input1 = cx.new(|cx| {
-            let input = NumberInput::new(window, cx).placeholder("Number Input", window, cx);
-            input.set_value(number_input1_value.to_string(), window, cx);
-            input
+            InputState::new(window, cx)
+                .placeholder("Number Input")
+                .default_text(number_input1_value.to_string())
         });
 
         let number_input2 = cx.new(|cx| {
-            NumberInput::new(window, cx)
-                .placeholder("Unsized Integer Number Input", window, cx)
-                .pattern(Regex::new(r"^\d+$").unwrap(), window, cx)
-                .small()
+            InputState::new(window, cx)
+                .placeholder("Unsized Integer Number Input")
+                .pattern(Regex::new(r"^\d+$").unwrap())
         });
 
         let number_input3 = cx.new(|cx| {
-            NumberInput::new(window, cx)
-                .placeholder("Number Input with mask pattern", window, cx)
-                .mask_pattern(
-                    MaskPattern::Number {
-                        separator: Some(','),
-                        fraction: Some(2),
-                    },
-                    window,
-                    cx,
-                )
+            InputState::new(window, cx)
+                .placeholder("Number Input with mask pattern")
+                .mask_pattern(MaskPattern::Number {
+                    separator: Some(','),
+                    fraction: Some(2),
+                })
         });
 
         let _subscriptions = vec![
@@ -110,7 +105,7 @@ impl NumberInputStory {
 
     fn on_number_input_event(
         &mut self,
-        this: &Entity<NumberInput>,
+        this: &Entity<InputState>,
         event: &NumberInputEvent,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -144,17 +139,17 @@ impl NumberInputStory {
                     if this == &self.number_input1 {
                         self.number_input1_value = self.number_input1_value - 1;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input1_value.to_string(), window, cx);
+                            input.set_text(self.number_input1_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input2 {
                         self.number_input2_value = self.number_input2_value - 1;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input2_value.to_string(), window, cx);
+                            input.set_text(self.number_input2_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input3 {
                         self.number_input3_value = self.number_input3_value - 1.0;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input3_value.to_string(), window, cx);
+                            input.set_text(self.number_input3_value.to_string(), window, cx);
                         });
                     }
                 }
@@ -162,17 +157,17 @@ impl NumberInputStory {
                     if this == &self.number_input1 {
                         self.number_input1_value = self.number_input1_value + 1;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input1_value.to_string(), window, cx);
+                            input.set_text(self.number_input1_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input2 {
                         self.number_input2_value = self.number_input2_value + 1;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input2_value.to_string(), window, cx);
+                            input.set_text(self.number_input2_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input3 {
                         self.number_input3_value = self.number_input3_value + 1.0;
                         this.update(cx, |input, cx| {
-                            input.set_value(self.number_input3_value.to_string(), window, cx);
+                            input.set_text(self.number_input3_value.to_string(), window, cx);
                         });
                     }
                 }
@@ -205,17 +200,17 @@ impl Render for NumberInputStory {
             .child(
                 section("Normal Size")
                     .max_w_md()
-                    .child(self.number_input1.clone()),
+                    .child(NumberInput::new(self.number_input1.clone())),
             )
             .child(
                 section("Small Size")
                     .max_w_md()
-                    .child(self.number_input2.clone()),
+                    .child(NumberInput::new(self.number_input2.clone()).small()),
             )
             .child(
                 section("With mask pattern")
                     .max_w_md()
-                    .child(self.number_input3.clone()),
+                    .child(NumberInput::new(self.number_input3.clone())),
             )
     }
 }

--- a/crates/story/src/number_input_story.rs
+++ b/crates/story/src/number_input_story.rs
@@ -60,7 +60,7 @@ impl NumberInputStory {
         let number_input1 = cx.new(|cx| {
             InputState::new(window, cx)
                 .placeholder("Number Input")
-                .default_text(number_input1_value.to_string())
+                .default_value(number_input1_value.to_string())
         });
 
         let number_input2 = cx.new(|cx| {

--- a/crates/story/src/number_input_story.rs
+++ b/crates/story/src/number_input_story.rs
@@ -139,17 +139,17 @@ impl NumberInputStory {
                     if this == &self.number_input1 {
                         self.number_input1_value = self.number_input1_value - 1;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input1_value.to_string(), window, cx);
+                            input.set_value(self.number_input1_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input2 {
                         self.number_input2_value = self.number_input2_value - 1;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input2_value.to_string(), window, cx);
+                            input.set_value(self.number_input2_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input3 {
                         self.number_input3_value = self.number_input3_value - 1.0;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input3_value.to_string(), window, cx);
+                            input.set_value(self.number_input3_value.to_string(), window, cx);
                         });
                     }
                 }
@@ -157,17 +157,17 @@ impl NumberInputStory {
                     if this == &self.number_input1 {
                         self.number_input1_value = self.number_input1_value + 1;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input1_value.to_string(), window, cx);
+                            input.set_value(self.number_input1_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input2 {
                         self.number_input2_value = self.number_input2_value + 1;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input2_value.to_string(), window, cx);
+                            input.set_value(self.number_input2_value.to_string(), window, cx);
                         });
                     } else if this == &self.number_input3 {
                         self.number_input3_value = self.number_input3_value + 1.0;
                         this.update(cx, |input, cx| {
-                            input.set_text(self.number_input3_value.to_string(), window, cx);
+                            input.set_value(self.number_input3_value.to_string(), window, cx);
                         });
                     }
                 }

--- a/crates/story/src/otp_input_story.rs
+++ b/crates/story/src/otp_input_story.rs
@@ -6,7 +6,7 @@ use gpui::{
 use gpui_component::{
     checkbox::Checkbox,
     h_flex,
-    input::{InputEvent, OtpInput},
+    input::{InputEvent, OtpInput, OtpState},
     v_flex, FocusableCycle, Sizable, StyledExt,
 };
 
@@ -24,11 +24,11 @@ pub fn init(cx: &mut App) {
 
 pub struct OtpInputStory {
     otp_masked: bool,
-    otp_input: Entity<OtpInput>,
+    otp_state: Entity<OtpState>,
     otp_value: Option<SharedString>,
-    otp_input_small: Entity<OtpInput>,
-    otp_input_large: Entity<OtpInput>,
-    opt_input_sized: Entity<OtpInput>,
+    otp_state_small: Entity<OtpState>,
+    otp_state_large: Entity<OtpState>,
+    otp_state_sized: Entity<OtpState>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -57,11 +57,11 @@ impl OtpInputStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let otp_input = cx.new(|cx| OtpInput::new(6, window, cx).masked(true));
+        let otp_state = cx.new(|cx| OtpState::new(6, window, cx).masked(true));
 
         let _subscriptions =
             vec![
-                cx.subscribe(&otp_input, |this, _, ev: &InputEvent, cx| match ev {
+                cx.subscribe(&otp_state, |this, _, ev: &InputEvent, cx| match ev {
                     InputEvent::Change(text) => {
                         this.otp_value = Some(text.clone());
                         cx.notify();
@@ -72,28 +72,22 @@ impl OtpInputStory {
 
         Self {
             otp_masked: true,
-            otp_input,
+            otp_state,
             otp_value: None,
-            otp_input_small: cx.new(|cx| {
-                OtpInput::new(6, window, cx)
+            otp_state_small: cx.new(|cx| {
+                OtpState::new(6, window, cx)
                     .default_value("123456")
                     .masked(true)
-                    .small()
-                    .groups(1)
             }),
-            otp_input_large: cx.new(|cx| {
-                OtpInput::new(6, window, cx)
-                    .groups(3)
-                    .large()
+            otp_state_large: cx.new(|cx| {
+                OtpState::new(6, window, cx)
                     .default_value("012345")
                     .masked(true)
             }),
-            opt_input_sized: cx.new(|cx| {
-                OtpInput::new(4, window, cx)
-                    .groups(1)
+            otp_state_sized: cx.new(|cx| {
+                OtpState::new(4, window, cx)
                     .masked(true)
                     .default_value("654321")
-                    .with_size(px(55.))
             }),
             _subscriptions,
         }
@@ -109,16 +103,16 @@ impl OtpInputStory {
 
     fn toggle_opt_masked(&mut self, _: &bool, window: &mut Window, cx: &mut Context<Self>) {
         self.otp_masked = !self.otp_masked;
-        self.otp_input.update(cx, |input, cx| {
+        self.otp_state.update(cx, |input, cx| {
             input.set_masked(self.otp_masked, window, cx)
         });
-        self.otp_input_small.update(cx, |input, cx| {
+        self.otp_state_small.update(cx, |input, cx| {
             input.set_masked(self.otp_masked, window, cx)
         });
-        self.otp_input_large.update(cx, |input, cx| {
+        self.otp_state_large.update(cx, |input, cx| {
             input.set_masked(self.otp_masked, window, cx)
         });
-        self.opt_input_sized.update(cx, |input, cx| {
+        self.otp_state_sized.update(cx, |input, cx| {
             input.set_masked(self.otp_masked, window, cx)
         });
     }
@@ -126,12 +120,12 @@ impl OtpInputStory {
 
 impl FocusableCycle for OtpInputStory {
     fn cycle_focus_handles(&self, _: &mut Window, cx: &mut App) -> Vec<FocusHandle> {
-        [self.otp_input.focus_handle(cx)].to_vec()
+        [self.otp_state.focus_handle(cx)].to_vec()
     }
 }
 impl Focusable for OtpInputStory {
     fn focus_handle(&self, cx: &gpui::App) -> gpui::FocusHandle {
-        self.otp_input.focus_handle(cx)
+        self.otp_state.focus_handle(cx)
     }
 }
 
@@ -159,13 +153,31 @@ impl Render for OtpInputStory {
             .child(
                 section("Normal")
                     .v_flex()
-                    .child(self.otp_input.clone())
+                    .child(OtpInput::new(self.otp_state.clone()))
                     .when_some(self.otp_value.clone(), |this, otp| {
                         this.child(format!("Your OTP: {}", otp))
                     }),
             )
-            .child(section("Small").child(self.otp_input_small.clone()))
-            .child(section("Large").child(self.otp_input_large.clone()))
-            .child(section("With Size").child(self.opt_input_sized.clone()))
+            .child(
+                section("Small").child(
+                    OtpInput::new(self.otp_state_small.clone())
+                        .groups(1)
+                        .small(),
+                ),
+            )
+            .child(
+                section("Large").child(
+                    OtpInput::new(self.otp_state_large.clone())
+                        .groups(3)
+                        .large(),
+                ),
+            )
+            .child(
+                section("With Size").child(
+                    OtpInput::new(self.otp_state_sized.clone())
+                        .groups(1)
+                        .with_size(px(55.)),
+                ),
+            )
     }
 }

--- a/crates/story/src/otp_input_story.rs
+++ b/crates/story/src/otp_input_story.rs
@@ -153,28 +153,16 @@ impl Render for OtpInputStory {
             .child(
                 section("Normal")
                     .v_flex()
-                    .child(OtpInput::new(self.otp_state.clone()))
+                    .child(OtpInput::new(&self.otp_state))
                     .when_some(self.otp_value.clone(), |this, otp| {
                         this.child(format!("Your OTP: {}", otp))
                     }),
             )
-            .child(
-                section("Small").child(
-                    OtpInput::new(self.otp_state_small.clone())
-                        .groups(1)
-                        .small(),
-                ),
-            )
-            .child(
-                section("Large").child(
-                    OtpInput::new(self.otp_state_large.clone())
-                        .groups(3)
-                        .large(),
-                ),
-            )
+            .child(section("Small").child(OtpInput::new(&self.otp_state_small).groups(1).small()))
+            .child(section("Large").child(OtpInput::new(&self.otp_state_large).groups(3).large()))
             .child(
                 section("With Size").child(
-                    OtpInput::new(self.otp_state_sized.clone())
+                    OtpInput::new(&self.otp_state_sized)
                         .groups(1)
                         .with_size(px(55.)),
                 ),

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -67,7 +67,7 @@ impl Render for Form {
             .p_4()
             .size_full()
             .child("This is a form container.")
-            .child(TextInput::new(self.input1.clone()))
+            .child(TextInput::new(&self.input1))
             .child(
                 Button::new("submit")
                     .label("Submit")

--- a/crates/story/src/popover_story.rs
+++ b/crates/story/src/popover_story.rs
@@ -7,7 +7,7 @@ use gpui_component::{
     button::{Button, ButtonVariants as _},
     divider::Divider,
     h_flex,
-    input::TextInput,
+    input::{InputState, TextInput},
     popover::{Popover, PopoverContent},
     v_flex, ContextModal, Sizable,
 };
@@ -41,13 +41,13 @@ pub fn init(cx: &mut App) {
 }
 
 struct Form {
-    input1: Entity<TextInput>,
+    input1: Entity<InputState>,
 }
 
 impl Form {
     fn new(window: &mut Window, cx: &mut App) -> Entity<Self> {
         cx.new(|cx| Self {
-            input1: cx.new(|cx| TextInput::new(window, cx)),
+            input1: cx.new(|cx| InputState::new(window, cx)),
         })
     }
 }
@@ -67,7 +67,7 @@ impl Render for Form {
             .p_4()
             .size_full()
             .child("This is a form container.")
-            .child(self.input1.clone())
+            .child(TextInput::new(self.input1.clone()))
             .child(
                 Button::new("submit")
                     .label("Submit")

--- a/crates/story/src/slider_story.rs
+++ b/crates/story/src/slider_story.rs
@@ -165,7 +165,7 @@ impl Render for SliderStory {
                     .max_w_md()
                     .v_flex()
                     .child(
-                        Slider::new(self.slider1.clone())
+                        Slider::new(&self.slider1)
                             .horizontal()
                             .disabled(self.disabled),
                     )
@@ -176,7 +176,7 @@ impl Render for SliderStory {
                     .max_w_md()
                     .v_flex()
                     .child(
-                        Slider::new(self.slider2.clone())
+                        Slider::new(&self.slider2)
                             .horizontal()
                             .disabled(self.disabled),
                     )
@@ -213,7 +213,7 @@ impl Render for SliderStory {
                         .items_center()
                         .justify_center()
                         .child(
-                            Slider::new(self.slider_hsl[0].clone())
+                            Slider::new(&self.slider_hsl[0])
                                 .vertical()
                                 .reverse()
                                 .disabled(self.disabled),
@@ -232,7 +232,7 @@ impl Render for SliderStory {
                         .items_center()
                         .justify_center()
                         .child(
-                            Slider::new(self.slider_hsl[1].clone())
+                            Slider::new(&self.slider_hsl[1])
                                 .vertical()
                                 .reverse()
                                 .disabled(self.disabled),
@@ -251,7 +251,7 @@ impl Render for SliderStory {
                         .items_center()
                         .justify_center()
                         .child(
-                            Slider::new(self.slider_hsl[2].clone())
+                            Slider::new(&self.slider_hsl[2])
                                 .vertical()
                                 .reverse()
                                 .disabled(self.disabled),
@@ -270,7 +270,7 @@ impl Render for SliderStory {
                         .items_center()
                         .justify_center()
                         .child(
-                            Slider::new(self.slider_hsl[3].clone())
+                            Slider::new(&self.slider_hsl[3])
                                 .vertical()
                                 .reverse()
                                 .disabled(self.disabled),

--- a/crates/story/src/slider_story.rs
+++ b/crates/story/src/slider_story.rs
@@ -5,7 +5,7 @@ use gpui::{
 use gpui_component::{
     clipboard::Clipboard,
     h_flex,
-    slider::{Slider, SliderEvent},
+    slider::{Slider, SliderEvent, SliderState},
     v_flex, Colorize as _, ContextModal, StyledExt,
 };
 
@@ -13,11 +13,11 @@ use crate::section;
 
 pub struct SliderStory {
     focus_handle: gpui::FocusHandle,
-    slider1: Entity<Slider>,
+    slider1: Entity<SliderState>,
     slider1_value: f32,
-    slider2: Entity<Slider>,
+    slider2: Entity<SliderState>,
     slider2_value: f32,
-    slider_hsl: [Entity<Slider>; 4],
+    slider_hsl: [Entity<SliderState>; 4],
     slider_hsl_value: Hsla,
     _subscritions: Vec<Subscription>,
 }
@@ -43,46 +43,42 @@ impl SliderStory {
 
     fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         let slider1 = cx.new(|_| {
-            Slider::horizontal()
+            SliderState::new()
                 .min(-255.)
                 .max(255.)
                 .default_value(15.)
                 .step(15.)
         });
 
-        let slider2 = cx.new(|_| Slider::horizontal().min(0.).max(5.).step(1.0));
+        let slider2 = cx.new(|_| SliderState::new().min(0.).max(5.).step(1.0));
         let slider_hsl = [
             cx.new(|_| {
-                Slider::vertical()
-                    .reverse()
+                SliderState::new()
                     .min(0.)
                     .max(1.)
                     .step(0.01)
                     .default_value(0.38)
             }),
             cx.new(|_| {
-                Slider::vertical()
-                    .reverse()
+                SliderState::new()
                     .min(0.)
                     .max(1.)
                     .step(0.01)
                     .default_value(0.5)
             }),
             cx.new(|_| {
-                Slider::vertical()
-                    .reverse()
+                SliderState::new()
                     .min(0.)
                     .max(1.)
                     .step(0.01)
                     .default_value(0.5)
             }),
             cx.new(|_| {
-                Slider::vertical()
-                    .reverse()
+                SliderState::new()
                     .min(0.)
                     .max(1.)
                     .step(0.01)
-                    .default_value(1.)
+                    .default_value(0.5)
             }),
         ];
 
@@ -154,14 +150,14 @@ impl Render for SliderStory {
                 section("Horizontal Slider")
                     .max_w_md()
                     .v_flex()
-                    .child(self.slider1.clone())
+                    .child(Slider::new(self.slider1.clone()).horizontal())
                     .child(format!("Value: {}", self.slider1_value)),
             )
             .child(
                 section("Slider (0 - 5)")
                     .max_w_md()
                     .v_flex()
-                    .child(self.slider2.clone())
+                    .child(Slider::new(self.slider2.clone()).horizontal())
                     .child(format!("Value: {}", self.slider2_value)),
             )
             .child(
@@ -194,7 +190,7 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(self.slider_hsl[0].clone())
+                        .child(Slider::new(self.slider_hsl[0].clone()).vertical().reverse())
                         .child(
                             v_flex()
                                 .items_center()
@@ -208,7 +204,7 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(self.slider_hsl[1].clone())
+                        .child(Slider::new(self.slider_hsl[1].clone()).vertical().reverse())
                         .child(
                             v_flex()
                                 .items_center()
@@ -222,7 +218,7 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(self.slider_hsl[2].clone())
+                        .child(Slider::new(self.slider_hsl[2].clone()).vertical().reverse())
                         .child(
                             v_flex()
                                 .items_center()
@@ -236,7 +232,7 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(self.slider_hsl[3].clone())
+                        .child(Slider::new(self.slider_hsl[3].clone()).vertical().reverse())
                         .child(
                             v_flex()
                                 .items_center()

--- a/crates/story/src/slider_story.rs
+++ b/crates/story/src/slider_story.rs
@@ -3,6 +3,7 @@ use gpui::{
     SharedString, Styled, Subscription, Window,
 };
 use gpui_component::{
+    checkbox::Checkbox,
     clipboard::Clipboard,
     h_flex,
     slider::{Slider, SliderEvent, SliderState},
@@ -19,6 +20,7 @@ pub struct SliderStory {
     slider2_value: f32,
     slider_hsl: [Entity<SliderState>; 4],
     slider_hsl_value: Hsla,
+    disabled: bool,
     _subscritions: Vec<Subscription>,
 }
 
@@ -128,6 +130,7 @@ impl SliderStory {
             slider2,
             slider_hsl,
             slider_hsl_value: gpui::red(),
+            disabled: false,
             _subscritions,
         }
     }
@@ -140,24 +143,43 @@ impl Focusable for SliderStory {
 }
 
 impl Render for SliderStory {
-    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let rgb = SharedString::from(self.slider_hsl_value.to_hex());
 
         v_flex()
             .items_center()
             .gap_y_3()
             .child(
+                h_flex().justify_between().child(
+                    Checkbox::new("disabled")
+                        .checked(self.disabled)
+                        .label("Disabled")
+                        .on_click(cx.listener(|this, check: &bool, _, cx| {
+                            this.disabled = *check;
+                            cx.notify();
+                        })),
+                ),
+            )
+            .child(
                 section("Horizontal Slider")
                     .max_w_md()
                     .v_flex()
-                    .child(Slider::new(self.slider1.clone()).horizontal())
+                    .child(
+                        Slider::new(self.slider1.clone())
+                            .horizontal()
+                            .disabled(self.disabled),
+                    )
                     .child(format!("Value: {}", self.slider1_value)),
             )
             .child(
                 section("Slider (0 - 5)")
                     .max_w_md()
                     .v_flex()
-                    .child(Slider::new(self.slider2.clone()).horizontal())
+                    .child(
+                        Slider::new(self.slider2.clone())
+                            .horizontal()
+                            .disabled(self.disabled),
+                    )
                     .child(format!("Value: {}", self.slider2_value)),
             )
             .child(
@@ -190,7 +212,12 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(Slider::new(self.slider_hsl[0].clone()).vertical().reverse())
+                        .child(
+                            Slider::new(self.slider_hsl[0].clone())
+                                .vertical()
+                                .reverse()
+                                .disabled(self.disabled),
+                        )
                         .child(
                             v_flex()
                                 .items_center()
@@ -204,7 +231,12 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(Slider::new(self.slider_hsl[1].clone()).vertical().reverse())
+                        .child(
+                            Slider::new(self.slider_hsl[1].clone())
+                                .vertical()
+                                .reverse()
+                                .disabled(self.disabled),
+                        )
                         .child(
                             v_flex()
                                 .items_center()
@@ -218,7 +250,12 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(Slider::new(self.slider_hsl[2].clone()).vertical().reverse())
+                        .child(
+                            Slider::new(self.slider_hsl[2].clone())
+                                .vertical()
+                                .reverse()
+                                .disabled(self.disabled),
+                        )
                         .child(
                             v_flex()
                                 .items_center()
@@ -232,7 +269,12 @@ impl Render for SliderStory {
                         .gap_3()
                         .items_center()
                         .justify_center()
-                        .child(Slider::new(self.slider_hsl[3].clone()).vertical().reverse())
+                        .child(
+                            Slider::new(self.slider_hsl[3].clone())
+                                .vertical()
+                                .reverse()
+                                .disabled(self.disabled),
+                        )
                         .child(
                             v_flex()
                                 .items_center()

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -617,7 +617,7 @@ impl TableStory {
             let mut input = InputState::new(window, cx)
                 .placeholder("Enter number of Stocks to display")
                 .validate(|s| s.parse::<usize>().is_ok());
-            input.set_text("5000", window, cx);
+            input.set_value("5000", window, cx);
             input
         });
 

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -14,7 +14,7 @@ use gpui_component::{
     checkbox::Checkbox,
     green, h_flex,
     indicator::Indicator,
-    input::{InputEvent, TextInput},
+    input::{InputEvent, InputState, TextInput},
     label::Label,
     popup_menu::{PopupMenu, PopupMenuExt},
     red,
@@ -576,7 +576,7 @@ impl TableDelegate for StockTableDelegate {
 
 pub struct TableStory {
     table: Entity<Table<StockTableDelegate>>,
-    num_stocks_input: Entity<TextInput>,
+    num_stocks_input: Entity<InputState>,
     stripe: bool,
     refresh_data: bool,
     size: Size,
@@ -614,7 +614,7 @@ impl TableStory {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         // Create the number input field with validation for positive integers
         let num_stocks_input = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx)
+            let mut input = InputState::new(window, cx)
                 .placeholder("Enter number of Stocks to display")
                 .validate(|s| s.parse::<usize>().is_ok());
             input.set_text("5000", window, cx);
@@ -669,7 +669,7 @@ impl TableStory {
     // Event handler for changes in the number input field
     fn on_num_stocks_input_change(
         &mut self,
-        _: &Entity<TextInput>,
+        _: &Entity<InputState>,
         event: &InputEvent,
         _: &mut Window,
         cx: &mut Context<Self>,
@@ -935,7 +935,7 @@ impl Render for TableStory {
                         .child(
                             h_flex()
                                 .min_w_32()
-                                .child(self.num_stocks_input.clone())
+                                .child(TextInput::new(self.num_stocks_input.clone()))
                                 .into_any_element(),
                         )
                         .when(delegate.loading, |this| {

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -935,7 +935,7 @@ impl Render for TableStory {
                         .child(
                             h_flex()
                                 .min_w_32()
-                                .child(TextInput::new(self.num_stocks_input.clone()))
+                                .child(TextInput::new(&self.num_stocks_input))
                                 .into_any_element(),
                         )
                         .when(delegate.loading, |this| {

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -677,7 +677,7 @@ impl TableStory {
         match event {
             // Update when the user presses Enter or the input loses focus
             InputEvent::PressEnter { .. } | InputEvent::Blur => {
-                let text = self.num_stocks_input.read(cx).text().to_string();
+                let text = self.num_stocks_input.read(cx).value().to_string();
                 if let Ok(num) = text.parse::<usize>() {
                     self.table.update(cx, |table, _| {
                         table.delegate_mut().update_stocks(num);

--- a/crates/story/src/textarea_story.rs
+++ b/crates/story/src/textarea_story.rs
@@ -138,7 +138,7 @@ impl Render for TextareaStory {
                     v_flex()
                         .gap_2()
                         .w_full()
-                        .child(TextInput::new(self.textarea.clone()))
+                        .child(TextInput::new(&self.textarea))
                         .child(
                             h_flex()
                                 .gap_2()

--- a/crates/story/src/textarea_story.rs
+++ b/crates/story/src/textarea_story.rs
@@ -54,7 +54,7 @@ impl TextareaStory {
             InputState::new(window, cx)
                 .multi_line()
                 .rows(10)
-                .placeholder("Enter text here...").default_text(
+                .placeholder("Enter text here...").default_value(
                 unindent::unindent(
                     r#"Hello 世界，this is GPUI component.
 

--- a/crates/story/src/textarea_story.rs
+++ b/crates/story/src/textarea_story.rs
@@ -4,7 +4,12 @@ use gpui::{
 };
 
 use crate::section;
-use gpui_component::{button::Button, h_flex, input::TextInput, v_flex, FocusableCycle, Sizable};
+use gpui_component::{
+    button::Button,
+    h_flex,
+    input::{InputState, TextInput},
+    v_flex, FocusableCycle, Sizable,
+};
 
 actions!(input_story, [Tab, TabPrev]);
 
@@ -18,7 +23,7 @@ pub fn init(cx: &mut App) {
 }
 
 pub struct TextareaStory {
-    textarea: Entity<TextInput>,
+    textarea: Entity<InputState>,
 }
 
 impl super::Story for TextareaStory {
@@ -46,11 +51,10 @@ impl TextareaStory {
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let textarea = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx)
+            InputState::new(window, cx)
                 .multi_line()
                 .rows(10)
-                .placeholder("Enter text here...");
-            input.set_text(
+                .placeholder("Enter text here...").default_text(
                 unindent::unindent(
                     r#"Hello 世界，this is GPUI component.
 
@@ -70,11 +74,8 @@ impl TextareaStory {
 
                 If you want to see the demo, here is a some demo applications.
                 "#,
-                ),
-                window,
-                cx,
-            );
-            input
+                )
+            )
         });
 
         Self { textarea }
@@ -137,7 +138,7 @@ impl Render for TextareaStory {
                     v_flex()
                         .gap_2()
                         .w_full()
-                        .child(self.textarea.clone())
+                        .child(TextInput::new(self.textarea.clone()))
                         .child(
                             h_flex()
                                 .gap_2()

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -8,7 +8,7 @@ use gpui::{
 use gpui_component::{
     badge::Badge,
     button::{Button, ButtonVariants as _},
-    color_picker::{ColorPicker, ColorPickerEvent},
+    color_picker::{ColorPicker, ColorPickerEvent, ColorState},
     locale,
     popup_menu::PopupMenuExt as _,
     scroll::ScrollbarShow,
@@ -20,10 +20,9 @@ use crate::{SelectFont, SelectLocale, SelectRadius, SelectScrollbarShow};
 
 pub struct AppTitleBar {
     title: SharedString,
-    theme_color: Option<Hsla>,
     locale_selector: Entity<LocaleSelector>,
     font_size_selector: Entity<FontSizeSelector>,
-    theme_color_picker: Entity<ColorPicker>,
+    theme_color: Entity<ColorState>,
     child: Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>,
     _subscriptions: Vec<Subscription>,
 }
@@ -43,17 +42,11 @@ impl AppTitleBar {
             Theme::global_mut(cx).scrollbar_show = ScrollbarShow::Hover;
         }
 
-        let theme_color_picker = cx.new(|cx| {
-            let mut picker = ColorPicker::new("theme-color-picker", window, cx)
-                .small()
-                .anchor(Corner::TopRight)
-                .icon(IconName::Palette);
-            picker.set_value(cx.theme().primary, window, cx);
-            picker
-        });
+        let theme_color =
+            cx.new(|cx| ColorState::new(window, cx).default_value(cx.theme().primary));
 
         let _subscriptions = vec![cx.subscribe_in(
-            &theme_color_picker,
+            &theme_color,
             window,
             |this, _, ev: &ColorPickerEvent, window, cx| match ev {
                 ColorPickerEvent::Change(color) => {
@@ -64,10 +57,9 @@ impl AppTitleBar {
 
         Self {
             title: title.into(),
-            theme_color: None,
             locale_selector,
             font_size_selector,
-            theme_color_picker,
+            theme_color,
             child: Rc::new(|_, _| div().into_any_element()),
             _subscriptions,
         }
@@ -88,10 +80,12 @@ impl AppTitleBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.theme_color = color;
-        if let Some(color) = self.theme_color {
+        if let Some(color) = color {
             let theme = cx.global_mut::<Theme>();
             theme.apply_color(color);
+            self.theme_color.update(cx, |state, cx| {
+                state.set_value(color, window, cx);
+            });
             window.refresh();
         }
     }
@@ -103,7 +97,7 @@ impl AppTitleBar {
         };
 
         Theme::change(mode, None, cx);
-        self.set_theme_color(self.theme_color, window, cx);
+        self.set_theme_color(self.theme_color.read(cx).value(), window, cx);
     }
 }
 
@@ -123,7 +117,12 @@ impl Render for AppTitleBar {
                     .gap_2()
                     .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child((self.child.clone())(window, cx))
-                    .child(self.theme_color_picker.clone())
+                    .child(
+                        ColorPicker::new("theme-color-picker", self.theme_color.clone())
+                            .small()
+                            .anchor(Corner::TopRight)
+                            .icon(IconName::Palette),
+                    )
                     .child(
                         Button::new("theme-mode")
                             .map(|this| {

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -8,7 +8,7 @@ use gpui::{
 use gpui_component::{
     badge::Badge,
     button::{Button, ButtonVariants as _},
-    color_picker::{ColorPicker, ColorPickerEvent, ColorState},
+    color_picker::{ColorPicker, ColorPickerEvent, ColorPickerState},
     locale,
     popup_menu::PopupMenuExt as _,
     scroll::ScrollbarShow,
@@ -22,7 +22,7 @@ pub struct AppTitleBar {
     title: SharedString,
     locale_selector: Entity<LocaleSelector>,
     font_size_selector: Entity<FontSizeSelector>,
-    theme_color: Entity<ColorState>,
+    theme_color: Entity<ColorPickerState>,
     child: Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>,
     _subscriptions: Vec<Subscription>,
 }
@@ -43,7 +43,7 @@ impl AppTitleBar {
         }
 
         let theme_color =
-            cx.new(|cx| ColorState::new(window, cx).default_value(cx.theme().primary));
+            cx.new(|cx| ColorPickerState::new(window, cx).default_value(cx.theme().primary));
 
         let _subscriptions = vec![cx.subscribe_in(
             &theme_color,

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -118,7 +118,7 @@ impl Render for AppTitleBar {
                     .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                     .child((self.child.clone())(window, cx))
                     .child(
-                        ColorPicker::new("theme-color-picker", self.theme_color.clone())
+                        ColorPicker::new(&self.theme_color)
                             .small()
                             .anchor(Corner::TopRight)
                             .icon(IconName::Palette),

--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -130,7 +130,6 @@ impl Focusable for WebViewStory {
 impl Render for WebViewStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let webview = self.webview.clone();
-        let address_input = self.address_input.clone();
 
         v_flex()
             .p_2()
@@ -140,7 +139,7 @@ impl Render for WebViewStory {
                 h_flex()
                     .gap_2()
                     .items_center()
-                    .child(TextInput::new(address_input.clone())),
+                    .child(TextInput::new(&self.address_input)),
             )
             .child(
                 div()

--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -4,7 +4,7 @@ use gpui::{
 };
 use gpui_component::{
     h_flex,
-    input::{InputEvent, TextInput},
+    input::{InputEvent, InputState, TextInput},
     v_flex,
     webview::WebView,
     wry, ActiveTheme,
@@ -18,7 +18,7 @@ pub fn init(_: &mut App) {
 pub struct WebViewStory {
     focus_handle: FocusHandle,
     webview: Entity<WebView>,
-    address_input: Entity<TextInput>,
+    address_input: Entity<InputState>,
 }
 
 impl super::Story for WebViewStory {
@@ -76,11 +76,8 @@ impl WebViewStory {
             WebView::new(webview, window, cx)
         });
 
-        let address_input = cx.new(|cx| {
-            let mut input = TextInput::new(window, cx);
-            input.set_text("https://google.com", window, cx);
-            input
-        });
+        let address_input =
+            cx.new(|cx| InputState::new(window, cx).default_text("https://google.com"));
 
         let url = address_input.read(cx).text().clone();
         webview.update(cx, |view, _| {
@@ -139,7 +136,12 @@ impl Render for WebViewStory {
             .p_2()
             .gap_3()
             .size_full()
-            .child(h_flex().gap_2().items_center().child(address_input.clone()))
+            .child(
+                h_flex()
+                    .gap_2()
+                    .items_center()
+                    .child(TextInput::new(address_input.clone())),
+            )
             .child(
                 div()
                     .flex_1()

--- a/crates/story/src/webview_story.rs
+++ b/crates/story/src/webview_story.rs
@@ -77,9 +77,9 @@ impl WebViewStory {
         });
 
         let address_input =
-            cx.new(|cx| InputState::new(window, cx).default_text("https://google.com"));
+            cx.new(|cx| InputState::new(window, cx).default_value("https://google.com"));
 
-        let url = address_input.read(cx).text().clone();
+        let url = address_input.read(cx).value().clone();
         webview.update(cx, |view, _| {
             view.load_url(&url);
         });
@@ -95,7 +95,7 @@ impl WebViewStory {
                 &address_input,
                 |this: &mut Self, input, event: &InputEvent, cx| match event {
                     InputEvent::PressEnter { .. } => {
-                        let url = input.read(cx).text().clone();
+                        let url = input.read(cx).value().clone();
                         this.webview.update(cx, |view, _| {
                             view.load_url(&url);
                         });

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -55,6 +55,7 @@ fn color_palettes() -> Vec<Vec<Hsla>> {
     ]
 }
 
+/// State of the [`ColorPicker`].
 pub struct ColorPickerState {
     focus_handle: FocusHandle,
     value: Option<Hsla>,

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -348,7 +348,7 @@ impl Focusable for ColorPicker {
 impl RenderOnce for ColorPicker {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let state = self.state.read(cx);
-        let bounds = state.bounds.clone();
+        let bounds = state.bounds;
         let display_title: SharedString = if let Some(value) = state.value {
             value.to_hex()
         } else {

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -2,7 +2,8 @@ use gpui::{
     anchored, canvas, deferred, div, prelude::FluentBuilder as _, px, relative, App, AppContext,
     Bounds, Context, Corner, ElementId, Entity, EventEmitter, FocusHandle, Focusable, Hsla,
     InteractiveElement as _, IntoElement, KeyBinding, MouseButton, ParentElement, Pixels, Point,
-    Render, SharedString, StatefulInteractiveElement as _, Styled, Subscription, Window,
+    Render, RenderOnce, SharedString, StatefulInteractiveElement as _, Styled, Subscription,
+    Window,
 };
 
 use crate::{
@@ -54,25 +55,18 @@ fn color_palettes() -> Vec<Vec<Hsla>> {
     ]
 }
 
-pub struct ColorPicker {
-    id: ElementId,
+pub struct ColorState {
     focus_handle: FocusHandle,
     value: Option<Hsla>,
-    featured_colors: Vec<Hsla>,
     hovered_color: Option<Hsla>,
-    label: Option<SharedString>,
-    icon: Option<Icon>,
-    size: Size,
-    anchor: Corner,
     state: Entity<InputState>,
-
     open: bool,
     bounds: Bounds<Pixels>,
     _subscriptions: Vec<Subscription>,
 }
 
-impl ColorPicker {
-    pub fn new(id: impl Into<ElementId>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+impl ColorState {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let state = cx.new(|cx| InputState::new(window, cx));
 
         let _subscriptions = vec![cx.subscribe_in(
@@ -97,41 +91,14 @@ impl ColorPicker {
         )];
 
         Self {
-            id: id.into(),
             focus_handle: cx.focus_handle(),
-            featured_colors: vec![
-                crate::black(),
-                crate::gray_600(),
-                crate::gray_400(),
-                crate::white(),
-                crate::red_600(),
-                crate::orange_600(),
-                crate::yellow_600(),
-                crate::green_600(),
-                crate::blue_600(),
-                crate::indigo_600(),
-                crate::purple_600(),
-            ],
             value: None,
             hovered_color: None,
-            size: Size::Medium,
-            label: None,
-            icon: None,
-            anchor: Corner::TopLeft,
             state,
             open: false,
             bounds: Bounds::default(),
             _subscriptions,
         }
-    }
-
-    /// Set the featured colors to be displayed in the color picker.
-    ///
-    /// This is used to display a set of colors that the user can quickly select from,
-    /// for example provided user's last used colors.
-    pub fn featured_colors(mut self, colors: Vec<Hsla>) -> Self {
-        self.featured_colors = colors;
-        self
     }
 
     /// Set default color value.
@@ -148,6 +115,100 @@ impl ColorPicker {
     /// Get current color value.
     pub fn value(&self) -> Option<Hsla> {
         self.value
+    }
+
+    fn on_escape(&mut self, _: &Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        if !self.open {
+            cx.propagate();
+        }
+
+        self.open = false;
+        cx.notify();
+    }
+
+    fn toggle_picker(&mut self, _: &gpui::ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
+        self.open = !self.open;
+        cx.notify();
+    }
+
+    fn update_value(
+        &mut self,
+        value: Option<Hsla>,
+        emit: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.value = value;
+        self.hovered_color = value;
+        self.state.update(cx, |view, cx| {
+            if let Some(value) = value {
+                view.set_value(value.to_hex(), window, cx);
+            } else {
+                view.set_value("", window, cx);
+            }
+        });
+        if emit {
+            cx.emit(ColorPickerEvent::Change(value));
+        }
+        cx.notify();
+    }
+}
+impl EventEmitter<ColorPickerEvent> for ColorState {}
+impl Render for ColorState {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        self.state.clone()
+    }
+}
+impl Focusable for ColorState {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+#[derive(IntoElement)]
+pub struct ColorPicker {
+    id: ElementId,
+    state: Entity<ColorState>,
+    featured_colors: Vec<Hsla>,
+    label: Option<SharedString>,
+    icon: Option<Icon>,
+    size: Size,
+    anchor: Corner,
+}
+
+impl ColorPicker {
+    pub fn new(id: impl Into<ElementId>, state: Entity<ColorState>) -> Self {
+        Self {
+            id: id.into(),
+            state,
+            featured_colors: vec![
+                crate::black(),
+                crate::gray_600(),
+                crate::gray_400(),
+                crate::white(),
+                crate::red_600(),
+                crate::orange_600(),
+                crate::yellow_600(),
+                crate::green_600(),
+                crate::blue_600(),
+                crate::indigo_600(),
+                crate::purple_600(),
+            ],
+
+            size: Size::Medium,
+            label: None,
+            icon: None,
+            anchor: Corner::TopLeft,
+        }
+    }
+
+    /// Set the featured colors to be displayed in the color picker.
+    ///
+    /// This is used to display a set of colors that the user can quickly select from,
+    /// for example provided user's last used colors.
+    pub fn featured_colors(mut self, colors: Vec<Hsla>) -> Self {
+        self.featured_colors = colors;
+        self
     }
 
     /// Set the size of the color picker, default is `Size::Medium`.
@@ -181,49 +242,14 @@ impl ColorPicker {
         self
     }
 
-    fn on_escape(&mut self, _: &Cancel, _: &mut Window, cx: &mut Context<Self>) {
-        if !self.open {
-            cx.propagate();
-        }
-
-        self.open = false;
-        cx.notify();
-    }
-
-    fn toggle_picker(&mut self, _: &gpui::ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
-        self.open = !self.open;
-        cx.notify();
-    }
-
-    fn update_value(
-        &mut self,
-        value: Option<Hsla>,
-        emit: bool,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.value = value;
-        self.hovered_color = value;
-        self.state.update(cx, |view, cx| {
-            if let Some(value) = value {
-                view.set_text(value.to_hex(), window, cx);
-            } else {
-                view.set_text("", window, cx);
-            }
-        });
-        if emit {
-            cx.emit(ColorPickerEvent::Change(value));
-        }
-        cx.notify();
-    }
-
     fn render_item(
         &self,
         color: Hsla,
         clickable: bool,
-        _: &mut Window,
-        cx: &mut Context<Self>,
+        window: &mut Window,
+        _: &mut App,
     ) -> impl IntoElement {
+        let state = self.state.clone();
         div()
             .id(SharedString::from(format!("color-{}", color.to_hex())))
             .h_5()
@@ -238,19 +264,23 @@ impl ColorPicker {
                         .shadow_sm()
                 })
                 .active(|this| this.border_color(color.darken(0.5)).bg(color.darken(0.2)))
-                .on_mouse_move(cx.listener(move |view, _, _, cx| {
-                    view.hovered_color = Some(color);
+                .on_mouse_move(window.listener_for(&state, move |state, _, _, cx| {
+                    state.hovered_color = Some(color);
                     cx.notify();
                 }))
-                .on_click(cx.listener(move |view, _, window, cx| {
-                    view.update_value(Some(color), true, window, cx);
-                    view.open = false;
-                    cx.notify();
-                }))
+                .on_click(window.listener_for(
+                    &state,
+                    move |state, _, window, cx| {
+                        state.update_value(Some(color), true, window, cx);
+                        state.open = false;
+                        cx.notify();
+                    },
+                ))
             })
     }
 
-    fn render_colors(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_colors(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.clone();
         v_flex()
             .gap_3()
             .child(
@@ -273,7 +303,7 @@ impl ColorPicker {
                         )
                     })),
             )
-            .when_some(self.hovered_color, |this, hovered_color| {
+            .when_some(state.read(cx).hovered_color, |this, hovered_color| {
                 this.child(Divider::horizontal()).child(
                     h_flex()
                         .gap_2()
@@ -287,7 +317,7 @@ impl ColorPicker {
                                 .size_5()
                                 .rounded(cx.theme().radius),
                         )
-                        .child(TextInput::new(self.state.clone())),
+                        .child(TextInput::new(state.read(cx).state.clone())),
                 )
             })
     }
@@ -308,29 +338,29 @@ impl Sizable for ColorPicker {
         self
     }
 }
-impl EventEmitter<ColorPickerEvent> for ColorPicker {}
+
 impl Focusable for ColorPicker {
-    fn focus_handle(&self, _: &App) -> FocusHandle {
-        self.focus_handle.clone()
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.state.read(cx).focus_handle.clone()
     }
 }
 
-impl Render for ColorPicker {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let display_title: SharedString = if let Some(value) = self.value {
+impl RenderOnce for ColorPicker {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let bounds = state.bounds.clone();
+        let display_title: SharedString = if let Some(value) = state.value {
             value.to_hex()
         } else {
             "".to_string()
         }
         .into();
 
-        let view = cx.entity().clone();
-
         div()
             .id(self.id.clone())
             .key_context(CONTEXT)
-            .track_focus(&self.focus_handle)
-            .on_action(cx.listener(Self::on_escape))
+            .track_focus(&state.focus_handle)
+            .on_action(window.listener_for(&self.state, ColorState::on_escape))
             .child(
                 h_flex()
                     .id("color-picker-input")
@@ -342,7 +372,7 @@ impl Render for ColorPicker {
                         this.child(
                             Button::new("btn")
                                 .ghost()
-                                .selected(self.open)
+                                .selected(state.open)
                                 .with_size(self.size)
                                 .icon(icon.clone()),
                         )
@@ -358,10 +388,10 @@ impl Render for ColorPicker {
                                 .shadow_sm()
                                 .overflow_hidden()
                                 .size_with(self.size)
-                                .when_some(self.value, |this, value| {
+                                .when_some(state.value, |this, value| {
                                     this.bg(value)
                                         .border_color(value.darken(0.3))
-                                        .when(self.open, |this| this.border_2())
+                                        .when(state.open, |this| this.border_2())
                                 })
                                 .when(!display_title.is_empty(), |this| {
                                     this.tooltip(move |_, cx| {
@@ -371,23 +401,26 @@ impl Render for ColorPicker {
                         )
                     })
                     .when_some(self.label.clone(), |this, label| this.child(label))
-                    .on_click(cx.listener(Self::toggle_picker))
+                    .on_click(window.listener_for(&self.state, ColorState::toggle_picker))
                     .child(
                         canvas(
-                            move |bounds, _, cx| view.update(cx, |r, _| r.bounds = bounds),
+                            {
+                                let state = self.state.clone();
+                                move |bounds, _, cx| state.update(cx, |r, _| r.bounds = bounds)
+                            },
                             |_, _, _, _| {},
                         )
                         .absolute()
                         .size_full(),
                     ),
             )
-            .when(self.open, |this| {
+            .when(state.open, |this| {
                 this.child(
                     deferred(
                         anchored()
                             .anchor(self.anchor)
                             .snap_to_window_with_margin(px(8.))
-                            .position(self.resolved_corner(self.bounds))
+                            .position(self.resolved_corner(bounds))
                             .child(
                                 div()
                                     .occlude()
@@ -407,8 +440,8 @@ impl Render for ColorPicker {
                                     .child(self.render_colors(window, cx))
                                     .on_mouse_up_out(
                                         MouseButton::Left,
-                                        cx.listener(|view, _, window, cx| {
-                                            view.on_escape(&Cancel, window, cx)
+                                        window.listener_for(&self.state, |state, _, window, cx| {
+                                            state.on_escape(&Cancel, window, cx)
                                         }),
                                     ),
                             ),

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -177,10 +177,10 @@ pub struct ColorPicker {
 }
 
 impl ColorPicker {
-    pub fn new(id: impl Into<ElementId>, state: Entity<ColorState>) -> Self {
+    pub fn new(state: &Entity<ColorState>) -> Self {
         Self {
-            id: id.into(),
-            state,
+            id: ("color-picker", state.entity_id()).into(),
+            state: state.clone(),
             featured_colors: vec![
                 crate::black(),
                 crate::gray_600(),
@@ -317,7 +317,7 @@ impl ColorPicker {
                                 .size_5()
                                 .rounded(cx.theme().radius),
                         )
-                        .child(TextInput::new(state.read(cx).state.clone())),
+                        .child(TextInput::new(&state.read(cx).state)),
                 )
             })
     }

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -10,7 +10,7 @@ use crate::{
     button::{Button, ButtonVariants},
     divider::Divider,
     h_flex,
-    input::{InputEvent, TextInput},
+    input::{InputEvent, InputState, TextInput},
     tooltip::Tooltip,
     v_flex, ActiveTheme as _, Colorize as _, Icon, Selectable as _, Sizable, Size, StyleSized,
 };
@@ -64,7 +64,7 @@ pub struct ColorPicker {
     icon: Option<Icon>,
     size: Size,
     anchor: Corner,
-    color_input: Entity<TextInput>,
+    state: Entity<InputState>,
 
     open: bool,
     bounds: Bounds<Pixels>,
@@ -73,10 +73,10 @@ pub struct ColorPicker {
 
 impl ColorPicker {
     pub fn new(id: impl Into<ElementId>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let color_input = cx.new(|cx| TextInput::new(window, cx).small());
+        let state = cx.new(|cx| InputState::new(window, cx));
 
         let _subscriptions = vec![cx.subscribe_in(
-            &color_input,
+            &state,
             window,
             |this, _, ev: &InputEvent, window, cx| match ev {
                 InputEvent::Change(value) => {
@@ -86,7 +86,7 @@ impl ColorPicker {
                     }
                 }
                 InputEvent::PressEnter { .. } => {
-                    let val = this.color_input.read(cx).text();
+                    let val = this.state.read(cx).text();
                     if let Ok(color) = Hsla::parse_hex(&val) {
                         this.open = false;
                         this.update_value(Some(color), true, window, cx);
@@ -118,7 +118,7 @@ impl ColorPicker {
             label: None,
             icon: None,
             anchor: Corner::TopLeft,
-            color_input,
+            state,
             open: false,
             bounds: Bounds::default(),
             _subscriptions,
@@ -204,7 +204,7 @@ impl ColorPicker {
     ) {
         self.value = value;
         self.hovered_color = value;
-        self.color_input.update(cx, |view, cx| {
+        self.state.update(cx, |view, cx| {
             if let Some(value) = value {
                 view.set_text(value.to_hex(), window, cx);
             } else {
@@ -287,7 +287,7 @@ impl ColorPicker {
                                 .size_5()
                                 .rounded(cx.theme().radius),
                         )
-                        .child(self.color_input.clone()),
+                        .child(TextInput::new(self.state.clone())),
                 )
             })
     }

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -55,7 +55,7 @@ fn color_palettes() -> Vec<Vec<Hsla>> {
     ]
 }
 
-pub struct ColorState {
+pub struct ColorPickerState {
     focus_handle: FocusHandle,
     value: Option<Hsla>,
     hovered_color: Option<Hsla>,
@@ -65,7 +65,7 @@ pub struct ColorState {
     _subscriptions: Vec<Subscription>,
 }
 
-impl ColorState {
+impl ColorPickerState {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let state = cx.new(|cx| InputState::new(window, cx));
 
@@ -153,13 +153,13 @@ impl ColorState {
         cx.notify();
     }
 }
-impl EventEmitter<ColorPickerEvent> for ColorState {}
-impl Render for ColorState {
+impl EventEmitter<ColorPickerEvent> for ColorPickerState {}
+impl Render for ColorPickerState {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         self.state.clone()
     }
 }
-impl Focusable for ColorState {
+impl Focusable for ColorPickerState {
     fn focus_handle(&self, _: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
@@ -168,7 +168,7 @@ impl Focusable for ColorState {
 #[derive(IntoElement)]
 pub struct ColorPicker {
     id: ElementId,
-    state: Entity<ColorState>,
+    state: Entity<ColorPickerState>,
     featured_colors: Vec<Hsla>,
     label: Option<SharedString>,
     icon: Option<Icon>,
@@ -177,7 +177,7 @@ pub struct ColorPicker {
 }
 
 impl ColorPicker {
-    pub fn new(state: &Entity<ColorState>) -> Self {
+    pub fn new(state: &Entity<ColorPickerState>) -> Self {
         Self {
             id: ("color-picker", state.entity_id()).into(),
             state: state.clone(),
@@ -360,7 +360,7 @@ impl RenderOnce for ColorPicker {
             .id(self.id.clone())
             .key_context(CONTEXT)
             .track_focus(&state.focus_handle)
-            .on_action(window.listener_for(&self.state, ColorState::on_escape))
+            .on_action(window.listener_for(&self.state, ColorPickerState::on_escape))
             .child(
                 h_flex()
                     .id("color-picker-input")
@@ -401,7 +401,7 @@ impl RenderOnce for ColorPicker {
                         )
                     })
                     .when_some(self.label.clone(), |this, label| this.child(label))
-                    .on_click(window.listener_for(&self.state, ColorState::toggle_picker))
+                    .on_click(window.listener_for(&self.state, ColorPickerState::toggle_picker))
                     .child(
                         canvas(
                             {

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -86,7 +86,7 @@ impl ColorPicker {
                     }
                 }
                 InputEvent::PressEnter { .. } => {
-                    let val = this.state.read(cx).text();
+                    let val = this.state.read(cx).value();
                     if let Ok(color) = Hsla::parse_hex(&val) {
                         this.open = false;
                         this.update_value(Some(color), true, window, cx);

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -237,6 +237,7 @@ pub enum DropdownEvent<D: DropdownDelegate + 'static> {
     Confirm(Option<<D::Item as DropdownItem>::Value>),
 }
 
+/// State of the [`Dropdown`].
 pub struct DropdownState<D: DropdownDelegate + 'static> {
     focus_handle: FocusHandle,
     list: Entity<List<DropdownListDelegate<D>>>,

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -519,10 +519,10 @@ impl<D> Dropdown<D>
 where
     D: DropdownDelegate + 'static,
 {
-    pub fn new(state: Entity<DropdownState<D>>) -> Self {
+    pub fn new(state: &Entity<DropdownState<D>>) -> Self {
         Self {
             id: ("dropdown", state.entity_id()).into(),
-            state,
+            state: state.clone(),
             placeholder: None,
             size: Size::Medium,
             icon: None,

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -1,8 +1,9 @@
 use gpui::{
     anchored, canvas, deferred, div, prelude::FluentBuilder, px, rems, AnyElement, App, AppContext,
-    Bounds, ClickEvent, Context, DismissEvent, ElementId, Entity, EventEmitter, FocusHandle,
+    Bounds, ClickEvent, Context, DismissEvent, ElementId, Empty, Entity, EventEmitter, FocusHandle,
     Focusable, InteractiveElement, IntoElement, KeyBinding, Length, ParentElement, Pixels, Render,
-    SharedString, StatefulInteractiveElement, Styled, Subscription, Task, WeakEntity, Window,
+    RenderOnce, SharedString, StatefulInteractiveElement, Styled, Subscription, Task, WeakEntity,
+    Window,
 };
 use rust_i18n::t;
 
@@ -99,12 +100,7 @@ pub trait DropdownDelegate: Sized {
         false
     }
 
-    fn perform_search(
-        &mut self,
-        _query: &str,
-        _window: &mut Window,
-        _: &mut Context<Dropdown<Self>>,
-    ) -> Task<()> {
+    fn perform_search(&mut self, _query: &str, _window: &mut Window, _: &mut App) -> Task<()> {
         Task::ready(())
     }
 }
@@ -131,7 +127,7 @@ impl<T: DropdownItem> DropdownDelegate for Vec<T> {
 
 struct DropdownListDelegate<D: DropdownDelegate + 'static> {
     delegate: D,
-    dropdown: WeakEntity<Dropdown<D>>,
+    dropdown: WeakEntity<DropdownState<D>>,
     selected_index: Option<usize>,
 }
 
@@ -241,25 +237,32 @@ pub enum DropdownEvent<D: DropdownDelegate + 'static> {
     Confirm(Option<<D::Item as DropdownItem>::Value>),
 }
 
-/// A Dropdown element.
-pub struct Dropdown<D: DropdownDelegate + 'static> {
-    id: ElementId,
+pub struct DropdownState<D: DropdownDelegate + 'static> {
     focus_handle: FocusHandle,
     list: Entity<List<DropdownListDelegate<D>>>,
     size: Size,
-    icon: Option<Icon>,
+    empty: Option<Box<dyn Fn(&Window, &App) -> AnyElement>>,
+    /// Store the bounds of the input
+    bounds: Bounds<Pixels>,
     open: bool,
+    selected_value: Option<<D::Item as DropdownItem>::Value>,
+    _subscriptions: Vec<Subscription>,
+}
+
+/// A Dropdown element.
+#[derive(IntoElement)]
+pub struct Dropdown<D: DropdownDelegate + 'static> {
+    id: ElementId,
+    state: Entity<DropdownState<D>>,
+    size: Size,
+    icon: Option<Icon>,
     cleanable: bool,
     placeholder: Option<SharedString>,
     title_prefix: Option<SharedString>,
-    selected_value: Option<<D::Item as DropdownItem>::Value>,
-    empty: Option<Box<dyn Fn(&Window, &App) -> AnyElement + 'static>>,
+    empty: Option<AnyElement>,
     width: Length,
     menu_width: Length,
-    /// Store the bounds of the input
-    bounds: Bounds<Pixels>,
     disabled: bool,
-    _subscriptions: Vec<Subscription>,
 }
 
 pub struct SearchableVec<T> {
@@ -306,12 +309,7 @@ impl<T: DropdownItem + Clone> DropdownDelegate for SearchableVec<T> {
         true
     }
 
-    fn perform_search(
-        &mut self,
-        query: &str,
-        _window: &mut Window,
-        _: &mut Context<Dropdown<Self>>,
-    ) -> Task<()> {
+    fn perform_search(&mut self, query: &str, _window: &mut Window, _: &mut App) -> Task<()> {
         self.matched_items = self
             .items
             .iter()
@@ -332,12 +330,11 @@ impl From<Vec<SharedString>> for SearchableVec<SharedString> {
     }
 }
 
-impl<D> Dropdown<D>
+impl<D> DropdownState<D>
 where
     D: DropdownDelegate + 'static,
 {
     pub fn new(
-        id: impl Into<ElementId>,
         delegate: D,
         selected_index: Option<usize>,
         window: &mut Window,
@@ -368,75 +365,17 @@ where
         ];
 
         let mut this = Self {
-            id: id.into(),
             focus_handle,
-            placeholder: None,
             list,
             size: Size::Medium,
-            icon: None,
             selected_value: None,
             open: false,
-            cleanable: false,
-            title_prefix: None,
-            empty: None,
-            width: Length::Auto,
-            menu_width: Length::Auto,
             bounds: Bounds::default(),
-            disabled: false,
+            empty: None,
             _subscriptions,
         };
         this.set_selected_index(selected_index, window, cx);
         this
-    }
-
-    /// Set the width of the dropdown input, default: Length::Auto
-    pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
-        self
-    }
-
-    /// Set the width of the dropdown menu, default: Length::Auto
-    pub fn menu_width(mut self, width: impl Into<Length>) -> Self {
-        self.menu_width = width.into();
-        self
-    }
-
-    /// Set the placeholder for display when dropdown value is empty.
-    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
-        self.placeholder = Some(placeholder.into());
-        self
-    }
-
-    /// Set the right icon for the dropdown input, instead of the default arrow icon.
-    pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
-        self.icon = Some(icon.into());
-        self
-    }
-
-    /// Set title prefix for the dropdown.
-    ///
-    /// e.g.: Country: United States
-    ///
-    /// You should set the label is `Country: `
-    pub fn title_prefix(mut self, prefix: impl Into<SharedString>) -> Self {
-        self.title_prefix = Some(prefix.into());
-        self
-    }
-
-    /// Set true to show the clear button when the input field is not empty.
-    pub fn cleanable(mut self) -> Self {
-        self.cleanable = true;
-        self
-    }
-
-    /// Set the disable state for the dropdown.
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = disabled;
-        self
-    }
-
-    pub fn set_disabled(&mut self, disabled: bool) {
-        self.disabled = disabled;
     }
 
     pub fn empty<E, F>(mut self, f: F) -> Self
@@ -556,6 +495,97 @@ where
         cx.emit(DropdownEvent::Confirm(None));
     }
 
+    /// Set the items for the dropdown.
+    pub fn set_items(&mut self, items: D, _: &mut Window, cx: &mut Context<Self>)
+    where
+        D: DropdownDelegate + 'static,
+    {
+        self.list.update(cx, |list, _| {
+            list.delegate_mut().delegate = items;
+        });
+    }
+}
+
+impl<D> Render for DropdownState<D>
+where
+    D: DropdownDelegate + 'static,
+{
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+impl<D> Dropdown<D>
+where
+    D: DropdownDelegate + 'static,
+{
+    pub fn new(id: impl Into<ElementId>, state: Entity<DropdownState<D>>) -> Self {
+        Self {
+            id: id.into(),
+            state,
+            placeholder: None,
+            size: Size::Medium,
+            icon: None,
+            cleanable: false,
+            title_prefix: None,
+            empty: None,
+            width: Length::Auto,
+            menu_width: Length::Auto,
+            disabled: false,
+        }
+    }
+
+    /// Set the width of the dropdown input, default: Length::Auto
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Set the width of the dropdown menu, default: Length::Auto
+    pub fn menu_width(mut self, width: impl Into<Length>) -> Self {
+        self.menu_width = width.into();
+        self
+    }
+
+    /// Set the placeholder for display when dropdown value is empty.
+    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
+    }
+
+    /// Set the right icon for the dropdown input, instead of the default arrow icon.
+    pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
+        self.icon = Some(icon.into());
+        self
+    }
+
+    /// Set title prefix for the dropdown.
+    ///
+    /// e.g.: Country: United States
+    ///
+    /// You should set the label is `Country: `
+    pub fn title_prefix(mut self, prefix: impl Into<SharedString>) -> Self {
+        self.title_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Set true to show the clear button when the input field is not empty.
+    pub fn cleanable(mut self) -> Self {
+        self.cleanable = true;
+        self
+    }
+
+    /// Set the disable state for the dropdown.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn empty(mut self, el: impl IntoElement) -> Self {
+        self.empty = Some(el.into_any_element());
+        self
+    }
+
     /// Returns the title element for the dropdown input.
     fn display_title(&self, _: &Window, cx: &App) -> impl IntoElement {
         let default_title = div()
@@ -569,11 +599,13 @@ where
                 this.text_color(cx.theme().muted_foreground)
             });
 
-        let Some(selected_index) = &self.selected_index(cx) else {
+        let Some(selected_index) = &self.state.read(cx).selected_index(cx) else {
             return default_title;
         };
 
         let Some(title) = self
+            .state
+            .read(cx)
             .list
             .read(cx)
             .delegate()
@@ -600,16 +632,6 @@ where
             })
             .child(title)
     }
-
-    /// Set the items for the dropdown.
-    pub fn set_items(&mut self, items: D, _: &mut Window, cx: &mut Context<Self>)
-    where
-        D: DropdownDelegate + 'static,
-    {
-        self.list.update(cx, |list, _| {
-            list.delegate_mut().delegate = items;
-        });
-    }
 }
 
 impl<D> Sizable for Dropdown<D>
@@ -622,9 +644,9 @@ where
     }
 }
 
-impl<D> EventEmitter<DropdownEvent<D>> for Dropdown<D> where D: DropdownDelegate + 'static {}
-impl<D> EventEmitter<DismissEvent> for Dropdown<D> where D: DropdownDelegate + 'static {}
-impl<D> Focusable for Dropdown<D>
+impl<D> EventEmitter<DropdownEvent<D>> for DropdownState<D> where D: DropdownDelegate + 'static {}
+impl<D> EventEmitter<DismissEvent> for DropdownState<D> where D: DropdownDelegate + 'static {}
+impl<D> Focusable for DropdownState<D>
 where
     D: DropdownDelegate,
 {
@@ -636,34 +658,49 @@ where
         }
     }
 }
+impl<D> Focusable for Dropdown<D>
+where
+    D: DropdownDelegate,
+{
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.state.focus_handle(cx)
+    }
+}
 
-impl<D> Render for Dropdown<D>
+impl<D> RenderOnce for Dropdown<D>
 where
     D: DropdownDelegate + 'static,
 {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let is_focused = self.focus_handle.is_focused(window);
-        let show_clean = self.cleanable && self.selected_index(cx).is_some();
-        let view = cx.entity().clone();
-        let bounds = self.bounds;
-        let allow_open = !(self.open || self.disabled);
-        let outline_visible = self.open || is_focused && !self.disabled;
-        let popup_radius = cx.theme().radius.min(px(8.));
-
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let is_focused = self.focus_handle(cx).is_focused(window);
         // If the size has change, set size to self.list, to change the QueryInput size.
-        if self.list.read(cx).size != self.size {
-            self.list
-                .update(cx, |this, cx| this.set_size(self.size, window, cx))
+        let old_size = self.state.read(cx).list.read(cx).size;
+        if old_size != self.size {
+            self.state
+                .read(cx)
+                .list
+                .clone()
+                .update(cx, |this, cx| this.set_size(self.size, window, cx));
+            self.state.update(cx, |this, _| {
+                this.size = self.size;
+            });
         }
+
+        let state = self.state.read(cx);
+        let show_clean = self.cleanable && state.selected_index(cx).is_some();
+        let bounds = state.bounds;
+        let allow_open = !(state.open || self.disabled);
+        let outline_visible = state.open || is_focused && !self.disabled;
+        let popup_radius = cx.theme().radius.min(px(8.));
 
         div()
             .id(self.id.clone())
             .key_context(CONTEXT)
-            .track_focus(&self.focus_handle)
-            .on_action(cx.listener(Self::up))
-            .on_action(cx.listener(Self::down))
-            .on_action(cx.listener(Self::enter))
-            .on_action(cx.listener(Self::escape))
+            .track_focus(&self.focus_handle(cx))
+            .on_action(window.listener_for(&self.state, DropdownState::up))
+            .on_action(window.listener_for(&self.state, DropdownState::down))
+            .on_action(window.listener_for(&self.state, DropdownState::enter))
+            .on_action(window.listener_for(&self.state, DropdownState::escape))
             .size_full()
             .relative()
             .input_text_size(self.size)
@@ -689,7 +726,7 @@ where
                     .when(outline_visible, |this| this.focused_border(cx))
                     .input_size(self.size)
                     .when(allow_open, |this| {
-                        this.on_click(cx.listener(Self::toggle_menu))
+                        this.on_click(window.listener_for(&self.state, DropdownState::toggle_menu))
                     })
                     .child(
                         h_flex()
@@ -710,7 +747,9 @@ where
                                     if self.disabled {
                                         this.disabled(true)
                                     } else {
-                                        this.on_click(cx.listener(Self::clean))
+                                        this.on_click(
+                                            window.listener_for(&self.state, DropdownState::clean),
+                                        )
                                     }
                                 }))
                             })
@@ -718,7 +757,7 @@ where
                                 let icon = match self.icon.clone() {
                                     Some(icon) => icon,
                                     None => {
-                                        if self.open {
+                                        if state.open {
                                             Icon::new(IconName::ChevronUp)
                                         } else {
                                             Icon::new(IconName::ChevronDown)
@@ -726,24 +765,25 @@ where
                                     }
                                 };
 
-                                this.child(icon.xsmall().text_color(
-                                    match self.disabled {
-                                        true => cx.theme().muted_foreground.opacity(0.5),
-                                        false => cx.theme().muted_foreground,
-                                    },
-                                ))
+                                this.child(icon.xsmall().text_color(match self.disabled {
+                                    true => cx.theme().muted_foreground.opacity(0.5),
+                                    false => cx.theme().muted_foreground,
+                                }))
                             }),
                     )
                     .child(
                         canvas(
-                            move |bounds, _, cx| view.update(cx, |r, _| r.bounds = bounds),
+                            {
+                                let state = self.state.clone();
+                                move |bounds, _, cx| state.update(cx, |r, _| r.bounds = bounds)
+                            },
                             |_, _, _, _| {},
                         )
                         .absolute()
                         .size_full(),
                     ),
             )
-            .when(self.open, |this| {
+            .when(state.open, |this| {
                 this.child(
                     deferred(
                         anchored().snap_to_window_with_margin(px(8.)).child(
@@ -762,11 +802,14 @@ where
                                         .border_color(cx.theme().border)
                                         .rounded(popup_radius)
                                         .shadow_md()
-                                        .child(self.list.clone()),
+                                        .child(state.list.clone()),
                                 )
-                                .on_mouse_down_out(cx.listener(|this, _, window, cx| {
-                                    this.escape(&Cancel, window, cx);
-                                })),
+                                .on_mouse_down_out(window.listener_for(
+                                    &self.state,
+                                    |this, _, window, cx| {
+                                        this.escape(&Cancel, window, cx);
+                                    },
+                                )),
                         ),
                     )
                     .with_priority(1),

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -519,9 +519,9 @@ impl<D> Dropdown<D>
 where
     D: DropdownDelegate + 'static,
 {
-    pub fn new(id: impl Into<ElementId>, state: Entity<DropdownState<D>>) -> Self {
+    pub fn new(state: Entity<DropdownState<D>>) -> Self {
         Self {
-            id: id.into(),
+            id: ("dropdown", state.entity_id()).into(),
             state,
             placeholder: None,
             size: Size::Medium,

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -514,10 +514,10 @@ impl Element for TextElement {
 
         // Set Root focused_input when self is focused
         if focused {
-            let input_view = self.input.clone();
-            if Root::read(window, cx).focused_input.as_ref() != Some(&input_view) {
+            let state = self.input.clone();
+            if Root::read(window, cx).focused_input.as_ref() != Some(&state) {
                 Root::update(window, cx, |root, _, cx| {
-                    root.focused_input = Some(input_view);
+                    root.focused_input = Some(state);
                     cx.notify();
                 });
             }
@@ -525,9 +525,9 @@ impl Element for TextElement {
 
         // And reset focused_input when next_frame start
         window.on_next_frame({
-            let input_view = self.input.clone();
+            let state = self.input.clone();
             move |window, cx| {
-                if !focused && Root::read(window, cx).focused_input.as_ref() == Some(&input_view) {
+                if !focused && Root::read(window, cx).focused_input.as_ref() == Some(&state) {
                     Root::update(window, cx, |root, _, cx| {
                         root.focused_input = None;
                         cx.notify();

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1,24 +1,34 @@
 use gpui::{
     fill, point, px, relative, size, App, Bounds, Corners, Element, ElementId, ElementInputHandler,
     Entity, GlobalElementId, IntoElement, LayoutId, MouseButton, MouseMoveEvent, PaintQuad, Path,
-    Pixels, Point, Style, TextAlign, TextRun, UnderlineStyle, Window, WrappedLine,
+    Pixels, Point, SharedString, Style, TextAlign, TextRun, UnderlineStyle, Window, WrappedLine,
 };
 use smallvec::SmallVec;
 
 use crate::{ActiveTheme as _, Root};
 
-use super::TextInput;
+use super::InputState;
 
 const RIGHT_MARGIN: Pixels = px(5.);
 const BOTTOM_MARGIN: Pixels = px(20.);
 
 pub(super) struct TextElement {
-    input: Entity<TextInput>,
+    input: Entity<InputState>,
+    placeholder: SharedString,
 }
 
 impl TextElement {
-    pub(super) fn new(input: Entity<TextInput>) -> Self {
-        Self { input }
+    pub(super) fn new(input: Entity<InputState>) -> Self {
+        Self {
+            input,
+            placeholder: SharedString::default(),
+        }
+    }
+
+    /// Set the placeholder text of the input field.
+    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
+        self.placeholder = placeholder.into();
+        self
     }
 
     fn paint_mouse_listeners(&mut self, window: &mut Window, _: &mut App) {
@@ -374,7 +384,7 @@ impl Element for TextElement {
         let line_height = window.line_height();
         let input = self.input.read(cx);
         let text = input.text.clone();
-        let placeholder = input.placeholder.clone();
+        let placeholder = self.placeholder.clone();
         let style = window.text_style();
         let mut bounds = bounds;
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -606,19 +606,19 @@ impl InputState {
         cx.notify();
     }
 
-    /// Set the default text of the input field.
-    pub fn default_text(mut self, text: impl Into<SharedString>) -> Self {
-        self.text = text.into();
+    /// Set the default value of the input field.
+    pub fn default_value(mut self, value: impl Into<SharedString>) -> Self {
+        self.text = value.into();
         self
     }
 
-    /// Return the text of the input field.
-    pub fn text(&self) -> &SharedString {
+    /// Return the value of the input field.
+    pub fn value(&self) -> &SharedString {
         &self.text
     }
 
-    /// Return the text without mask.
-    pub fn unmask_text(&self) -> SharedString {
+    /// Return the value without mask.
+    pub fn unmask_value(&self) -> SharedString {
         self.mask_pattern.unmask(&self.text).into()
     }
 
@@ -1612,7 +1612,7 @@ impl EntityInputHandler for InputState {
         self.update_preferred_x_offset(cx);
         self.update_scroll_offset(None, cx);
         self.check_to_auto_grow(window, cx);
-        cx.emit(InputEvent::Change(self.unmask_text()));
+        cx.emit(InputEvent::Change(self.unmask_value()));
         cx.notify();
     }
 
@@ -1647,7 +1647,7 @@ impl EntityInputHandler for InputState {
             .map(|range_utf16| self.range_from_utf16(range_utf16))
             .map(|new_range| new_range.start + range.start..new_range.end + range.end)
             .unwrap_or_else(|| range.start + new_text.len()..range.start + new_text.len());
-        cx.emit(InputEvent::Change(self.unmask_text()));
+        cx.emit(InputEvent::Change(self.unmask_value()));
         cx.notify();
     }
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -10,34 +10,23 @@ use std::ops::Range;
 use std::rc::Rc;
 use unicode_segmentation::*;
 
-use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    actions, div, impl_internal_actions, point, px, relative, AnyElement, App, AppContext, Bounds,
-    ClipboardItem, Context, DefiniteLength, Entity, EntityInputHandler, EventEmitter, FocusHandle,
-    Focusable, InteractiveElement as _, IntoElement, KeyBinding, KeyDownEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, Point, Rems, Render,
-    RenderOnce, ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription,
+    actions, div, impl_internal_actions, point, prelude::FluentBuilder as _, px, relative, App,
+    AppContext, Bounds, ClipboardItem, Context, DefiniteLength, Entity, EntityInputHandler,
+    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
+    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription,
     UTF16Selection, Window, WrappedLine,
 };
 
 // TODO:
 // - Move cursor to skip line eof empty chars.
 
-use super::blink_cursor::BlinkCursor;
-use super::change::Change;
-use super::element::TextElement;
-use super::mask_pattern::MaskPattern;
-use super::number_input;
-
-use crate::button::{Button, ButtonVariants as _};
-use crate::history::History;
-use crate::indicator::Indicator;
-use crate::input::clear_button;
-use crate::scroll::{Scrollbar, ScrollbarAxis, ScrollbarState};
-use crate::{h_flex, StyledExt};
-use crate::{ActiveTheme, Root};
-use crate::{IconName, Size};
-use crate::{Sizable, StyleSized};
+use super::{
+    blink_cursor::BlinkCursor, change::Change, element::TextElement, mask_pattern::MaskPattern,
+    number_input,
+};
+use crate::{history::History, scroll::ScrollbarState, Root};
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]
 pub struct Enter {
@@ -208,8 +197,6 @@ pub struct InputState {
     pub(super) multi_line: bool,
     pub(super) history: History<Change>,
     pub(super) blink_cursor: Entity<BlinkCursor>,
-    pub(super) prefix: Option<Box<dyn Fn(&mut Window, &mut Context<Self>) -> AnyElement + 'static>>,
-    pub(super) suffix: Option<Box<dyn Fn(&mut Window, &mut Context<Self>) -> AnyElement + 'static>>,
     pub(super) loading: bool,
     /// Range in UTF-8 length for the selected text.
     ///
@@ -293,8 +280,6 @@ impl InputState {
             masked: false,
             clean_on_escape: false,
             loading: false,
-            prefix: None,
-            suffix: None,
             height: None,
             pattern: None,
             validate: None,
@@ -619,6 +604,12 @@ impl InputState {
     pub fn set_loading(&mut self, loading: bool, _: &mut Window, cx: &mut Context<Self>) {
         self.loading = loading;
         cx.notify();
+    }
+
+    /// Set the default text of the input field.
+    pub fn default_text(mut self, text: impl Into<SharedString>) -> Self {
+        self.text = text.into();
+        self
     }
 
     /// Return the text of the input field.

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -2,15 +2,15 @@ mod blink_cursor;
 mod change;
 mod clear_button;
 mod element;
-mod input;
 mod mask_pattern;
 mod number_input;
 mod otp_input;
+mod state;
 mod text_input;
 
 pub(crate) use clear_button::*;
-pub use input::*;
 pub use mask_pattern::MaskPattern;
 pub use number_input::{NumberInput, NumberInputEvent, StepAction};
 pub use otp_input::*;
+pub use state::*;
 pub use text_input::*;

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -6,9 +6,11 @@ mod input;
 mod mask_pattern;
 mod number_input;
 mod otp_input;
+mod text_input;
 
 pub(crate) use clear_button::*;
 pub use input::*;
 pub use mask_pattern::MaskPattern;
 pub use number_input::{NumberInput, NumberInputEvent, StepAction};
 pub use otp_input::*;
+pub use text_input::*;

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -50,13 +50,13 @@ impl NumberInput {
         self
     }
 
-    pub fn increment(state: Entity<InputState>, window: &mut Window, cx: &mut App) {
+    pub fn increment(state: &Entity<InputState>, window: &mut Window, cx: &mut App) {
         state.update(cx, |state, cx| {
             state.on_action_increment(&Increment, window, cx);
         })
     }
 
-    pub fn decrement(state: Entity<InputState>, window: &mut Window, cx: &mut App) {
+    pub fn decrement(state: &Entity<InputState>, window: &mut Window, cx: &mut App) {
         state.update(cx, |state, cx| {
             state.on_action_decrement(&Decrement, window, cx);
         })
@@ -137,11 +137,11 @@ impl RenderOnce for NumberInput {
                     .on_click({
                         let state = self.state.clone();
                         move |_, window, cx| {
-                            Self::decrement(state.clone(), window, cx);
+                            Self::decrement(&state, window, cx);
                         }
                     }),
             )
-            .child(TextInput::new(self.state.clone()).no_gap())
+            .child(TextInput::new(&self.state).no_gap())
             .child(
                 Button::new("plus")
                     .ghost()
@@ -150,7 +150,7 @@ impl RenderOnce for NumberInput {
                     .on_click({
                         let state = self.state.clone();
                         move |_, window, cx| {
-                            Self::increment(state.clone(), window, cx);
+                            Self::increment(&state, window, cx);
                         }
                     }),
             )

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -32,9 +32,10 @@ pub struct NumberInput {
 }
 
 impl NumberInput {
-    pub fn new(state: Entity<InputState>) -> Self {
+    /// Create a new [`NumberInput`] element bind to the [`InputState`].
+    pub fn new(state: &Entity<InputState>) -> Self {
         Self {
-            state,
+            state: state.clone(),
             size: Size::default(),
             placeholder: SharedString::default(),
         }

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -141,7 +141,7 @@ impl RenderOnce for NumberInput {
                         }
                     }),
             )
-            .child(TextInput::new(self.state.clone()))
+            .child(TextInput::new(self.state.clone()).no_gap())
             .child(
                 Button::new("plus")
                     .ghost()

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -1,18 +1,17 @@
 use gpui::{
-    actions, prelude::FluentBuilder as _, px, App, AppContext as _, Context, Entity, EventEmitter,
-    FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding, ParentElement, Render,
-    SharedString, Styled, Subscription, Window,
+    actions, prelude::FluentBuilder as _, px, App, Context, Entity, EventEmitter, FocusHandle,
+    Focusable, InteractiveElement, IntoElement, KeyBinding, ParentElement, RenderOnce,
+    SharedString, Styled, Window,
 };
-use regex::Regex;
 
 use crate::{
     button::{Button, ButtonVariants as _},
     h_flex,
-    input::{InputEvent, TextInput},
+    input::InputEvent,
     ActiveTheme, IconName, Sizable, Size, StyleSized, StyledExt as _,
 };
 
-use super::MaskPattern;
+use super::InputState;
 
 actions!(number_input, [Increment, Decrement]);
 
@@ -25,140 +24,60 @@ pub fn init(cx: &mut App) {
     ]);
 }
 
+#[derive(IntoElement)]
 pub struct NumberInput {
-    input: Entity<TextInput>,
+    input: Entity<InputState>,
+    placeholder: SharedString,
     size: Size,
-    _subscriptions: Vec<Subscription>,
-    _synced_size: bool,
 }
 
 impl NumberInput {
-    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        // Default pattern for the number input.
-        let pattern = Regex::new(r"^-?(\d+)?\.?(\d+)?$").unwrap();
-
-        let input = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .pattern(pattern)
-                .no_gap()
-                .appearance(false)
-        });
-
-        let _subscriptions = vec![cx.subscribe(&input, |_, _, event: &InputEvent, cx| {
-            cx.emit(NumberInputEvent::Input(event.clone()));
-        })];
-
+    pub fn new(input: Entity<InputState>) -> Self {
         Self {
             input,
             size: Size::default(),
-            _synced_size: false,
-            _subscriptions,
+            placeholder: SharedString::default(),
         }
     }
 
-    pub fn placeholder(
-        self,
-        placeholder: impl Into<SharedString>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        self.input.update(cx, |input, cx| {
-            input.set_placeholder(placeholder, window, cx)
-        });
+    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
+        self.placeholder = placeholder.into();
         self
     }
 
-    pub fn set_size(&mut self, size: Size, window: &mut Window, cx: &mut Context<Self>) {
-        self.size = size;
-        self.sync_size_to_input_if_needed(window, cx);
-    }
-
-    pub fn set_placeholder(
-        &self,
-        text: impl Into<SharedString>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.input.update(cx, |input, cx| {
-            input.set_placeholder(text, window, cx);
-        });
-    }
-
-    pub fn pattern(
-        self,
-        pattern: regex::Regex,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        self.input
-            .update(cx, |input, cx| input.set_pattern(pattern, window, cx));
+    pub fn size(mut self, size: impl Into<Size>) -> Self {
+        self.size = size.into();
         self
     }
 
-    pub fn mask_pattern(
-        self,
-        mask_pattern: MaskPattern,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        self.input.update(cx, |input, cx| {
-            input.pattern = None;
-            input.set_mask_pattern(mask_pattern, window, cx)
-        });
-        self
+    pub fn increment(state: Entity<InputState>, window: &mut Window, cx: &mut App) {
+        state.update(cx, |state, cx| {
+            state.on_action_increment(&Increment, window, cx);
+        })
     }
 
-    pub fn set_value(
-        &self,
-        text: impl Into<SharedString>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.input
-            .update(cx, |input, cx| input.set_text(text, window, cx));
+    pub fn decrement(state: Entity<InputState>, window: &mut Window, cx: &mut App) {
+        state.update(cx, |state, cx| {
+            state.on_action_decrement(&Decrement, window, cx);
+        })
     }
+}
 
-    pub fn set_disabled(&self, disabled: bool, window: &mut Window, cx: &mut Context<Self>) {
-        self.input
-            .update(cx, |input, cx| input.set_disabled(disabled, window, cx));
-    }
-
-    pub fn increment(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.on_action_increment(&Increment, window, cx);
-    }
-
-    pub fn decrement(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.on_action_decrement(&Decrement, window, cx);
-    }
-
+impl InputState {
     fn on_action_increment(&mut self, _: &Increment, window: &mut Window, cx: &mut Context<Self>) {
-        self.on_step(StepAction::Increment, window, cx);
+        self.on_number_input_step(StepAction::Increment, window, cx);
     }
 
     fn on_action_decrement(&mut self, _: &Decrement, window: &mut Window, cx: &mut Context<Self>) {
-        self.on_step(StepAction::Decrement, window, cx);
+        self.on_number_input_step(StepAction::Decrement, window, cx);
     }
 
-    fn on_step(&mut self, action: StepAction, _: &mut Window, cx: &mut Context<Self>) {
-        if self.input.read(cx).disabled {
+    fn on_number_input_step(&mut self, action: StepAction, _: &mut Window, cx: &mut Context<Self>) {
+        if self.disabled {
             return;
         }
 
         cx.emit(NumberInputEvent::Step(action));
-    }
-
-    fn sync_size_to_input_if_needed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self._synced_size {
-            self.input
-                .update(cx, |input, cx| input.set_size(self.size, window, cx));
-            self._synced_size = true;
-        }
-    }
-}
-
-impl Focusable for NumberInput {
-    fn focus_handle(&self, cx: &App) -> FocusHandle {
-        self.input.focus_handle(cx)
     }
 }
 
@@ -167,25 +86,28 @@ pub enum StepAction {
     Decrement,
     Increment,
 }
-
 pub enum NumberInputEvent {
     Input(InputEvent),
     Step(StepAction),
 }
+impl EventEmitter<NumberInputEvent> for InputState {}
 
-impl EventEmitter<NumberInputEvent> for NumberInput {}
+impl Focusable for NumberInput {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.input.focus_handle(cx)
+    }
+}
+
 impl Sizable for NumberInput {
     fn with_size(mut self, size: impl Into<Size>) -> Self {
         self.size = size.into();
         self
     }
 }
-impl Render for NumberInput {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+impl RenderOnce for NumberInput {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let focused = self.input.focus_handle(cx).is_focused(window);
 
-        // Sync size to input at first.
-        self.sync_size_to_input_if_needed(window, cx);
         let btn_size = match self.size {
             Size::XSmall | Size::Small => Size::Size(px(16.)),
             _ => Size::XSmall,
@@ -193,8 +115,8 @@ impl Render for NumberInput {
 
         h_flex()
             .key_context(KEY_CONTENT)
-            .on_action(cx.listener(Self::on_action_increment))
-            .on_action(cx.listener(Self::on_action_decrement))
+            .on_action(window.listener_for(&self.input, InputState::on_action_increment))
+            .on_action(window.listener_for(&self.input, InputState::on_action_decrement))
             .flex_1()
             .input_size(self.size)
             .px(match self.size {
@@ -212,9 +134,12 @@ impl Render for NumberInput {
                     .ghost()
                     .with_size(btn_size)
                     .icon(IconName::Minus)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.on_step(StepAction::Decrement, window, cx)
-                    })),
+                    .on_click({
+                        let state = self.input.clone();
+                        move |_, window, cx| {
+                            Self::decrement(state.clone(), window, cx);
+                        }
+                    }),
             )
             .child(self.input.clone())
             .child(
@@ -222,9 +147,12 @@ impl Render for NumberInput {
                     .ghost()
                     .with_size(btn_size)
                     .icon(IconName::Plus)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.on_step(StepAction::Increment, window, cx)
-                    })),
+                    .on_click({
+                        let state = self.input.clone();
+                        move |_, window, cx| {
+                            Self::increment(state.clone(), window, cx);
+                        }
+                    }),
             )
     }
 }

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -11,7 +11,7 @@ use crate::{
     ActiveTheme, IconName, Sizable, Size, StyleSized, StyledExt as _,
 };
 
-use super::InputState;
+use super::{InputState, TextInput};
 
 actions!(number_input, [Increment, Decrement]);
 
@@ -26,15 +26,15 @@ pub fn init(cx: &mut App) {
 
 #[derive(IntoElement)]
 pub struct NumberInput {
-    input: Entity<InputState>,
+    state: Entity<InputState>,
     placeholder: SharedString,
     size: Size,
 }
 
 impl NumberInput {
-    pub fn new(input: Entity<InputState>) -> Self {
+    pub fn new(state: Entity<InputState>) -> Self {
         Self {
-            input,
+            state,
             size: Size::default(),
             placeholder: SharedString::default(),
         }
@@ -94,7 +94,7 @@ impl EventEmitter<NumberInputEvent> for InputState {}
 
 impl Focusable for NumberInput {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
-        self.input.focus_handle(cx)
+        self.state.focus_handle(cx)
     }
 }
 
@@ -106,7 +106,7 @@ impl Sizable for NumberInput {
 }
 impl RenderOnce for NumberInput {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let focused = self.input.focus_handle(cx).is_focused(window);
+        let focused = self.state.focus_handle(cx).is_focused(window);
 
         let btn_size = match self.size {
             Size::XSmall | Size::Small => Size::Size(px(16.)),
@@ -115,8 +115,8 @@ impl RenderOnce for NumberInput {
 
         h_flex()
             .key_context(KEY_CONTENT)
-            .on_action(window.listener_for(&self.input, InputState::on_action_increment))
-            .on_action(window.listener_for(&self.input, InputState::on_action_decrement))
+            .on_action(window.listener_for(&self.state, InputState::on_action_increment))
+            .on_action(window.listener_for(&self.state, InputState::on_action_decrement))
             .flex_1()
             .input_size(self.size)
             .px(match self.size {
@@ -135,20 +135,20 @@ impl RenderOnce for NumberInput {
                     .with_size(btn_size)
                     .icon(IconName::Minus)
                     .on_click({
-                        let state = self.input.clone();
+                        let state = self.state.clone();
                         move |_, window, cx| {
                             Self::decrement(state.clone(), window, cx);
                         }
                     }),
             )
-            .child(self.input.clone())
+            .child(TextInput::new(self.state.clone()))
             .child(
                 Button::new("plus")
                     .ghost()
                     .with_size(btn_size)
                     .icon(IconName::Plus)
                     .on_click({
-                        let state = self.input.clone();
+                        let state = self.state.clone();
                         move |_, window, cx| {
                             Self::increment(state.clone(), window, cx);
                         }

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -186,9 +186,10 @@ pub struct OtpInput {
 }
 
 impl OtpInput {
-    pub fn new(state: Entity<OtpState>) -> Self {
+    /// Create a new [`OtpInput`] element bind to the [`OtpState`].
+    pub fn new(state: &Entity<OtpState>) -> Self {
         Self {
-            state,
+            state: state.clone(),
             number_of_groups: 2,
             size: Size::Medium,
         }

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -1,38 +1,23 @@
 use gpui::{
-    div, prelude::FluentBuilder, px, AnyElement, AppContext as _, Context, Entity, EventEmitter,
-    FocusHandle, Focusable, InteractiveElement, IntoElement, KeyDownEvent, MouseButton,
-    MouseDownEvent, ParentElement as _, Render, SharedString, Styled as _, Subscription, Window,
+    div, prelude::FluentBuilder, px, AnyElement, App, AppContext as _, Context, Empty, Entity,
+    EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyDownEvent,
+    MouseButton, MouseDownEvent, ParentElement as _, Render, RenderOnce, SharedString, Styled as _,
+    Subscription, Window,
 };
 
+use super::{blink_cursor::BlinkCursor, InputEvent};
 use crate::{h_flex, v_flex, ActiveTheme, Icon, IconName, Sizable, Size};
 
-use super::{blink_cursor::BlinkCursor, InputEvent};
-
-pub enum InputOptEvent {
-    /// When all OTP input have filled, this event will be triggered.
-    Change(SharedString),
-}
-
-/// A One Time Password (OTP) input element.
-///
-/// This can accept a fixed length number and can be masked.
-///
-/// Use case example:
-///
-/// - SMS OTP
-/// - Authenticator OTP
-pub struct OtpInput {
+pub struct OtpState {
     focus_handle: FocusHandle,
-    length: usize,
-    number_of_groups: usize,
-    masked: bool,
     value: SharedString,
     blink_cursor: Entity<BlinkCursor>,
-    size: Size,
+    masked: bool,
+    length: usize,
     _subscriptions: Vec<Subscription>,
 }
 
-impl OtpInput {
+impl OtpState {
     pub fn new(length: usize, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         let blink_cursor = cx.new(|_| BlinkCursor::new());
@@ -56,21 +41,13 @@ impl OtpInput {
         ];
 
         Self {
-            focus_handle: focus_handle.clone(),
             length,
-            number_of_groups: 2,
+            focus_handle: focus_handle.clone(),
             value: SharedString::default(),
-            masked: false,
             blink_cursor: blink_cursor.clone(),
-            size: Size::Medium,
+            masked: false,
             _subscriptions,
         }
-    }
-
-    /// Set number of groups in the OTP Input.
-    pub fn groups(mut self, n: usize) -> Self {
-        self.number_of_groups = n;
-        self
     }
 
     /// Set default value of the OTP Input.
@@ -181,6 +158,48 @@ impl OtpInput {
         });
     }
 }
+impl Focusable for OtpState {
+    fn focus_handle(&self, _: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+impl EventEmitter<InputEvent> for OtpState {}
+impl Render for OtpState {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+/// A One Time Password (OTP) input element.
+///
+/// This can accept a fixed length number and can be masked.
+///
+/// Use case example:
+///
+/// - SMS OTP
+/// - Authenticator OTP
+#[derive(IntoElement)]
+pub struct OtpInput {
+    state: Entity<OtpState>,
+    number_of_groups: usize,
+    size: Size,
+}
+
+impl OtpInput {
+    pub fn new(state: Entity<OtpState>) -> Self {
+        Self {
+            state,
+            number_of_groups: 2,
+            size: Size::Medium,
+        }
+    }
+
+    /// Set number of groups in the OTP Input.
+    pub fn groups(mut self, n: usize) -> Self {
+        self.number_of_groups = n;
+        self
+    }
+}
 
 impl Sizable for OtpInput {
     fn with_size(mut self, size: impl Into<crate::Size>) -> Self {
@@ -188,18 +207,11 @@ impl Sizable for OtpInput {
         self
     }
 }
-
-impl Focusable for OtpInput {
-    fn focus_handle(&self, _: &gpui::App) -> FocusHandle {
-        self.focus_handle.clone()
-    }
-}
-impl EventEmitter<InputEvent> for OtpInput {}
-
-impl Render for OtpInput {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let blink_show = self.blink_cursor.read(cx).visible();
-        let is_focused = self.focus_handle.is_focused(window);
+impl RenderOnce for OtpInput {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let blink_show = state.blink_cursor.read(cx).visible();
+        let is_focused = state.focus_handle.is_focused(window);
 
         let text_size = match self.size {
             Size::XSmall => px(14.),
@@ -211,18 +223,18 @@ impl Render for OtpInput {
 
         let mut groups: Vec<Vec<AnyElement>> = Vec::with_capacity(self.number_of_groups);
         let mut group_ix = 0;
-        let group_items_count = self.length / self.number_of_groups;
+        let group_items_count = state.length / self.number_of_groups;
         for _ in 0..self.number_of_groups {
             groups.push(vec![]);
         }
 
-        for i in 0..self.length {
-            let c = self.value.chars().nth(i);
+        for i in 0..state.length {
+            let c = state.value.chars().nth(i);
             if i % group_items_count == 0 && i != 0 {
                 group_ix += 1;
             }
 
-            let is_input_focused = i == self.value.chars().count() && is_focused;
+            let is_input_focused = i == state.value.chars().count() && is_focused;
 
             groups[group_ix].push(
                 h_flex()
@@ -243,10 +255,13 @@ impl Render for OtpInput {
                         Size::Large => this.w_11().h_11(),
                         Size::Size(px) => this.w(px).h(px),
                     })
-                    .on_mouse_down(MouseButton::Left, cx.listener(Self::on_input_mouse_down))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        window.listener_for(&self.state, OtpState::on_input_mouse_down),
+                    )
                     .map(|this| match c {
                         Some(c) => {
-                            if self.masked {
+                            if state.masked {
                                 this.child(
                                     Icon::new(IconName::Asterisk)
                                         .text_color(cx.theme().secondary_foreground)
@@ -271,8 +286,8 @@ impl Render for OtpInput {
         }
 
         v_flex()
-            .track_focus(&self.focus_handle)
-            .on_key_down(cx.listener(Self::on_key_down))
+            .track_focus(&self.state.read(cx).focus_handle)
+            .on_key_down(window.listener_for(&self.state, OtpState::on_key_down))
             .items_center()
             .child(
                 h_flex().items_center().gap_5().children(

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -191,6 +191,7 @@ pub fn init(cx: &mut App) {
     number_input::init(cx);
 }
 
+/// InputState to keep editing state of the [`super::TextInput`].
 pub struct InputState {
     pub(super) focus_handle: FocusHandle,
     pub(super) text: SharedString,
@@ -220,24 +221,24 @@ pub struct InputState {
     pub(super) disabled: bool,
     pub(super) masked: bool,
     pub(super) clean_on_escape: bool,
-
     pub(super) height: Option<DefiniteLength>,
     pub(super) rows: usize,
     pub(super) min_rows: usize,
     pub(super) max_rows: Option<usize>,
-
     pub(super) pattern: Option<regex::Regex>,
     pub(super) validate: Option<Box<dyn Fn(&str) -> bool + 'static>>,
     pub(crate) scroll_handle: ScrollHandle,
     pub(super) scrollbar_state: Rc<Cell<ScrollbarState>>,
     /// The size of the scrollable content.
     pub(crate) scroll_size: gpui::Size<Pixels>,
-    /// To remember the horizontal column (x-coordinate) of the cursor position.
-    preferred_x_offset: Option<Pixels>,
-    _subscriptions: Vec<Subscription>,
+
     /// The mask pattern for formatting the input text
     pub(crate) mask_pattern: MaskPattern,
     pub(super) placeholder: SharedString,
+
+    /// To remember the horizontal column (x-coordinate) of the cursor position.
+    preferred_x_offset: Option<Pixels>,
+    _subscriptions: Vec<Subscription>,
 }
 
 impl EventEmitter<InputEvent> for InputState {}

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -11,11 +11,11 @@ use std::rc::Rc;
 use unicode_segmentation::*;
 
 use gpui::{
-    actions, div, impl_internal_actions, point, prelude::FluentBuilder as _, px, relative, App,
-    AppContext, Bounds, ClipboardItem, Context, DefiniteLength, Entity, EntityInputHandler,
-    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
-    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription,
+    actions, div, impl_internal_actions, point, prelude::FluentBuilder as _, px, App, AppContext,
+    Bounds, ClipboardItem, Context, DefiniteLength, Entity, EntityInputHandler, EventEmitter,
+    FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding, KeyDownEvent,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, Point,
+    Render, ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription,
     UTF16Selection, Window, WrappedLine,
 };
 
@@ -220,10 +220,12 @@ pub struct InputState {
     pub(super) disabled: bool,
     pub(super) masked: bool,
     pub(super) clean_on_escape: bool,
+
+    pub(super) height: Option<DefiniteLength>,
     pub(super) rows: usize,
     pub(super) min_rows: usize,
     pub(super) max_rows: Option<usize>,
-    pub(super) height: Option<gpui::DefiniteLength>,
+
     pub(super) pattern: Option<regex::Regex>,
     pub(super) validate: Option<Box<dyn Fn(&str) -> bool + 'static>>,
     pub(crate) scroll_handle: ScrollHandle,
@@ -280,12 +282,12 @@ impl InputState {
             masked: false,
             clean_on_escape: false,
             loading: false,
-            height: None,
             pattern: None,
             validate: None,
             rows: 2,
             min_rows: 2,
             max_rows: None,
+            height: None,
             last_layout: None,
             last_bounds: None,
             last_selected_range: None,
@@ -296,8 +298,8 @@ impl InputState {
             scroll_size: gpui::size(px(0.), px(0.)),
             preferred_x_offset: None,
             placeholder: SharedString::default(),
-            _subscriptions,
             mask_pattern: MaskPattern::default(),
+            _subscriptions,
         }
     }
 
@@ -558,18 +560,6 @@ impl InputState {
     pub fn set_masked(&mut self, masked: bool, _: &mut Window, cx: &mut Context<Self>) {
         self.masked = masked;
         cx.notify();
-    }
-
-    /// Set full height of the input (Multi-line only).
-    pub fn h_full(mut self) -> Self {
-        self.height = Some(relative(1.));
-        self
-    }
-
-    /// Set height of the input (Multi-line only).
-    pub fn h(mut self, height: impl Into<DefiniteLength>) -> Self {
-        self.height = Some(height.into());
-        self
     }
 
     /// Set true to clear the input by pressing Escape key.

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -489,14 +489,14 @@ impl InputState {
     /// Set the text of the input field.
     ///
     /// And the selection_range will be reset to 0..0.
-    pub fn set_text(
+    pub fn set_value(
         &mut self,
-        text: impl Into<SharedString>,
+        value: impl Into<SharedString>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.history.ignore = true;
-        self.replace_text(text, window, cx);
+        self.replace_text(value, window, cx);
         self.history.ignore = false;
         // Ensure cursor to start when set text
         self.selected_range = self.text.len()..self.text.len();

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -37,9 +37,9 @@ impl Sizable for TextInput {
 }
 
 impl TextInput {
-    pub fn new(state: Entity<InputState>) -> Self {
+    pub fn new(state: &Entity<InputState>) -> Self {
         Self {
-            state,
+            state: state.clone(),
             size: Size::default(),
             no_gap: false,
             prefix: None,

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    div, px, AnyElement, App, Entity, InteractiveElement as _, IntoElement, MouseButton,
-    ParentElement as _, Pixels, Rems, RenderOnce, Styled as _, Window,
+    div, px, relative, AnyElement, App, DefiniteLength, Entity, InteractiveElement as _,
+    IntoElement, MouseButton, ParentElement as _, Rems, RenderOnce, Styled as _, Window,
 };
 
 use crate::button::{Button, ButtonVariants as _};
@@ -22,10 +22,11 @@ pub struct TextInput {
     no_gap: bool,
     prefix: Option<AnyElement>,
     suffix: Option<AnyElement>,
-    height: Option<Pixels>,
+    height: Option<DefiniteLength>,
     appearance: bool,
     cleanable: bool,
     mask_toggle: bool,
+    disabled: bool,
 }
 
 impl Sizable for TextInput {
@@ -47,6 +48,7 @@ impl TextInput {
             appearance: true,
             cleanable: false,
             mask_toggle: false,
+            disabled: false,
         }
     }
 
@@ -57,6 +59,18 @@ impl TextInput {
 
     pub fn suffix(mut self, suffix: impl IntoElement) -> Self {
         self.suffix = Some(suffix.into_any_element());
+        self
+    }
+
+    /// Set full height of the input (Multi-line only).
+    pub fn h_full(mut self) -> Self {
+        self.height = Some(relative(1.));
+        self
+    }
+
+    /// Set height of the input (Multi-line only).
+    pub fn h(mut self, height: impl Into<DefiniteLength>) -> Self {
+        self.height = Some(height.into());
         self
     }
 
@@ -75,6 +89,12 @@ impl TextInput {
     /// Set to enable toggle button for password mask state.
     pub fn mask_toggle(mut self) -> Self {
         self.mask_toggle = true;
+        self
+    }
+
+    /// Set to disable the input field.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
         self
     }
 
@@ -113,6 +133,12 @@ impl TextInput {
 impl RenderOnce for TextInput {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         const LINE_HEIGHT: Rems = Rems(1.25);
+
+        self.state.update(cx, |state, _| {
+            state.height = self.height;
+            state.disabled = self.disabled;
+        });
+
         let state = self.state.read(cx);
         let focused = state.focus_handle.is_focused(window);
         let mut gap_x = match self.size {

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -37,6 +37,7 @@ impl Sizable for TextInput {
 }
 
 impl TextInput {
+    /// Create a new [`TextInput`] element bind to the [`InputState`].
     pub fn new(state: &Entity<InputState>) -> Self {
         Self {
             state: state.clone(),

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -1,0 +1,251 @@
+use gpui::prelude::FluentBuilder as _;
+use gpui::{
+    div, px, AnyElement, App, Entity, InteractiveElement as _, IntoElement, MouseButton,
+    ParentElement as _, Pixels, Rems, RenderOnce, Styled as _, Window,
+};
+
+use crate::button::{Button, ButtonVariants as _};
+use crate::indicator::Indicator;
+use crate::input::clear_button;
+use crate::scroll::{Scrollbar, ScrollbarAxis};
+use crate::ActiveTheme;
+use crate::{h_flex, StyledExt};
+use crate::{IconName, Size};
+use crate::{Sizable, StyleSized};
+
+use super::InputState;
+
+#[derive(IntoElement)]
+pub struct TextInput {
+    state: Entity<InputState>,
+    size: Size,
+    no_gap: bool,
+    prefix: Option<AnyElement>,
+    suffix: Option<AnyElement>,
+    height: Option<Pixels>,
+    appearance: bool,
+}
+
+impl TextInput {
+    pub fn new(state: Entity<InputState>) -> Self {
+        Self {
+            state,
+            size: Size::default(),
+            no_gap: false,
+            prefix: None,
+            suffix: None,
+            height: None,
+            appearance: false,
+        }
+    }
+
+    pub fn prefix(mut self, prefix: impl IntoElement) -> Self {
+        self.prefix = Some(prefix.into_any_element());
+        self
+    }
+
+    pub fn suffix(mut self, suffix: impl IntoElement) -> Self {
+        self.suffix = Some(suffix.into_any_element());
+        self
+    }
+
+    /// Set the appearance of the input field.
+    pub fn appearance(mut self, appearance: bool) -> Self {
+        self.appearance = appearance;
+        self
+    }
+
+    fn render_toggle_mask_button(
+        state: Entity<InputState>,
+        _: &mut Window,
+        cx: &App,
+    ) -> Option<impl IntoElement> {
+        if !state.read(cx).mask_toggle {
+            return None;
+        }
+
+        Some(
+            Button::new("toggle-mask")
+                .icon(IconName::Eye)
+                .xsmall()
+                .ghost()
+                .on_mouse_down(MouseButton::Left, {
+                    let state = state.clone();
+                    move |_, window, cx| {
+                        state.update(cx, |state, cx| {
+                            state.set_masked(false, window, cx);
+                        })
+                    }
+                })
+                .on_mouse_up(MouseButton::Left, {
+                    let state = state.clone();
+                    move |_, window, cx| {
+                        state.update(cx, |state, cx| {
+                            state.set_masked(true, window, cx);
+                        })
+                    }
+                }),
+        )
+    }
+}
+
+impl RenderOnce for TextInput {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        const LINE_HEIGHT: Rems = Rems(1.25);
+        let state = self.state.read(cx);
+        let focused = state.focus_handle.is_focused(window);
+        let mut gap_x = match self.size {
+            Size::Small => px(4.),
+            Size::Large => px(8.),
+            _ => px(4.),
+        };
+        if self.no_gap {
+            gap_x = px(0.);
+        }
+
+        let prefix = self.prefix;
+        let suffix = self.suffix;
+        let show_clear_button =
+            state.cleanable && !state.loading && !state.text.is_empty() && state.is_single_line();
+        let bg = if state.disabled {
+            cx.theme().muted
+        } else {
+            cx.theme().background
+        };
+
+        div()
+            .flex()
+            .id("input")
+            .key_context(crate::input::CONTEXT)
+            .track_focus(&state.focus_handle)
+            .when(!state.disabled, |this| {
+                this.on_action(window.listener_for(&self.state, InputState::backspace))
+                    .on_action(window.listener_for(&self.state, InputState::delete))
+                    .on_action(
+                        window.listener_for(&self.state, InputState::delete_to_beginning_of_line),
+                    )
+                    .on_action(window.listener_for(&self.state, InputState::delete_to_end_of_line))
+                    .on_action(window.listener_for(&self.state, InputState::delete_previous_word))
+                    .on_action(window.listener_for(&self.state, InputState::delete_next_word))
+                    .on_action(window.listener_for(&self.state, InputState::enter))
+                    .on_action(window.listener_for(&self.state, InputState::escape))
+            })
+            .on_action(window.listener_for(&self.state, InputState::left))
+            .on_action(window.listener_for(&self.state, InputState::right))
+            .on_action(window.listener_for(&self.state, InputState::select_left))
+            .on_action(window.listener_for(&self.state, InputState::select_right))
+            .when(state.multi_line, |this| {
+                this.on_action(window.listener_for(&self.state, InputState::up))
+                    .on_action(window.listener_for(&self.state, InputState::down))
+                    .on_action(window.listener_for(&self.state, InputState::select_up))
+                    .on_action(window.listener_for(&self.state, InputState::select_down))
+            })
+            .on_action(window.listener_for(&self.state, InputState::select_all))
+            .on_action(window.listener_for(&self.state, InputState::select_to_start_of_line))
+            .on_action(window.listener_for(&self.state, InputState::select_to_end_of_line))
+            .on_action(window.listener_for(&self.state, InputState::select_to_previous_word))
+            .on_action(window.listener_for(&self.state, InputState::select_to_next_word))
+            .on_action(window.listener_for(&self.state, InputState::home))
+            .on_action(window.listener_for(&self.state, InputState::end))
+            .on_action(window.listener_for(&self.state, InputState::move_to_start))
+            .on_action(window.listener_for(&self.state, InputState::move_to_end))
+            .on_action(window.listener_for(&self.state, InputState::move_to_previous_word))
+            .on_action(window.listener_for(&self.state, InputState::move_to_next_word))
+            .on_action(window.listener_for(&self.state, InputState::select_to_start))
+            .on_action(window.listener_for(&self.state, InputState::select_to_end))
+            .on_action(window.listener_for(&self.state, InputState::show_character_palette))
+            .on_action(window.listener_for(&self.state, InputState::copy))
+            .on_action(window.listener_for(&self.state, InputState::paste))
+            .on_action(window.listener_for(&self.state, InputState::cut))
+            .on_action(window.listener_for(&self.state, InputState::undo))
+            .on_action(window.listener_for(&self.state, InputState::redo))
+            .on_key_down(window.listener_for(&self.state, InputState::on_key_down))
+            .on_mouse_down(
+                MouseButton::Left,
+                window.listener_for(&self.state, InputState::on_mouse_down),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                window.listener_for(&self.state, InputState::on_mouse_up),
+            )
+            .on_scroll_wheel(window.listener_for(&self.state, InputState::on_scroll_wheel))
+            .size_full()
+            .line_height(LINE_HEIGHT)
+            .input_py(self.size)
+            .input_h(self.size)
+            .cursor_text()
+            .when(state.multi_line, |this| {
+                this.h_auto()
+                    .when_some(self.height, |this, height| this.h(height))
+            })
+            .when(self.appearance, |this| {
+                this.bg(bg)
+                    .border_color(cx.theme().input)
+                    .border_1()
+                    .rounded(cx.theme().radius)
+                    .when(cx.theme().shadow, |this| this.shadow_sm())
+                    .when(focused, |this| this.focused_border(cx))
+            })
+            .when(prefix.is_none(), |this| this.input_pl(self.size))
+            .input_pr(self.size)
+            .items_center()
+            .gap(gap_x)
+            .children(prefix)
+            .child(self.state.clone())
+            .child(
+                h_flex()
+                    .id("suffix")
+                    .absolute()
+                    .gap(gap_x)
+                    .when(self.appearance, |this| this.bg(bg))
+                    .items_center()
+                    .when(suffix.is_none(), |this| this.pr_1())
+                    .right_0()
+                    .when(state.loading, |this| {
+                        this.child(Indicator::new().color(cx.theme().muted_foreground))
+                    })
+                    .children(Self::render_toggle_mask_button(
+                        self.state.clone(),
+                        window,
+                        cx,
+                    ))
+                    .when(show_clear_button, |this| {
+                        this.child(clear_button(cx).on_click({
+                            let state = self.state.clone();
+                            move |_, window, cx| {
+                                state.update(cx, |state, cx| {
+                                    state.clean(window, cx);
+                                })
+                            }
+                        }))
+                    })
+                    .children(suffix),
+            )
+            .when(state.is_multi_line(), |this| {
+                let entity_id = self.state.entity_id();
+                if state.last_layout.is_some() {
+                    let scroll_size = state.scroll_size;
+
+                    this.relative().child(
+                        div()
+                            .absolute()
+                            .top_0()
+                            .left_0()
+                            .right(px(1.))
+                            .bottom_0()
+                            .child(
+                                Scrollbar::vertical(
+                                    entity_id,
+                                    state.scrollbar_state.clone(),
+                                    state.scroll_handle.clone(),
+                                    scroll_size,
+                                )
+                                .axis(ScrollbarAxis::Vertical),
+                            ),
+                    )
+                } else {
+                    this
+                }
+            })
+    }
+}

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     div, px, AnyElement, App, Entity, InteractiveElement as _, IntoElement, MouseButton,
-    ParentElement as _, Pixels, Rems, RenderOnce, SharedString, Styled as _, Window,
+    ParentElement as _, Pixels, Rems, RenderOnce, Styled as _, Window,
 };
 
 use crate::button::{Button, ButtonVariants as _};
@@ -86,11 +86,7 @@ impl TextInput {
         self
     }
 
-    fn render_toggle_mask_button(
-        state: Entity<InputState>,
-        _: &mut Window,
-        cx: &App,
-    ) -> impl IntoElement {
+    fn render_toggle_mask_button(state: Entity<InputState>) -> impl IntoElement {
         Button::new("toggle-mask")
             .icon(IconName::Eye)
             .xsmall()
@@ -216,6 +212,7 @@ impl RenderOnce for TextInput {
             .items_center()
             .gap(gap_x)
             .children(prefix)
+            // TODO: Define height here, and use it in the input element
             .child(self.state.clone())
             .child(
                 h_flex()
@@ -230,11 +227,7 @@ impl RenderOnce for TextInput {
                         this.child(Indicator::new().color(cx.theme().muted_foreground))
                     })
                     .when(self.mask_toggle, |this| {
-                        this.child(Self::render_toggle_mask_button(
-                            self.state.clone(),
-                            window,
-                            cx,
-                        ))
+                        this.child(Self::render_toggle_mask_button(self.state.clone()))
                     })
                     .when(show_clear_button, |this| {
                         this.child(clear_button(cx).on_click({

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -560,7 +560,7 @@ where
         };
 
         let initial_view = if let Some(input) = &self.query_input {
-            if input.read(cx).text().is_empty() {
+            if input.read(cx).value().is_empty() {
                 self.delegate().render_initial(window, cx)
             } else {
                 None

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -586,7 +586,7 @@ where
                         .border_b_1()
                         .border_color(cx.theme().border)
                         .child(
-                            TextInput::new(input)
+                            TextInput::new(&input)
                                 .with_size(self.size)
                                 .prefix(
                                     Icon::new(IconName::Search)

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 use std::{cell::Cell, rc::Rc};
 
 use crate::actions::{Cancel, Confirm, SelectNext, SelectPrev};
+use crate::input::InputState;
 use crate::Icon;
 use crate::{
     input::{InputEvent, TextInput},
@@ -148,7 +149,7 @@ pub struct List<D: ListDelegate> {
     focus_handle: FocusHandle,
     delegate: D,
     max_height: Option<Length>,
-    query_input: Option<Entity<TextInput>>,
+    query_input: Option<Entity<InputState>>,
     last_query: Option<String>,
     selectable: bool,
     querying: bool,
@@ -170,10 +171,9 @@ where
 {
     pub fn new(delegate: D, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let query_input = cx.new(|cx| {
-            TextInput::new(window, cx)
-                .appearance(false)
-                .prefix(|_, cx| Icon::new(IconName::Search).text_color(cx.theme().muted_foreground))
-                .placeholder(t!("List.search_placeholder"))
+            InputState::new(window, cx)
+                // .prefix(|_, cx| Icon::new(IconName::Search).text_color(cx.theme().muted_foreground))
+                // .placeholder(t!("List.search_placeholder"))
                 .cleanable()
         });
 
@@ -235,7 +235,7 @@ where
 
     pub fn set_query_input(
         &mut self,
-        query_input: Entity<TextInput>,
+        query_input: Entity<InputState>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -245,7 +245,7 @@ where
     }
 
     /// Get the query input entity.
-    pub fn query_input(&self) -> Option<&Entity<TextInput>> {
+    pub fn query_input(&self) -> Option<&Entity<InputState>> {
         self.query_input.as_ref()
     }
 
@@ -310,7 +310,7 @@ where
 
     fn on_query_input_event(
         &mut self,
-        _: &Entity<TextInput>,
+        _: &Entity<InputState>,
         event: &InputEvent,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -591,7 +591,14 @@ where
                         })
                         .border_b_1()
                         .border_color(cx.theme().border)
-                        .child(input),
+                        .child(
+                            TextInput::new(input)
+                                .prefix(
+                                    Icon::new(IconName::Search)
+                                        .text_color(cx.theme().muted_foreground),
+                                )
+                                .appearance(false),
+                        ),
                 )
             })
             .when(loading, |this| {

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -3,12 +3,12 @@ use std::{cell::Cell, rc::Rc};
 
 use crate::actions::{Cancel, Confirm, SelectNext, SelectPrev};
 use crate::input::InputState;
-use crate::Icon;
 use crate::{
     input::{InputEvent, TextInput},
     scroll::{Scrollbar, ScrollbarState},
     v_flex, ActiveTheme, IconName, Size,
 };
+use crate::{Icon, Sizable as _};
 use gpui::{
     div, prelude::FluentBuilder, uniform_list, AnyElement, AppContext, Entity, FocusHandle,
     Focusable, InteractiveElement, IntoElement, KeyBinding, Length, ListSizingBehavior,
@@ -173,8 +173,7 @@ where
         let query_input = cx.new(|cx| {
             InputState::new(window, cx)
                 // .prefix(|_, cx| Icon::new(IconName::Search).text_color(cx.theme().muted_foreground))
-                // .placeholder(t!("List.search_placeholder"))
-                .cleanable()
+                .placeholder(t!("List.search_placeholder"))
         });
 
         let _query_input_subscription =
@@ -202,12 +201,7 @@ where
     }
 
     /// Set the size
-    pub fn set_size(&mut self, size: Size, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(input) = &self.query_input {
-            input.update(cx, |input, cx| {
-                input.set_size(size, window, cx);
-            })
-        }
+    pub fn set_size(&mut self, size: Size, _: &mut Window, _: &mut Context<Self>) {
         self.size = size;
     }
 
@@ -593,10 +587,12 @@ where
                         .border_color(cx.theme().border)
                         .child(
                             TextInput::new(input)
+                                .with_size(self.size)
                                 .prefix(
                                     Icon::new(IconName::Search)
                                         .text_color(cx.theme().muted_foreground),
                                 )
+                                .cleanable()
                                 .appearance(false),
                         ),
                 )

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -1,6 +1,6 @@
 use crate::{
     drawer::Drawer,
-    input::{InputState, TextInput},
+    input::InputState,
     modal::Modal,
     notification::{Notification, NotificationList},
     window_border, ActiveTheme, Placement,

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -1,6 +1,6 @@
 use crate::{
     drawer::Drawer,
-    input::TextInput,
+    input::{InputState, TextInput},
     modal::Modal,
     notification::{Notification, NotificationList},
     window_border, ActiveTheme, Placement,
@@ -51,7 +51,7 @@ pub trait ContextModal: Sized {
     fn notifications(&mut self, cx: &mut App) -> Rc<Vec<Entity<Notification>>>;
 
     /// Return current focused Input entity.
-    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<TextInput>>;
+    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>>;
     /// Returns true if there is a focused Input entity.
     fn has_focused_input(&mut self, cx: &mut App) -> bool;
 }
@@ -175,7 +175,7 @@ impl ContextModal for Window {
         Root::read(self, cx).focused_input.is_some()
     }
 
-    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<TextInput>> {
+    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>> {
         Root::read(self, cx).focused_input.clone()
     }
 }
@@ -246,7 +246,7 @@ pub struct Root {
     previous_focus_handle: Option<FocusHandle>,
     active_drawer: Option<ActiveDrawer>,
     pub(crate) active_modals: Vec<ActiveModal>,
-    pub(super) focused_input: Option<Entity<TextInput>>,
+    pub(super) focused_input: Option<Entity<InputState>>,
     pub notification: Entity<NotificationList>,
     drawer_size: Option<DefiniteLength>,
     view: AnyView,

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -19,6 +19,7 @@ pub enum SliderEvent {
     Change(f32),
 }
 
+/// State of the [`Slider`].
 pub struct SliderState {
     min: f32,
     max: f32,
@@ -149,6 +150,7 @@ pub struct Slider {
 }
 
 impl Slider {
+    /// Create a new [`Slider`] element bind to the [`SliderState`].
     pub fn new(state: &Entity<SliderState>) -> Self {
         Self {
             axis: Axis::Horizontal,

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -149,11 +149,11 @@ pub struct Slider {
 }
 
 impl Slider {
-    pub fn new(state: Entity<SliderState>) -> Self {
+    pub fn new(state: &Entity<SliderState>) -> Self {
         Self {
             axis: Axis::Horizontal,
             reverse: false,
-            state,
+            state: state.clone(),
             disabled: false,
         }
     }

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -1,9 +1,9 @@
 use crate::{h_flex, tooltip::Tooltip, ActiveTheme, AxisExt};
 use gpui::{
-    canvas, div, prelude::FluentBuilder as _, px, AppContext as _, Axis, Bounds, Context,
-    DragMoveEvent, Empty, EntityId, EventEmitter, InteractiveElement, IntoElement, MouseButton,
-    MouseDownEvent, ParentElement as _, Pixels, Point, Render, StatefulInteractiveElement as _,
-    Styled, Window,
+    canvas, div, prelude::FluentBuilder as _, px, App, AppContext as _, Axis, Bounds, Context,
+    DragMoveEvent, Empty, Entity, EntityId, EventEmitter, InteractiveElement, IntoElement,
+    MouseButton, MouseDownEvent, ParentElement as _, Pixels, Point, Render, RenderOnce,
+    StatefulInteractiveElement as _, Styled, Window,
 };
 
 #[derive(Clone)]
@@ -19,46 +19,25 @@ pub enum SliderEvent {
     Change(f32),
 }
 
-/// A Slider element.
-pub struct Slider {
-    axis: Axis,
+pub struct SliderState {
     min: f32,
     max: f32,
     step: f32,
     value: f32,
-    reverse: bool,
-    percentage: f32,
     bounds: Bounds<Pixels>,
+    percentage: f32,
 }
 
-impl Slider {
-    fn new(axis: Axis) -> Self {
+impl SliderState {
+    pub fn new() -> Self {
         Self {
-            axis,
             min: 0.0,
             max: 100.0,
             step: 1.0,
             value: 0.0,
             percentage: 0.0,
-            reverse: false,
             bounds: Bounds::default(),
         }
-    }
-
-    /// Create a horizontal slider.
-    pub fn horizontal() -> Self {
-        Self::new(Axis::Horizontal)
-    }
-
-    /// Create a vertical slider.
-    pub fn vertical() -> Self {
-        Self::new(Axis::Vertical)
-    }
-
-    /// Set the reverse direction of the slider, default: false
-    pub fn reverse(mut self) -> Self {
-        self.reverse = true;
-        self
     }
 
     /// Set the minimum value of the slider, default: 0.0
@@ -107,19 +86,20 @@ impl Slider {
     /// Update value by mouse position
     fn update_value_by_position(
         &mut self,
+        axis: Axis,
+        reverse: bool,
         position: Point<Pixels>,
         _: &mut gpui::Window,
         cx: &mut gpui::Context<Self>,
     ) {
         let bounds = self.bounds;
-        let axis = self.axis;
         let min = self.min;
         let max = self.max;
         let step = self.step;
 
         let percentage = match axis {
             Axis::Horizontal => {
-                if self.reverse {
+                if reverse {
                     1. - (position.x - bounds.left()).clamp(px(0.), bounds.size.width)
                         / bounds.size.width
                 } else {
@@ -128,7 +108,7 @@ impl Slider {
                 }
             }
             Axis::Vertical => {
-                if self.reverse {
+                if reverse {
                     1. - (position.y - bounds.top()).clamp(px(0.), bounds.size.height)
                         / bounds.size.height
                 } else {
@@ -150,15 +130,61 @@ impl Slider {
         cx.emit(SliderEvent::Change(self.value));
         cx.notify();
     }
+}
+
+impl EventEmitter<SliderEvent> for SliderState {}
+impl Render for SliderState {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+/// A Slider element.
+#[derive(IntoElement)]
+pub struct Slider {
+    state: Entity<SliderState>,
+    axis: Axis,
+    reverse: bool,
+}
+
+impl Slider {
+    pub fn new(state: Entity<SliderState>) -> Self {
+        Self {
+            axis: Axis::Horizontal,
+            reverse: false,
+            state,
+        }
+    }
+
+    /// As a horizontal slider.
+    pub fn horizontal(mut self) -> Self {
+        self.axis = Axis::Horizontal;
+        self
+    }
+
+    /// As a vertical slider.
+    pub fn vertical(mut self) -> Self {
+        self.axis = Axis::Vertical;
+        self
+    }
+
+    /// Set the reverse direction of the slider, default: false
+    pub fn reverse(mut self) -> Self {
+        self.reverse = true;
+        self
+    }
 
     fn render_thumb(
         &self,
         thumb_bar_size: Pixels,
-        _: &mut Window,
-        cx: &mut Context<Self>,
+        window: &mut Window,
+        cx: &mut App,
     ) -> impl gpui::IntoElement {
-        let value = self.value;
-        let entity_id = cx.entity_id();
+        let state = self.state.read(cx);
+        let entity_id = self.state.entity_id();
+        let value = state.value;
+        let reverse = self.reverse;
+        let axis = self.axis;
 
         div()
             .id("slider-thumb")
@@ -166,8 +192,9 @@ impl Slider {
                 cx.stop_propagation();
                 cx.new(|_| drag.clone())
             })
-            .on_drag_move(
-                cx.listener(move |view, e: &DragMoveEvent<DragThumb>, window, cx| {
+            .on_drag_move(window.listener_for(
+                &self.state,
+                move |view, e: &DragMoveEvent<DragThumb>, window, cx| {
                     match e.drag(cx) {
                         DragThumb(id) => {
                             if *id != entity_id {
@@ -175,25 +202,31 @@ impl Slider {
                             }
 
                             // set value by mouse position
-                            view.update_value_by_position(e.event.position, window, cx)
+                            view.update_value_by_position(
+                                axis,
+                                reverse,
+                                e.event.position,
+                                window,
+                                cx,
+                            )
                         }
                     }
-                }),
-            )
+                },
+            ))
             .absolute()
-            .map(|this| match self.reverse {
+            .map(|this| match reverse {
                 true => this
-                    .when(self.axis.is_horizontal(), |this| {
+                    .when(axis.is_horizontal(), |this| {
                         this.bottom(px(-5.)).right(thumb_bar_size).mr(-px(8.))
                     })
-                    .when(self.axis.is_vertical(), |this| {
+                    .when(axis.is_vertical(), |this| {
                         this.bottom(thumb_bar_size).right(px(-5.)).mb(-px(8.))
                     }),
                 false => this
-                    .when(self.axis.is_horizontal(), |this| {
+                    .when(axis.is_horizontal(), |this| {
                         this.top(px(-5.)).left(thumb_bar_size).ml(-px(8.))
                     })
-                    .when(self.axis.is_vertical(), |this| {
+                    .when(axis.is_vertical(), |this| {
                         this.top(thumb_bar_size).left(px(-5.)).mt(-px(8.))
                     }),
             })
@@ -205,39 +238,39 @@ impl Slider {
             .bg(cx.theme().slider_thumb)
             .tooltip(move |window, cx| Tooltip::new(format!("{}", value)).build(window, cx))
     }
-
-    fn on_mouse_down(
-        &mut self,
-        event: &MouseDownEvent,
-        window: &mut gpui::Window,
-        cx: &mut gpui::Context<Self>,
-    ) {
-        self.update_value_by_position(event.position, window, cx);
-    }
 }
 
-impl EventEmitter<SliderEvent> for Slider {}
-
-impl Render for Slider {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let thumb_bar_size = match self.axis {
-            Axis::Horizontal => self.percentage * self.bounds.size.width,
-            Axis::Vertical => self.percentage * self.bounds.size.height,
+impl RenderOnce for Slider {
+    fn render(self, window: &mut Window, cx: &mut gpui::App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let axis = self.axis;
+        let reverse = self.reverse;
+        let thumb_bar_size = match axis {
+            Axis::Horizontal => state.percentage * state.bounds.size.width,
+            Axis::Vertical => state.percentage * state.bounds.size.height,
         };
 
         div()
-            .id("slider")
+            .id(("slider", self.state.entity_id()))
             .flex_1()
-            .when(self.axis.is_vertical(), |this| {
+            .when(axis.is_vertical(), |this| {
                 this.flex().items_center().justify_center()
             })
             .child(
                 h_flex()
-                    .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
-                    .when(self.axis.is_horizontal(), |this| {
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        window.listener_for(
+                            &self.state,
+                            move |view, e: &MouseDownEvent, window, cx| {
+                                view.update_value_by_position(axis, reverse, e.position, window, cx)
+                            },
+                        ),
+                    )
+                    .when(axis.is_horizontal(), |this| {
                         this.items_center().h_6().w_full()
                     })
-                    .when(self.axis.is_vertical(), |this| {
+                    .when(axis.is_vertical(), |this| {
                         this.justify_center().w_6().h_full()
                     })
                     .flex_shrink_0()
@@ -245,20 +278,20 @@ impl Render for Slider {
                         div()
                             .id("slider-bar")
                             .relative()
-                            .when(self.axis.is_horizontal(), |this| this.w_full().h_1p5())
-                            .when(self.axis.is_vertical(), |this| this.h_full().w_1p5())
+                            .when(axis.is_horizontal(), |this| this.w_full().h_1p5())
+                            .when(axis.is_vertical(), |this| this.h_full().w_1p5())
                             .bg(cx.theme().slider_bar.opacity(0.2))
                             .active(|this| this.bg(cx.theme().slider_bar.opacity(0.4)))
                             .rounded(px(3.))
                             .child(
                                 div()
                                     .absolute()
-                                    .when(!self.reverse, |this| this.top_0().left_0())
-                                    .when(self.reverse, |this| this.bottom_0().right_0())
-                                    .when(self.axis.is_horizontal(), |this| {
+                                    .when(!reverse, |this| this.top_0().left_0())
+                                    .when(reverse, |this| this.bottom_0().right_0())
+                                    .when(axis.is_horizontal(), |this| {
                                         this.h_full().w(thumb_bar_size)
                                     })
-                                    .when(self.axis.is_vertical(), |this| {
+                                    .when(axis.is_vertical(), |this| {
                                         this.w_full().h(thumb_bar_size)
                                     })
                                     .bg(cx.theme().slider_bar)
@@ -266,9 +299,9 @@ impl Render for Slider {
                             )
                             .child(self.render_thumb(thumb_bar_size, window, cx))
                             .child({
-                                let view = cx.entity().clone();
+                                let state = self.state.clone();
                                 canvas(
-                                    move |bounds, _, cx| view.update(cx, |r, _| r.bounds = bounds),
+                                    move |bounds, _, cx| state.update(cx, |r, _| r.bounds = bounds),
                                     |_, _, _, _| {},
                                 )
                                 .absolute()

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -221,6 +221,7 @@ impl Matcher {
     }
 }
 
+/// Use to store the state of the calendar.
 pub struct CalendarState {
     focus_handle: FocusHandle,
     view_mode: ViewMode,

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use chrono::{Datelike, Local, NaiveDate};
 use gpui::{
-    prelude::FluentBuilder as _, px, relative, ClickEvent, Context, ElementId, EventEmitter,
-    FocusHandle, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
-    StatefulInteractiveElement, Styled, Window,
+    prelude::FluentBuilder as _, px, relative, App, ClickEvent, Context, ElementId, Empty, Entity,
+    EventEmitter, FocusHandle, InteractiveElement, IntoElement, ParentElement, Render, RenderOnce,
+    SharedString, StatefulInteractiveElement, Styled, Window,
 };
 use rust_i18n::t;
 
@@ -126,7 +126,7 @@ impl Date {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ViewMode {
     Day,
     Month,
@@ -221,35 +221,42 @@ impl Matcher {
     }
 }
 
-pub struct Calendar {
+pub struct CalendarState {
     focus_handle: FocusHandle,
-    size: Size,
-    date: Date,
     view_mode: ViewMode,
+    date: Date,
     current_year: i32,
     current_month: u8,
     years: Vec<Vec<i32>>,
     year_page: i32,
+    today: NaiveDate,
     /// Number of the months view to show.
     number_of_months: usize,
-    today: NaiveDate,
     disabled: Option<Matcher>,
 }
 
-impl Calendar {
+#[derive(IntoElement)]
+pub struct Calendar {
+    size: Size,
+    state: Entity<CalendarState>,
+    bordered: bool,
+    /// Number of the months view to show.
+    number_of_months: usize,
+}
+
+impl CalendarState {
     pub fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         let today = Local::now().naive_local().date();
         Self {
             focus_handle: cx.focus_handle(),
-            size: Size::default(),
             view_mode: ViewMode::Day,
             date: Date::Single(None),
             current_month: today.month() as u8,
             current_year: today.year(),
             years: vec![],
             year_page: 0,
-            number_of_months: 1,
             today,
+            number_of_months: 1,
             disabled: None,
         }
         .year_range((today.year() - 50, today.year() + 50))
@@ -291,16 +298,10 @@ impl Calendar {
         self.date
     }
 
-    /// Set number of months to show, default is 1.
-    pub fn number_of_months(mut self, number_of_months: usize) -> Self {
-        self.number_of_months = number_of_months;
-        self
-    }
-
-    pub fn set_size(&mut self, size: Size, _: &mut Window, cx: &mut Context<Self>) {
-        self.size = size;
-        cx.notify();
-    }
+    // pub fn set_size(&mut self, size: Size, _: &mut Window, cx: &mut Context<Self>) {
+    //     self.size = size;
+    //     cx.notify();
+    // }
 
     pub fn set_number_of_months(
         &mut self,
@@ -435,22 +436,238 @@ impl Calendar {
         .into()
     }
 
-    fn render_week(
+    fn set_view_mode(&mut self, mode: ViewMode, _: &mut Window, cx: &mut Context<Self>) {
+        self.view_mode = mode;
+        cx.notify();
+    }
+
+    fn months(&self) -> Vec<SharedString> {
+        [
+            t!("Calendar.month.January"),
+            t!("Calendar.month.February"),
+            t!("Calendar.month.March"),
+            t!("Calendar.month.April"),
+            t!("Calendar.month.May"),
+            t!("Calendar.month.June"),
+            t!("Calendar.month.July"),
+            t!("Calendar.month.August"),
+            t!("Calendar.month.September"),
+            t!("Calendar.month.October"),
+            t!("Calendar.month.November"),
+            t!("Calendar.month.December"),
+        ]
+        .iter()
+        .map(|s| s.clone().into())
+        .collect()
+    }
+}
+
+impl Render for CalendarState {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+impl Calendar {
+    pub fn new(state: Entity<CalendarState>) -> Self {
+        Self {
+            size: Size::default(),
+            state,
+            bordered: true,
+            number_of_months: 1,
+        }
+    }
+
+    /// Set number of months to show, default is 1.
+    pub fn number_of_months(mut self, number_of_months: usize) -> Self {
+        self.number_of_months = number_of_months;
+        self
+    }
+
+    /// Set bordered, default: `true`.
+    pub fn bordered(mut self, bordered: bool) -> Self {
+        self.bordered = bordered;
+        self
+    }
+
+    fn render_day(
         &self,
-        week: impl Into<SharedString>,
-        _: &mut Window,
-        cx: &mut Context<Self>,
+        d: &NaiveDate,
+        offset_month: usize,
+        window: &mut Window,
+        cx: &mut App,
     ) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let (_, month) = state.offset_year_month(offset_month);
+        let day = d.day();
+        let is_current_month = d.month() == month;
+        let is_active = state.date.is_active(d) && is_current_month;
+        let is_in_range = state.date.is_in_range(d);
+
+        let date = *d;
+        let is_today = *d == state.today;
+        let disabled = state
+            .disabled
+            .as_ref()
+            .map_or(false, |disabled| disabled.matched(&date));
+
+        self.item_button(
+            d.ordinal() as usize,
+            day.to_string(),
+            is_active,
+            is_in_range,
+            !is_current_month || disabled,
+            disabled,
+            window,
+            cx,
+        )
+        .when(is_today && !is_active, |this| {
+            this.border_1().border_color(cx.theme().border)
+        }) // Add border for today
+        .when(!disabled, |this| {
+            this.on_click(window.listener_for(
+                &self.state,
+                move |view, _: &ClickEvent, window, cx| {
+                    if view.date.is_single() {
+                        view.set_date(date, window, cx);
+                        cx.emit(CalendarEvent::Selected(view.date()));
+                    } else {
+                        let start = view.date.start();
+                        let end = view.date.end();
+
+                        if start.is_none() && end.is_none() {
+                            view.set_date(Date::Range(Some(date), None), window, cx);
+                        } else if start.is_some() && end.is_none() {
+                            if date < start.unwrap() {
+                                view.set_date(Date::Range(Some(date), None), window, cx);
+                            } else {
+                                view.set_date(
+                                    Date::Range(Some(start.unwrap()), Some(date)),
+                                    window,
+                                    cx,
+                                );
+                            }
+                        } else {
+                            view.set_date(Date::Range(Some(date), None), window, cx);
+                        }
+
+                        if view.date.is_complete() {
+                            cx.emit(CalendarEvent::Selected(view.date()));
+                        }
+                    }
+                },
+            ))
+        })
+    }
+
+    fn render_header(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let current_year = state.current_year;
+        let view_mode = state.view_mode;
+        let disabled = view_mode.is_month();
+        let multiple_months = self.number_of_months > 1;
+        let icon_size = match self.size {
+            Size::Small => Size::Small,
+            Size::Large => Size::Medium,
+            _ => Size::Medium,
+        };
+
         h_flex()
-            .map(|this| match self.size {
-                Size::Small => this.size_7().rounded(cx.theme().radius / 2.0),
-                Size::Large => this.size_10().rounded(cx.theme().radius),
-                _ => this.size_9().rounded(cx.theme().radius),
+            .gap_0p5()
+            .justify_between()
+            .items_center()
+            .child(
+                Button::new("prev")
+                    .icon(IconName::ArrowLeft)
+                    .ghost()
+                    .disabled(disabled)
+                    .with_size(icon_size)
+                    .when(view_mode.is_day(), |this| {
+                        this.on_click(window.listener_for(&self.state, CalendarState::prev_month))
+                    })
+                    .when(view_mode.is_year(), |this| {
+                        this.when(!state.has_prev_year_page(), |this| this.disabled(true))
+                            .on_click(
+                                window.listener_for(&self.state, CalendarState::prev_year_page),
+                            )
+                    }),
+            )
+            .when(!multiple_months, |this| {
+                this.child(
+                    h_flex()
+                        .justify_center()
+                        .gap_3()
+                        .child(
+                            Button::new("month")
+                                .ghost()
+                                .label(state.month_name(0))
+                                .compact()
+                                .with_size(self.size)
+                                .selected(view_mode.is_month())
+                                .on_click(window.listener_for(
+                                    &self.state,
+                                    move |view, _, window, cx| {
+                                        if view_mode.is_month() {
+                                            view.set_view_mode(ViewMode::Day, window, cx);
+                                        } else {
+                                            view.set_view_mode(ViewMode::Month, window, cx);
+                                        }
+                                        cx.notify();
+                                    },
+                                )),
+                        )
+                        .child(
+                            Button::new("year")
+                                .ghost()
+                                .label(current_year.to_string())
+                                .compact()
+                                .with_size(self.size)
+                                .selected(view_mode.is_year())
+                                .on_click(window.listener_for(
+                                    &self.state,
+                                    |view, _, window, cx| {
+                                        if view.view_mode.is_year() {
+                                            view.set_view_mode(ViewMode::Day, window, cx);
+                                        } else {
+                                            view.set_view_mode(ViewMode::Year, window, cx);
+                                        }
+                                        cx.notify();
+                                    },
+                                )),
+                        ),
+                )
             })
-            .justify_center()
-            .text_color(cx.theme().muted_foreground)
-            .text_sm()
-            .child(week.into())
+            .when(multiple_months, |this| {
+                this.child(h_flex().flex_1().justify_around().children(
+                    (0..self.number_of_months).map(|n| {
+                        h_flex()
+                            .justify_center()
+                            .map(|this| match self.size {
+                                Size::Small => this.gap_2(),
+                                Size::Large => this.gap_4(),
+                                _ => this.gap_3(),
+                            })
+                            .child(state.month_name(n))
+                            .child(current_year.to_string())
+                    }),
+                ))
+            })
+            .child(
+                Button::new("next")
+                    .icon(IconName::ArrowRight)
+                    .ghost()
+                    .disabled(disabled)
+                    .with_size(icon_size)
+                    .when(view_mode.is_day(), |this| {
+                        this.on_click(window.listener_for(&self.state, CalendarState::next_month))
+                    })
+                    .when(view_mode.is_year(), |this| {
+                        this.when(!state.has_next_year_page(), |this| this.disabled(true))
+                            .on_click(
+                                window.listener_for(&self.state, CalendarState::next_year_page),
+                            )
+                    }),
+            )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -463,7 +680,7 @@ impl Calendar {
         muted: bool,
         disabled: bool,
         _: &mut Window,
-        cx: &mut Context<Self>,
+        cx: &mut App,
     ) -> impl IntoElement + Styled + StatefulInteractiveElement {
         h_flex()
             .id(id.into())
@@ -501,196 +718,8 @@ impl Calendar {
             .child(label.into())
     }
 
-    fn render_day(
-        &self,
-        d: &NaiveDate,
-        offset_month: usize,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let (_, month) = self.offset_year_month(offset_month);
-        let day = d.day();
-        let is_current_month = d.month() == month;
-        let is_active = self.date.is_active(d) && is_current_month;
-        let is_in_range = self.date.is_in_range(d);
-
-        let date = *d;
-        let is_today = *d == self.today;
-        let disabled = self
-            .disabled
-            .as_ref()
-            .map_or(false, |disabled| disabled.matched(&date));
-
-        self.item_button(
-            d.ordinal() as usize,
-            day.to_string(),
-            is_active,
-            is_in_range,
-            !is_current_month || disabled,
-            disabled,
-            window,
-            cx,
-        )
-        .when(is_today && !is_active, |this| {
-            this.border_1().border_color(cx.theme().border)
-        }) // Add border for today
-        .when(!disabled, |this| {
-            this.on_click(cx.listener(move |view, _: &ClickEvent, window, cx| {
-                if view.date.is_single() {
-                    view.set_date(date, window, cx);
-                    cx.emit(CalendarEvent::Selected(view.date()));
-                } else {
-                    let start = view.date.start();
-                    let end = view.date.end();
-
-                    if start.is_none() && end.is_none() {
-                        view.set_date(Date::Range(Some(date), None), window, cx);
-                    } else if start.is_some() && end.is_none() {
-                        if date < start.unwrap() {
-                            view.set_date(Date::Range(Some(date), None), window, cx);
-                        } else {
-                            view.set_date(
-                                Date::Range(Some(start.unwrap()), Some(date)),
-                                window,
-                                cx,
-                            );
-                        }
-                    } else {
-                        view.set_date(Date::Range(Some(date), None), window, cx);
-                    }
-
-                    if view.date.is_complete() {
-                        cx.emit(CalendarEvent::Selected(view.date()));
-                    }
-                }
-            }))
-        })
-    }
-
-    fn set_view_mode(&mut self, mode: ViewMode, _: &mut Window, cx: &mut Context<Self>) {
-        self.view_mode = mode;
-        cx.notify();
-    }
-
-    fn months(&self) -> Vec<SharedString> {
-        [
-            t!("Calendar.month.January"),
-            t!("Calendar.month.February"),
-            t!("Calendar.month.March"),
-            t!("Calendar.month.April"),
-            t!("Calendar.month.May"),
-            t!("Calendar.month.June"),
-            t!("Calendar.month.July"),
-            t!("Calendar.month.August"),
-            t!("Calendar.month.September"),
-            t!("Calendar.month.October"),
-            t!("Calendar.month.November"),
-            t!("Calendar.month.December"),
-        ]
-        .iter()
-        .map(|s| s.clone().into())
-        .collect()
-    }
-
-    fn render_header(&self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let current_year = self.current_year;
-        let disabled = self.view_mode.is_month();
-        let multiple_months = self.number_of_months > 1;
-        let icon_size = match self.size {
-            Size::Small => Size::Small,
-            Size::Large => Size::Medium,
-            _ => Size::Medium,
-        };
-
-        h_flex()
-            .gap_0p5()
-            .justify_between()
-            .items_center()
-            .child(
-                Button::new("prev")
-                    .icon(IconName::ArrowLeft)
-                    .ghost()
-                    .disabled(disabled)
-                    .with_size(icon_size)
-                    .when(self.view_mode.is_day(), |this| {
-                        this.on_click(cx.listener(Self::prev_month))
-                    })
-                    .when(self.view_mode.is_year(), |this| {
-                        this.when(!self.has_prev_year_page(), |this| this.disabled(true))
-                            .on_click(cx.listener(Self::prev_year_page))
-                    }),
-            )
-            .when(!multiple_months, |this| {
-                this.child(
-                    h_flex()
-                        .justify_center()
-                        .gap_3()
-                        .child(
-                            Button::new("month")
-                                .ghost()
-                                .label(self.month_name(0))
-                                .compact()
-                                .with_size(self.size)
-                                .selected(self.view_mode.is_month())
-                                .on_click(cx.listener(|view, _, window, cx| {
-                                    if view.view_mode.is_month() {
-                                        view.set_view_mode(ViewMode::Day, window, cx);
-                                    } else {
-                                        view.set_view_mode(ViewMode::Month, window, cx);
-                                    }
-                                    cx.notify();
-                                })),
-                        )
-                        .child(
-                            Button::new("year")
-                                .ghost()
-                                .label(current_year.to_string())
-                                .compact()
-                                .with_size(self.size)
-                                .selected(self.view_mode.is_year())
-                                .on_click(cx.listener(|view, _, window, cx| {
-                                    if view.view_mode.is_year() {
-                                        view.set_view_mode(ViewMode::Day, window, cx);
-                                    } else {
-                                        view.set_view_mode(ViewMode::Year, window, cx);
-                                    }
-                                    cx.notify();
-                                })),
-                        ),
-                )
-            })
-            .when(multiple_months, |this| {
-                this.child(h_flex().flex_1().justify_around().children(
-                    (0..self.number_of_months).map(|n| {
-                        h_flex()
-                            .justify_center()
-                            .map(|this| match self.size {
-                                Size::Small => this.gap_2(),
-                                Size::Large => this.gap_4(),
-                                _ => this.gap_3(),
-                            })
-                            .child(self.month_name(n))
-                            .child(current_year.to_string())
-                    }),
-                ))
-            })
-            .child(
-                Button::new("next")
-                    .icon(IconName::ArrowRight)
-                    .ghost()
-                    .disabled(disabled)
-                    .with_size(icon_size)
-                    .when(self.view_mode.is_day(), |this| {
-                        this.on_click(cx.listener(Self::next_month))
-                    })
-                    .when(self.view_mode.is_year(), |this| {
-                        this.when(!self.has_next_year_page(), |this| this.disabled(true))
-                            .on_click(cx.listener(Self::next_year_page))
-                    }),
-            )
-    }
-
-    fn render_days(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_days(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
         let weeks = [
             t!("Calendar.week.0"),
             t!("Calendar.week.1"),
@@ -709,7 +738,8 @@ impl Calendar {
             })
             .justify_between()
             .children(
-                self.days()
+                state
+                    .days()
                     .chunks(5)
                     .enumerate()
                     .map(|(offset_month, days)| {
@@ -732,8 +762,28 @@ impl Calendar {
             )
     }
 
-    fn render_months(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let months = self.months();
+    fn render_week(
+        &self,
+        week: impl Into<SharedString>,
+        _: &mut Window,
+        cx: &mut App,
+    ) -> impl IntoElement {
+        h_flex()
+            .map(|this| match self.size {
+                Size::Small => this.size_7().rounded(cx.theme().radius / 2.0),
+                Size::Large => this.size_10().rounded(cx.theme().radius),
+                _ => this.size_9().rounded(cx.theme().radius),
+            })
+            .justify_center()
+            .text_color(cx.theme().muted_foreground)
+            .text_sm()
+            .child(week.into())
+    }
+
+    fn render_months(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let months = state.months();
+        let current_month = state.current_month;
 
         h_flex()
             .mt_3()
@@ -751,7 +801,7 @@ impl Calendar {
                     .iter()
                     .enumerate()
                     .map(|(ix, month)| {
-                        let active = (ix + 1) as u8 == self.current_month;
+                        let active = (ix + 1) as u8 == current_month;
 
                         self.item_button(
                             ix,
@@ -765,7 +815,8 @@ impl Calendar {
                         )
                         .w(relative(0.3))
                         .text_sm()
-                        .on_click(cx.listener(
+                        .on_click(window.listener_for(
+                            &self.state,
                             move |view, _, window, cx| {
                                 view.current_month = (ix + 1) as u8;
                                 view.set_view_mode(ViewMode::Day, window, cx);
@@ -777,8 +828,10 @@ impl Calendar {
             )
     }
 
-    fn render_years(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let current_page_years = &self.years[self.year_page as usize];
+    fn render_years(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let state = self.state.read(cx);
+        let current_year = state.current_year;
+        let current_page_years = &self.state.read(cx).years[state.year_page as usize].clone();
 
         h_flex()
             .id("years")
@@ -796,7 +849,7 @@ impl Calendar {
                     .enumerate()
                     .map(|(ix, year)| {
                         let year = *year;
-                        let active = year == self.current_year;
+                        let active = year == current_year;
 
                         self.item_button(
                             ix,
@@ -809,7 +862,8 @@ impl Calendar {
                             cx,
                         )
                         .w(relative(0.2))
-                        .on_click(cx.listener(
+                        .on_click(window.listener_for(
+                            &self.state,
                             move |view, _, window, cx| {
                                 view.current_year = year;
                                 view.set_view_mode(ViewMode::Day, window, cx);
@@ -828,23 +882,30 @@ impl Sizable for Calendar {
         self
     }
 }
-impl EventEmitter<CalendarEvent> for Calendar {}
+impl EventEmitter<CalendarEvent> for CalendarState {}
+impl RenderOnce for Calendar {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let view_mode = self.state.read(cx).view_mode;
+        let number_of_months = self.number_of_months;
+        self.state
+            .update(cx, |state, _| state.number_of_months = number_of_months);
 
-impl Render for Calendar {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl gpui::IntoElement {
         v_flex()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.state.read(cx).focus_handle)
+            .when(self.bordered, |this| {
+                this.border_1().border_color(cx.theme().border).p_3()
+            })
             .gap_0p5()
             .child(self.render_header(window, cx))
             .child(
                 v_flex()
-                    .when(self.view_mode.is_day(), |this| {
+                    .when(view_mode.is_day(), |this| {
                         this.child(self.render_days(window, cx))
                     })
-                    .when(self.view_mode.is_month(), |this| {
+                    .when(view_mode.is_month(), |this| {
                         this.child(self.render_months(window, cx))
                     })
-                    .when(self.view_mode.is_year(), |this| {
+                    .when(view_mode.is_year(), |this| {
                         this.child(self.render_years(window, cx))
                     }),
             )

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -469,10 +469,10 @@ impl Render for CalendarState {
 }
 
 impl Calendar {
-    pub fn new(state: Entity<CalendarState>) -> Self {
+    pub fn new(state: &Entity<CalendarState>) -> Self {
         Self {
             size: Size::default(),
-            state,
+            state: state.clone(),
             bordered: true,
             number_of_months: 1,
         }

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -258,12 +258,10 @@ impl Render for DateState {
 }
 
 impl DatePicker {
-    pub fn new(id: impl Into<ElementId>, state: Entity<DateState>) -> Self {
-        let id = id.into();
-
+    pub fn new(state: &Entity<DateState>) -> Self {
         Self {
-            id,
-            state,
+            id: ("date-picker", state.entity_id()).into(),
+            state: state.clone(),
             cleanable: true,
             placeholder: None,
             size: Size::default(),
@@ -422,7 +420,7 @@ impl RenderOnce for DatePicker {
                                             )
                                         })
                                         .child(
-                                            Calendar::new(state.calendar.clone())
+                                            Calendar::new(&state.calendar)
                                                 .number_of_months(self.number_of_months)
                                                 .bordered(false)
                                                 .with_size(self.size),

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -56,7 +56,7 @@ impl DateRangePreset {
     }
 }
 
-pub struct DateState {
+pub struct DatePickerState {
     focus_handle: FocusHandle,
     date: Date,
     open: bool,
@@ -66,14 +66,14 @@ pub struct DateState {
     _subscriptions: Vec<Subscription>,
 }
 
-impl Focusable for DateState {
+impl Focusable for DatePickerState {
     fn focus_handle(&self, _: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
-impl EventEmitter<DatePickerEvent> for DateState {}
+impl EventEmitter<DatePickerEvent> for DatePickerState {}
 
-impl DateState {
+impl DatePickerState {
     /// Create a date state.
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         Self::new_with_range(false, window, cx)
@@ -230,7 +230,7 @@ impl DateState {
 #[derive(IntoElement)]
 pub struct DatePicker {
     id: ElementId,
-    state: Entity<DateState>,
+    state: Entity<DatePickerState>,
     cleanable: bool,
     placeholder: Option<SharedString>,
     size: Size,
@@ -251,14 +251,14 @@ impl Focusable for DatePicker {
     }
 }
 
-impl Render for DateState {
+impl Render for DatePickerState {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl gpui::IntoElement {
         Empty
     }
 }
 
 impl DatePicker {
-    pub fn new(state: &Entity<DateState>) -> Self {
+    pub fn new(state: &Entity<DatePickerState>) -> Self {
         Self {
             id: ("date-picker", state.entity_id()).into(),
             state: state.clone(),
@@ -322,7 +322,7 @@ impl RenderOnce for DatePicker {
             .key_context("DatePicker")
             .track_focus(&self.focus_handle(cx))
             .when(state.open, |this| {
-                this.on_action(window.listener_for(&self.state, DateState::escape))
+                this.on_action(window.listener_for(&self.state, DatePickerState::escape))
             })
             .w_full()
             .relative()
@@ -348,7 +348,9 @@ impl RenderOnce for DatePicker {
                     .when(is_focused, |this| this.focused_border(cx))
                     .input_size(self.size)
                     .when(!state.open, |this| {
-                        this.on_click(window.listener_for(&self.state, DateState::toggle_calendar))
+                        this.on_click(
+                            window.listener_for(&self.state, DatePickerState::toggle_calendar),
+                        )
                     })
                     .child(
                         h_flex()
@@ -358,11 +360,9 @@ impl RenderOnce for DatePicker {
                             .gap_1()
                             .child(div().w_full().overflow_hidden().child(display_title))
                             .when(show_clean, |this| {
-                                this.child(
-                                    clear_button(cx).on_click(
-                                        window.listener_for(&self.state, DateState::clean),
-                                    ),
-                                )
+                                this.child(clear_button(cx).on_click(
+                                    window.listener_for(&self.state, DatePickerState::clean),
+                                ))
                             })
                             .when(!show_clean, |this| {
                                 this.child(

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -1,9 +1,9 @@
 use chrono::NaiveDate;
 use gpui::{
     anchored, deferred, div, prelude::FluentBuilder as _, px, App, AppContext, Context, ElementId,
-    Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement as _, KeyBinding, Length,
-    MouseButton, ParentElement as _, Render, SharedString, StatefulInteractiveElement as _, Styled,
-    Subscription, Window,
+    Empty, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement,
+    KeyBinding, Length, MouseButton, ParentElement as _, Render, RenderOnce, SharedString,
+    StatefulInteractiveElement as _, Styled, Subscription, Window,
 };
 use rust_i18n::t;
 
@@ -15,7 +15,7 @@ use crate::{
     v_flex, ActiveTheme, Icon, IconName, Sizable, Size, StyleSized as _, StyledExt as _,
 };
 
-use super::calendar::{Calendar, CalendarEvent, Date, Matcher};
+use super::calendar::{Calendar, CalendarEvent, CalendarState, Date, Matcher};
 
 pub fn init(cx: &mut App) {
     let context = Some("DatePicker");
@@ -55,43 +55,36 @@ impl DateRangePreset {
         }
     }
 }
-pub struct DatePicker {
-    id: ElementId,
+
+pub struct DateState {
     focus_handle: FocusHandle,
     date: Date,
-    cleanable: bool,
-    placeholder: Option<SharedString>,
     open: bool,
-    size: Size,
-    width: Length,
+    calendar: Entity<CalendarState>,
     date_format: SharedString,
-    calendar: Entity<Calendar>,
     number_of_months: usize,
-    presets: Option<Vec<DateRangePreset>>,
     _subscriptions: Vec<Subscription>,
 }
 
-impl DatePicker {
+impl Focusable for DateState {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+impl EventEmitter<DatePickerEvent> for DateState {}
+
+impl DateState {
     /// Create a date picker.
-    pub fn new(id: impl Into<ElementId>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        Self::new_with_range(id, false, window, cx)
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self::new_with_range(false, window, cx)
     }
 
     /// Create a date picker with range mode.
-    pub fn range_picker(
-        id: impl Into<ElementId>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        Self::new_with_range(id, true, window, cx)
+    pub fn range_picker(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self::new_with_range(true, window, cx)
     }
 
-    fn new_with_range(
-        id: impl Into<ElementId>,
-        is_range: bool,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
+    fn new_with_range(is_range: bool, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let date = if is_range {
             Date::Range(None, None)
         } else {
@@ -99,7 +92,7 @@ impl DatePicker {
         };
 
         let calendar = cx.new(|cx| {
-            let mut this = Calendar::new(window, cx);
+            let mut this = CalendarState::new(window, cx);
             this.set_date(date, window, cx);
             this
         });
@@ -116,18 +109,12 @@ impl DatePicker {
         )];
 
         Self {
-            id: id.into(),
             focus_handle: cx.focus_handle(),
             date,
             calendar,
             open: false,
-            size: Size::default(),
-            width: Length::Auto,
             date_format: "%Y/%m/%d".into(),
-            cleanable: false,
             number_of_months: 1,
-            placeholder: None,
-            presets: None,
             _subscriptions,
         }
     }
@@ -138,33 +125,9 @@ impl DatePicker {
         self
     }
 
-    /// Set the placeholder of the date picker, default: "".
-    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
-        self.placeholder = Some(placeholder.into());
-        self
-    }
-
-    /// Set true to show the clear button when the input field is not empty.
-    pub fn cleanable(mut self) -> Self {
-        self.cleanable = true;
-        self
-    }
-
-    /// Set width of the date picker input field, default is `Length::Auto`.
-    pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
-        self
-    }
-
     /// Set the number of months calendar view to display, default is 1.
     pub fn number_of_months(mut self, number_of_months: usize) -> Self {
         self.number_of_months = number_of_months;
-        self
-    }
-
-    /// Set preset ranges for the date picker.
-    pub fn presets(mut self, presets: Vec<DateRangePreset>) -> Self {
-        self.presets = Some(presets);
         self
     }
 
@@ -200,12 +163,6 @@ impl DatePicker {
         self.calendar.update(cx, |view, cx| {
             view.set_disabled(disabled.into(), window, cx);
         });
-    }
-
-    /// Set size of the date picker.
-    pub fn set_size(&mut self, size: Size, _: &mut Window, cx: &mut Context<Self>) {
-        self.size = size;
-        cx.notify();
     }
 
     fn escape(&mut self, _: &Cancel, window: &mut Window, cx: &mut Context<Self>) {
@@ -270,7 +227,18 @@ impl DatePicker {
     }
 }
 
-impl EventEmitter<DatePickerEvent> for DatePicker {}
+#[derive(IntoElement)]
+pub struct DatePicker {
+    id: ElementId,
+    state: Entity<DateState>,
+    cleanable: bool,
+    placeholder: Option<SharedString>,
+    size: Size,
+    width: Length,
+    number_of_months: usize,
+    presets: Option<Vec<DateRangePreset>>,
+}
+
 impl Sizable for DatePicker {
     fn with_size(mut self, size: impl Into<Size>) -> Self {
         self.size = size.into();
@@ -278,35 +246,80 @@ impl Sizable for DatePicker {
     }
 }
 impl Focusable for DatePicker {
-    fn focus_handle(&self, _: &App) -> FocusHandle {
-        self.focus_handle.clone()
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.state.focus_handle(cx)
     }
 }
 
-impl Render for DatePicker {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl gpui::IntoElement {
+impl Render for DateState {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl gpui::IntoElement {
+        Empty
+    }
+}
+
+impl DatePicker {
+    pub fn new(id: impl Into<ElementId>, state: Entity<DateState>) -> Self {
+        let id = id.into();
+
+        Self {
+            id,
+            state,
+            cleanable: true,
+            placeholder: None,
+            size: Size::default(),
+            width: Length::Auto,
+            number_of_months: 2,
+            presets: None,
+        }
+    }
+
+    /// Set the placeholder of the date picker, default: "".
+    pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
+    }
+
+    /// Set true to show the clear button when the input field is not empty.
+    pub fn cleanable(mut self) -> Self {
+        self.cleanable = true;
+        self
+    }
+
+    /// Set width of the date picker input field, default is `Length::Auto`.
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Set preset ranges for the date picker.
+    pub fn presets(mut self, presets: Vec<DateRangePreset>) -> Self {
+        self.presets = Some(presets);
+        self
+    }
+}
+
+impl RenderOnce for DatePicker {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         // This for keep focus border style, when click on the popup.
-        let is_focused = self.focus_handle.contains_focused(window, cx);
-        let show_clean = self.cleanable && self.date.is_some();
+        let is_focused = self.focus_handle(cx).contains_focused(window, cx);
+        let state = self.state.read(cx);
+        let show_clean = self.cleanable && state.date.is_some();
         let placeholder = self
             .placeholder
             .clone()
             .unwrap_or_else(|| t!("DatePicker.placeholder").into());
-        let display_title = self
+        let display_title = state
             .date
-            .format(&self.date_format)
+            .format(&state.date_format)
             .unwrap_or(placeholder.clone());
-
-        self.calendar.update(cx, |view, cx| {
-            view.set_size(self.size, window, cx);
-            view.set_number_of_months(self.number_of_months, window, cx);
-        });
 
         div()
             .id(self.id.clone())
             .key_context("DatePicker")
-            .track_focus(&self.focus_handle)
-            .when(self.open, |this| this.on_action(cx.listener(Self::escape)))
+            .track_focus(&self.focus_handle(cx))
+            .when(state.open, |this| {
+                this.on_action(window.listener_for(&self.state, DateState::escape))
+            })
             .w_full()
             .relative()
             .map(|this| match self.width {
@@ -330,8 +343,8 @@ impl Render for DatePicker {
                     .input_text_size(self.size)
                     .when(is_focused, |this| this.focused_border(cx))
                     .input_size(self.size)
-                    .when(!self.open, |this| {
-                        this.on_click(cx.listener(Self::toggle_calendar))
+                    .when(!state.open, |this| {
+                        this.on_click(window.listener_for(&self.state, DateState::toggle_calendar))
                     })
                     .child(
                         h_flex()
@@ -341,7 +354,11 @@ impl Render for DatePicker {
                             .gap_1()
                             .child(div().w_full().overflow_hidden().child(display_title))
                             .when(show_clean, |this| {
-                                this.child(clear_button(cx).on_click(cx.listener(Self::clean)))
+                                this.child(
+                                    clear_button(cx).on_click(
+                                        window.listener_for(&self.state, DateState::clean),
+                                    ),
+                                )
                             })
                             .when(!show_clean, |this| {
                                 this.child(
@@ -352,7 +369,7 @@ impl Render for DatePicker {
                             }),
                     ),
             )
-            .when(self.open, |this| {
+            .when(state.open, |this| {
                 this.child(
                     deferred(
                         anchored().snap_to_window_with_margin(px(8.)).child(
@@ -367,7 +384,7 @@ impl Render for DatePicker {
                                 .bg(cx.theme().background)
                                 .on_mouse_up_out(
                                     MouseButton::Left,
-                                    cx.listener(|view, _, window, cx| {
+                                    window.listener_for(&self.state, |view, _, window, cx| {
                                         view.escape(&Cancel, window, cx);
                                     }),
                                 )
@@ -385,7 +402,8 @@ impl Render for DatePicker {
                                                                 .small()
                                                                 .ghost()
                                                                 .label(preset.label.clone())
-                                                                .on_click(cx.listener(
+                                                                .on_click(window.listener_for(
+                                                                    &self.state,
                                                                     move |this, _, window, cx| {
                                                                         this.select_preset(
                                                                             &preset, window, cx,
@@ -397,7 +415,12 @@ impl Render for DatePicker {
                                                 ),
                                             )
                                         })
-                                        .child(self.calendar.clone()),
+                                        .child(
+                                            Calendar::new(state.calendar.clone())
+                                                .number_of_months(self.number_of_months)
+                                                .bordered(false)
+                                                .with_size(self.size),
+                                        ),
                                 ),
                         ),
                     )

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -56,6 +56,7 @@ impl DateRangePreset {
     }
 }
 
+/// Use to store the state of the date picker.
 pub struct DatePickerState {
     focus_handle: FocusHandle,
     date: Date,

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -74,13 +74,13 @@ impl Focusable for DateState {
 impl EventEmitter<DatePickerEvent> for DateState {}
 
 impl DateState {
-    /// Create a date picker.
+    /// Create a date state.
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         Self::new_with_range(false, window, cx)
     }
 
-    /// Create a date picker with range mode.
-    pub fn range_picker(window: &mut Window, cx: &mut Context<Self>) -> Self {
+    /// Create a date state with range mode.
+    pub fn range(window: &mut Window, cx: &mut Context<Self>) -> Self {
         Self::new_with_range(true, window, cx)
     }
 
@@ -294,6 +294,12 @@ impl DatePicker {
     /// Set preset ranges for the date picker.
     pub fn presets(mut self, presets: Vec<DateRangePreset>) -> Self {
         self.presets = Some(presets);
+        self
+    }
+
+    /// Set number of months to display in the calendar, default is 2.
+    pub fn number_of_months(mut self, number_of_months: usize) -> Self {
+        self.number_of_months = number_of_months;
         self
     }
 }


### PR DESCRIPTION
This PR to improve `TextInput` and `NumberInput` as a stateless mode by split a `TextState` to keep the editing state.

- TextInput, ColorPicker - RenderOnce for appearance
- TextState, ColorState - Entity For keep editing state

So we can easily control the UI style in render stage.

## Break Changes

- `TextInput` separated to as `InputState` (for Entity) and `TextInput` for render.
    ```diff
    - let text_input = cx.new(|cx| TextInput::new(window, cx))
    + let input_state = cx.new(|cx| InputState::new(window, cx))
    ```

    ```diff
    - div().child(text_input);
    + div().child(TextInput::new(text_input));
    ```

- TextInput - Renamed `text` to `value`, `set_text` to `set_value` and also added `default_value` method to set default value.
- `ColorPicker` separated to as `ColorPickerState` and `ColorPicker` like input.
- `Calendar` separated to as `CalendarState` and `Calendar` like input.
  - Added bordered and default true to `Calendar`.
- `DatePicker` separated to as `DatePickerState` and `DatePicker` like input.
- `Slider` separated to as `SliderState` and `Slider` like input.
  - Add `disabled` state to slider.
- `Dropdown` separated to as `DropdownState` and `Dropdown`.