### PR TITLE
input: Simplify newline logic for multi-line text and fix auto-grow lines count.

### DIFF
--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -61,6 +61,10 @@ pub enum InputMode {
 }
 
 impl InputMode {
+    pub(super) fn is_code_editor(&self) -> bool {
+        matches!(self, InputMode::CodeEditor { .. })
+    }
+
     pub(super) fn set_rows(&mut self, new_rows: usize) {
         match self {
             InputMode::MultiLine { rows, .. } => {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1244,7 +1244,11 @@ impl InputState {
     pub(super) fn enter(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
         if self.is_multi_line() {
             // Get current line indent
-            let indent = self.indent_of_next_line(window, cx);
+            let indent = if self.mode.is_code_editor() {
+                self.indent_of_next_line(window, cx)
+            } else {
+                "".to_string()
+            };
 
             // Add newline and indent
             let new_line_text = format!("\n{}", indent);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1243,26 +1243,12 @@ impl InputState {
 
     pub(super) fn enter(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
         if self.is_multi_line() {
-            let is_eof = self.selected_range.end == self.text.len();
-
             // Get current line indent
             let indent = self.indent_of_next_line(window, cx);
-            self.replace_text_in_range(None, "\n", window, cx);
 
-            // Move cursor to the start of the next line
-            let mut new_offset = self.cursor_offset() - 1;
-            if is_eof {
-                new_offset += 1;
-            }
-            self.move_to(self.next_boundary(new_offset), window, cx);
-
-            // Add indent
-            self.replace_text_in_range(
-                Some(self.range_to_utf16(&(self.cursor_offset()..self.cursor_offset()))),
-                &indent,
-                window,
-                cx,
-            );
+            // Add newline and indent
+            let new_line_text = format!("\n{}", indent);
+            self.replace_text_in_range(None, &new_line_text, window, cx);
         }
 
         cx.emit(InputEvent::PressEnter {

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -95,15 +95,6 @@ impl TextWrapper {
             prev_line_ix += line.len() + 1;
         }
 
-        // Add last empty line.
-        if text.chars().last().unwrap_or('\n') == '\n' {
-            wrapped_lines.push(text.len()..text.len());
-            lines.push(LineWrap {
-                wrap_lines: 0,
-                range: text.len()..text.len(),
-            });
-        }
-
         self.text = text;
         self.wrapped_lines = wrapped_lines;
         self.lines = lines;


### PR DESCRIPTION
- Fix to only keep indent in CodeEditor mode.

https://github.com/user-attachments/assets/4b926a18-b0b5-4419-97dd-21778cd20fb3
