### PR TITLE
input: Avoid blocking vertical scroll events in single-line mode (#1562)

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -6,10 +6,9 @@ use anyhow::Result;
 use gpui::{
     actions, div, point, prelude::FluentBuilder as _, px, Action, App, AppContext, Bounds,
     ClipboardItem, Context, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable,
-    InteractiveElement as _, IntoElement, IsZero, KeyBinding, KeyDownEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, Point, Render,
-    ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription, Task, UTF16Selection,
-    Window,
+    InteractiveElement as _, IntoElement, KeyBinding, KeyDownEvent, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, Point, Render, ScrollHandle,
+    ScrollWheelEvent, SharedString, Styled as _, Subscription, Task, UTF16Selection, Window,
 };
 use ropey::{Rope, RopeSlice};
 use serde::Deserialize;
@@ -1298,12 +1297,6 @@ impl InputState {
             .map(|layout| layout.line_height)
             .unwrap_or(window.line_height());
         let delta = event.delta.pixel_delta(line_height);
-
-        // In single-line mode, if this is a pure vertical scroll, don't block
-        // the event so parent containers can handle page scrolling
-        if self.mode.is_single_line() && delta.x.is_zero() && !delta.y.is_zero() {
-            return;
-        }
 
         let old_offset = self.scroll_handle.offset();
         self.update_scroll_offset(Some(old_offset + delta), cx);


### PR DESCRIPTION
  Fixes #1562

  ## Problem
  Single-line input fields were blocking all scroll wheel events, preventing parent containers from handling vertical page scrolling.

  ## Solution
  - Check if input is in single-line mode and scroll is purely vertical
  - Allow vertical scroll events to propagate in single-line mode
  - Only stop propagation when scroll offset actually changes

  ## Behavior
  - Single-line inputs: vertical scroll passes through to parent
  - Multi-line inputs: all scroll behavior unchanged
  - Horizontal scrolling still works in both modes