### PR TITLE
sidebar: Add to support ContextMenu for SidebarMenuItem.

### DIFF
--- a/crates/story/src/sidebar_story.rs
+++ b/crates/story/src/sidebar_story.rs
@@ -1,18 +1,29 @@
 use std::collections::HashMap;
 
 use gpui::{
-    actions, div, prelude::FluentBuilder, relative, Action, App, AppContext, ClickEvent, Context, Entity, Focusable, InteractiveElement, IntoElement, ParentElement, Render, SharedString, Styled, Window
+    actions, div, prelude::FluentBuilder, relative, Action, App, AppContext, ClickEvent, Context,
+    Entity, Focusable, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
+    Styled, Window,
 };
 
 use gpui_component::{
-    badge::Badge, blue_500, breadcrumb::{Breadcrumb, BreadcrumbItem}, context_menu::ContextMenuExt, divider::Divider, h_flex, popup_menu::PopupMenuExt, sidebar::{
+    badge::Badge,
+    blue_500,
+    breadcrumb::{Breadcrumb, BreadcrumbItem},
+    context_menu::ContextMenuExt,
+    divider::Divider,
+    h_flex,
+    popup_menu::PopupMenuExt,
+    sidebar::{
         Sidebar, SidebarFooter, SidebarGroup, SidebarHeader, SidebarMenu, SidebarMenuItem,
         SidebarToggleButton,
-    }, switch::Switch, v_flex, white, ActiveTheme, Icon, IconName, Side, Sizable
+    },
+    switch::Switch,
+    v_flex, white, ActiveTheme, Icon, IconName, Side, Sizable,
 };
 use serde::Deserialize;
 
-actions!(story, [HideMenu]);
+actions!(story, [ToggleSidebar]);
 
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
 #[action(namespace = story, no_json)]
@@ -48,7 +59,7 @@ impl SidebarStory {
         }
     }
 
