### PR TITLE
scrollbar: Fix content size

### DIFF
--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -87,8 +87,7 @@ impl ScrollHandleOffsetable for UniformListScrollHandle {
     }
 
     fn content_size(&self) -> Size<Pixels> {
-        let state = self.0.borrow();
-        let base_handle = &state.base_handle;
+        let base_handle = &self.0.borrow().base_handle;
         base_handle.max_offset() + base_handle.bounds().size
     }
 }


### PR DESCRIPTION
Caused by PR #1078 incorrect changes, and GPUI was changed API https://github.com/zed-industries/zed/pull/34832

The content size of the scrollable area should be its max scroll offset plus the container size.

