### PR TITLE
chore: Fix button example so that it scrolls in the y direction

### DIFF
--- a/crates/story/examples/button.rs
+++ b/crates/story/examples/button.rs
@@ -19,7 +19,12 @@ impl Example {
 
 impl Render for Example {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().p_4().size_full().child(self.root.clone())
+        div()
+            .p_4()
+            .id("button_example")
+            .overflow_y_scroll()
+            .size_full()
+            .child(self.root.clone())
     }
 }
 


### PR DESCRIPTION

The button example was not scrolling in the y direction and therefore
you were *NOT* able to see the entire ButtonStory.

This minor fix now enables one to see the entire ButtonStory.

The only code that needed to be added was

```rust
            .id("button_example")
            .overflow_y_scroll()
```