### PR TITLE
code-editor: Fix highlight offset on Windows.

### DIFF
--- a/crates/ui/src/input/code_highlighter.rs
+++ b/crates/ui/src/input/code_highlighter.rs
@@ -53,7 +53,7 @@ impl CodeHighlighter {
 
         let mut lines = vec![];
         let mut new_cache = HashMap::new();
-        for line in text.lines() {
+        for line in text.split('\n') {
             let cache_key = gpui::hash(&line);
 
             // cache hit


### PR DESCRIPTION
Again, caused by need `split('\n')` not use `.lines()`.