### PR TITLE
chore: Use `html5minify` instead of minify-html.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "time",
+ "time 0.3.41",
  "version_check",
 ]
 
@@ -3150,12 +3150,13 @@ dependencies = [
  "gpui",
  "gpui-component-macros",
  "html5ever 0.27.0",
+ "html5minify",
  "image",
  "indexset",
  "indoc",
  "itertools 0.13.0",
  "markdown",
- "markup5ever_rcdom",
+ "markup5ever_rcdom 0.3.0",
  "num-traits",
  "once_cell",
  "paste",
@@ -3167,7 +3168,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "simple-minify-html",
  "smallvec",
  "smol 1.3.0",
  "tracing",
@@ -3439,6 +3439,20 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.10.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
@@ -3463,6 +3477,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.105",
+]
+
+[[package]]
+name = "html5minify"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0717993787d29fc1177a9a5233f7979517fdaa8eb498fb45ae36ffe6c65a17"
+dependencies = [
+ "html5ever 0.25.2",
+ "markup5ever_rcdom 0.1.0",
 ]
 
 [[package]]
@@ -4360,6 +4384,20 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
@@ -4388,6 +4426,18 @@ dependencies = [
 
 [[package]]
 name = "markup5ever_rcdom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b"
+dependencies = [
+ "html5ever 0.25.2",
+ "markup5ever 0.10.1",
+ "tendril",
+ "xml5ever 0.16.2",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
@@ -4395,7 +4445,7 @@ dependencies = [
  "html5ever 0.27.0",
  "markup5ever 0.12.1",
  "tendril",
- "xml5ever",
+ "xml5ever 0.18.1",
 ]
 
 [[package]]
@@ -5651,7 +5701,7 @@ dependencies = [
  "indexmap 2.10.0",
  "quick-xml 0.38.1",
  "serde",
- "time",
+ "time 0.3.41",
 ]
 
 [[package]]
@@ -7250,20 +7300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "simple-minify-html"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2e14af458c754ee7a0fc21fbb93b824101e2c13a6bd5dc94a32c156a773e36"
-dependencies = [
- "aho-corasick",
- "itertools 0.14.0",
- "memchr",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7996,6 +8032,17 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -9099,6 +9146,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -10413,6 +10466,18 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml5ever"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.10.1",
+ "time 0.1.45",
+]
 
 [[package]]
 name = "xml5ever"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -87,7 +87,8 @@ markdown = "1.0.0"
 # HTML Parser
 html5ever = "0.27"
 markup5ever_rcdom = "0.3.0"
-simple-minify-html = "0.17.2"
+# For minifying HTML
+html5minify = "0.3"
 
 # Calendar
 chrono = "0.4.38"

--- a/crates/ui/src/text/html.rs
+++ b/crates/ui/src/text/html.rs
@@ -91,7 +91,9 @@ fn cleanup_html(source: &str) -> Vec<u8> {
 
     let mut w = std::io::Cursor::new(vec![]);
     let mut r = std::io::Cursor::new(source.clone());
-    if let Ok(()) = html5minify::minify(&mut r, &mut w) {
+    let mut minify = html5minify::Minifier::new(&mut w);
+    minify.omit_doctype(true);
+    if let Ok(()) = minify.minify(&mut r) {
         w.into_inner()
     } else {
         source
@@ -791,7 +793,7 @@ mod tests {
         let cleaned = super::cleanup_html(html);
         assert_eq!(
             String::from_utf8(cleaned).unwrap(),
-            "<p>and <code>code</code> text</p>"
+            "<p>and <code>code</code> text"
         );
 
         let html = r#"<p>
@@ -802,7 +804,7 @@ mod tests {
         let cleaned = super::cleanup_html(html);
         assert_eq!(
             String::from_utf8(cleaned).unwrap(),
-            "<p>and <em> <code>code</code> <i>italic</i> </em> text</p>"
+            "<p>and <em><code>code</code> <i>italic</i></em> text"
         );
     }
 
@@ -838,7 +840,7 @@ mod tests {
         assert_eq!(
             node.to_markdown(),
             indoc::indoc! {r#"
-            and * code italic * text
+            and *code italic* text
 
             ![Example](https://example.com/image.png "Example Image")
 


### PR DESCRIPTION
Ref #1132 

This change to reduce release mode binary size from 21MB to 12MB.

## HTML Render example

<img width="1712" height="1312" alt="image" src="https://github.com/user-attachments/assets/f07c02c9-1b0e-4aa4-b81a-d2b0ac4f7260" />
