### PR TITLE
Add ability to disable resizing of the window

### DIFF
--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -219,6 +219,7 @@ pub struct Root {
     pub notification: Entity<NotificationList>,
     sheet_size: Option<DefiniteLength>,
     view: AnyView,
+    is_resizable: bool,
 }
 
 #[derive(Clone)]
@@ -244,7 +245,18 @@ impl Root {
             notification: cx.new(|cx| NotificationList::new(window, cx)),
             sheet_size: None,
             view,
+            is_resizable: true,
         }
+    }
+
+    pub fn set_resizable(&mut self, enabled: bool) -> &mut Self {
+        self.is_resizable = enabled;
+        self
+    }
+
+    pub fn with_resizable(mut self, enabled: bool) -> Self {
+        self.is_resizable = enabled;
+        self
     }
 
     pub fn update<F, R>(window: &mut Window, cx: &mut App, f: F) -> R
@@ -390,7 +402,9 @@ impl Render for Root {
         let base_font_size = cx.theme().font_size;
         window.set_rem_size(base_font_size);
 
-        window_border().child(
+        window_border()
+        .with_resizable(self.is_resizable)
+        .child(
             div()
                 .id("root")
                 .key_context(CONTEXT)

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -23,14 +23,26 @@ pub fn window_border() -> WindowBorder {
 /// Window border use to render a custom window border and shadow for Linux.
 #[derive(IntoElement, Default)]
 pub struct WindowBorder {
+    is_resizable: bool,
     children: Vec<AnyElement>,
 }
 
 impl WindowBorder {
     pub fn new() -> Self {
         Self {
+            is_resizable: true,
             ..Default::default()
         }
+    }
+
+    pub fn set_resizable(&mut self, resizable: bool) -> &mut Self {
+        self.is_resizable = resizable;
+        self
+    }
+
+    pub fn with_resizable(mut self, resizable: bool) -> Self {
+        self.is_resizable = resizable;
+        self
     }
 }
 
@@ -87,6 +99,9 @@ impl RenderOnce for WindowBorder {
                                 )
                             },
                             move |_bounds, hitbox, window, _| {
+                                if !self.is_resizable {
+                                    return;
+                                }
                                 let mouse = window.mouse_position();
                                 let size = window.window_bounds().get_bounds().size;
                                 let Some(edge) = resize_edge(mouse, SHADOW_SIZE, size) else {
@@ -125,6 +140,9 @@ impl RenderOnce for WindowBorder {
                     .when(!tiling.left, |div| div.pl(SHADOW_SIZE))
                     .when(!tiling.right, |div| div.pr(SHADOW_SIZE))
                     .on_mouse_down(MouseButton::Left, move |_, window, _| {
+                        if !self.is_resizable {
+                            return;
+                        }
                         let size = window.window_bounds().get_bounds().size;
                         let pos = window.mouse_position();
 


### PR DESCRIPTION
It is currently not possible to disable window resizing in gpui-component.

It would be nice if gpui-component inherited `is_resizable` from `WindowOptions`, but AFAIK, there is no way to access that value of the window after window creation, so I added the resizable option to `Root` (and `WindowBorder`) instead, with `true` as the default value to maintain the current behavior when unset.

If you are unhappy with the API in the PR, but agree that resizing should be something that can be disabled, then treat this as a feature request.
