### PR TITLE
code-editor: Update CodeEditor to support external language.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6772,6 +6772,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-navi",
  "unindent",
 ]
 
@@ -7703,6 +7705,17 @@ version = "0.5.0"
 source = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?tag=v0.5.0#afaa4138517363362f54c89330c9d79391e81168"
 dependencies = [
  "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-navi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff190c235d2c0106d8d4c567e990f7776b80a2643b7d201a672cae308675424d"
+dependencies = [
+ "cc",
+ "tree-sitter",
  "tree-sitter-language",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6772,7 +6772,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing-subscriber",
- "tree-sitter",
  "tree-sitter-navi",
  "unindent",
 ]

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2024"
+edition = "2021"
 name = "gpui-component-macros"
 version = "0.1.0"
 

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -20,6 +20,8 @@ serde = "1"
 serde_json = "1"
 unindent = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tree-sitter = "0.25.4"
+tree-sitter-navi = "0.2.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18" }

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -20,7 +20,6 @@ serde = "1"
 serde_json = "1"
 unindent = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tree-sitter = "0.25.4"
 tree-sitter-navi = "0.2.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/story/examples/fixtures/test.nv
+++ b/crates/story/examples/fixtures/test.nv
@@ -1,0 +1,18 @@
+use std.net.http.client.{HttpClient, Request};
+use std.net.http.OK;
+
+fn main() throws {
+    let client = HttpClient.new(
+        max_redirect_count: 5,
+        user_agent: "navi-client",
+    );
+    let req = try Request.get("https://httpbin.org/get");
+    let res = try client.request(req);
+
+    if (res.status() != OK) {
+        try println("Failed to fetch repo", res.text());
+        return;
+    }
+
+    try println(res.text());
+}

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -9,16 +9,17 @@ use tree_sitter::{
 };
 use tree_sitter_highlight::{HighlightConfiguration, Highlighter};
 
