### PR TITLE
feat: assets interpolate folder path via rust embed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5864,6 +5864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
+ "shellexpand",
  "syn 2.0.105",
  "walkdir",
 ]
@@ -6483,6 +6484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs 4.0.0",
 ]
 
 [[package]]

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -16,7 +16,7 @@ raw-window-handle = { version = "0.6", features = ["std"] }
 regex = "1"
 reqwest_client.workspace = true
 smol.workspace = true
-rust-embed = "8.5.0"
+rust-embed = { version = "8.7.2", features = ["interpolate-folder-path"] }
 serde = "1"
 serde_json = "1"
 unindent = "0.2.3"

--- a/crates/story/src/assets.rs
+++ b/crates/story/src/assets.rs
@@ -1,14 +1,11 @@
-use std::{borrow::Cow, path::PathBuf};
-
-use anyhow::{anyhow, Result};
-
-use gpui::AssetSource;
+use anyhow::anyhow;
+use gpui::{AssetSource, Result, SharedString};
 use rust_embed::RustEmbed;
+use std::borrow::Cow;
 
 #[derive(RustEmbed)]
-#[folder = "../../assets"]
-#[include = "icons/**/*"]
-#[exclude = "*.DS_Store"]
+#[folder = "$CARGO_MANIFEST_DIR/../../assets"]
+#[include = "icons/**/*.svg"]
 pub struct Assets;
 
 impl AssetSource for Assets {
@@ -19,26 +16,12 @@ impl AssetSource for Assets {
 
         Self::get(path)
             .map(|f| Some(f.data))
-            .or_else(|| {
-                let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                let path = manifest_dir.join(path);
-
-                std::fs::read(path)
-                    .map(|data| Some(std::borrow::Cow::Owned(data)))
-                    .ok()
-            })
-            .ok_or_else(|| anyhow!("could not find asset at path \"{}\"", path))
+            .ok_or_else(|| anyhow!("could not find asset at path \"{path}\""))
     }
 
-    fn list(&self, path: &str) -> gpui::Result<Vec<gpui::SharedString>> {
+    fn list(&self, path: &str) -> Result<Vec<SharedString>> {
         Ok(Self::iter()
-            .filter_map(|p| {
-                if p.starts_with(path) {
-                    Some(p.into())
-                } else {
-                    None
-                }
-            })
+            .filter_map(|p| p.starts_with(path).then(|| p.into()))
             .collect())
     }
 }


### PR DESCRIPTION
Use `rust-embed` feature `interpolate-folder-path` to always (`debug`/`release`) load assets from the correct `assets` directory