### PR TITLE
input: Delete selected text with modifier keys

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1062,19 +1062,20 @@ impl InputState {
     ) {
         if !self.selected_range.is_empty() {
             self.replace_text_in_range(None, "", window, cx);
-        } else {
-            let mut offset = self.start_of_line();
-            if offset == self.cursor() {
-                offset = offset.saturating_sub(1);
-            }
-            self.replace_text_in_range_silent(
-                Some(self.range_to_utf16(&(offset..self.cursor()))),
-                "",
-                window,
-                cx,
-            );
+            self.pause_blink_cursor(cx);
+            return;
         }
 
+        let mut offset = self.start_of_line();
+        if offset == self.cursor() {
+            offset = offset.saturating_sub(1);
+        }
+        self.replace_text_in_range_silent(
+            Some(self.range_to_utf16(&(offset..self.cursor()))),
+            "",
+            window,
+            cx,
+        );
         self.pause_blink_cursor(cx);
     }
 
@@ -1086,19 +1087,20 @@ impl InputState {
     ) {
         if !self.selected_range.is_empty() {
             self.replace_text_in_range(None, "", window, cx);
-        } else {
-            let mut offset = self.end_of_line();
-            if offset == self.cursor() {
-                offset = (offset + 1).clamp(0, self.text.len());
-            }
-            self.replace_text_in_range_silent(
-                Some(self.range_to_utf16(&(self.cursor()..offset))),
-                "",
-                window,
-                cx,
-            );
+            self.pause_blink_cursor(cx);
+            return;
         }
 
+        let mut offset = self.end_of_line();
+        if offset == self.cursor() {
+            offset = (offset + 1).clamp(0, self.text.len());
+        }
+        self.replace_text_in_range_silent(
+            Some(self.range_to_utf16(&(self.cursor()..offset))),
+            "",
+            window,
+            cx,
+        );
         self.pause_blink_cursor(cx);
     }
 
@@ -1110,16 +1112,17 @@ impl InputState {
     ) {
         if !self.selected_range.is_empty() {
             self.replace_text_in_range(None, "", window, cx);
-        } else {
-            let offset = self.previous_start_of_word();
-            self.replace_text_in_range_silent(
-                Some(self.range_to_utf16(&(offset..self.cursor()))),
-                "",
-                window,
-                cx,
-            );
+            self.pause_blink_cursor(cx);
+            return;
         }
 
+        let offset = self.previous_start_of_word();
+        self.replace_text_in_range_silent(
+            Some(self.range_to_utf16(&(offset..self.cursor()))),
+            "",
+            window,
+            cx,
+        );
         self.pause_blink_cursor(cx);
     }
 
@@ -1131,16 +1134,17 @@ impl InputState {
     ) {
         if !self.selected_range.is_empty() {
             self.replace_text_in_range(None, "", window, cx);
-        } else {
-            let offset = self.next_end_of_word();
-            self.replace_text_in_range_silent(
-                Some(self.range_to_utf16(&(self.cursor()..offset))),
-                "",
-                window,
-                cx,
-            );
+            self.pause_blink_cursor(cx);
+            return;
         }
 
+        let offset = self.next_end_of_word();
+        self.replace_text_in_range_silent(
+            Some(self.range_to_utf16(&(self.cursor()..offset))),
+            "",
+            window,
+            cx,
+        );
         self.pause_blink_cursor(cx);
     }
 


### PR DESCRIPTION
In most applications, when text is selected and backspace/delete is pressed, the selection is simply deleted.

Currently, gpui-component will ignore the selected text and delete the previous/next word when Ctrl is pressed.

This can be very confusing especially if you do ctrl+a then ctrl+backspace, expecting the input to be cleared.

This PR makes it so that if there is an active selection, the active selection is deleted before doing any extra processing.