### PR TITLE
input: Use shape line for soft wrap lines.

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -545,6 +545,9 @@ impl TextElement {
                 .lines
                 .get(visible_range.start + ix)
                 .expect("line should exists in text_wrapper");
+            if line_item.len() != line.len() {
+                dbg!(&line, &line_item.wrapped_lines);
+            }
             debug_assert_eq!(line_item.len(), line.len());
 
             let mut line_layout = LineLayout::new();
@@ -849,8 +852,6 @@ impl Element for TextElement {
             None
         };
 
-        // NOTE: Here 50 lines about 150µs
-        // let measure = crate::Measure::new("shape_text");
         let lines = Self::layout_lines(
             &text,
             &state.text_wrapper,
@@ -859,7 +860,6 @@ impl Element for TextElement {
             &runs,
             window,
         );
-        // measure.end();
 
         let mut longest_line_width = wrap_width.unwrap_or(px(0.));
         if state.mode.is_multi_line() && !state.soft_wrap && lines.len() > 1 {

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -545,11 +545,14 @@ impl TextElement {
                 .lines
                 .get(visible_range.start + ix)
                 .expect("line should exists in text_wrapper");
+            debug_assert_eq!(line_item.len(), line.len());
+
             let mut line_layout = LineLayout::new();
             let mut wrapped_lines = SmallVec::with_capacity(1);
 
             for range in &line_item.wrapped_lines {
                 let line_runs = runs_for_range(runs, offset, &range);
+                // the `line` not have `\n`, but the `wrapped_lines` range contains `\n` len
                 let sub_line: SharedString = line[range.clone()].to_string().into();
                 let shaped_line =
                     window

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -554,20 +554,18 @@ impl TextElement {
                 let line_runs = runs_for_range(runs, offset, &range);
                 // the `line` not have `\n`, but the `wrapped_lines` range contains `\n` len
                 let sub_line: SharedString = line[range.clone()].to_string().into();
-                let shaped_line =
-                    window
-                        .text_system()
-                        .shape_line(sub_line.into(), font_size, &line_runs, None);
+                let shaped_line = window
+                    .text_system()
+                    .shape_line(sub_line, font_size, &line_runs, None);
 
                 wrapped_lines.push(shaped_line);
             }
-            offset += line_item.len();
 
             line_layout.set_wrapped_lines(wrapped_lines);
             lines.push(line_layout);
 
             // +1 for the `\n`
-            offset += 1;
+            offset += line_item.len() + 1;
         }
 
         lines

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -560,9 +560,8 @@ impl TextElement {
                         .shape_line(sub_line.into(), font_size, &line_runs, None);
 
                 wrapped_lines.push(shaped_line);
-
-                offset += range.len();
             }
+            offset += line_item.len();
 
             line_layout.set_wrapped_lines(wrapped_lines);
             lines.push(line_layout);

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -552,7 +552,6 @@ impl TextElement {
 
             for range in &line_item.wrapped_lines {
                 let line_runs = runs_for_range(runs, offset, &range);
-                // the `line` not have `\n`, but the `wrapped_lines` range contains `\n` len
                 let sub_line: SharedString = line[range.clone()].to_string().into();
                 let shaped_line = window
                     .text_system()

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -545,9 +545,9 @@ impl TextElement {
                 .lines
                 .get(visible_range.start + ix)
                 .expect("line should exists in text_wrapper");
-            if line_item.len() != line.len() {
-                dbg!(&line, &line_item.wrapped_lines);
-            }
+            // if line_item.len() != line.len() {
+            //     dbg!(&line, &line_item.wrapped_lines);
+            // }
             debug_assert_eq!(line_item.len(), line.len());
 
             let mut line_layout = LineLayout::new();

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -565,7 +565,7 @@ impl TextElement {
             lines.push(line_layout);
 
             // +1 for the `\n`
-            offset += line_item.len() + 1;
+            offset += line.len() + 1;
         }
 
         lines

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -550,7 +550,6 @@ impl TextElement {
 
             for range in &line_item.wrapped_lines {
                 let line_runs = runs_for_range(runs, offset, &range);
-
                 let sub_line: SharedString = line[range.clone()].to_string().into();
                 let shaped_line =
                     window
@@ -1212,6 +1211,7 @@ impl Element for TextElement {
         self.paint_mouse_listeners(window, cx);
     }
 }
+
 /// Get the runs for the given range.
 ///
 /// The range is the byte range of the wrapped line.
@@ -1310,5 +1310,6 @@ mod tests {
         assert_runs(runs_for_range(&runs, 0, &(5..8)), &[3]);
         assert_runs(runs_for_range(&runs, 3, &(0..3)), &[1, 2]);
         assert_runs(runs_for_range(&runs, 3, &(2..10)), &[4, 1, 3]);
+        assert_runs(runs_for_range(&runs, 9, &(0..8)), &[1, 7]);
     }
 }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1543,7 +1543,7 @@ impl InputState {
         }
 
         self.selecting = true;
-        let offset = self.index_for_mouse_position(event.position, window, cx);
+        let offset = self.index_for_mouse_position(event.position);
 
         if self.handle_click_hover_definition(event, offset, window, cx) {
             return;
@@ -1585,7 +1585,7 @@ impl InputState {
         cx: &mut Context<Self>,
     ) {
         // Show diagnostic popover on mouse move
-        let offset = self.index_for_mouse_position(event.position, window, cx);
+        let offset = self.index_for_mouse_position(event.position);
         self.handle_mouse_move(offset, event, window, cx);
 
         if self.mode.is_code_editor() {
@@ -1813,12 +1813,7 @@ impl InputState {
         }
     }
 
-    pub(crate) fn index_for_mouse_position(
-        &self,
-        position: Point<Pixels>,
-        _window: &Window,
-        _cx: &App,
-    ) -> usize {
+    pub(crate) fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
         // If the text is empty, always return 0
         if self.text.len() == 0 {
             return 0;
@@ -2113,7 +2108,7 @@ impl InputState {
             return;
         }
 
-        let offset = self.index_for_mouse_position(event.position, window, cx);
+        let offset = self.index_for_mouse_position(event.position);
         self.select_to(offset, cx);
     }
 

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1852,7 +1852,7 @@ impl InputState {
             let line_origin = self.line_origin_with_y_offset(&mut y_offset, line, line_height);
             let pos = inner_position - line_origin;
 
-            let Some(rendered_line) = last_layout.lines.get(ix) else {
+            let Some(line_layout) = last_layout.lines.get(ix) else {
                 if pos.y < line_origin.y + line_height {
                     break;
                 }
@@ -1862,25 +1862,18 @@ impl InputState {
 
             // Return offset by use closest_index_for_x if is single line mode.
             if self.mode.is_single_line() {
-                return rendered_line.closest_index_for_x(pos.x);
+                return line_layout.closest_index_for_x(pos.x);
             }
 
-            if let Some(v) = rendered_line.closest_index_for_position(pos, line_height) {
+            if let Some(v) = line_layout.closest_index_for_position(pos, line_height) {
                 index += v;
                 break;
-            } else if let Some(v) =
-                rendered_line.index_for_position(point(px(0.), pos.y), line_height)
-            {
-                // Click in the this line but not in the text, move cursor to the end of the line.
-                // The fallback index is saved in Err from `index_for_position` method.
-                index += v;
+            } else if pos.y < px(0.) {
                 break;
-            } else {
-                index += rendered_line.len();
             }
 
-            // +1 for revert `lines` split `\n`
-            index += 1;
+            // +1 for `\n`
+            index += line_layout.len() + 1;
         }
 
         if index > self.text.len() {

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -441,6 +441,17 @@ mod tests {
             "Hello, 世界!\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 4);
+        assert_eq!(wrapper.lines.len(), 4);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["Hello, 世界!"],
+                &["This is second line."],
+                &["This is third line."],
+                &["这里是第 4 行。New text"],
+            ],
+        );
 
         // Replace first line `Hello` to `AAA`
         let range = 0..5;
@@ -452,6 +463,16 @@ mod tests {
             "AAA, 世界!\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 4);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["AAA, 世界!"],
+                &["This is second line."],
+                &["This is third line."],
+                &["这里是第 4 行。New text"],
+            ],
+        );
 
         // Remove the second line
         let start_offset = text.line_start_offset(1);
@@ -464,6 +485,15 @@ mod tests {
             "AAA, 世界!\nThis is third line.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 3);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["AAA, 世界!"],
+                &["This is third line."],
+                &["这里是第 4 行。New text"],
+            ],
+        );
 
         // Replace the first 2 lines to "This is a new line."
         let range = text.line_start_offset(0)..text.line_end_offset(1) + 1;
@@ -475,6 +505,15 @@ mod tests {
             "This is a new line.\nThis is new line 2.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 3);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["This is a new line."],
+                &["This is new line 2."],
+                &["这里是第 4 行。New text"],
+            ],
+        );
 
         // Add a new line at the end
         let range = text.len()..text.len();
@@ -486,6 +525,16 @@ mod tests {
             "This is a new line.\nThis is new line 2.\n这里是第 4 行。New text\nThis is a new line at the end."
         );
         assert_eq!(wrapper.lines.len(), 4);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["This is a new line."],
+                &["This is new line 2."],
+                &["这里是第 4 行。New text"],
+                &["This is a new line at the end."],
+            ],
+        );
 
         // Add a new line at the beginning
         let range = 0..0;

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -241,17 +241,14 @@ impl TextWrapper {
 pub(crate) struct LineLayout {
     /// Total bytes length of this line.
     len: usize,
-    /// The start offset of this line in the whole text.
-    pub(crate) start_offset: usize,
     /// The soft wrapped lines of this line (Include the first line).
     pub(crate) wrapped_lines: SmallVec<[ShapedLine; 1]>,
     pub(crate) longest_width: Pixels,
 }
 
 impl LineLayout {
-    pub(crate) fn new(start_offset: usize) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            start_offset,
             len: 0,
             longest_width: px(0.),
             wrapped_lines: SmallVec::new(),
@@ -286,8 +283,9 @@ impl LineLayout {
     ) -> Option<Point<Pixels>> {
         let mut acc_len = 0;
         let mut offset_y = px(0.);
+
         for line in self.wrapped_lines.iter() {
-            let range = acc_len..=line.len();
+            let range = acc_len..=(acc_len + line.len());
             if range.contains(&offset) {
                 let x = line.x_for_index(offset.saturating_sub(acc_len));
                 return Some(point(x, offset_y));

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -257,8 +257,7 @@ impl LineLayout {
 
     pub(crate) fn set_wrapped_lines(&mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) {
         self.len = wrapped_lines.iter().map(|l| l.text.len()).sum();
-        let width = self
-            .wrapped_lines
+        let width = wrapped_lines
             .iter()
             .map(|l| l.width)
             .max()

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -546,6 +546,17 @@ mod tests {
             "This is a new line at the beginning.\nThis is a new line.\nThis is new line 2.\n这里是第 4 行。New text\nThis is a new line at the end."
         );
         assert_eq!(wrapper.lines.len(), 5);
+        assert_wrapper_lines(
+            &text,
+            &wrapper,
+            &[
+                &["This is a new line at the beginning."],
+                &["This is a new line."],
+                &["This is new line 2."],
+                &["这里是第 4 行。New text"],
+                &["This is a new line at the end."],
+            ],
+        );
 
         // Remove all to at least one line in `lines`.
         let range = 0..text.len();
@@ -554,6 +565,7 @@ mod tests {
         wrapper._update(&text, &range, &Rope::from(new_text), &mut fake_wrap_line);
         assert_eq!(text.to_string(), "");
         assert_eq!(wrapper.lines.len(), 1);
+        assert_eq!(wrapper.lines[0].wrapped_lines, vec![0..0]);
 
         // Test update_all
         let range = 0..text.len();

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 use crate::input::RopeExt;
 
 /// A line with soft wrapped lines info.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(super) struct LineItem {
     /// The original line text.
     line: Rope,
@@ -394,8 +394,9 @@ mod tests {
         };
 
         let mut wrapper = TextWrapper::new(font, px(14.), None);
-        let mut text =
-            Rope::from("Hello, 世界!\nThis is second line.\nThis is third line.\n这里是第 4 行。");
+        let mut text = Rope::from(
+            "Hello, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。",
+        );
 
         fn fake_wrap_line(_line: &str, _wrap_width: Pixels) -> Vec<Boundary> {
             vec![]
@@ -424,7 +425,7 @@ mod tests {
             &text,
             &wrapper,
             &[
-                &["Hello, 世界!"],
+                &["Hello, 世界!\r"],
                 &["This is second line."],
                 &["This is third line."],
                 &["这里是第 4 行。"],
@@ -438,7 +439,7 @@ mod tests {
         wrapper._update(&text, &range, &Rope::from(new_text), &mut fake_wrap_line);
         assert_eq!(
             text.to_string(),
-            "Hello, 世界!\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
+            "Hello, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 4);
         assert_eq!(wrapper.lines.len(), 4);
@@ -446,7 +447,7 @@ mod tests {
             &text,
             &wrapper,
             &[
-                &["Hello, 世界!"],
+                &["Hello, 世界!\r"],
                 &["This is second line."],
                 &["This is third line."],
                 &["这里是第 4 行。New text"],
@@ -460,14 +461,15 @@ mod tests {
         wrapper._update(&text, &range, &Rope::from(new_text), &mut fake_wrap_line);
         assert_eq!(
             text.to_string(),
-            "AAA, 世界!\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
+            "AAA, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
+        dbg!(&wrapper.lines);
         assert_eq!(wrapper.lines.len(), 4);
         assert_wrapper_lines(
             &text,
             &wrapper,
             &[
-                &["AAA, 世界!"],
+                &["AAA, 世界!\r"],
                 &["This is second line."],
                 &["This is third line."],
                 &["这里是第 4 行。New text"],
@@ -482,14 +484,14 @@ mod tests {
         wrapper._update(&text, &range, &Rope::from(""), &mut fake_wrap_line);
         assert_eq!(
             text.to_string(),
-            "AAA, 世界!\nThis is third line.\n这里是第 4 行。New text"
+            "AAA, 世界!\r\nThis is third line.\n这里是第 4 行。New text"
         );
         assert_eq!(wrapper.lines.len(), 3);
         assert_wrapper_lines(
             &text,
             &wrapper,
             &[
-                &["AAA, 世界!"],
+                &["AAA, 世界!\r"],
                 &["This is third line."],
                 &["这里是第 4 行。New text"],
             ],

--- a/crates/ui/src/input/text_wrapper.rs
+++ b/crates/ui/src/input/text_wrapper.rs
@@ -256,7 +256,7 @@ impl LineLayout {
     }
 
     pub(crate) fn set_wrapped_lines(&mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) {
-        self.len = wrapped_lines.iter().map(|l| l.text.len()).sum();
+        self.len = wrapped_lines.iter().map(|l| l.len).sum();
         let width = wrapped_lines
             .iter()
             .map(|l| l.width)
@@ -578,5 +578,17 @@ mod tests {
             "This is a full text.\nThis is a second line."
         );
         assert_eq!(wrapper.lines.len(), 2);
+    }
+
+    #[test]
+    fn test_line_layout() {
+        let mut line_layout = LineLayout::new();
+
+        let line1 = ShapedLine::default().with_len(100);
+        let line2 = ShapedLine::default().with_len(50);
+        let wrapped_lines = smallvec::smallvec![line1, line2];
+        line_layout.set_wrapped_lines(wrapped_lines);
+        assert_eq!(line_layout.len(), 150);
+        assert_eq!(line_layout.wrapped_lines.len(), 2);
     }
 }


### PR DESCRIPTION
This change aim to fix the before version `shape_text` (in Element paint) and `wrap_line` (in TextWrapper cached soft wrap map) may have difference wrap width.

Now move to based on TextWrapper's wrap map to paint text by use `shape_line` method.