### PR TITLE
number_input: Allow signed numbers

### DIFF
--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -218,10 +218,9 @@ impl MaskPattern {
                 }
 
                 // check if the integer part is valid
-                if !int_part
-                    .chars()
-                    .all(|ch| ch.is_ascii_digit() || is_sign(&ch) || Some(ch) == *separator)
-                {
+                if !int_part.chars().enumerate().all(|(i, ch)| {
+                    ch.is_ascii_digit() || is_sign(&ch) && i == 0 || Some(ch) == *separator
+                }) {
                     return false;
                 }
 

--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -203,25 +203,19 @@ impl MaskPattern {
                 }
 
                 // only one symbol is valid
-                if int_part
-                    .chars()
-                    .filter(is_digit_sign)
-                    .collect::<Vec<_>>()
-                    .len()
-                    > 1
-                {
+                if int_part.chars().filter(is_sign).collect::<Vec<_>>().len() > 1 {
                     return false;
                 }
 
                 // symbol is not valid if not at the beginning
-                if int_part.chars().position(|ch| is_digit_sign(&ch)) > Some(0) {
+                if int_part.chars().position(|ch| is_sign(&ch)) > Some(0) {
                     return false;
                 }
 
                 // check if the integer part is valid
                 if !int_part
                     .chars()
-                    .all(|ch| ch.is_ascii_digit() || is_digit_sign(&ch) || Some(ch) == *separator)
+                    .all(|ch| ch.is_ascii_digit() || is_sign(&ch) || Some(ch) == *separator)
                 {
                     return false;
                 }
@@ -307,14 +301,14 @@ impl MaskPattern {
                     let mut chars: Vec<char> = int_part.chars().rev().collect();
 
                     // Removing the symbol from formatting to avoid cases such as: -,123
-                    let maybe_symbol = if let Some(pos) = chars.iter().position(is_digit_sign) {
+                    let maybe_symbol = if let Some(pos) = chars.iter().position(is_sign) {
                         Some(chars.remove(pos))
                     } else {
                         None
                     };
 
                     let mut result = String::new();
-                    for (i, ch) in chars.iter().filter(|ch| !is_digit_sign(ch)).enumerate() {
+                    for (i, ch) in chars.iter().filter(|ch| !is_sign(ch)).enumerate() {
                         if i > 0 && i % 3 == 0 {
                             result.push(sep);
                         }
@@ -410,7 +404,7 @@ impl MaskPattern {
     }
 }
 
-fn is_digit_sign(ch: &char) -> bool {
+fn is_sign(ch: &char) -> bool {
     matches!(ch, '+' | '-')
 }
 

--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -308,7 +308,7 @@ impl MaskPattern {
                     };
 
                     let mut result = String::new();
-                    for (i, ch) in chars.iter().filter(|ch| !is_sign(ch)).enumerate() {
+                    for (i, ch) in chars.iter().enumerate() {
                         if i > 0 && i % 3 == 0 {
                             result.push(sep);
                         }

--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -202,7 +202,7 @@ impl MaskPattern {
                     return false;
                 }
 
-                // Only one symbol is valid
+                // only one symbol is valid
                 if int_part
                     .chars()
                     .filter(|ch| is_digit_sign(*ch))
@@ -210,6 +210,11 @@ impl MaskPattern {
                     .len()
                     > 1
                 {
+                    return false;
+                }
+
+                // symbol is not valid if not at the beginning
+                if int_part.chars().position(|ch| is_digit_sign(ch)) > Some(0) {
                     return false;
                 }
 
@@ -601,6 +606,10 @@ mod tests {
         assert_eq!(mask.is_valid("+-"), false);
         assert_eq!(mask.is_valid("-+"), false);
         assert_eq!(mask.is_valid("+-1234567"), false);
+
+        // No symbol is valid in the middle of the number
+        assert_eq!(mask.is_valid("1,-234,567"), false);
+        assert_eq!(mask.is_valid("12-34567.89"), false);
 
         // Symbols in fractions are invalid
         assert_eq!(mask.is_valid("+1234567.-"), false);

--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -202,12 +202,12 @@ impl MaskPattern {
                     return false;
                 }
 
-                // only one symbol is valid
+                // only one sign is valid
                 if int_part.chars().filter(is_sign).collect::<Vec<_>>().len() > 1 {
                     return false;
                 }
 
-                // symbol is not valid if not at the beginning
+                // sign is only valid at the beginning of the string
                 if int_part.chars().position(|ch| is_sign(&ch)) > Some(0) {
                     return false;
                 }
@@ -300,8 +300,8 @@ impl MaskPattern {
                     // Reverse the integer part for easier grouping
                     let mut chars: Vec<char> = int_part.chars().rev().collect();
 
-                    // Removing the symbol from formatting to avoid cases such as: -,123
-                    let maybe_symbol = if let Some(pos) = chars.iter().position(is_sign) {
+                    // Removing the sign from formatting to avoid cases such as: -,123
+                    let maybe_signed = if let Some(pos) = chars.iter().position(is_sign) {
                         Some(chars.remove(pos))
                     } else {
                         None
@@ -326,8 +326,8 @@ impl MaskPattern {
                         int_with_sep
                     };
 
-                    let final_str = if let Some(symbol) = maybe_symbol {
-                        format!("{}{}", symbol, final_str)
+                    let final_str = if let Some(sign) = maybe_signed {
+                        format!("{}{}", sign, final_str)
                     } else {
                         final_str
                     };
@@ -608,19 +608,19 @@ mod tests {
         assert_eq!(mask.is_valid("+1234567."), true);
         assert_eq!(mask.is_valid("+1234567.89"), true);
 
-        // Only one symbol is valid
+        // Only one sign is valid
         assert_eq!(mask.is_valid("+-"), false);
         assert_eq!(mask.is_valid("-+"), false);
         assert_eq!(mask.is_valid("+-1234567"), false);
 
-        // No symbol is valid in the middle of the number
+        // No sign is valid in the middle of the number
         assert_eq!(mask.is_valid("1,-234,567"), false);
         assert_eq!(mask.is_valid("12-34567.89"), false);
 
-        // Symbols in fractions are invalid
+        // Signs in fractions are invalid
         assert_eq!(mask.is_valid("+1234567.-"), false);
 
-        // The separator does not show up before the symbol i.e. -,123
+        // The separator does not show up before the sign i.e. -,123
         assert_eq!(mask.mask("-123"), "-123");
 
         assert_eq!(mask.mask("-1234567"), "-1,234,567");

--- a/crates/ui/src/input/mask_pattern.rs
+++ b/crates/ui/src/input/mask_pattern.rs
@@ -202,13 +202,18 @@ impl MaskPattern {
                     return false;
                 }
 
-                // only one sign is valid
-                if int_part.chars().filter(is_sign).collect::<Vec<_>>().len() > 1 {
-                    return false;
-                }
+                let sign_positions: Vec<usize> = int_part
+                    .chars()
+                    .enumerate()
+                    .filter_map(|(i, ch)| match is_sign(&ch) {
+                        true => Some(i),
+                        false => None,
+                    })
+                    .collect();
 
+                // only one sign is valid
                 // sign is only valid at the beginning of the string
-                if int_part.chars().position(|ch| is_sign(&ch)) > Some(0) {
+                if sign_positions.len() > 1 || sign_positions.first() > Some(&0) {
                     return false;
                 }
 
@@ -404,6 +409,7 @@ impl MaskPattern {
     }
 }
 
+#[inline]
 fn is_sign(ch: &char) -> bool {
     matches!(ch, '+' | '-')
 }


### PR DESCRIPTION
Allow negative numbers and explicit positive numbers.

Added these tests:

1. Only one sign at the start of the number.
2. No signs in the middle of the number.
3. No signs in the fractional part.
4. Sign doesn't break formatting.

https://github.com/user-attachments/assets/89c4f4c7-d3bf-4cc1-aeca-7e9bedd02e20



