### PR TITLE
highlighter: Fix some case update will get incorrect syntax highlight.

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -272,15 +272,19 @@ impl SyntaxHighlighter {
 
         // Incremental parsing to only update changed ranges.
         if let Some(changed_ranges) = changed_ranges {
-            let mut total_range = 0..0;
+            let mut total_range = (None, None);
             for change_range in changed_ranges {
-                if total_range.start == 0 {
-                    total_range.start = change_range.start_byte;
+                // dbg!(change_range);
+                if total_range.0.is_none() {
+                    total_range.0 = Some(change_range.start_byte);
                 }
-                if total_range.end == 0 {
-                    total_range.end = change_range.end_byte;
+                if total_range.1.is_none() {
+                    total_range.1 = Some(change_range.end_byte);
                 }
             }
+            let total_range = total_range.0.unwrap_or(0)..total_range.1.unwrap_or(0);
+
+            // println!("------- total_range: {:?}", total_range);
 
             if total_range.len() == 0 {
                 return;


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/911a4750-be80-4d1d-819b-65eb43f0f97c

## After

https://github.com/user-attachments/assets/9e8c964d-a50e-4bf1-aede-5d712ca4fcf6

