### PR TITLE
dropdown: Replace specialized impl From Vec<SharedString> to Vec<T: DropdownItem + Clone>

### DIFF
--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -281,6 +281,15 @@ impl<T: DropdownItem + Clone> SearchableVec<T> {
     }
 }
 
+impl<T: DropdownItem + Clone> From<Vec<T>> for SearchableVec<T> {
+    fn from(items: Vec<T>) -> Self {
+        Self {
+            items: items.clone(),
+            matched_items: items,
+        }
+    }
+}
+
 impl<T: DropdownItem + Clone> DropdownDelegate for SearchableVec<T> {
     type Item = T;
 
@@ -319,15 +328,6 @@ impl<T: DropdownItem + Clone> DropdownDelegate for SearchableVec<T> {
             .collect();
 
         Task::ready(())
-    }
-}
-
-impl From<Vec<SharedString>> for SearchableVec<SharedString> {
-    fn from(items: Vec<SharedString>) -> Self {
-        Self {
-            items: items.clone(),
-            matched_items: items,
-        }
     }
 }
 


### PR DESCRIPTION
Needed for a proc macro i plan to publish when ready
```rs
#[derive(Clone, DropdownItemFtl, EsFluent, EnumIter, EnumString)]
#[fluent(enumerable)]
pub enum PreferedLanguage {
    English,
    French,
    Chinese,
}

#[derive(Clone, DropdownItemFtl, EsFluent, EnumIter, EnumString)]
#[fluent(enumerable)]
pub enum Country {
    UnitedStates,
    France,
    China,
}

#[derive(GpuiForm)]
pub struct User {
    #[gpui_form(component(input))]
    pub username: Option<String>,

    #[gpui_form(component(input))]
    pub email: String,

    #[gpui_form(component(number_input))]
    pub age: Option<u32>,

    #[gpui_form(component(number_input))]
    pub balance: Decimal,

    #[gpui_form(component(check_box))]
    pub subscribe_newsletter: bool,

    #[gpui_form(component(switch))]
    pub enable_notifications: bool,

    #[gpui_form(component(dropdown(searchable)))]
    pub country: Option<Country>,

    #[gpui_form(component(dropdown()))]
    pub preferred_language: PreferedLanguage,

    #[gpui_form(component(calendar))]
    pub birth_date: chrono::NaiveDate,

    #[gpui_form(component(date_picker))]
    pub appointment_date: chrono::NaiveDate,

    #[gpui_form(component(progress))]
    pub completion_percentage: f32,

    #[gpui_form(skip)]
    pub skip_me: bool,
}
```