### PR TITLE
markdown: Fix that style attribute values are extracted correctly from img element

### DIFF
--- a/crates/ui/src/text/html.rs
+++ b/crates/ui/src/text/html.rs
@@ -242,14 +242,12 @@ fn style_attrs(attrs: &RefCell<Vec<html5ever::Attribute>>) -> HashMap<String, St
     };
 
     for decl in css_text.split(';') {
-        for rule in decl.split(':') {
-            let mut parts = rule.splitn(2, ':');
-            if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
-                styles.insert(
-                    key.trim().to_lowercase().to_string(),
-                    value.trim().to_string(),
-                );
-            }
+        let mut parts = decl.splitn(2, ':');
+        if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+            styles.insert(
+                key.trim().to_lowercase().to_string(),
+                value.trim().to_string(),
+            );
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue with parsing the styles attribute values. The main issue it fixes is that we tried splitting on `:` twice which we should only do once.

Before this change see the following variable values: 
decl="width: 10px" 
rule=["width", "10px"] (each iteration one value)

And for each rule value we tried splitting again on `:` which is wrong we should only do this once.