### PR TITLE
plot: Apply linear scale based on the direction of given range

### DIFF
--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -107,7 +107,7 @@ where
             .flat_map(|v| self.y.iter().map(|y_fn| y_fn(v)))
             .chain(Some(Y::zero()))
             .collect::<Vec<_>>();
-        let y = ScaleLinear::new(domain, vec![10., height]);
+        let y = ScaleLinear::new(domain, vec![height, 10.]);
 
         // Draw X axis
         let data_len = self.data.len();

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -106,7 +106,7 @@ where
                 .map(|v| y_fn(v))
                 .chain(Some(Y::zero()))
                 .collect(),
-            vec![10., height],
+            vec![height, 10.],
         );
 
         // Draw X axis

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -98,7 +98,7 @@ where
                 .map(|v| y_fn(v))
                 .chain(Some(Y::zero()))
                 .collect(),
-            vec![10., height],
+            vec![height, 10.],
         );
 
         // Draw X axis


### PR DESCRIPTION
## Breaking Change
- Apply linear scale based on the direction of given range.

```diff
- ScaleLinear::new(vec![1., 2., 3.], vec![0., 100.])
+ ScaleLinear::new(vec![1., 2., 3.], vec![100., 0.])
```

Currently, you can draw the linear scale from minimum to maximum or from maximum to minimum; it depends on the direction of the range.