### PR TITLE
dropdown: Fix dropdown menu width align to input width.

### DIFF
--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -968,7 +968,7 @@ where
                             div()
                                 .occlude()
                                 .map(|this| match self.menu_width {
-                                    Length::Auto => this.w(bounds.size.width),
+                                    Length::Auto => this.w(bounds.size.width + px(2.)),
                                     Length::Definite(w) => this.w(w),
                                 })
                                 .child(


### PR DESCRIPTION
This caused by the `bounds` of `canvas` prepaint callback now is not including the border widths.

## Before

<img width="1070" height="967" alt="image" src="https://github.com/user-attachments/assets/9ad963bb-c2b0-4b21-bbd6-8e961f779d2f" />

## After

<img width="1229" height="1097" alt="image" src="https://github.com/user-attachments/assets/568f71be-932f-4126-b37a-b92aea3bf88a" />
