### PR TITLE
tiles: Ensure to response correct panel on drag or resize.

### DIFF
--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -285,7 +285,7 @@ impl Tiles {
         _: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        let Some(resizing_id) = self.resizing_id.clone() else {
+        let Some(resizing_id) = self.resizing_id else {
             return;
         };
         let Some(item) = self.panels.iter_mut().find(|item| item.id == resizing_id) else {
@@ -829,7 +829,7 @@ impl Tiles {
         item: &TileItem,
     ) -> AnyElement {
         let item_id = item.id;
-        let item_bounds = item.bounds.clone();
+        let item_bounds = item.bounds;
 
         h_flex()
             .id("drag-bar")


### PR DESCRIPTION
Use `item_id` to store the dragging and resizing item.