### PR TITLE
plot: Add stroke style per each Y series

### DIFF
--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -23,9 +23,9 @@ where
     data: Vec<T>,
     x: Option<Rc<dyn Fn(&T) -> X>>,
     y: Vec<Rc<dyn Fn(&T) -> Y>>,
-    stroke: Vec<Hsla>,
-    stroke_style: Vec<StrokeStyle>,
-    fill: Vec<Background>,
+    strokes: Vec<Hsla>,
+    stroke_styles: Vec<StrokeStyle>,
+    fills: Vec<Background>,
     tick_margin: usize,
 }
 
@@ -40,9 +40,9 @@ where
     {
         Self {
             data: data.into_iter().collect(),
-            stroke_style: vec![],
-            stroke: vec![],
-            fill: vec![],
+            stroke_styles: vec![],
+            strokes: vec![],
+            fills: vec![],
             tick_margin: 1,
             x: None,
             y: vec![],
@@ -60,27 +60,27 @@ where
     }
 
     pub fn stroke(mut self, stroke: impl Into<Hsla>) -> Self {
-        self.stroke.push(stroke.into());
+        self.strokes.push(stroke.into());
         self
     }
 
     pub fn fill(mut self, fill: impl Into<Background>) -> Self {
-        self.fill.push(fill.into());
+        self.fills.push(fill.into());
         self
     }
 
     pub fn natural(mut self) -> Self {
-        self.stroke_style.push(StrokeStyle::Natural);
+        self.stroke_styles.push(StrokeStyle::Natural);
         self
     }
 
     pub fn linear(mut self) -> Self {
-        self.stroke_style.push(StrokeStyle::Linear);
+        self.stroke_styles.push(StrokeStyle::Linear);
         self
     }
 
     pub fn step_after(mut self) -> Self {
-        self.stroke_style.push(StrokeStyle::StepAfter);
+        self.stroke_styles.push(StrokeStyle::StepAfter);
         self
     }
 
@@ -163,15 +163,16 @@ where
             let y_fn = y_fn.clone();
 
             let fill = *self
-                .fill
+                .fills
                 .get(i)
                 .unwrap_or(&cx.theme().chart_2.opacity(0.4).into());
 
-            let stroke = *self.stroke.get(i).unwrap_or(&cx.theme().chart_2);
+            let stroke = *self.strokes.get(i).unwrap_or(&cx.theme().chart_2);
+
             let stroke_style = *self
-                .stroke_style
+                .stroke_styles
                 .get(i)
-                .unwrap_or(self.stroke_style.first().unwrap_or(&Default::default()));
+                .unwrap_or(self.stroke_styles.first().unwrap_or(&Default::default()));
 
             Area::new()
                 .data(&self.data)


### PR DESCRIPTION
Enables the user to set different `stroke_style` to each Y data series, keeping retrocompatibility with the previous API.

<img width="1300" height="411" alt="Screenshot from 2025-10-13 11-33-28" src="https://github.com/user-attachments/assets/d665b87c-0d79-479c-9156-15a0f1c8ca10" />
