### PR TITLE
chore: Switch `gpui` to depends on Zed official.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2754,7 +2754,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2791,6 +2791,7 @@ dependencies = [
  "image",
  "inventory",
  "itertools 0.14.0",
+ "libc",
  "log",
  "lyon",
  "media",
@@ -2907,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3177,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3194,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -3955,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -5656,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "derive_refineable",
  "workspace-hack",
@@ -5751,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6284,7 +6285,7 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 [[package]]
 name = "semantic_version"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "serde",
@@ -6771,7 +6772,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "arrayvec",
  "log",
@@ -7888,7 +7889,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/huacnlee/zed.git?branch=webview#85befe24cc564f1f526ead3b09fd22d98b146248"
+source = "git+https://github.com/zed-industries/zed.git#ab6125ddde518c0c021ecae54f64d86b8c4f5008"
 dependencies = [
  "anyhow",
  "async-fs 2.1.2",
@@ -7912,8 +7913,6 @@ dependencies = [
  "tempfile",
  "tendril",
  "unicase",
- "unicode-script",
- "unicode-segmentation",
  "walkdir",
  "workspace-hack",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/story"]
 resolver = "2"
 
 [workspace.dependencies]
-gpui = { git = "https://github.com/huacnlee/zed.git", branch = "webview" }
+gpui = { git = "https://github.com/zed-industries/zed.git" }
 gpui-component = { path = "crates/ui" }
 story = { path = "crates/story" }
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ We built multi-theme support in the application. This feature is not included in
 
 GPUI and GPUI Component are still in development, so you need to add dependencies by git.
 
-GPUI Component depends on a specific version of `gpui` (kept updated with upstream) to include WebView support.
-
 ```toml
-gpui = { git = "https://github.com/huacnlee/zed.git", branch = "webview" }
+gpui = { git = "https://github.com/zed-industries/zed.git" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component.git" }
 ```
 

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -13,7 +13,7 @@ gpui-component = { workspace = true, features = ["webview"] }
 rand = "0.8"
 raw-window-handle = { version = "0.6", features = ["std"] }
 regex = "1"
-reqwest_client = { git = "https://github.com/huacnlee/zed.git", branch = "webview" }
+reqwest_client = { git = "https://github.com/zed-industries/zed.git" }
 rust-embed = "8.5.0"
 serde = "1"
 serde_json = "1"

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -351,7 +351,10 @@ impl<M: ManagedView> Element for Popover<M> {
             .popover_layout_id
             .map(|id| window.layout_bounds(id));
 
-        let hitbox = window.insert_hitbox(trigger_bounds.unwrap_or_default(), false);
+        let hitbox = window.insert_hitbox(
+            trigger_bounds.unwrap_or_default(),
+            gpui::HitboxBehavior::Normal,
+        );
 
         PrepaintState {
             trigger_bounds,

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -93,7 +93,7 @@ impl Element for ScrollableMask {
             size: bounds.size,
         };
 
-        window.insert_hitbox(cover_bounds, false)
+        window.insert_hitbox(cover_bounds, gpui::HitboxBehavior::Normal)
     }
 
     fn paint(

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -464,7 +464,7 @@ impl Element for Scrollbar {
         cx: &mut App,
     ) -> Self::PrepaintState {
         let hitbox = window.with_content_mask(Some(ContentMask { bounds }), |window| {
-            window.insert_hitbox(bounds, false)
+            window.insert_hitbox(bounds, gpui::HitboxBehavior::Normal)
         });
 
         let mut states = vec![];
@@ -613,7 +613,7 @@ impl Element for Scrollbar {
             };
 
             let bar_hitbox = window.with_content_mask(Some(ContentMask { bounds }), |window| {
-                window.insert_hitbox(bounds, false)
+                window.insert_hitbox(bounds, gpui::HitboxBehavior::Normal)
             });
 
             states.push(AxisPrepaintState {

--- a/crates/ui/src/webview.rs
+++ b/crates/ui/src/webview.rs
@@ -187,7 +187,7 @@ impl Element for WebViewElement {
             .unwrap();
 
         // Create a hitbox to handle mouse event
-        Some(window.insert_hitbox(bounds, false))
+        Some(window.insert_hitbox(bounds, gpui::HitboxBehavior::Normal))
     }
 
     fn paint(

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -2,8 +2,8 @@
 // https://github.com/zed-industries/zed/blob/a8afc63a91f6b75528540dcffe73dc8ce0c92ad8/crates/gpui/examples/window_shadow.rs
 use gpui::{
     canvas, div, point, prelude::FluentBuilder as _, px, AnyElement, App, Bounds, CursorStyle,
-    Decorations, Edges, Hsla, InteractiveElement as _, IntoElement, MouseButton, ParentElement,
-    Pixels, Point, RenderOnce, ResizeEdge, Size, Styled as _, Window,
+    Decorations, Edges, HitboxBehavior, Hsla, InteractiveElement as _, IntoElement, MouseButton,
+    ParentElement, Pixels, Point, RenderOnce, ResizeEdge, Size, Styled as _, Window,
 };
 
 use crate::ActiveTheme;
@@ -83,7 +83,7 @@ impl RenderOnce for WindowBorder {
                                         point(px(0.0), px(0.0)),
                                         window.window_bounds().get_bounds().size,
                                     ),
-                                    false,
+                                    HitboxBehavior::Normal,
                                 )
                             },
                             move |_bounds, hitbox, window, _| {


### PR DESCRIPTION
Now, GPUI have merged `window_handle` support for all platforms.

- https://github.com/zed-industries/zed/pull/24327
- https://github.com/zed-industries/zed/pull/24545
- https://github.com/zed-industries/zed/pull/28152

It's time to depends on Zed official main branch.