-    fn on_hide_menu_clicking(&mut self, _: &HideMenu, _: &mut Window, cx: &mut Context<Self>) {
+    fn on_toggle_sidebar_click(&mut self, _: &ToggleSidebar, _: &mut Window, cx: &mut Context<Self>) {
         self.collapsed = !self.collapsed;
         cx.notify()
     }
@@ -242,7 +253,7 @@ impl Render for SidebarStory {
         ];
 
         h_flex()
-            .on_action(cx.listener(Self::on_hide_menu_clicking))
+            .on_action(cx.listener(Self::on_toggle_sidebar_click))
             .rounded(cx.theme().radius)
             .border_1()
             .border_color(cx.theme().border)
@@ -315,8 +326,11 @@ impl Render for SidebarStory {
                                     .context_menu({
                                         move |this, _window, _cx| {
                                             this.external_link_icon(false)
-                                                .menu("Toggle Sidebar", Box::new(HideMenu))
-                                                .link("About", "https://github.com/longbridge/gpui-component")
+                                                .menu("Toggle Sidebar", Box::new(ToggleSidebar))
+                                                .link(
+                                                    "About",
+                                                    "https://github.com/longbridge/gpui-component",
+                                                )
                                                 .separator()
                                                 .label("This is a label")
                                                 .separator()

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -64,14 +64,14 @@ pub struct SidebarMenuItem {
     handler: Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>,
     active: bool,
     collapsed: bool,
-    children: Vec<Self>,
-    context_menu: Vec<AnyElement>,
+    items: Vec<Self>,
+    children: Vec<AnyElement>,
     suffix: Option<AnyElement>,
 }
 
 impl ParentElement for SidebarMenuItem {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
-        self.context_menu.extend(elements);
+        self.children.extend(elements);
     }
 }
 
@@ -87,8 +87,8 @@ impl SidebarMenuItem {
             handler: Rc::new(|_, _, _| {}),
             active: false,
             collapsed: false,
+            items: Vec::new(),
             children: Vec::new(),
-            context_menu: Vec::new(),
             suffix: None,
         }
     }
@@ -127,7 +127,7 @@ impl SidebarMenuItem {
     }
 
     pub fn children(mut self, children: impl IntoIterator<Item = impl Into<Self>>) -> Self {
-        self.children = children.into_iter().map(Into::into).collect();
+        self.items = children.into_iter().map(Into::into).collect();
         self
     }
 
@@ -138,7 +138,7 @@ impl SidebarMenuItem {
     }
 
     fn is_submenu(&self) -> bool {
-        self.children.len() > 0
+        self.items.len() > 0
     }
 
     fn is_open(&self) -> bool {
@@ -161,7 +161,7 @@ impl RenderOnce for SidebarMenuItem {
         div()
             .id(self.id.clone())
             .w_full()
-            .children(self.context_menu)
+            .children(self.children)
             .child(
                 h_flex()
                     .size_full()
@@ -229,7 +229,7 @@ impl RenderOnce for SidebarMenuItem {
                         .pl_2p5()
                         .py_0p5()
                         .children(
-                            self.children
+                            self.items
                                 .into_iter()
                                 .enumerate()
                                 .map(|(ix, item)| item.id(ix)),

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,8 +1,10 @@
 use crate::{h_flex, v_flex, ActiveTheme as _, Collapsible, Icon, IconName, StyledExt};
+use crate::context_menu::ContextMenuExt;
 use gpui::{
     div, percentage, prelude::FluentBuilder as _, AnyElement, App, ClickEvent, ElementId,
     InteractiveElement as _, IntoElement, ParentElement as _, RenderOnce, SharedString,
     StatefulInteractiveElement as _, Styled as _, Window,
+    ParentElement
 };
 use std::rc::Rc;
 
@@ -64,8 +66,17 @@ pub struct SidebarMenuItem {
     active: bool,
     collapsed: bool,
     children: Vec<Self>,
+    context_menu: Vec<AnyElement>,
     suffix: Option<AnyElement>,
 }
+
+impl ParentElement for SidebarMenuItem {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.context_menu.extend(elements);
+    }
+}
+
+impl ContextMenuExt for SidebarMenuItem {}
 
 impl SidebarMenuItem {
     /// Create a new SidebarMenuItem with a label
@@ -78,6 +89,7 @@ impl SidebarMenuItem {
             active: false,
             collapsed: false,
             children: Vec::new(),
+            context_menu: Vec::new(),
             suffix: None,
         }
     }
@@ -150,6 +162,7 @@ impl RenderOnce for SidebarMenuItem {
         div()
             .id(self.id.clone())
             .w_full()
+            .children(self.context_menu)
             .child(
                 h_flex()
                     .size_full()

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,10 +1,9 @@
-use crate::{h_flex, v_flex, ActiveTheme as _, Collapsible, Icon, IconName, StyledExt};
 use crate::context_menu::ContextMenuExt;
+use crate::{h_flex, v_flex, ActiveTheme as _, Collapsible, Icon, IconName, StyledExt};
 use gpui::{
     div, percentage, prelude::FluentBuilder as _, AnyElement, App, ClickEvent, ElementId,
-    InteractiveElement as _, IntoElement, ParentElement as _, RenderOnce, SharedString,
-    StatefulInteractiveElement as _, Styled as _, Window,
-    ParentElement
+    InteractiveElement as _, IntoElement, ParentElement, RenderOnce,
+    SharedString, StatefulInteractiveElement as _, Styled as _, Window,
 };
 use std::rc::Rc;
 


### PR DESCRIPTION
Support for a context menu in the SidebarMenuItem component. My use case is that I want to show a context menu instead of only allowing to clicking on the menu item.

Please advise if this is a proper approach.

![image](https://github.com/user-attachments/assets/0178534d-8531-4e7d-9f7d-b963a0eb759b)
