### PR TITLE
input: Update input behaviors to do not unselect on blur or press escape.

### DIFF
--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -29,6 +29,7 @@ pub struct InputStory {
     phone_input: Entity<InputState>,
     mask_input2: Entity<InputState>,
     currency_input: Entity<InputState>,
+    custom_input: Entity<InputState>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -90,6 +91,8 @@ impl InputStory {
                 fraction: Some(3),
             })
         });
+        let custom_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("here is a custom input"));
 
         let _subscriptions = vec![
             cx.subscribe_in(&input1, window, Self::on_input_event),
@@ -116,6 +119,7 @@ impl InputStory {
             phone_input,
             mask_input2,
             currency_input,
+            custom_input,
             _subscriptions,
         }
     }
@@ -277,7 +281,7 @@ impl Render for InputStory {
                         .bg(cx.theme().secondary)
                         .text_color(cx.theme().secondary_foreground)
                         .w_full()
-                        .child(TextInput::new(&self.input1).appearance(false)),
+                        .child(TextInput::new(&self.custom_input).appearance(false)),
                 ),
             )
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1494,9 +1494,6 @@ impl InputState {
         if self.marked_range.is_some() {
             self.unmark_text(window, cx);
         }
-        if self.selected_range.len() > 0 {
-            return self.unselect(window, cx);
-        }
 
         if self.clean_on_escape {
             return self.clean(window, cx);
@@ -1904,8 +1901,9 @@ impl InputState {
         cx.notify()
     }
 
-    fn unselect(&mut self, _: &mut Window, cx: &mut Context<Self>) {
-        let offset = self.next_boundary(self.cursor().offset);
+    /// Unselects the currently selected text.
+    pub fn unselect(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        let offset = self.cursor().offset;
         self.selected_range = (offset..offset).into();
         cx.notify()
     }
@@ -1976,7 +1974,6 @@ impl InputState {
     }
 
     fn on_blur(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.unselect(window, cx);
         self.blink_cursor.update(cx, |cursor, cx| {
             cursor.stop(cx);
         });


### PR DESCRIPTION
- Also to pub `unselect` for manually use, and fix this method will incorrect to move right 1 char.