+use crate::highlighter::LanguageRegistry;
+
 use super::{HighlightTheme, Language};
 
 /// A syntax highlighter that supports incremental parsing, multiline text,
 /// and caching of highlight results.
 #[allow(unused)]
 pub struct SyntaxHighlighter {
-    language_name: &'static str,
-    language: Option<Language>,
+    language: SharedString,
     query: Option<Query>,
-    injection_queries: HashMap<&'static str, Query>,
+    injection_queries: HashMap<SharedString, Query>,
     parser: Parser,
     old_tree: Option<Tree>,
     text: SharedString,
@@ -47,19 +48,22 @@ pub struct SyntaxHighlighter {
 
 impl SyntaxHighlighter {
     /// Create a new SyntaxHighlighter for HTML.
-    pub fn new(lang: &str) -> Self {
-        Self::build_combined_injections_query(&lang).unwrap()
+    pub fn new(lang: &str, cx: &App) -> Self {
+        Self::build_combined_injections_query(&lang, cx).expect(&format!(
+            "failed to build language {}, please make sure have registered the language in LanguageRegistry",
+            lang
+        ))
     }
 
     /// Build the combined injections query for the given language.
     ///
     /// https://github.com/tree-sitter/tree-sitter/blob/v0.25.5/highlight/src/lib.rs#L336
-    fn build_combined_injections_query(lang: &str) -> Option<Self> {
-        let language = Language::from_str(&lang);
-        let Some(language) = language else {
+    fn build_combined_injections_query(lang: &str, cx: &App) -> Option<Self> {
+        let language_registy = LanguageRegistry::global(cx);
+        let config = language_registy.language(&lang);
+        let Some(config) = config else {
             return None;
         };
-        let config = language.config();
 
         let mut parser = Parser::new();
         _ = parser.set_language(&config.language);
@@ -146,19 +150,19 @@ impl SyntaxHighlighter {
         }
 
         let mut injection_queries = HashMap::new();
-        for inj_language in language.injection_languages() {
-            let inj_config = inj_language.config();
-
-            match Query::new(&inj_config.language, &inj_config.highlights) {
-                Ok(q) => {
-                    injection_queries.insert(inj_language.name(), q);
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "failed to build injection query for {:?}: {:?}",
-                        inj_language,
-                        e
-                    );
+        for inj_language in config.injection_languages.iter() {
+            if let Some(inj_config) = language_registy.language(&inj_language) {
+                match Query::new(&inj_config.language, &inj_config.highlights) {
+                    Ok(q) => {
+                        injection_queries.insert(inj_config.name.clone(), q);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "failed to build injection query for {:?}: {:?}",
+                            inj_config.name,
+                            e
+                        );
+                    }
                 }
             }
         }
@@ -166,8 +170,7 @@ impl SyntaxHighlighter {
         // let highlight_indices = vec![None; query.capture_names().len()];
 
         Some(Self {
-            language_name: language.name(),
-            language: Some(language),
+            language: config.name.clone(),
             query: Some(query),
             injection_queries,
             parser,
@@ -188,21 +191,28 @@ impl SyntaxHighlighter {
         })
     }
 
-    pub fn set_language(&mut self, lang: impl Into<SharedString>) {
-        let lang = lang.into();
-        let language = Language::from_str(&lang);
+    pub fn set_language(&mut self, language: impl Into<SharedString>, cx: &App) {
+        let language = language.into();
+
         if self.language == language {
             return;
         }
 
         // FIXME: use build_combined_injections_query to build the query.
-
-        if let Some(language) = language {
+        self.query = None;
+        if let Some(language) = Language::from_str(&language) {
+            self.query = Some(language.query());
             _ = self.parser.set_language(&language.config().language);
+        } else {
+            if let Some(config) = LanguageRegistry::global(cx).language(&language) {
+                _ = self.parser.set_language(&config.language);
+                if let Ok(query) = tree_sitter::Query::new(&config.language, &config.highlights) {
+                    self.query = Some(query);
+                }
+            }
         }
 
         self.language = language;
-        self.query = language.map(|l| l.query());
         self.old_tree = None;
         self.text = SharedString::new("");
         self.highlighter = Highlighter::new();
@@ -464,21 +474,26 @@ impl SyntaxHighlighter {
     /// - `include_children`: Whether to include the children of the content node.
     fn injection_for_match<'a>(
         &self,
-        parent_name: Option<&'a str>,
+        parent_name: Option<SharedString>,
         query: &'a Query,
         query_match: &QueryMatch<'a, 'a>,
         source: &'a [u8],
-    ) -> (Option<&'a str>, Option<Node<'a>>, bool) {
+    ) -> (Option<SharedString>, Option<Node<'a>>, bool) {
         let content_capture_index = self.injection_content_capture_index;
         let language_capture_index = self.injection_language_capture_index;
 
-        let mut language_name = None;
+        let mut language_name: Option<SharedString> = None;
         let mut content_node = None;
 
         for capture in query_match.captures {
             let index = Some(capture.index);
             if index == language_capture_index {
-                language_name = capture.node.utf8_text(source).ok();
+                language_name = capture
+                    .node
+                    .utf8_text(source)
+                    .ok()
+                    .map(ToString::to_string)
+                    .map(SharedString::from);
             } else if index == content_capture_index {
                 content_node = Some(capture.node);
             }
@@ -496,7 +511,8 @@ impl SyntaxHighlighter {
                             .value
                             .as_ref()
                             .map(std::convert::AsRef::as_ref)
-                            .to_owned();
+                            .map(ToString::to_string)
+                            .map(SharedString::from);
                     }
                 }
 
@@ -505,7 +521,7 @@ impl SyntaxHighlighter {
                 // layer.
                 "injection.self" => {
                     if language_name.is_none() {
-                        language_name = Some(self.language_name);
+                        language_name = Some(self.language.clone());
                     }
                 }
 
@@ -514,7 +530,7 @@ impl SyntaxHighlighter {
                 // parent layer
                 "injection.parent" => {
                     if language_name.is_none() {
-                        language_name = parent_name;
+                        language_name = parent_name.clone().map(SharedString::from);
                     }
                 }
 

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -49,7 +49,7 @@ pub struct SyntaxHighlighter {
 impl SyntaxHighlighter {
     /// Create a new SyntaxHighlighter for HTML.
     pub fn new(lang: &str, cx: &App) -> Self {
-        Self::build_combined_injections_query(&lang, cx).expect(&format!(
+        Self::build_combined_injections_query(&lang, cx).unwrap_or_else(|| panic!(
             "failed to build language {}, please make sure have registered the language in LanguageRegistry",
             lang
         ))
@@ -59,8 +59,8 @@ impl SyntaxHighlighter {
     ///
     /// https://github.com/tree-sitter/tree-sitter/blob/v0.25.5/highlight/src/lib.rs#L336
     fn build_combined_injections_query(lang: &str, cx: &App) -> Option<Self> {
-        let language_registy = LanguageRegistry::global(cx);
-        let config = language_registy.language(&lang);
+        let registry = LanguageRegistry::global(cx);
+        let config = registry.language(&lang);
         let Some(config) = config else {
             return None;
         };
@@ -151,7 +151,7 @@ impl SyntaxHighlighter {
 
         let mut injection_queries = HashMap::new();
         for inj_language in config.injection_languages.iter() {
-            if let Some(inj_config) = language_registy.language(&inj_language) {
+            if let Some(inj_config) = registry.language(&inj_language) {
                 match Query::new(&inj_config.language, &inj_config.highlights) {
                     Ok(q) => {
                         injection_queries.insert(inj_config.name.clone(), q);
@@ -530,7 +530,7 @@ impl SyntaxHighlighter {
                 // parent layer
                 "injection.parent" => {
                     if language_name.is_none() {
-                        language_name = parent_name.clone().map(SharedString::from);
+                        language_name = parent_name.clone();
                     }
                 }
 

--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -8,7 +8,16 @@ use std::{
 };
 
 use super::LanguageConfig;
-use crate::ThemeMode;
+use crate::{highlighter::languages, ThemeMode};
+
+pub(super) fn init(cx: &mut App) {
+    let mut register = LanguageRegistry::new();
+    for language in languages::Language::all() {
+        register.register(language.name(), &language.config());
+    }
+
+    cx.set_global(register);
+}
 
 pub(super) const HIGHLIGHT_NAMES: [&str; 40] = [
     "attribute",
@@ -359,10 +368,6 @@ impl HighlightTheme {
     }
 }
 
-pub fn init(cx: &mut App) {
-    cx.set_global(LanguageRegistry::new());
-}
-
 /// Registry for code highlighter languages.
 #[derive(Clone)]
 pub struct LanguageRegistry {
@@ -394,19 +399,28 @@ impl LanguageRegistry {
         self.languages.insert(lang.to_string(), config.clone());
     }
 
-    #[allow(unused)]
-    pub(crate) fn set_theme(&mut self, light_theme: &HighlightTheme, dark_theme: &HighlightTheme) {
-        self.light_theme = Arc::new(light_theme.clone());
-        self.dark_theme = Arc::new(dark_theme.clone());
+    /// Set highlighter theme.
+    pub fn set_theme(&mut self, light: &HighlightTheme, dark: &HighlightTheme) {
+        self.light_theme = Arc::new(light.clone());
+        self.dark_theme = Arc::new(dark.clone());
     }
 
-    #[allow(unused)]
     pub(crate) fn theme(&self, is_dark: bool) -> &Arc<HighlightTheme> {
         if is_dark {
             &self.dark_theme
         } else {
             &self.light_theme
         }
+    }
+
+    /// Returns a reference to the map of registered languages.
+    pub fn languages(&self) -> &HashMap<String, LanguageConfig> {
+        &self.languages
+    }
+
+    /// Returns the language configuration for the given language name.
+    pub fn language(&self, name: &str) -> Option<&LanguageConfig> {
+        self.languages.get(name)
     }
 }
 

--- a/crates/ui/src/text/element.rs
+++ b/crates/ui/src/text/element.rs
@@ -222,7 +222,7 @@ impl CodeBlock {
             .clone();
         let mut styles = vec![];
         if let Some(lang) = &lang {
-            let mut highlighter = SyntaxHighlighter::new(&lang);
+            let mut highlighter = SyntaxHighlighter::new(&lang, cx);
             highlighter.update(&(0..0), code.clone(), "", cx);
             styles = highlighter.styles(&(0..code.len()), &theme);
         };


### PR DESCRIPTION
Add [Navi](https://navi-lang.org) language for example to external language for CodeEditor.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/73afa56d-31bd-4867-a9f2-0a8cf790af0f" />
