### PR TITLE
select/date_picker: Set default cleanable state to false

### DIFF
--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -306,7 +306,7 @@ impl Default for SelectOptions {
             style: StyleRefinement::default(),
             size: Size::default(),
             icon: None,
-            cleanable: true,
+            cleanable: false,
             placeholder: None,
             title_prefix: None,
             empty: None,

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -301,7 +301,7 @@ impl DatePicker {
         Self {
             id: ("date-picker", state.entity_id()).into(),
             state: state.clone(),
-            cleanable: true,
+            cleanable: false,
             placeholder: None,
             size: Size::default(),
             style: StyleRefinement::default(),


### PR DESCRIPTION
The default was accidentally set to true for Select in 893e323.
The Select::cleanable() method sets it to true, so the default should be false.

(Same with DatePicker, I just searched for `cleanable: true` in the codebase and it had the same problem :) )