### PR TITLE
input: Improve Input performance by only shape visible lines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .DS_Store
 /docks.json
+/profile.json
 .vscode
 index.scip
 *.log

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -361,7 +361,7 @@ impl TextElement {
         input_height: Pixels,
     ) -> (Range<usize>, Pixels) {
         // Add extra rows to avoid showing empty space when scroll to bottom.
-        let extra_rows = 2;
+        let extra_rows = 1;
         let mut visible_top = px(0.);
         if state.mode.is_single_line() {
             return (0..1, visible_top);

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -359,11 +359,11 @@ impl TextElement {
         let mut visible_range = 0..total_lines;
         let mut line_bottom = px(0.);
         for (ix, line) in state.text_wrapper.lines.iter().enumerate() {
-            let wraped_height = (line.wrap_lines + 1) * line_height;
-            line_bottom += wraped_height;
+            let wrapped_height = (line.wrap_lines + 1) * line_height;
+            line_bottom += wrapped_height;
 
             if line_bottom < -scroll_top {
-                visible_top = line_bottom - wraped_height;
+                visible_top = line_bottom - wrapped_height;
                 visible_range.start = ix;
             }
 

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -59,6 +59,7 @@ impl TextElement {
     /// - cursor bounds
     /// - scroll offset
     /// - current line index
+    #[allow(clippy::too_many_arguments)]
     fn layout_cursor(
         &self,
         visible_range: &Range<usize>,
@@ -198,6 +199,7 @@ impl TextElement {
         (cursor_bounds, scroll_offset, current_line_index)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_selections(
         &self,
         visible_range: &Range<usize>,

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -871,7 +871,7 @@ impl Element for TextElement {
         let line_height = window.line_height();
         let origin = bounds.origin;
 
-        let invisible_top_padding = visible_range.start * line_height;
+        let invisible_top_padding = prepaint.last_layout.visible_top;
 
         let mut mask_offset_y = px(0.);
         if self.state.read(cx).masked {

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -6,6 +6,8 @@ use gpui::{
     Path, Pixels, Point, SharedString, Size, Style, TextAlign, TextRun, UnderlineStyle, Window,
     WrappedLine,
 };
+use itertools::Itertools;
+use rope::Rope;
 use smallvec::SmallVec;
 
 use crate::{
@@ -60,6 +62,8 @@ impl TextElement {
     /// - current line index
     fn layout_cursor(
         &self,
+        visible_range: &Range<usize>,
+        offset_y: Pixels,
         lines: &[WrappedLine],
         line_height: Pixels,
         bounds: &mut Bounds<Pixels>,
@@ -89,9 +93,11 @@ impl TextElement {
         let mut cursor_start = None;
         let mut cursor_end = None;
 
-        let mut prev_lines_offset = 0;
-        let mut offset_y = px(0.);
+        let mut prev_lines_offset = state.text.line_start_offset(visible_range.start);
+        let mut offset_y = offset_y;
         for (line_ix, line) in lines.iter().enumerate() {
+            let line_ix = visible_range.start + line_ix;
+
             // break loop if all cursor positions are found
             if cursor_pos.is_some() && cursor_start.is_some() && cursor_end.is_some() {
                 break;
@@ -195,6 +201,8 @@ impl TextElement {
 
     fn layout_selections(
         &self,
+        visible_range: &Range<usize>,
+        offset_y: Pixels,
         lines: &[WrappedLine],
         line_height: Pixels,
         bounds: &mut Bounds<Pixels>,
@@ -219,10 +227,10 @@ impl TextElement {
             (selected_range.end, selected_range.start)
         };
 
-        let mut prev_lines_offset = 0;
+        let mut prev_lines_offset = state.text.line_start_offset(visible_range.start);
+        let mut offset_y = offset_y;
         let mut line_corners = vec![];
 
-        let mut offset_y = px(0.);
         for line in lines.iter() {
             let line_size = line.size(line_height);
             let line_wrap_width = line_size.width;
@@ -331,29 +339,30 @@ impl TextElement {
     /// Calculate the visible range of lines in the viewport.
     ///
     /// The visible range is based on unwrapped lines (Zero based).
+    ///
+    /// Returns (visible_range, offset_y)
     fn calculate_visible_range(
         &self,
         state: &InputState,
         line_height: Pixels,
         input_height: Pixels,
-    ) -> Range<usize> {
+    ) -> (Range<usize>, Pixels) {
+        let mut offset_y = px(0.);
         if state.mode.is_single_line() {
-            return 0..1;
+            return (0..1, offset_y);
         }
 
-        let Some(last_layout) = state.last_layout.as_ref() else {
-            return 0..1;
-        };
-
+        let total_lines = state.text_wrapper.len();
         let scroll_top = state.scroll_handle.offset().y;
-        let total_lines = last_layout.lines.len();
 
         let mut visible_range = 0..total_lines;
         let mut line_bottom = px(0.);
-        for (ix, line) in last_layout.lines.iter().enumerate() {
-            line_bottom += (line.wrap_boundaries.len() + 1) * line_height;
+        for (ix, line) in state.text_wrapper.lines.iter().enumerate() {
+            let wraped_height = (line.wrap_lines + 1) * line_height;
+            line_bottom += wraped_height;
 
             if line_bottom < -scroll_top {
+                offset_y = line_bottom - wraped_height;
                 visible_range.start = ix;
             }
 
@@ -363,15 +372,16 @@ impl TextElement {
             }
         }
 
-        visible_range
+        (visible_range, offset_y)
     }
 
     /// First usize is the offset of skipped.
     fn highlight_lines(
         &mut self,
         visible_range: &Range<usize>,
+        _offset_y: Pixels,
         cx: &mut App,
-    ) -> Option<(usize, Vec<(Range<usize>, HighlightStyle)>)> {
+    ) -> Option<Vec<(Range<usize>, HighlightStyle)>> {
         let theme = cx.theme().highlight_theme.clone();
         self.state.update(cx, |state, cx| match &state.mode {
             InputMode::CodeEditor {
@@ -389,22 +399,17 @@ impl TextElement {
                     return None;
                 };
 
-                let mut offset = 0;
-                let mut skipped_offset = 0;
+                let mut offset = state.text.line_start_offset(visible_range.start);
                 let mut styles = vec![];
 
-                for (ix, line) in state.text.lines().enumerate() {
+                for line in state
+                    .text
+                    .lines()
+                    .skip(visible_range.start)
+                    .take(visible_range.len())
+                {
                     // +1 for `\n`
                     let line_len = line.len() + 1;
-                    if ix < visible_range.start {
-                        offset += line_len;
-                        skipped_offset = offset;
-                        continue;
-                    }
-                    if ix > visible_range.end {
-                        break;
-                    }
-
                     let range = offset..offset + line_len;
                     let line_styles = highlighter.styles(&range, &theme);
                     styles = gpui::combine_highlights(styles, line_styles).collect();
@@ -415,7 +420,7 @@ impl TextElement {
                 let mut marker_styles = vec![];
                 for marker in markers.iter() {
                     if let Some(range) = &marker.range {
-                        if range.start < skipped_offset {
+                        if range.start < offset {
                             continue;
                         }
 
@@ -431,7 +436,7 @@ impl TextElement {
 
                 styles = gpui::combine_highlights(marker_styles, styles).collect();
 
-                Some((skipped_offset, styles))
+                Some(styles)
             }
             _ => None,
         })
@@ -543,8 +548,9 @@ impl Element for TextElement {
         let state = self.state.read(cx);
         let line_height = window.line_height();
 
-        let visible_range = self.calculate_visible_range(&state, line_height, bounds.size.height);
-        let highlight_styles = self.highlight_lines(&visible_range, cx);
+        let (visible_range, offset_y) =
+            self.calculate_visible_range(&state, line_height, bounds.size.height);
+        let highlight_styles = self.highlight_lines(&visible_range, offset_y, cx);
 
         let state = self.state.read(cx);
         let multi_line = state.mode.is_multi_line();
@@ -556,11 +562,17 @@ impl Element for TextElement {
         let mut bounds = bounds;
 
         let (display_text, text_color) = if is_empty {
-            (placeholder, cx.theme().muted_foreground)
+            (
+                Rope::from(placeholder.as_str()),
+                cx.theme().muted_foreground,
+            )
         } else if state.masked {
-            ("*".repeat(text.chars_count()).into(), cx.theme().foreground)
+            (
+                Rope::from("*".repeat(text.chars_count())),
+                cx.theme().foreground,
+            )
         } else {
-            (text.to_string().into(), cx.theme().foreground)
+            (text.clone(), cx.theme().foreground)
         };
 
         let text_style = window.text_style();
@@ -607,14 +619,8 @@ impl Element for TextElement {
         };
 
         let runs = if !is_empty {
-            if let Some((skipped_offset, highlight_styles)) = highlight_styles {
+            if let Some(highlight_styles) = highlight_styles {
                 let mut runs = vec![];
-                if skipped_offset > 0 {
-                    runs.push(TextRun {
-                        len: skipped_offset,
-                        ..run.clone()
-                    });
-                }
 
                 runs.extend(highlight_styles.iter().map(|(range, style)| {
                     let mut run = text_style.clone().highlight(*style).to_run(range.len());
@@ -665,19 +671,23 @@ impl Element for TextElement {
 
         // NOTE: If there have about 10K lines, this will take about 5~6ms.
         // let measure = Measure::new("shape_text");
+        let visible_text = display_text
+            .lines()
+            .skip(visible_range.start)
+            .take(visible_range.len())
+            .join("\n");
+
         let lines = window
             .text_system()
-            .shape_text(display_text, font_size, &runs, wrap_width, None)
+            .shape_text(visible_text.into(), font_size, &runs, wrap_width, None)
             .expect("failed to shape text");
         // measure.end();
 
         let mut max_line_width = px(0.);
-        let mut total_wrapped_lines = 0;
+        let total_wrapped_lines = state.text_wrapper.len();
         for line in lines.iter() {
             // FIXME: The `shape_text` measured width is not stable, sometime will large, sometime small.
             max_line_width = max_line_width.max(line.width());
-            // +1 is the first line, `wrap_boundaries` is the wrapped lines after the `\n`.
-            total_wrapped_lines += 1 + line.wrap_boundaries.len();
         }
 
         let scroll_size = size(
@@ -721,6 +731,8 @@ impl Element for TextElement {
         // Calculate the scroll offset to keep the cursor in view
 
         let (cursor_bounds, cursor_scroll_offset, current_line_index) = self.layout_cursor(
+            &visible_range,
+            offset_y,
             &lines,
             line_height,
             &mut bounds,
@@ -730,6 +742,8 @@ impl Element for TextElement {
         );
 
         let selection_path = self.layout_selections(
+            &visible_range,
+            offset_y,
             &lines,
             line_height,
             &mut bounds,
@@ -760,13 +774,8 @@ impl Element for TextElement {
             }];
 
             // build line numbers
-            for (ix, line) in lines
-                .iter()
-                .skip(visible_range.start)
-                .take(visible_range.len())
-                .enumerate()
-            {
-                let ix = ix + visible_range.start;
+            for (ix, line) in lines.iter().enumerate() {
+                let ix = visible_range.start + ix;
                 let line_no = ix + 1;
 
                 let mut line_no_text = format!("{:>4}", line_no);
@@ -794,9 +803,10 @@ impl Element for TextElement {
         PrepaintState {
             bounds,
             last_layout: LastLayout {
+                visible_range,
+                offset_y,
                 lines: Rc::new(lines),
                 line_height,
-                visible_range,
                 line_number_width,
                 wrap_width,
             },
@@ -859,10 +869,7 @@ impl Element for TextElement {
         let line_height = window.line_height();
         let origin = bounds.origin;
 
-        let mut invisible_top_padding = px(0.);
-        for line in prepaint.last_layout.lines.iter().take(visible_range.start) {
-            invisible_top_padding += line.size(line_height).height;
-        }
+        let invisible_top_padding = visible_range.start * line_height;
 
         let mut mask_offset_y = px(0.);
         if self.state.read(cx).masked {
@@ -910,12 +917,7 @@ impl Element for TextElement {
 
         // Paint text
         let mut offset_y = mask_offset_y + invisible_top_padding;
-        for line in prepaint
-            .last_layout
-            .iter()
-            .skip(visible_range.start)
-            .take(visible_range.len())
-        {
+        for line in prepaint.last_layout.lines.iter() {
             let p = point(
                 origin.x + prepaint.last_layout.line_number_width,
                 origin.y + offset_y,

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -132,6 +132,14 @@ impl TextElement {
             prev_lines_offset += line.len() + 1;
         }
 
+        // If cursor_pos and cursor_end is still None, it means the cursor is at the end of the text.
+        if cursor_pos.is_none() {
+            cursor_pos = Some(point(px(0.), offset_y));
+        }
+        if cursor_end.is_none() {
+            cursor_end = cursor_pos;
+        }
+
         if let (Some(cursor_pos), Some(cursor_start), Some(cursor_end)) =
             (cursor_pos, cursor_start, cursor_end)
         {

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -6,7 +6,6 @@ use gpui::{
     Path, Pixels, Point, SharedString, Size, Style, TextAlign, TextRun, UnderlineStyle, Window,
     WrappedLine,
 };
-use itertools::Itertools;
 use rope::Rope;
 use smallvec::SmallVec;
 

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -673,13 +673,11 @@ impl Element for TextElement {
             None
         };
 
-        // NOTE: If there have about 10K lines, this will take about 5~6ms.
-        // let measure = Measure::new("shape_text");
+        // NOTE: Here 50 lines about 150µs
+        // let measure = crate::Measure::new("shape_text");
         let visible_text = display_text
-            .lines()
-            .skip(visible_range.start)
-            .take(visible_range.len())
-            .join("\n");
+            .slice_rows(visible_range.start as u32..visible_range.end as u32)
+            .to_string();
 
         let lines = window
             .text_system()

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -711,9 +711,9 @@ impl Element for TextElement {
             visible_top,
             visible_start_offset,
             line_height,
-            lines: Rc::new(lines),
             wrap_width,
             line_number_width,
+            lines: Rc::new(lines),
         };
 
         // `position_for_index` for example

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -348,6 +348,8 @@ impl TextElement {
         line_height: Pixels,
         input_height: Pixels,
     ) -> (Range<usize>, Pixels) {
+        // Add extra rows to avoid showing empty space when scroll to bottom.
+        let extra_rows = 2;
         let mut visible_top = px(0.);
         if state.mode.is_single_line() {
             return (0..1, visible_top);
@@ -368,7 +370,7 @@ impl TextElement {
             }
 
             if line_bottom + scroll_top >= input_height {
-                visible_range.end = (ix + 1).min(total_lines);
+                visible_range.end = (ix + extra_rows).min(total_lines);
                 break;
             }
         }

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -425,24 +425,22 @@ impl TextElement {
                     offset = range.end;
                 }
 
-                let mut marker_styles = vec![];
-                for marker in markers.iter() {
-                    if let Some(range) = &marker.range {
-                        if range.start < offset {
-                            continue;
-                        }
+                // Combine marker styles
+                if !markers.is_empty() {
+                    let mut marker_styles = vec![];
+                    for marker in markers.iter() {
+                        if let Some(range) = &marker.range {
+                            if range.start < visible_start_offset {
+                                continue;
+                            }
 
-                        let node_range = range.start..range.end;
-                        if node_range.start >= visible_range.start
-                            || node_range.end <= visible_range.end
-                        {
                             marker_styles
-                                .push((node_range, marker.severity.highlight_style(&theme, cx)));
+                                .push((range.clone(), marker.severity.highlight_style(&theme, cx)));
                         }
                     }
-                }
 
-                styles = gpui::combine_highlights(marker_styles, styles).collect();
+                    styles = gpui::combine_highlights(marker_styles, styles).collect();
+                }
 
                 Some(styles)
             }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1737,8 +1737,6 @@ impl InputState {
 
             let Some(rendered_line) = last_layout.lines.get(ix) else {
                 if pos.y < line_origin.y + line_height {
-                    // Click in the empty space of the last line, move cursor to the end of the text.
-                    index = self.text.len();
                     break;
                 }
 

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -217,8 +217,8 @@ pub fn init(cx: &mut App) {
 pub(super) struct LastLayout {
     /// The visible range (no wrap) of lines in the viewport.
     pub(super) visible_range: Range<usize>,
-    /// The visible range offset y.
-    pub(super) offset_y: Pixels,
+    /// The first visible line top position in scroll viewport.
+    pub(super) visible_top: Pixels,
     /// The last layout lines (Only have visible lines).
     pub(super) lines: Rc<SmallVec<[WrappedLine; 1]>>,
     /// The line_height of text layout, this will change will InputElement painted.
@@ -539,7 +539,7 @@ impl InputState {
         let line_height = last_layout.line_height;
 
         let mut prev_lines_offset = 0;
-        let mut y_offset = last_layout.offset_y;
+        let mut y_offset = last_layout.visible_top;
         for (line_index, line) in last_layout.lines.iter().enumerate() {
             let local_offset = offset.saturating_sub(prev_lines_offset);
             if let Some(pos) = line.position_for_index(local_offset, line_height) {
@@ -1729,7 +1729,7 @@ impl InputState {
         let inner_position = position - bounds.origin - point(line_number_width, px(0.));
 
         let mut index = self.text.line_start_offset(last_layout.visible_range.start);
-        let mut y_offset = last_layout.offset_y;
+        let mut y_offset = last_layout.visible_top;
         for (_, line) in last_layout.lines.iter().enumerate() {
             let line_origin = self.line_origin_with_y_offset(&mut y_offset, &line, line_height);
             let pos = inner_position - line_origin;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -220,6 +220,8 @@ pub(super) struct LastLayout {
     pub(super) visible_range: Range<usize>,
     /// The first visible line top position in scroll viewport.
     pub(super) visible_top: Pixels,
+    /// The start byte offset of the first visible line.
+    pub(super) visible_start_offset: usize,
     /// The last layout lines (Only have visible lines).
     pub(super) lines: Rc<SmallVec<[WrappedLine; 1]>>,
     /// The line_height of text layout, this will change will InputElement painted.
@@ -531,7 +533,7 @@ impl InputState {
         };
         let line_height = last_layout.line_height;
 
-        let mut prev_lines_offset = self.text.line_start_offset(last_layout.visible_range.start);
+        let mut prev_lines_offset = last_layout.visible_start_offset;
         let mut y_offset = last_layout.visible_top;
         for (line_index, line) in last_layout.lines.iter().enumerate() {
             let local_offset = offset.saturating_sub(prev_lines_offset);
@@ -1721,7 +1723,7 @@ impl InputState {
         // - included the scroll offset.
         let inner_position = position - bounds.origin - point(line_number_width, px(0.));
 
-        let mut index = self.text.line_start_offset(last_layout.visible_range.start);
+        let mut index = last_layout.visible_start_offset;
         let mut y_offset = last_layout.visible_top;
         for (ix, line) in self
             .text_wrapper
@@ -2257,7 +2259,7 @@ impl EntityInputHandler for InputState {
         let mut end_origin = None;
         let line_number_origin = point(line_number_width, px(0.));
         let mut y_offset = last_layout.visible_top;
-        let mut index_offset = self.text.line_start_offset(last_layout.visible_range.start);
+        let mut index_offset = last_layout.visible_start_offset;
 
         for line in last_layout.lines.iter() {
             if start_origin.is_some() && end_origin.is_some() {
@@ -2305,7 +2307,7 @@ impl EntityInputHandler for InputState {
         let last_layout = self.last_layout.as_ref()?;
         let line_height = last_layout.line_height;
         let line_point = self.last_bounds?.localize(&point)?;
-        let offset = self.text.line_start_offset(last_layout.visible_range.start);
+        let offset = last_layout.visible_start_offset;
 
         for line in last_layout.lines.iter() {
             if let Ok(utf8_index) = line.index_for_position(line_point, line_height) {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -682,6 +682,17 @@ impl InputState {
     /// Update the soft wrap mode for multi-line input, default is true.
     pub fn set_soft_wrap(&mut self, wrap: bool, _: &mut Window, cx: &mut Context<Self>) {
         self.soft_wrap = wrap;
+        if wrap {
+            let wrap_width = self
+                .last_layout
+                .as_ref()
+                .and_then(|b| b.wrap_width)
+                .unwrap_or(self.input_bounds.size.width);
+
+            self.text_wrapper.set_wrap_width(Some(wrap_width), cx);
+        } else {
+            self.text_wrapper.set_wrap_width(None, cx);
+        }
         cx.notify();
     }
 

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -216,7 +216,7 @@ pub fn init(cx: &mut App) {
 
 #[derive(Clone)]
 pub(super) struct LastLayout {
-    /// The visible range (no wrap) of lines in the viewport.
+    /// The visible range (no wrap) of lines in the viewport, the value is row (0-based) index.
     pub(super) visible_range: Range<usize>,
     /// The first visible line top position in scroll viewport.
     pub(super) visible_top: Pixels,

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -22,7 +22,7 @@ pub(super) struct LineWrap {
 /// After use lines to calculate the scroll size of the TextArea
 pub(super) struct TextWrapper {
     pub(super) text: Rope,
-    /// The wrapped lines, value is start and end index of the line.
+    /// The wrapped lines (Inlucde the first line), value is start and end index of the line.
     pub(super) wrapped_lines: Vec<Range<usize>>,
     /// The lines by split \n
     pub(super) lines: Vec<LineWrap>,
@@ -43,6 +43,11 @@ impl TextWrapper {
             wrapped_lines: Vec::new(),
             lines: Vec::new(),
         }
+    }
+
+    /// Get the total number of lines including wrapped lines.
+    pub(super) fn len(&self) -> usize {
+        self.wrapped_lines.len()
     }
 
     pub(super) fn set_wrap_width(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {


### PR DESCRIPTION
Close #1193

Ref issue #1220 

This PR aim to shape text in visible ranges to reduce `shape_text` time for large document case.

- Fix rendering might be delayed and cause blanks when scrolling to follow the selection.
- Fix `RopeExt::lines` method to avoid call `line` method on skipped iter.