### PR TITLE
list: Fix incorrect next selection when select index is none

### DIFF
--- a/crates/ui/src/list/cache.rs
+++ b/crates/ui/src/list/cache.rs
@@ -105,8 +105,9 @@ impl RowsCache {
     }
 
     /// Return prev row, if the row is the first in the first section, goes to the last row.
-    pub(crate) fn prev(&self, path: IndexPath) -> IndexPath {
-        let mut path = path;
+    pub(crate) fn prev(&self, path: Option<IndexPath>) -> IndexPath {
+        let mut path = path.unwrap_or_default();
+
         if path.section == 0 && path.row == 0 {
             path.section = self.sections_count().saturating_sub(1);
             path.row = self.rows_count(path.section).saturating_sub(1);
@@ -123,8 +124,11 @@ impl RowsCache {
     }
 
     /// Returns the next row, if the row is the last in the last section, goes to the first row.
-    pub(crate) fn next(&self, path: IndexPath) -> IndexPath {
-        let mut path = path;
+    pub(crate) fn next(&self, path: Option<IndexPath>) -> IndexPath {
+        let Some(mut path) = path else {
+            return IndexPath::default();
+        };
+
         if path.section + 1 == self.sections_count()
             && path.row + 1 == self.rows_count(path.section)
         {
@@ -223,56 +227,56 @@ mod tests {
         row_cache.sections = Rc::new(vec![2, 4, 3]);
 
         assert_eq!(
-            row_cache.next(IndexPath::new(0).section(0)),
+            row_cache.next(Some(IndexPath::new(0).section(0))),
             IndexPath::new(1).section(0)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(1).section(0)),
+            row_cache.next(Some(IndexPath::new(1).section(0))),
             IndexPath::new(0).section(1)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(0).section(1)),
+            row_cache.next(Some(IndexPath::new(0).section(1))),
             IndexPath::new(1).section(1)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(3).section(1)),
+            row_cache.next(Some(IndexPath::new(3).section(1))),
             IndexPath::new(0).section(2)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(0).section(2)),
+            row_cache.next(Some(IndexPath::new(0).section(2))),
             IndexPath::new(1).section(2)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(1).section(2)),
+            row_cache.next(Some(IndexPath::new(1).section(2))),
             IndexPath::new(2).section(2)
         );
         assert_eq!(
-            row_cache.next(IndexPath::new(2).section(2)),
+            row_cache.next(Some(IndexPath::new(2).section(2))),
             IndexPath::new(0).section(0)
         );
 
         assert_eq!(
-            row_cache.prev(IndexPath::new(0).section(0)),
+            row_cache.prev(Some(IndexPath::new(0).section(0))),
             IndexPath::new(2).section(2)
         );
         assert_eq!(
-            row_cache.prev(IndexPath::new(1).section(0)),
+            row_cache.prev(Some(IndexPath::new(1).section(0))),
             IndexPath::new(0).section(0)
         );
         assert_eq!(
-            row_cache.prev(IndexPath::new(0).section(1)),
+            row_cache.prev(Some(IndexPath::new(0).section(1))),
             IndexPath::new(1).section(0)
         );
         assert_eq!(
-            row_cache.prev(IndexPath::new(1).section(1)),
+            row_cache.prev(Some(IndexPath::new(1).section(1))),
             IndexPath::new(0).section(1)
         );
         assert_eq!(
-            row_cache.prev(IndexPath::new(3).section(1)),
+            row_cache.prev(Some(IndexPath::new(3).section(1))),
             IndexPath::new(2).section(1)
         );
         assert_eq!(
-            row_cache.prev(IndexPath::new(0).section(2)),
+            row_cache.prev(Some(IndexPath::new(0).section(2))),
             IndexPath::new(3).section(1)
         );
     }

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -367,9 +367,7 @@ where
             return;
         }
 
-        let prev_ix = self
-            .rows_cache
-            .prev(self.selected_index.unwrap_or(IndexPath::default()));
+        let prev_ix = self.rows_cache.prev(self.selected_index);
         self.select_item(prev_ix, window, cx);
     }
 
@@ -383,9 +381,7 @@ where
             return;
         }
 
-        let next_ix = self
-            .rows_cache
-            .next(self.selected_index.unwrap_or_default());
+        let next_ix = self.rows_cache.next(self.selected_index);
         self.select_item(next_ix, window, cx);
     }
 


### PR DESCRIPTION
Previously, pressing next would select the second item.