### PR TITLE
inspector: Add live editor to inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "enum-iterator",
  "gpui",
  "gpui-component-macros",
+ "gpui_macros",
  "html5ever 0.27.0",
  "indoc",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "2"
 
 [workspace.dependencies]
 gpui = { git = "https://github.com/zed-industries/zed.git" }
+gpui_macros = { git = "https://github.com/zed-industries/zed.git" }
 reqwest_client = { git = "https://github.com/zed-industries/zed.git" }
 sum_tree = { git = "https://github.com/zed-industries/zed.git" }
 gpui-component = { path = "crates/ui" }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [features]
 decimal = ["dep:rust_decimal"]
-inspector = []
+inspector = ["gpui/inspector"]
 webview = ["dep:wry"]
 # For syntax highlighting in Markdown and CodeEditor.
 tree-sitter-languages = [

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -50,6 +50,7 @@ tree-sitter-languages = [
 [dependencies]
 gpui.workspace = true
 sum_tree.workspace = true
+gpui_macros.workspace = true
 gpui-component-macros.workspace = true
 rust-i18n.workspace = true
 schemars.workspace = true

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -56,7 +56,10 @@ macro_rules! font_weight {
 }
 
 /// Extends [`gpui::Styled`] with specific styling methods.
-#[cfg_attr(debug_assertions, gpui_macros::derive_inspector_reflection)]
+#[cfg_attr(
+    any(feature = "inspector", debug_assertions),
+    gpui_macros::derive_inspector_reflection
+)]
 pub trait StyledExt: Styled + Sized {
     /// Refine the style of this element, applying the given style refinement.
     fn refine_style(mut self, style: &StyleRefinement) -> Self {

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -56,6 +56,7 @@ macro_rules! font_weight {
 }
 
 /// Extends [`gpui::Styled`] with specific styling methods.
+#[cfg_attr(debug_assertions, gpui_macros::derive_inspector_reflection)]
 pub trait StyledExt: Styled + Sized {
     /// Refine the style of this element, applying the given style refinement.
     fn refine_style(mut self, style: &StyleRefinement) -> Self {


### PR DESCRIPTION
Inspired by Zed, this PR implements a simple live Rust and JSON style editor for the inspector.

The rust style editor only supports `Styled` and `StyledExt` method calls with no arguments.



https://github.com/user-attachments/assets/df7f1746-92d7-416c-afd5-e389ac3ea9ae

