### PR TITLE
table: fix row border missing on first frame

### DIFF
--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -1006,7 +1006,7 @@ where
 
         if row_ix < rows_count {
             let is_last_row = row_ix + 1 == rows_count;
-            let need_render_border = !is_last_row || !is_filled;
+            let need_render_border = is_selected || !is_last_row || !is_filled;
 
             let mut tr = self.delegate.render_tr(row_ix, window, cx);
             let style = tr.style().clone();


### PR DESCRIPTION
Currently, the bounds are zero on the first frame.
Therefore, the extra_rows_count will always be zero on the first frame.
This causes rendering issues for row border & row stripes.

Unfortunately, I don't know how to get the correct height on the first frame to fix the row stripes.

However, an easy fix for the row border rendering issue is to disable the table_is_filled check. The check is problematic anyways since the border affects the height of the element.

I attached a video showing the issue, the border doesn't render on the first frame and the height of the element also shifts due to the border:

https://github.com/user-attachments/assets/b154c686-cd9c-4b6b-8ba6-c79640297abc

