### PR TITLE
table: Fix missing border on first frame

### DIFF
--- a/crates/ui/src/table/mod.rs
+++ b/crates/ui/src/table/mod.rs
@@ -1310,7 +1310,7 @@ where
             rows_count
         };
         let right_clicked_row = self.right_clicked_row;
-        let is_filled = total_height <= actual_height;
+        let is_filled = total_height > Pixels::ZERO && total_height <= actual_height;
 
         let loading_view = if loading {
             Some(


### PR DESCRIPTION
After all the adjustments, the original issue that https://github.com/longbridge/gpui-component/pull/1505 was trying to fix reappeared.

The fix is simple: don't consider the table to be filled if the height is zero.