### PR TITLE
dock: Adjust tab panel menu button position to align with content.

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -606,7 +606,8 @@ impl TabPanel {
                 .line_height(rems(1.0))
                 .h(px(30.))
                 .py_2()
-                .px_3()
+                .pl_3()
+                .pr_2()
                 .when(left_dock_button.is_some(), |this| this.pl_2())
                 .when(right_dock_button.is_some(), |this| this.pr_2())
                 .when_some(title_style, |this, theme| {


### PR DESCRIPTION
## Before

<img width="1316" height="981" alt="image" src="https://github.com/user-attachments/assets/ad2a96a0-5e82-4caa-85da-76f24d4deef1" />

## After

<img width="1306" height="796" alt="image" src="https://github.com/user-attachments/assets/abc2d5d5-d9de-4cf0-9c39-eb965ffb9c46" />
