### PR TITLE
Revert "modal: Avoid background color with alpha."

### DIFF
--- a/crates/story/src/modal_story.rs
+++ b/crates/story/src/modal_story.rs
@@ -394,8 +394,8 @@ impl Render for ModalStory {
                                     window.open_modal(cx, move |modal, _, cx| {
                                         modal
                                             .rounded_lg()
-                                            .bg(cx.theme().green.alpha(0.2))
-                                            .text_color(cx.theme().foreground)
+                                            .bg(cx.theme().cyan)
+                                            .text_color(cx.theme().info_foreground)
                                             .title("Custom Modal Title")
                                             .child("This is a custom modal content.")
                                     });

--- a/crates/ui/src/modal.rs
+++ b/crates/ui/src/modal.rs
@@ -374,17 +374,6 @@ impl RenderOnce for Modal {
         let animation = Animation::new(Duration::from_secs_f64(0.25))
             .with_easing(cubic_bezier(0.32, 0.72, 0., 1.));
 
-        let content_bg = div()
-            .size_full()
-            .absolute()
-            .top_0()
-            .left_0()
-            .right_0()
-            .bottom_0()
-            .refine_style(&self.style);
-        let mut style = self.style;
-        style.background = None;
-
         anchored()
             .position(point(window_paddings.left, window_paddings.top))
             .snap_to_window()
@@ -423,7 +412,7 @@ impl RenderOnce for Modal {
                             .pt(paddings.top)
                             .pb(paddings.bottom)
                             .gap(paddings.top.min(px(16.)))
-                            .refine_style(&style)
+                            .refine_style(&self.style)
                             .px_0()
                             .key_context(CONTEXT)
                             .track_focus(&self.focus_handle)
@@ -465,7 +454,6 @@ impl RenderOnce for Modal {
                             .top(y)
                             .w(self.width)
                             .when_some(self.max_width, |this, w| this.max_w(w))
-                            .child(content_bg)
                             .when_some(self.title, |this, title| {
                                 this.child(
                                     div()


### PR DESCRIPTION
Reverts longbridge/gpui-component#1154

By #1162 changes, this is not needed anymore.