### PR TITLE
list: Add support for scrolling to item with the given strategy

### DIFF
--- a/crates/story/src/list_story.rs
+++ b/crates/story/src/list_story.rs
@@ -4,7 +4,7 @@ use fake::Fake;
 use gpui::{
     actions, div, prelude::FluentBuilder as _, px, App, AppContext, Context, Edges, ElementId,
     Entity, FocusHandle, Focusable, InteractiveElement, IntoElement, ParentElement, Render,
-    RenderOnce, SharedString, Styled, Subscription, Task, Timer, Window,
+    RenderOnce, ScrollStrategy, SharedString, Styled, Subscription, Task, Timer, Window,
 };
 
 use gpui_component::{
@@ -392,7 +392,24 @@ impl Render for ListStory {
                             .small()
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.company_list.update(cx, |list, cx| {
-                                    list.scroll_to_item(0, window, cx);
+                                    list.scroll_to_item(0, ScrollStrategy::Top, window, cx);
+                                    cx.notify();
+                                })
+                            })),
+                    )
+                    .child(
+                        Button::new("scroll-center")
+                            .outline()
+                            .child("Scroll to Center")
+                            .small()
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.company_list.update(cx, |list, cx| {
+                                    list.scroll_to_item(
+                                        list.delegate().items_count(cx) / 2,
+                                        ScrollStrategy::Center,
+                                        window,
+                                        cx,
+                                    );
                                 })
                             })),
                     )
@@ -405,6 +422,7 @@ impl Render for ListStory {
                                 this.company_list.update(cx, |list, cx| {
                                     list.scroll_to_item(
                                         list.delegate().items_count(cx) - 1,
+                                        ScrollStrategy::Top,
                                         window,
                                         cx,
                                     );
@@ -419,7 +437,12 @@ impl Render for ListStory {
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.company_list.update(cx, |list, cx| {
                                     if let Some(selected) = list.selected_index() {
-                                        list.scroll_to_item(selected, window, cx);
+                                        list.scroll_to_item(
+                                            selected,
+                                            ScrollStrategy::Top,
+                                            window,
+                                            cx,
+                                        );
                                     }
                                 })
                             })),

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -308,9 +308,14 @@ where
     }
 
     /// Scroll to the item at the given index.
-    pub fn scroll_to_item(&mut self, ix: usize, _: &mut Window, cx: &mut Context<Self>) {
-        self.vertical_scroll_handle
-            .scroll_to_item(ix, ScrollStrategy::Top);
+    pub fn scroll_to_item(
+        &mut self,
+        ix: usize,
+        strategy: ScrollStrategy,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.vertical_scroll_handle.scroll_to_item(ix, strategy);
         cx.notify();
     }
 


### PR DESCRIPTION
## Breaking Change
- Add `strategy` to the `scroll_to_item` method.

```diff
+ list.scroll_to_item(selected, ScrollStrategy::Center, window, cx);
- list.scroll_to_item(selected, window, cx);
```