### PR TITLE
fix the #851 issue:In Scrollable example, the view on the bottom has …

### DIFF
--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -323,7 +323,7 @@ impl Render for ScrollableStory {
                             .bottom_0()
                             .child(
                                 Scrollbar::both(&self.scroll_state_list, &self.scroll_handle_list)
-                                    .axis(ScrollbarAxis::Vertical),
+                                    .axis(self.axis),
                             )
                     })
             })

--- a/crates/story/src/scrollable_story.rs
+++ b/crates/story/src/scrollable_story.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use gpui::{
-    div, px, size, App, AppContext, Axis, Context, Entity, Focusable, InteractiveElement,
+    div, px, size, App, AppContext, StatefulInteractiveElement, Context, Entity, Focusable, InteractiveElement,
     IntoElement, ParentElement, Pixels, Render, ScrollHandle, SharedString, Size, Styled, Window,
 };
 use gpui_component::{
@@ -19,6 +19,10 @@ pub struct ScrollableStory {
     scroll_handle: ScrollHandle,
     scroll_size: gpui::Size<Pixels>,
     scroll_state: ScrollbarState,
+    // handle the scrollable in the bottom list part, vertical scrollable only
+    scroll_handle_list: ScrollHandle,
+    scroll_state_list: ScrollbarState,
+
     items: Vec<String>,
     item_sizes: Rc<Vec<Size<Pixels>>>,
     test_width: Pixels,
@@ -43,6 +47,8 @@ impl ScrollableStory {
             scroll_handle: ScrollHandle::new(),
             scroll_state: ScrollbarState::default(),
             scroll_size: gpui::Size::default(),
+            scroll_handle_list: ScrollHandle::new(),
+            scroll_state_list: ScrollbarState::default(),
             items,
             item_sizes: Rc::new(item_sizes),
             test_width,
@@ -285,14 +291,17 @@ impl Render for ScrollableStory {
                     .border_1()
                     .border_color(cx.theme().border)
                     .w_full()
-                    .max_h(px(400.))
+                    // .max_h(px(400.)) // move the max_h to the next level
                     .min_h(px(200.))
                     .child(
                         v_flex()
                             .p_3()
                             .w(self.test_width)
                             .id("test-1")
-                            .scrollable(Axis::Vertical)
+                            // .scrollable(Axis::Vertical)
+                            .max_h(px(400.))
+                            .overflow_y_scroll()
+                            .track_scroll(&self.scroll_handle_list)
                             .gap_1()
                             .child("Scrollable Example")
                             .children(self.items.iter().take(500).map(|item| {
@@ -305,6 +314,18 @@ impl Render for ScrollableStory {
                                     .child(item.to_string())
                             })),
                     )
+                    .child({
+                        div()
+                            .absolute()
+                            .top_0()
+                            .left_0()
+                            .right_0()
+                            .bottom_0()
+                            .child(
+                                Scrollbar::both(&self.scroll_state_list, &self.scroll_handle_list)
+                                    .axis(ScrollbarAxis::Vertical),
+                            )
+                    })
             })
     }
 }


### PR DESCRIPTION
…no scrollbar (.scrollable()) #851

```
    scroll_state: ScrollbarState,
    scroll_handle_list: ScrollHandle,
```

I have added a state to handle the scroll bar status for the list view. This code is entirely generated by `Claude Code`, and I have thoroughly validated it.

If I reuse the original `scroll_state`, the horizontal scroll on the first part will be impacted.