### PR TITLE
table: Change `context_menu` method in TableDelegate to mutable `window` and `cx`.

### DIFF
--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -354,8 +354,8 @@ impl TableDelegate for StockTableDelegate {
         &self,
         row_ix: usize,
         menu: PopupMenu,
-        _window: &Window,
-        _cx: &App,
+        _window: &mut Window,
+        _cx: &mut App,
     ) -> PopupMenu {
         menu.menu(
             format!("Selected Row: {}", row_ix),

--- a/crates/ui/src/table/delegate.rs
+++ b/crates/ui/src/table/delegate.rs
@@ -47,7 +47,13 @@ pub trait TableDelegate: Sized + 'static {
     }
 
     /// Render the context menu for the row at the given row index.
-    fn context_menu(&self, row_ix: usize, menu: PopupMenu, window: &Window, cx: &App) -> PopupMenu {
+    fn context_menu(
+        &self,
+        row_ix: usize,
+        menu: PopupMenu,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> PopupMenu {
         menu
     }
 

--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -1404,9 +1404,9 @@ where
                         let view = cx.entity().clone();
                         move |this, window: &mut Window, cx: &mut Context<PopupMenu>| {
                             if let Some(row_ix) = view.read(cx).right_clicked_row {
-                                view.read(cx)
-                                    .delegate
-                                    .context_menu(row_ix, this, window, cx)
+                                view.update(cx, |menu, cx| {
+                                    menu.delegate().context_menu(row_ix, this, window, cx)
+                                })
                             } else {
                                 this
                             }

--- a/docs/docs/components/table.md
+++ b/docs/docs/components/table.md
@@ -210,7 +210,7 @@ impl TableDelegate for MyTableDelegate {
     }
 
     // Context menu for right-click
-    fn context_menu(&self, row_ix: usize, menu: PopupMenu, _: &Window, _: &App) -> PopupMenu {
+    fn context_menu(&self, row_ix: usize, menu: PopupMenu, _: &mut Window, _: &mut App) -> PopupMenu {
         let row = &self.data[row_ix];
         menu.menu(format!("Edit {}", row.name), Box::new(EditRowAction(row_ix)))
             .menu("Delete", Box::new(DeleteRowAction(row_ix)))


### PR DESCRIPTION
## Break Change

- The `window`, `cx` has changed from `&Window`, `&App` to `&mut Window`, `&mut App`.

```diff
- fn context_menu(&self, row_ix: usize, menu: PopupMenu, window: &Window, cx: &App)
+ fn context_menu(&self, row_ix: usize, menu: PopupMenu, window: &mut Window, cx: &mut App)
```