### PR TITLE
Change gpui-component version to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ We built multi-theme support in the application. This feature is not included in
 
 ## Usage
 
-GPUI and GPUI Component are still in development, so you need to add dependencies by git.
-
 ```toml
 gpui = "0.2.2"
-gpui-component = "0.3.0"
+gpui-component = "0.3.1"
 ```
 
 ### Basic Example


### PR DESCRIPTION
Updated gpui-component version in README. 

Removed verbage about requiring git based toml including since the crate is now released on crates.io