### PR TITLE
code-editor: Add `go_to_line` method to CodeEditor.

### DIFF
--- a/crates/story/examples/code-editor.rs
+++ b/crates/story/examples/code-editor.rs
@@ -212,7 +212,7 @@ impl Example {
                         let column = parts.next().and_then(|c| c);
 
                         editor.update(cx, |state, cx| {
-                            state.go_to_line(line, column.unwrap_or(1), window, cx);
+                            state.go_to_line(line, column, window, cx);
                         });
 
                         true

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -804,9 +804,31 @@ impl InputState {
         self.mask_pattern.unmask(&self.text).into()
     }
 
-    /// Return the line and column (1-based) of the cursor.
+    /// Return the (1-based) line and column of the cursor.
     pub fn line_column(&self) -> LineColumn {
         self.text_wrapper.line_column(self.cursor().offset)
+    }
+
+    /// Set (1-based) line and column of the cursor.
+    ///
+    /// This will move the cursor to the specified line and column, and update the selection range.
+    ///
+    /// - The `column` is optional, if it is `None`, it will return the start of the line.
+    /// - If the `line` is 0, it will return 0.
+    /// - If the `line` is greater than the number of lines, it will return
+    ///   the length of the text.
+    ///
+    /// Ignore, if the line, column is invalid.
+    pub fn go_to_line(
+        &mut self,
+        line: usize,
+        column: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(offset) = self.text_wrapper.offset_for_line_column(line, column) {
+            self.move_to(Cursor::new(offset), window, cx);
+        }
     }
 
     /// Focus the input field.

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -822,11 +822,14 @@ impl InputState {
     pub fn go_to_line(
         &mut self,
         line: usize,
-        column: usize,
+        column: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(offset) = self.text_wrapper.offset_for_line_column(line, column) {
+        if let Some(offset) = self
+            .text_wrapper
+            .offset_for_line_column(line, column.unwrap_or(1))
+        {
             self.move_to(Cursor::new(offset), window, cx);
         }
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1344,6 +1344,9 @@ impl InputState {
             // Add newline and indent
             let new_line_text = format!("\n{}", indent);
             self.replace_text_in_range(None, &new_line_text, window, cx);
+        } else {
+            // Single line input, just emit the event (e.g.: In a modal dialog to confirm).
+            cx.propagate();
         }
 
         cx.emit(InputEvent::PressEnter {

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -115,4 +115,32 @@ impl TextWrapper {
 
         (line + 1, column + 1).into()
     }
+
+    /// Returns the offset of the given line and column (1-based).
+    ///
+    /// - If the `line` is 0, it will return 0.
+    /// - If the `line` is greater than the number of lines, it will return
+    ///   the length of the text.
+    pub(super) fn offset_for_line_column(&self, line: usize, column: usize) -> Option<usize> {
+        if line == 0 || self.lines.is_empty() {
+            return None;
+        }
+
+        let line = line.saturating_sub(1);
+        if line >= self.lines.len() {
+            return Some(self.text.len());
+        }
+
+        let Some(line_wrap) = &self.lines.get(line) else {
+            return None;
+        };
+
+        let offset = line_wrap.range.start;
+        if column == 0 {
+            return Some(offset);
+        }
+        let offset = offset + column.saturating_sub(1).min(line_wrap.range.len());
+
+        Some(offset)
+    }
 }


### PR DESCRIPTION
- Fix to emit `enter` press key in Input single-line mode.