### PR TITLE
input: Fix auto-grow height.

### DIFF
--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -60,7 +60,7 @@ impl FormStory {
         let bio_input = cx.new(|cx| {
             InputState::new(window, cx)
                 .multi_line()
-                .rows(5)
+                .rows(1)
                 .max_rows(20)
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -59,9 +59,7 @@ impl FormStory {
             cx.new(|cx| InputState::new(window, cx).placeholder("Enter text here..."));
         let bio_input = cx.new(|cx| {
             InputState::new(window, cx)
-                .multi_line()
-                .rows(5)
-                .max_rows(20)
+                .auto_grow(5, 20)
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")
         });

--- a/crates/story/src/form_story.rs
+++ b/crates/story/src/form_story.rs
@@ -60,7 +60,7 @@ impl FormStory {
         let bio_input = cx.new(|cx| {
             InputState::new(window, cx)
                 .multi_line()
-                .rows(1)
+                .rows(5)
                 .max_rows(20)
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")

--- a/crates/story/src/textarea_story.rs
+++ b/crates/story/src/textarea_story.rs
@@ -81,10 +81,7 @@ impl TextareaStory {
 
         let textarea_auto_grow = cx.new(|cx| {
             InputState::new(window, cx)
-                .multi_line()
-                .rows(1)
-                .max_rows(5)
-                .auto_grow()
+                .auto_grow(1, 5)
                 .placeholder("Enter text here...")
                 .default_value("Hello 世界，this is GPUI component.")
         });

--- a/crates/story/src/textarea_story.rs
+++ b/crates/story/src/textarea_story.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    actions, App, AppContext as _, ClickEvent, Context, Entity, FocusHandle, Focusable,
+    actions, px, App, AppContext as _, ClickEvent, Context, Entity, FocusHandle, Focusable,
     InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Render, Styled, Window,
 };
 
@@ -24,6 +24,7 @@ pub fn init(cx: &mut App) {
 
 pub struct TextareaStory {
     textarea: Entity<InputState>,
+    textarea_auto_grow: Entity<InputState>,
 }
 
 impl super::Story for TextareaStory {
@@ -78,7 +79,20 @@ impl TextareaStory {
             )
         });
 
-        Self { textarea }
+        let textarea_auto_grow = cx.new(|cx| {
+            InputState::new(window, cx)
+                .multi_line()
+                .rows(1)
+                .max_rows(5)
+                .auto_grow()
+                .placeholder("Enter text here...")
+                .default_value("Hello 世界，this is GPUI component.")
+        });
+
+        Self {
+            textarea,
+            textarea_auto_grow,
+        }
     }
 
     fn tab(&mut self, _: &Tab, window: &mut Window, cx: &mut Context<Self>) {
@@ -138,7 +152,7 @@ impl Render for TextareaStory {
                     v_flex()
                         .gap_2()
                         .w_full()
-                        .child(TextInput::new(&self.textarea))
+                        .child(TextInput::new(&self.textarea).h(px(320.)))
                         .child(
                             h_flex()
                                 .gap_2()
@@ -155,6 +169,13 @@ impl Render for TextareaStory {
                                         .on_click(cx.listener(Self::on_replace_text_to_textarea)),
                                 ),
                         ),
+                ),
+            )
+            .child(
+                section("Textarea Auto Grow").child(
+                    v_flex()
+                        .w_full()
+                        .child(TextInput::new(&self.textarea_auto_grow)),
                 ),
             )
     }

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -60,7 +60,7 @@ impl TextElement {
         let mut cursor = None;
 
         // If the input has a fixed height (Otherwise is auto-grow), we need to add a bottom margin to the input.
-        let bottom_margin = if input.auto_grow {
+        let bottom_margin = if input.is_auto_grow() {
             px(0.)
         } else {
             BOTTOM_MARGIN_ROWS * line_height + line_height
@@ -366,12 +366,12 @@ impl Element for TextElement {
         style.size.width = relative(1.).into();
         if self.input.read(cx).is_multi_line() {
             style.flex_grow = 1.0;
-            if let Some(h) = input.height {
+            if let Some(h) = input.mode.height() {
                 style.size.height = h.into();
                 style.min_size.height = line_height.into();
             } else {
                 style.size.height = relative(1.).into();
-                style.min_size.height = (input.rows.max(1) as f32 * line_height).into();
+                style.min_size.height = (input.mode.rows() * line_height).into();
             }
         } else {
             // For single-line inputs, the minimum height should be the line height

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -378,6 +378,10 @@ impl Element for TextElement {
                         .unwrap_or(usize::MAX)
                         .min(rows)
                         .max(input.min_rows);
+                    println!(
+                        "------------ rows: {}, scroll_height: {}",
+                        rows, input.scroll_size.height
+                    );
                     rows.clamp(input.min_rows, max_rows)
                 } else {
                     input.rows

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -589,7 +589,7 @@ impl Element for TextElement {
             input.last_bounds = Some(bounds);
             input.last_cursor_offset = Some(input.cursor_offset());
             input.last_line_height = line_height;
-            input.input_bounds = input_bounds;
+            input.set_input_bounds(input_bounds, cx);
             input.last_selected_range = Some(selected_range);
             input.scroll_size = scroll_size;
             input

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -370,25 +370,8 @@ impl Element for TextElement {
                 style.size.height = h.into();
                 style.min_size.height = line_height.into();
             } else {
-                // Check to auto grow
-                let rows = if input.auto_grow {
-                    let rows = (input.scroll_size.height / line_height) as usize;
-                    let max_rows = input
-                        .max_rows
-                        .unwrap_or(usize::MAX)
-                        .min(rows)
-                        .max(input.min_rows);
-                    println!(
-                        "------------ rows: {}, scroll_height: {}",
-                        rows, input.scroll_size.height
-                    );
-                    rows.clamp(input.min_rows, max_rows)
-                } else {
-                    input.rows
-                };
-
                 style.size.height = relative(1.).into();
-                style.min_size.height = (rows.max(1) as f32 * line_height).into();
+                style.min_size.height = (input.rows.max(1) as f32 * line_height).into();
             }
         } else {
             // For single-line inputs, the minimum height should be the line height

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -10,7 +10,7 @@ use crate::{ActiveTheme as _, Root};
 use super::InputState;
 
 const RIGHT_MARGIN: Pixels = px(5.);
-const BOTTOM_MARGIN: Pixels = px(20.);
+const BOTTOM_MARGIN_ROWS: usize = 1;
 
 pub(super) struct TextElement {
     input: Entity<InputState>,
@@ -63,7 +63,7 @@ impl TextElement {
         let bottom_margin = if input.auto_grow {
             px(0.)
         } else {
-            BOTTOM_MARGIN
+            BOTTOM_MARGIN_ROWS * line_height + line_height
         };
         // The cursor corresponds to the current cursor position in the text no only the line.
         let mut cursor_pos = None;
@@ -124,7 +124,7 @@ impl TextElement {
                     > bounds.size.height - bottom_margin
                 {
                     // cursor is out of bottom
-                    bounds.size.height - cursor_pos.y - line_height - bottom_margin
+                    bounds.size.height - bottom_margin - cursor_pos.y
                 } else if scroll_offset.y + cursor_pos.y < px(0.) {
                     // cursor is out of top
                     scroll_offset.y - cursor_pos.y

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -61,7 +61,7 @@ impl TextElement {
 
         // If the input has a fixed height (Otherwise is auto-grow), we need to add a bottom margin to the input.
         let bottom_margin = if input.is_auto_grow() {
-            px(0.)
+            px(0.) + line_height
         } else {
             BOTTOM_MARGIN_ROWS * line_height + line_height
         };

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -7,6 +7,7 @@ mod number_input;
 mod otp_input;
 mod state;
 mod text_input;
+mod text_wrapper;
 
 pub(crate) use clear_button::*;
 pub use mask_pattern::MaskPattern;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1000,6 +1000,26 @@ impl InputState {
         });
     }
 
+    pub(super) fn check_to_auto_grow(&mut self, _: &mut Context<Self>) {
+        if !self.auto_grow {
+            return;
+        }
+        if !self.is_multi_line() {
+            return;
+        }
+        let rows = (self.scroll_size.height / self.last_line_height) as usize;
+        let max_rows = self
+            .max_rows
+            .unwrap_or(usize::MAX)
+            .min(rows)
+            .max(self.min_rows);
+        self.rows = rows.clamp(self.min_rows, max_rows);
+        println!(
+            "------------ updated {} rows: {}",
+            self.scroll_size.height, self.rows
+        );
+    }
+
     pub(super) fn clean(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.replace_text("", window, cx);
     }
@@ -1597,6 +1617,7 @@ impl EntityInputHandler for InputState {
         self.marked_range.take();
         self.update_preferred_x_offset(cx);
         self.update_scroll_offset(None, cx);
+        self.check_to_auto_grow(cx);
         cx.emit(InputEvent::Change(self.unmask_value()));
         cx.notify();
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -992,23 +992,6 @@ impl InputState {
         });
     }
 
-    fn check_to_auto_grow(&mut self, _: &mut Window, cx: &mut Context<Self>) {
-        if !self.is_multi_line() {
-            return;
-        }
-        let Some(max_rows) = self.max_rows else {
-            return;
-        };
-
-        let changed_rows = ((self.scroll_size.height - self.input_bounds.size.height)
-            / self.last_line_height) as isize;
-
-        self.rows = (self.rows as isize + changed_rows)
-            .clamp(self.min_rows as isize, max_rows as isize)
-            .max(0) as usize;
-        cx.notify();
-    }
-
     pub(super) fn clean(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.replace_text("", window, cx);
     }
@@ -1568,6 +1551,10 @@ impl EntityInputHandler for InputState {
         self.marked_range = None;
     }
 
+    /// Replace text in range.
+    ///
+    /// - If the new text is invalid, it will not be replaced.
+    /// - If `range_utf16` is not provided, the current selected range will be used.
     fn replace_text_in_range(
         &mut self,
         range_utf16: Option<Range<usize>>,
@@ -1602,7 +1589,6 @@ impl EntityInputHandler for InputState {
         self.marked_range.take();
         self.update_preferred_x_offset(cx);
         self.update_scroll_offset(None, cx);
-        self.check_to_auto_grow(window, cx);
         cx.emit(InputEvent::Change(self.unmask_value()));
         cx.notify();
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1624,6 +1624,18 @@ impl InputState {
         }
         cx.notify();
     }
+
+    pub(super) fn set_input_bounds(&mut self, new_bounds: Bounds<Pixels>, cx: &mut Context<Self>) {
+        let wrap_width_changed = self.input_bounds.size.width != new_bounds.size.width;
+        self.input_bounds = new_bounds;
+
+        // Update text_wrapper wrap_width if changed.
+        if wrap_width_changed {
+            self.text_wrapper
+                .set_wrap_width(Some(new_bounds.size.width), cx);
+            self.mode.update_auto_grow(&self.text_wrapper);
+        }
+    }
 }
 
 impl EntityInputHandler for InputState {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -225,6 +225,7 @@ pub struct InputState {
     pub(super) rows: usize,
     pub(super) min_rows: usize,
     pub(super) max_rows: Option<usize>,
+    pub(super) auto_grow: bool,
     pub(super) pattern: Option<regex::Regex>,
     pub(super) validate: Option<Box<dyn Fn(&str) -> bool + 'static>>,
     pub(crate) scroll_handle: ScrollHandle,
@@ -288,6 +289,7 @@ impl InputState {
             rows: 2,
             min_rows: 2,
             max_rows: None,
+            auto_grow: false,
             height: None,
             last_layout: None,
             last_bounds: None,
@@ -484,6 +486,12 @@ impl InputState {
     /// default: None
     pub fn max_rows(mut self, max_rows: usize) -> Self {
         self.max_rows = Some(max_rows);
+        self
+    }
+
+    /// Set the auto-grow mode for the multi-line Textarea.
+    pub fn auto_grow(mut self) -> Self {
+        self.auto_grow = true;
         self
     }
 

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -136,7 +136,7 @@ impl RenderOnce for TextInput {
         const LINE_HEIGHT: Rems = Rems(1.25);
 
         self.state.update(cx, |state, _| {
-            state.height = self.height;
+            state.mode.set_height(self.height);
             state.disabled = self.disabled;
         });
 
@@ -182,7 +182,7 @@ impl RenderOnce for TextInput {
             .on_action(window.listener_for(&self.state, InputState::right))
             .on_action(window.listener_for(&self.state, InputState::select_left))
             .on_action(window.listener_for(&self.state, InputState::select_right))
-            .when(state.multi_line, |this| {
+            .when(state.is_multi_line(), |this| {
                 this.on_action(window.listener_for(&self.state, InputState::up))
                     .on_action(window.listener_for(&self.state, InputState::down))
                     .on_action(window.listener_for(&self.state, InputState::select_up))
@@ -222,7 +222,7 @@ impl RenderOnce for TextInput {
             .input_py(self.size)
             .input_h(self.size)
             .cursor_text()
-            .when(state.multi_line, |this| {
+            .when(state.is_multi_line(), |this| {
                 this.h_auto()
                     .when_some(self.height, |this, height| this.h(height))
             })

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -1,0 +1,66 @@
+use std::ops::Range;
+
+use gpui::{App, Font, LineFragment, Pixels, SharedString};
+
+/// Used to prepare the text with soft_wrap to be get lines to displayed in the TextArea
+///
+/// After use lines to calculate the scroll size of the TextArea
+pub(super) struct TextWrapper {
+    pub(super) text: SharedString,
+    /// The wrapped lines, value is start and end index of the line (by split \n).
+    pub(super) wrapped_lines: Vec<Range<usize>>,
+    pub(super) font: Font,
+    pub(super) font_size: Pixels,
+    /// If is none, it means the text is not wrapped
+    pub(super) wrap_width: Option<Pixels>,
+}
+
+#[allow(unused)]
+impl TextWrapper {
+    pub(super) fn new(font: Font, font_size: Pixels, wrap_width: Option<Pixels>) -> Self {
+        Self {
+            text: SharedString::default(),
+            font,
+            font_size,
+            wrap_width,
+            wrapped_lines: Vec::new(),
+        }
+    }
+
+    pub(super) fn set_wrap_width(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
+        self.wrap_width = wrap_width;
+        self.update(self.text.clone(), cx);
+    }
+
+    pub(super) fn set_font(&mut self, font: Font, cx: &mut App) {
+        self.font = font;
+        self.update(self.text.clone(), cx);
+    }
+
+    pub(super) fn update(&mut self, text: SharedString, cx: &mut App) {
+        let mut wrapped_lines = vec![];
+        let wrap_width = self.wrap_width.unwrap_or(Pixels::MAX);
+        let mut line_wrapper = cx
+            .text_system()
+            .line_wrapper(self.font.clone(), self.font_size);
+
+        for line in text.lines() {
+            let mut prev_boundary_ix = 0;
+            for boundary in line_wrapper.wrap_line(&[LineFragment::text(line)], wrap_width) {
+                wrapped_lines.push(prev_boundary_ix..boundary.ix);
+                prev_boundary_ix = boundary.ix;
+            }
+
+            // Reset of the line
+            if !line[prev_boundary_ix..].is_empty() || prev_boundary_ix == 0 {
+                wrapped_lines.push(prev_boundary_ix..line.len());
+            }
+        }
+        if text.chars().last().unwrap_or('\n') == '\n' {
+            wrapped_lines.push(text.len()..text.len());
+        }
+
+        self.text = text;
+        self.wrapped_lines = wrapped_lines;
+    }
+}

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -28,6 +28,10 @@ impl TextWrapper {
     }
 
     pub(super) fn set_wrap_width(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
+        if self.wrap_width == wrap_width {
+            return;
+        }
+
         self.wrap_width = wrap_width;
         self.update(self.text.clone(), cx);
     }
@@ -56,6 +60,8 @@ impl TextWrapper {
                 wrapped_lines.push(prev_boundary_ix..line.len());
             }
         }
+
+        // Add last empty line.
         if text.chars().last().unwrap_or('\n') == '\n' {
             wrapped_lines.push(text.len()..text.len());
         }


### PR DESCRIPTION
Fix #864 

Updated InputState API to split `single_line`, `multi_line` and `auto_grow`.

The `InputState::new` for default single_line, and added `multi_line` and `auto_grow` to change other mode.

### With no wrap

https://github.com/user-attachments/assets/22a8f0d6-e264-4f39-bb30-386a41975d2b

### With soft wrap

https://github.com/user-attachments/assets/b71f0fb1-5937-470b-a278-8b1de7cfd7d7
