### PR TITLE
date_picker: Impl `Styled` for DatePicker and Calendar to support override styles.

### DIFF
--- a/crates/story/src/date_picker_story.rs
+++ b/crates/story/src/date_picker_story.rs
@@ -182,18 +182,14 @@ impl Render for DatePickerStory {
                 ),
             )
             .child(
-                section("Small with 180px width").max_w_md().child(
-                    DatePicker::new(&self.date_picker_small)
-                        .small()
-                        .width(px(180.)),
-                ),
+                section("Small with 180px width")
+                    .max_w_md()
+                    .child(DatePicker::new(&self.date_picker_small).small().w(px(180.))),
             )
             .child(
-                section("Large").max_w_md().child(
-                    DatePicker::new(&self.date_picker_large)
-                        .large()
-                        .width(px(300.)),
-                ),
+                section("Large")
+                    .max_w_md()
+                    .child(DatePicker::new(&self.date_picker_large).large().w(px(300.))),
             )
             .child(
                 section("Custom (First 5 days of each month disabled)")


### PR DESCRIPTION
## Break Changes

- date_picker: Removed `width` method, use `w`, `w_full` instead.

    ```diff
    - .width(px(100.))
    + .w(px(100.))
    ```

- calendar: Removed `bordered` method, use `border` method from GPUI instead.

    ```diff
    - .bordered(false)
    + .border_0()
    ```
