### PR TITLE
root: Update Linux window radius to use theme `radius_lg`.

### DIFF
--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -81,7 +81,7 @@ pub use styled::*;
 pub use time::*;
 pub use title_bar::*;
 pub use virtual_list::{h_virtual_list, v_virtual_list, VirtualList, VirtualListScrollHandle};
-pub use window_border::{window_border, window_paddings, WindowBorder};
+pub use window_border::window_paddings;
 
 pub use icon::*;
 pub use kbd::*;

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -3,7 +3,8 @@ use crate::{
     input::InputState,
     modal::Modal,
     notification::{Notification, NotificationList},
-    window_border, ActiveTheme, Placement,
+    window_border::WindowBorder,
+    ActiveTheme, Placement,
 };
 use gpui::{
     canvas, div, prelude::FluentBuilder as _, AnyView, App, AppContext, Context, DefiniteLength,
@@ -376,7 +377,7 @@ impl Render for Root {
         let base_font_size = cx.theme().font_size;
         window.set_rem_size(base_font_size);
 
-        window_border().child(
+        WindowBorder::new().child(
             div()
                 .id("root")
                 .relative()

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -13,16 +13,10 @@ const SHADOW_SIZE: Pixels = Pixels(0.0);
 #[cfg(target_os = "linux")]
 const SHADOW_SIZE: Pixels = Pixels(12.0);
 const BORDER_SIZE: Pixels = Pixels(1.0);
-pub(crate) const BORDER_RADIUS: Pixels = Pixels(0.0);
-
-/// Create a new window border.
-pub fn window_border() -> WindowBorder {
-    WindowBorder::new()
-}
 
 /// Window border use to render a custom window border and shadow for Linux.
 #[derive(IntoElement, Default)]
-pub struct WindowBorder {
+pub(crate) struct WindowBorder {
     children: Vec<AnyElement>,
 }
 
@@ -115,10 +109,10 @@ impl RenderOnce for WindowBorder {
                         .absolute(),
                     )
                     .when(!(tiling.top || tiling.right), |div| {
-                        div.rounded_tr(BORDER_RADIUS)
+                        div.rounded_tr(cx.theme().radius_lg)
                     })
                     .when(!(tiling.top || tiling.left), |div| {
-                        div.rounded_tl(BORDER_RADIUS)
+                        div.rounded_tl(cx.theme().radius_lg)
                     })
                     .when(!tiling.top, |div| div.pt(SHADOW_SIZE))
                     .when(!tiling.bottom, |div| div.pb(SHADOW_SIZE))
@@ -142,10 +136,10 @@ impl RenderOnce for WindowBorder {
                         Decorations::Client { tiling } => div
                             // .border_color(cx.theme().window_border)
                             .when(!(tiling.top || tiling.right), |div| {
-                                div.rounded_tr(BORDER_RADIUS)
+                                div.rounded_tr(cx.theme().radius_lg)
                             })
                             .when(!(tiling.top || tiling.left), |div| {
-                                div.rounded_tl(BORDER_RADIUS)
+                                div.rounded_tl(cx.theme().radius_lg)
                             })
                             .border_color(cx.theme().window_border)
                             .when(!tiling.top, |div| div.border_t(BORDER_SIZE))


### PR DESCRIPTION
Close #1170

## Break Change

- Removed pub method `window_border`, `WindowBorder`, them should be internal feature.

<img width="1060" height="795" alt="image" src="https://github.com/user-attachments/assets/7fd7886a-9245-4583-9411-74ad27acdb75" />

Depends on https://github.com/zed-industries/zed/pull/35083