### PR TITLE
modal: Add scrollbar to modal again with `scrollable` option method.

### DIFF
--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -367,6 +367,7 @@ impl Render for ModalStory {
                                             .overlay(modal_overlay)
                                             .overlay_closable(overlay_closable)
                                             .title("Modal with scrollbar")
+                                            .scrollable()
                                             .child(TextView::markdown(
                                                 "markdown1",
                                                 include_str!("../../../README.md"),

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -355,6 +355,15 @@ impl RenderOnce for Modal {
         let x = bounds.center().x - self.width / 2.;
         let border_radius = (cx.theme().radius * 2.).min(px(20.));
 
+        let mut padding_right = px(16.);
+        let mut padding_left = px(16.);
+        if let Some(pl) = self.style.padding.left {
+            padding_left = pl.to_pixels(self.width.into(), window.rem_size());
+        }
+        if let Some(pr) = self.style.padding.right {
+            padding_right = pr.to_pixels(self.width.into(), window.rem_size());
+        }
+
         anchored()
             .position(point(window_paddings.left, window_paddings.top))
             .snap_to_window()
@@ -391,9 +400,10 @@ impl RenderOnce for Modal {
                             .rounded(border_radius)
                             .shadow_xl()
                             .min_h_24()
-                            .p_4()
+                            .py_4()
                             .gap_4()
                             .refine_style(&self.style)
+                            .px_0()
                             .key_context(CONTEXT)
                             .track_focus(&self.focus_handle)
                             .when(self.keyboard, |this| {
@@ -426,6 +436,7 @@ impl RenderOnce for Modal {
                                     }
                                 })
                             })
+                            // Ther style is can't be override.
                             .absolute()
                             .occlude()
                             .relative()
@@ -435,7 +446,12 @@ impl RenderOnce for Modal {
                             .when_some(self.max_width, |this, w| this.max_w(w))
                             .when_some(self.title, |this, title| {
                                 this.child(
-                                    div().font_semibold().line_height(relative(1.)).child(title),
+                                    div()
+                                        .font_semibold()
+                                        .pl(padding_left)
+                                        .pr(padding_right)
+                                        .line_height(relative(1.))
+                                        .child(title),
                                 )
                             })
                             .when(self.show_close, |this| {
@@ -455,21 +471,28 @@ impl RenderOnce for Modal {
                                 )
                             })
                             .child(
-                                div()
-                                    .w_full()
-                                    .flex_1()
-                                    .overflow_hidden()
-                                    .child(self.content),
+                                div().w_full().flex_1().overflow_hidden().child(
+                                    v_flex()
+                                        .pl(padding_left)
+                                        .pr(padding_right)
+                                        .scrollable(
+                                            window.current_view(),
+                                            crate::scroll::ScrollbarAxis::Vertical,
+                                        )
+                                        .child(self.content),
+                                ),
                             )
                             .when(self.footer.is_some(), |this| {
                                 let footer = self.footer.unwrap();
 
-                                this.child(h_flex().gap_2().justify_end().children(footer(
-                                    render_ok,
-                                    render_cancel,
-                                    window,
-                                    cx,
-                                )))
+                                this.child(
+                                    h_flex()
+                                        .gap_2()
+                                        .pl(padding_left)
+                                        .pr(padding_right)
+                                        .justify_end()
+                                        .children(footer(render_ok, render_cancel, window, cx)),
+                                )
                             })
                             .with_animation(
                                 "slide-down",

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -90,6 +90,7 @@ pub struct Modal {
     overlay: bool,
     overlay_closable: bool,
     keyboard: bool,
+    scrollable: bool,
 
     /// This will be change when open the modal, the focus handle is create when open the modal.
     pub(crate) focus_handle: FocusHandle,
@@ -126,6 +127,7 @@ impl Modal {
             button_props: ModalButtonProps::default(),
             show_close: true,
             overlay_closable: true,
+            scrollable: false,
         }
     }
 
@@ -260,6 +262,12 @@ impl Modal {
 
     pub(crate) fn has_overlay(&self) -> bool {
         self.overlay
+    }
+
+    /// Set to support scrollbar in the modal content area, defaults to `false`.
+    pub fn scrollable(mut self) -> Self {
+        self.scrollable = true;
+        self
     }
 }
 
@@ -470,18 +478,20 @@ impl RenderOnce for Modal {
                                         }),
                                 )
                             })
-                            .child(
-                                div().w_full().flex_1().overflow_hidden().child(
-                                    v_flex()
-                                        .pl(padding_left)
-                                        .pr(padding_right)
-                                        .scrollable(
-                                            window.current_view(),
-                                            crate::scroll::ScrollbarAxis::Vertical,
-                                        )
-                                        .child(self.content),
-                                ),
-                            )
+                            .child(div().w_full().flex_1().overflow_hidden().child(
+                                v_flex().pl(padding_left).pr(padding_right).map(|this| {
+                                    match self.scrollable {
+                                        true => this
+                                            .scrollable(
+                                                window.current_view(),
+                                                crate::scroll::ScrollbarAxis::Vertical,
+                                            )
+                                            .child(self.content)
+                                            .into_any_element(),
+                                        false => this.child(self.content).into_any_element(),
+                                    }
+                                }),
+                            ))
                             .when(self.footer.is_some(), |this| {
                                 let footer = self.footer.unwrap();
 

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -436,7 +436,7 @@ impl RenderOnce for Modal {
                                     }
                                 })
                             })
-                            // Ther style is can't be override.
+                            // There style is high priority, can't be overridden.
                             .absolute()
                             .occlude()
                             .relative()


### PR DESCRIPTION
Continue #970 to add back the scrollbar to Modal again with new fixes.