### PR TITLE
button_group: Fix overriding button click when no on_click

### DIFF
--- a/crates/ui/src/button/button_group.rs
+++ b/crates/ui/src/button/button_group.rs
@@ -219,8 +219,10 @@ impl RenderOnce for ButtonGroup {
                         .when_some(self.variant, |this, variant| this.with_variant(variant))
                         .when(self.compact, |this| this.compact())
                         .when(self.outline, |this| this.outline())
-                        .on_click(move |_, _, _| {
-                            state.set(Some(child_index));
+                        .when(self.on_click.is_some(), |this| {
+                            this.on_click(move |_, _, _| {
+                                state.set(Some(child_index));
+                            })
                         });
 
                         child


### PR DESCRIPTION
When `on_click` is not specified on the button group, this PR allows for specifying on_click on each individual button.

e.g.

```rs
let buttons = ButtonGroup::new(("buttons", index)).layout(Axis::Vertical)
    .child(Button::new(("install", index)).label("Install").icon(download_icon).success().on_click(move |_, _, cx| {
          // Install
    })
    .child(Button::new(("open", index)).label("Open Page").icon(IconName::Globe).info().on_click(move |_, _, cx| {
         // Open page
    }));
```