### PR TITLE
scrollbar: Improve Scrollbar to get correct scroll size.

### DIFF
--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -198,8 +198,6 @@ impl Render for ScrollableStory {
         _: &mut gpui::Window,
         cx: &mut gpui::Context<Self>,
     ) -> impl gpui::IntoElement {
-        let view = cx.entity().clone();
-
         v_flex()
             .size_full()
             .gap_4()
@@ -273,12 +271,8 @@ impl Render for ScrollableStory {
                                     .right_0()
                                     .bottom_0()
                                     .child(
-                                        Scrollbar::both(
-                                            view.entity_id(),
-                                            self.scroll_state.clone(),
-                                            self.scroll_handle.clone(),
-                                        )
-                                        .axis(self.axis),
+                                        Scrollbar::both(&self.scroll_state, &self.scroll_handle)
+                                            .axis(self.axis),
                                     )
                             }),
                     ),
@@ -297,7 +291,7 @@ impl Render for ScrollableStory {
                             .p_3()
                             .w(self.test_width)
                             .id("test-1")
-                            .scrollable(cx.entity().entity_id(), Axis::Vertical)
+                            .scrollable(Axis::Vertical)
                             .gap_1()
                             .child("Scrollable Example")
                             .children(self.items.iter().take(500).map(|item| {

--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -1069,7 +1069,6 @@ impl EventEmitter<DismissEvent> for Tiles {}
 impl Render for Tiles {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let view = cx.entity().clone();
-        let view_id = view.entity_id();
         let panels = self.sorted_panels();
         let scroll_bounds =
             self.panels
@@ -1140,12 +1139,8 @@ impl Render for Tiles {
                     .right_0()
                     .bottom_0()
                     .child(
-                        Scrollbar::both(
-                            view_id,
-                            self.scroll_state.clone(),
-                            self.scroll_handle.clone(),
-                        )
-                        .scroll_size(scroll_size),
+                        Scrollbar::both(&self.scroll_state, &self.scroll_handle)
+                            .scroll_size(scroll_size),
                     ),
             )
             .size_full()

--- a/crates/ui/src/drawer.rs
+++ b/crates/ui/src/drawer.rs
@@ -202,11 +202,10 @@ impl RenderOnce for Drawer {
                             )
                             .child(
                                 // Body
-                                div().flex_1().overflow_hidden().child(
-                                    v_flex()
-                                        .scrollable(window.current_view(), Axis::Vertical)
-                                        .child(self.content),
-                                ),
+                                div()
+                                    .flex_1()
+                                    .overflow_hidden()
+                                    .child(v_flex().scrollable(Axis::Vertical).child(self.content)),
                             )
                             .when_some(self.footer, |this, footer| {
                                 // Footer

--- a/crates/ui/src/input/text_input.rs
+++ b/crates/ui/src/input/text_input.rs
@@ -298,7 +298,6 @@ impl RenderOnce for TextInput {
             })
             .refine_style(&self.style)
             .when(state.is_multi_line(), |this| {
-                let entity_id = self.state.entity_id();
                 if state.last_layout.is_some() {
                     this.relative().child(
                         div()
@@ -308,12 +307,8 @@ impl RenderOnce for TextInput {
                             .right(px(1.))
                             .bottom_0()
                             .child(
-                                Scrollbar::vertical(
-                                    entity_id,
-                                    state.scroll_state.clone(),
-                                    state.scroll_handle.clone(),
-                                )
-                                .scroll_size(state.scroll_size),
+                                Scrollbar::vertical(&state.scroll_state, &state.scroll_handle)
+                                    .scroll_size(state.scroll_size),
                             ),
                     )
                 } else {

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -287,15 +287,14 @@ where
         self.selected_index
     }
 
-    fn render_scrollbar(&self, _: &mut Window, cx: &mut Context<Self>) -> Option<impl IntoElement> {
+    fn render_scrollbar(&self, _: &mut Window, _: &mut Context<Self>) -> Option<impl IntoElement> {
         if !self.scrollbar_visible {
             return None;
         }
 
         Some(Scrollbar::uniform_scroll(
-            cx.entity().entity_id(),
-            self.scroll_state.clone(),
-            self.vertical_scroll_handle.clone(),
+            &self.scroll_state,
+            &self.vertical_scroll_handle,
         ))
     }
 

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -943,11 +943,7 @@ impl Render for PopupMenu {
                         .left_0()
                         .right_0p5()
                         .bottom_0p5()
-                        .child(Scrollbar::vertical(
-                            cx.entity_id(),
-                            self.scroll_state.clone(),
-                            self.scroll_handle.clone(),
-                        )),
+                        .child(Scrollbar::vertical(&self.scroll_state, &self.scroll_handle)),
                 )
             })
     }

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -475,7 +475,7 @@ impl RenderOnce for Modal {
                                     v_flex()
                                         .pl(padding_left)
                                         .pr(padding_right)
-                                        .scrollable(window.current_view(), Axis::Vertical)
+                                        .scrollable(Axis::Vertical)
                                         .child(self.content),
                                 ),
                             )

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -1,6 +1,6 @@
 use super::{Scrollbar, ScrollbarAxis, ScrollbarState};
 use gpui::{
-    div, relative, AnyElement, App, Bounds, Div, Element, ElementId, EntityId, GlobalElementId,
+    div, relative, AnyElement, App, Bounds, Div, Element, ElementId, GlobalElementId,
     InspectorElementId, InteractiveElement, Interactivity, IntoElement, LayoutId, ParentElement,
     Pixels, Position, ScrollHandle, SharedString, Stateful, StatefulInteractiveElement, Style,
     StyleRefinement, Styled, Window,
@@ -10,7 +10,6 @@ use gpui::{
 pub struct Scrollable<E> {
     id: ElementId,
     element: Option<E>,
-    view_id: EntityId,
     axis: ScrollbarAxis,
     /// This is a fake element to handle Styled, InteractiveElement, not used.
     _element: Stateful<Div>,
@@ -20,18 +19,15 @@ impl<E> Scrollable<E>
 where
     E: Element,
 {
-    pub(crate) fn new(view_id: EntityId, element: E, axis: impl Into<ScrollbarAxis>) -> Self {
-        let id = ElementId::Name(SharedString::from(format!(
-            "scrollable-{}-{:?}",
-            view_id,
-            element.id(),
-        )));
+    pub(crate) fn new(axis: impl Into<ScrollbarAxis>, element: E) -> Self {
+        let id = ElementId::Name(SharedString::from(
+            format!("scrollable-{:?}", element.id(),),
+        ));
 
         Self {
             element: Some(element),
             _element: div().id("fake"),
             id,
-            view_id,
             axis: axis.into(),
         }
     }
@@ -164,7 +160,6 @@ where
         style.size.height = relative(1.0).into();
 
         let axis = self.axis;
-        let view_id = self.view_id;
         let scroll_id = self.id.clone();
         let content = self.element.take().map(|c| c.into_any_element());
 
@@ -190,12 +185,7 @@ where
                         .right_0()
                         .bottom_0()
                         .child(
-                            Scrollbar::both(
-                                view_id,
-                                element_state.state.clone(),
-                                element_state.handle.clone(),
-                            )
-                            .axis(axis),
+                            Scrollbar::both(&element_state.state, &element_state.handle).axis(axis),
                         ),
                 )
                 .into_any_element();

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -185,8 +185,7 @@ impl RenderOnce for SidebarToggleButton {
 }
 
 impl<E: Collapsible + IntoElement> RenderOnce for Sidebar<E> {
-    fn render(mut self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let view_id = window.current_view();
+    fn render(mut self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         v_flex()
             .id("sidebar")
             .w(self.width)
@@ -215,7 +214,7 @@ impl<E: Collapsible + IntoElement> RenderOnce for Sidebar<E> {
                                 .map(|(ix, c)| div().id(ix).child(c.collapsed(self.collapsed))),
                         )
                         .gap_2()
-                        .scrollable(view_id, ScrollbarAxis::Vertical),
+                        .scrollable(ScrollbarAxis::Vertical),
                 ),
             )
             .when_some(self.footer.take(), |this, footer| {

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -5,8 +5,8 @@ use crate::{
     ActiveTheme,
 };
 use gpui::{
-    div, px, App, Axis, DefiniteLength, Div, Edges, Element, ElementId, EntityId, FocusHandle,
-    Pixels, Refineable, StyleRefinement, Styled, Window,
+    div, px, App, Axis, DefiniteLength, Div, Edges, Element, ElementId, FocusHandle, Pixels,
+    Refineable, StyleRefinement, Styled, Window,
 };
 use serde::{Deserialize, Serialize};
 
@@ -144,11 +144,11 @@ pub trait StyledExt: Styled + Sized {
     ///
     /// Current this is only have a vertical scrollbar.
     #[inline]
-    fn scrollable(self, view_id: EntityId, axis: impl Into<ScrollbarAxis>) -> Scrollable<Self>
+    fn scrollable(self, axis: impl Into<ScrollbarAxis>) -> Scrollable<Self>
     where
         Self: Element,
     {
-        Scrollable::new(view_id, self, axis)
+        Scrollable::new(axis, self)
     }
 
     font_weight!(font_thin, THIN);

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -861,14 +861,7 @@ where
                 .on_scroll_wheel(cx.listener(|_, _: &ScrollWheelEvent, _, cx| {
                     cx.notify();
                 }))
-                .child(
-                    Scrollbar::uniform_scroll(
-                        cx.entity().entity_id(),
-                        state,
-                        self.vertical_scroll_handle.clone(),
-                    )
-                    .max_fps(60),
-                ),
+                .child(Scrollbar::uniform_scroll(&state, &self.vertical_scroll_handle).max_fps(60)),
         )
     }
 
@@ -890,9 +883,8 @@ where
                 cx.notify();
             }))
             .child(Scrollbar::horizontal(
-                cx.entity().entity_id(),
-                state,
-                self.horizontal_scroll_handle.clone(),
+                &state,
+                &self.horizontal_scroll_handle,
             ))
     }
 


### PR DESCRIPTION
Continue #984

- Fixes there may Scrollbar size not match the content size. Close #979
- Improved Table scrollbar to only render at scrollable area when there have fixed columns.

<img width="850" alt="image" src="https://github.com/user-attachments/assets/84f54515-e61a-484f-b2b4-ea5abb98ddb8" />


## Break Changes

- The `Scrollbar` has been removed `entity_id` and `scroll_size` argument from new method, it will get that value from `scroll_handle`.
  - There still have a `scroll_size` optional method, if you want to give your own. 
  - Also changed the `scroll_state`, `scroll_handle` to receive a ref.

```diff
- Scrollbar::vertical(entity_id, scroll_state, scroll_handle, scroll_size);
+ Scrollbar::vertical(&scroll_state, &scroll_handle);
+ Scrollbar::vertical(&scroll_state, &scroll_handle).scroll_size(scroll_size);
```