### PR TITLE
tabs: Remove underline variant TabBar paddings.

### DIFF
--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -204,12 +204,7 @@ impl RenderOnce for TabBar {
                     _ => px(12.),
                 };
 
-                let padding = Edges {
-                    left: gap,
-                    right: gap,
-                    ..Default::default()
-                };
-                (cx.theme().transparent, padding, gap)
+                (cx.theme().transparent, Edges::all(px(0.)), gap)
             }
         };
 


### PR DESCRIPTION
<img width="833" height="125" alt="image" src="https://github.com/user-attachments/assets/72028761-6e5a-4cbe-aff3-780f3dc4e948" />
