### PR TITLE
Revert "chore: Update GPUI dependency."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -696,7 +696,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "gpui"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6cc8eeb8b75347d602fb1919e2c42f26c43c2a75d71b46200a8c24e8ba4c4c"
+checksum = "c8a209a56079b7af7d158e410aaad8666edf5ad55450803eaace98a4eef383f7"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2824,14 +2824,6 @@ dependencies = [
  "foreign-types 0.5.0",
  "futures",
  "gpui-macros",
- "gpui_collections",
- "gpui_http_client",
- "gpui_media",
- "gpui_refineable",
- "gpui_semantic_version",
- "gpui_sum_tree",
- "gpui_util",
- "gpui_util_macros",
  "image",
  "inventory",
  "itertools 0.14.0",
@@ -2879,8 +2871,16 @@ dependencies = [
  "x11-clipboard",
  "x11rb",
  "xkbcommon",
+ "zed-collections",
  "zed-font-kit",
+ "zed-http-client",
+ "zed-media",
+ "zed-refineable",
  "zed-scap",
+ "zed-semantic-version",
+ "zed-sum-tree",
+ "zed-util",
+ "zed-util-macros",
  "zed-xim",
 ]
 
@@ -2895,7 +2895,6 @@ dependencies = [
  "gpui",
  "gpui-component-macros",
  "gpui-macros",
- "gpui_sum_tree",
  "html5ever 0.27.0",
  "indoc",
  "itertools 0.13.0",
@@ -2950,6 +2949,7 @@ dependencies = [
  "tree-sitter-zig",
  "unicode-segmentation",
  "uuid",
+ "zed-sum-tree",
 ]
 
 [[package]]
@@ -2963,173 +2963,12 @@ dependencies = [
 
 [[package]]
 name = "gpui-macros"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73707a975cb38d764f90acc59dc651dfe86dc693af2f9719ad4b1026a05d830c"
+checksum = "756549abfa9eef8391c685ae8a79a1a0e30b7d6e51f32cdce61998c689718710"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote",
- "syn 2.0.105",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_collections"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e961a1c901b2d015c8f1bbac6f5a506cdd578d2e0e25581404b9bf359528d7"
-dependencies = [
- "indexmap",
- "rustc-hash 2.1.1",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_derive_refineable"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d8fb6574830b12cf49e373e01ffb31dda3e6454377f19f8bf731959b0cc797"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.105",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_http_client"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f4575da99bf7f35489e2a7d0d0858d9f0537d40f88aa8702fc78cb5abdfb8b"
-dependencies = [
- "anyhow",
- "async-compression",
- "async-fs 2.1.3",
- "async-tar",
- "bytes",
- "derive_more",
- "futures",
- "gpui_util",
- "http",
- "http-body",
- "log",
- "parking_lot",
- "serde",
- "serde_json",
- "sha2",
- "tempfile",
- "url",
- "workspace-hack",
- "zed-reqwest",
-]
-
-[[package]]
-name = "gpui_media"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7f3d9e83c35efc9b53372485410d0b51d6ce39f3405e22c7306d3a3b133c5"
-dependencies = [
- "anyhow",
- "bindgen 0.71.1",
- "core-foundation 0.10.1",
- "core-video",
- "ctor",
- "foreign-types 0.5.0",
- "metal",
- "objc",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_perf"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87032a24b8ad5eba847e9585c840f7cf1747c7a38ab5a3227820d9da37abb68"
-dependencies = [
- "gpui_collections",
- "serde",
- "serde_json",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_refineable"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1ac7c0f175a56ff4edceeeb8515bea86576563d78608e16fed9c3be2cc54fc"
-dependencies = [
- "gpui_derive_refineable",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_semantic_version"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dde41ea7acf6b9bf3bd421d7c4e1e7ca2923a9cbe795c84a068feceb6fa32f"
-dependencies = [
- "anyhow",
- "serde",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_sum_tree"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6125543986a188ddb7735b65d10954c73f85a0b4e72ef1a7859c8311f3b874"
-dependencies = [
- "arrayvec",
- "log",
- "rayon",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_util"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679e3626691f3ca246509dcd108467596ad58bc3a4a92b640ad69a17deb056f3"
-dependencies = [
- "anyhow",
- "async-fs 2.1.3",
- "async_zip",
- "command-fds",
- "dirs 4.0.0",
- "dunce",
- "futures",
- "futures-lite 1.13.0",
- "globset",
- "gpui_collections",
- "itertools 0.14.0",
- "libc",
- "log",
- "nix 0.29.0",
- "regex",
- "rust-embed",
- "schemars",
- "serde",
- "serde_json",
- "serde_json_lenient",
- "shlex",
- "smol 2.0.2",
- "take-until",
- "tempfile",
- "tendril",
- "unicase",
- "walkdir",
- "which",
- "workspace-hack",
-]
-
-[[package]]
-name = "gpui_util_macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f75f86119f7fc8ba6cd5937262d4529be647c0b7d2bcbf3f335165faa5876e2"
-dependencies = [
- "gpui_perf",
  "quote",
  "syn 2.0.105",
  "workspace-hack",
@@ -4752,7 +4591,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -6035,12 +5874,12 @@ dependencies = [
  "bytes",
  "futures",
  "gpui",
- "gpui_http_client",
  "log",
  "regex",
  "rustls",
  "rustls-platform-verifier",
  "tokio",
+ "zed-http-client",
  "zed-reqwest",
 ]
 
@@ -9731,6 +9570,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1b9b3b5d39c11198dda53dbd50e18fbcaebc854c7c62921bf444cb5f21ab8a"
+dependencies = [
+ "indexmap",
+ "rustc-hash 2.1.1",
+ "workspace-hack",
+]
+
+[[package]]
+name = "zed-derive-refineable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0438b07ec0b8965715363dd1096a28e2d758408b7d67d683510b57dc2d121210"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+ "workspace-hack",
+]
+
+[[package]]
 name = "zed-font-kit"
 version = "0.14.1-zed"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9753,6 +9615,72 @@ dependencies = [
  "walkdir",
  "winapi",
  "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "zed-http-client"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f2bb8e91cfc16ef201813d76fa6c4e98e5193f07f88d51c7b912d3761f72f"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "async-fs 2.1.3",
+ "async-tar",
+ "bytes",
+ "derive_more",
+ "futures",
+ "http",
+ "http-body",
+ "log",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "url",
+ "workspace-hack",
+ "zed-reqwest",
+ "zed-util",
+]
+
+[[package]]
+name = "zed-media"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b145013b2053b9b9bef788405815240e4d8648a3c8271ce9e49c7ef2384f48e7"
+dependencies = [
+ "anyhow",
+ "bindgen 0.71.1",
+ "core-foundation 0.10.1",
+ "core-video",
+ "ctor",
+ "foreign-types 0.5.0",
+ "metal",
+ "objc",
+ "workspace-hack",
+]
+
+[[package]]
+name = "zed-perf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfdb2834f17691d64bbb21aa7b7dd2e933df9711c5c60874973254f37b335c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "workspace-hack",
+ "zed-collections",
+]
+
+[[package]]
+name = "zed-refineable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1898ca1f0e28bbe3fe1183899f79c083b646f8b8cea3ae52be6834ab29e0d656"
+dependencies = [
+ "workspace-hack",
+ "zed-derive-refineable",
 ]
 
 [[package]]
@@ -9828,6 +9756,78 @@ dependencies = [
  "windows-capture",
  "x11",
  "xcb",
+]
+
+[[package]]
+name = "zed-semantic-version"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963eb3815502d03cdb116555e624baa87c286466cc2ad6b022ab5154d4032911"
+dependencies = [
+ "anyhow",
+ "serde",
+ "workspace-hack",
+]
+
+[[package]]
+name = "zed-sum-tree"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d490156d0d7311855564d6e1d6dccab992405a0c0e15e1c8ef18920c02177e35"
+dependencies = [
+ "arrayvec",
+ "log",
+ "rayon",
+ "workspace-hack",
+]
+
+[[package]]
+name = "zed-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989eeb4bc093333d33226f5a478d97d1d9b305fce5798bc89dd094768b4286b7"
+dependencies = [
+ "anyhow",
+ "async-fs 2.1.3",
+ "async_zip",
+ "command-fds",
+ "dirs 4.0.0",
+ "dunce",
+ "futures",
+ "futures-lite 1.13.0",
+ "globset",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "regex",
+ "rust-embed",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_json_lenient",
+ "shlex",
+ "smol 2.0.2",
+ "take-until",
+ "tempfile",
+ "tendril",
+ "unicase",
+ "walkdir",
+ "which",
+ "workspace-hack",
+ "zed-collections",
+]
+
+[[package]]
+name = "zed-util-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47eb0c78e38dfec0e59237f5cff5613a926c0262c3688ce070029ca3cc54fa63"
+dependencies = [
+ "quote",
+ "syn 2.0.105",
+ "workspace-hack",
+ "zed-perf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ gpui-component = { path = "crates/ui" }
 gpui-component-macros = { path = "crates/macros", version = "0.2.0" }
 story = { path = "crates/story" }
 
-gpui = "0.2.1"
-gpui-macros = "0.2.1"
-sum-tree = { version = "0.2.1", package = "gpui_sum_tree" }
-http-client = { version = "0.2.1", package = "gpui_http_client" }
+gpui = "0.2.0"
+gpui-macros = "0.2.0"
+sum-tree = { version = "0.2.0", package = "zed-sum-tree" }
+http-client = { version = "0.2.0", package = "zed-http-client" }
+reqwest = { version = "0.12.15-zed", package = "zed-reqwest" }
 
 anyhow = "1"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We built multi-theme support in the application. This feature is not included in
 GPUI and GPUI Component are still in development, so you need to add dependencies by git.
 
 ```toml
-gpui = "0.2.1"
+gpui = "0.2.0"
 gpui-component = "0.2.0"
 ```
 

--- a/crates/reqwest_client/Cargo.toml
+++ b/crates/reqwest_client/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/reqwest_client.rs"
 doctest = true
 
 [dependencies]
-reqwest = { version = "0.12.15-zed", package = "zed-reqwest" }
+reqwest.workspace = true
 http-client.workspace = true
 anyhow.workspace = true
 log.workspace = true


### PR DESCRIPTION
Reverts longbridge/gpui-component#1374

Because `gpui v0.2.1` have but, the text render not in vertical center on Windows.