### PR TITLE
editor: Improve TextWrapper performance by only rebuild changed lines.

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2283,7 +2283,7 @@ impl EntityInputHandler for InputState {
             diagnostics.reset(&self.text)
         }
         self.text_wrapper
-            .update(&self.text, &range, new_text, false, cx);
+            .update(&self.text, &range, &Rope::from(new_text), false, cx);
         self.mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
         self.selected_range = (new_offset..new_offset).into();
@@ -2333,7 +2333,7 @@ impl EntityInputHandler for InputState {
             diagnostics.reset(&self.text)
         }
         self.text_wrapper
-            .update(&self.text, &range, new_text, false, cx);
+            .update(&self.text, &range, &Rope::from(new_text), false, cx);
         self.mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
         if new_text.is_empty() {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2282,7 +2282,8 @@ impl EntityInputHandler for InputState {
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
-        self.text_wrapper.update(&self.text, false, cx);
+        self.text_wrapper
+            .update(&self.text, &range, new_text, false, cx);
         self.mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
         self.selected_range = (new_offset..new_offset).into();
@@ -2331,7 +2332,8 @@ impl EntityInputHandler for InputState {
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
-        self.text_wrapper.update(&self.text, false, cx);
+        self.text_wrapper
+            .update(&self.text, &range, new_text, false, cx);
         self.mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
         if new_text.is_empty() {
@@ -2437,7 +2439,7 @@ impl Focusable for InputState {
 
 impl Render for InputState {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        self.text_wrapper.update(&self.text, false, cx);
+        self.text_wrapper.update_all(&self.text, false, cx);
         self.mode
             .update_highlighter(&(0..0), &self.text, "", false, cx);
 

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -350,5 +350,16 @@ mod tests {
         );
         assert_eq!(text.to_string(), "");
         assert_eq!(wrapper.lines.len(), 1);
+
+        // Test update_all
+        let range = 0..text.len();
+        let new_text = "This is a full text.\nThis is a second line.";
+        text.replace(range.clone(), new_text);
+        wrapper._update(&text, &range, &text, false, &mut fake_wrap_line);
+        assert_eq!(
+            text.to_string(),
+            "This is a full text.\nThis is a second line."
+        );
+        assert_eq!(wrapper.lines.len(), 2);
     }
 }

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -122,7 +122,6 @@ impl TextWrapper {
         let end_row = self.text.offset_to_point(range.end).row as usize;
         let end_row = end_row.min(self.lines.len().saturating_sub(1));
         let rows_range = start_row..=end_row;
-        dbg!(&rows_range);
 
         // To add the new lines.
         let new_start_row = text.offset_to_point(range.start).row as usize;
@@ -132,37 +131,35 @@ impl TextWrapper {
         let new_range = new_start_offset..new_end_offset;
 
         let mut new_lines = vec![];
-        if new_range.len() > 0 {
-            let wrap_width = self.wrap_width;
-            let mut line_wrapper = cx
-                .text_system()
-                .line_wrapper(self.font.clone(), self.font_size);
-            for line in text.slice(new_range).lines() {
-                let line_str = line.to_string();
-                let mut wrapped_lines = vec![];
-                let mut prev_boundary_ix = 0;
 
-                // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
-                if let Some(wrap_width) = wrap_width {
-                    // Here only have wrapped line, if there is no wrap meet, the `line_wraps` result will empty.
-                    for boundary in
-                        line_wrapper.wrap_line(&[LineFragment::text(&line_str)], wrap_width)
-                    {
-                        wrapped_lines.push(prev_boundary_ix..boundary.ix);
-                        prev_boundary_ix = boundary.ix;
-                    }
+        let wrap_width = self.wrap_width;
+        let mut line_wrapper = cx
+            .text_system()
+            .line_wrapper(self.font.clone(), self.font_size);
+        for line in text.slice(new_range).lines() {
+            let line_str = line.to_string();
+            let mut wrapped_lines = vec![];
+            let mut prev_boundary_ix = 0;
+
+            // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
+            if let Some(wrap_width) = wrap_width {
+                // Here only have wrapped line, if there is no wrap meet, the `line_wraps` result will empty.
+                for boundary in line_wrapper.wrap_line(&[LineFragment::text(&line_str)], wrap_width)
+                {
+                    wrapped_lines.push(prev_boundary_ix..boundary.ix);
+                    prev_boundary_ix = boundary.ix;
                 }
-
-                // Reset of the line
-                if !line_str[prev_boundary_ix..].is_empty() || prev_boundary_ix == 0 {
-                    wrapped_lines.push(prev_boundary_ix..line.len());
-                }
-
-                new_lines.push(LineItem {
-                    line: line.clone(),
-                    wrapped_lines,
-                });
             }
+
+            // Reset of the line
+            if !line_str[prev_boundary_ix..].is_empty() || prev_boundary_ix == 0 {
+                wrapped_lines.push(prev_boundary_ix..line.len());
+            }
+
+            new_lines.push(LineItem {
+                line: line.clone(),
+                wrapped_lines,
+            });
         }
 
         // dbg!(&new_lines.len());

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -122,6 +122,7 @@ impl TextWrapper {
         let end_row = self.text.offset_to_point(range.end).row as usize;
         let end_row = end_row.min(self.lines.len().saturating_sub(1));
         let rows_range = start_row..=end_row;
+        dbg!(&rows_range);
 
         // To add the new lines.
         let new_start_row = text.offset_to_point(range.start).row as usize;
@@ -173,14 +174,6 @@ impl TextWrapper {
         }
 
         // dbg!(self.lines.len());
-
-        // At least one line
-        if self.lines.len() == 0 {
-            self.lines.push(LineItem {
-                line: Rope::new(),
-                wrapped_lines: vec![],
-            });
-        }
         self.text = text.clone();
         self.soft_lines = self.lines.iter().map(|l| l.lines_len()).sum();
     }


### PR DESCRIPTION
Continue #1220 

Now, we can support editing on 100K lines (release mode).


https://github.com/user-attachments/assets/2daccc85-c713-4ddf-b08d-840cb1bb2643


