### PR TITLE
list: Fix search input padding.

### DIFF
--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -595,8 +595,8 @@ where
                 this.child(
                     div()
                         .map(|this| match self.size {
-                            Size::Small => this.py_0().px_1p5(),
-                            _ => this.py_1().px_2(),
+                            Size::Small => this.px_1p5(),
+                            _ => this.px_2(),
                         })
                         .border_b_1()
                         .border_color(cx.theme().border)


### PR DESCRIPTION
This change to fix #965 affected search input size.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/f8fce042-2f53-4dc3-a725-64a1b0ed6630" />
<img width="550" alt="image" src="https://github.com/user-attachments/assets/048e9ef8-da2d-4b9b-ad24-ccda55695c8b" />
<img width="517" alt="image" src="https://github.com/user-attachments/assets/f06f7e9a-bf30-4e01-a0aa-0a1db6b2c6e1" />
