### PR TITLE
dock: Show keybinding for ToggleZoom menu and button.

### DIFF
--- a/crates/story/examples/dock.rs
+++ b/crates/story/examples/dock.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use gpui::*;
 use gpui_component::{
     button::{Button, ButtonVariants as _},
-    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement, ToggleZoom},
+    dock::{ClosePanel, DockArea, DockAreaState, DockEvent, DockItem, DockPlacement, ToggleZoom},
     popup_menu::PopupMenuExt,
     IconName, Root, Sizable, Theme,
 };
@@ -41,7 +41,10 @@ pub fn init(cx: &mut App) {
     gpui_component::init(cx);
     story::init(cx);
 
-    cx.bind_keys(vec![KeyBinding::new("shift-escape", ToggleZoom, None)]);
+    cx.bind_keys(vec![
+        KeyBinding::new("shift-escape", ToggleZoom, None),
+        KeyBinding::new("ctrl-w", ClosePanel, None),
+    ]);
 
     cx.activate(true);
 }

--- a/crates/story/examples/dock.rs
+++ b/crates/story/examples/dock.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use gpui::*;
 use gpui_component::{
     button::{Button, ButtonVariants as _},
-    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement},
+    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement, ToggleZoom},
     popup_menu::PopupMenuExt,
     IconName, Root, Sizable, Theme,
 };
@@ -40,6 +40,8 @@ pub fn init(cx: &mut App) {
 
     gpui_component::init(cx);
     story::init(cx);
+
+    cx.bind_keys(vec![KeyBinding::new("shift-escape", ToggleZoom, None)]);
 
     cx.activate(true);
 }

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -14,7 +14,7 @@ use crate::{
     h_flex,
     popup_menu::{PopupMenu, PopupMenuExt},
     tab::{Tab, TabBar},
-    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable,
+    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable, StyledExt,
 };
 
 use super::{
@@ -444,7 +444,7 @@ impl TabPanel {
                             .icon(icon)
                             .xsmall()
                             .ghost()
-                            .tooltip(tooltip)
+                            .tooltip_with_action(tooltip, &ToggleZoom, None)
                             .when(zoomed, |this| this.selected(true))
                             .on_click(cx.listener(|view, _, window, cx| {
                                 view.on_action_toggle_zoom(&ToggleZoom, window, cx)
@@ -799,6 +799,7 @@ impl TabPanel {
         let is_render_in_tabs = self.panels.len() > 1 && self.inner_padding(cx);
 
         v_flex()
+            .id("active-panel")
             .group("")
             .flex_1()
             .when(is_render_in_tabs, |this| this.pt_2())

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -14,7 +14,7 @@ use crate::{
     h_flex,
     popup_menu::{PopupMenu, PopupMenuExt},
     tab::{Tab, TabBar},
-    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable, StyledExt,
+    v_flex, ActiveTheme, AxisExt, IconName, Placement, Selectable, Sizable,
 };
 
 use super::{


### PR DESCRIPTION
And binding `Shift-Esc` for example to toggle zoom panel, `Ctrl-W` for close panel.

![image](https://github.com/user-attachments/assets/993dcbb3-ae39-467f-bf4c-d5faf5639b35)