### PR TITLE
input: Fix x offset resetting for single line inputs

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -952,7 +952,9 @@ impl Element for TextElement {
         );
 
         let mut longest_line_width = wrap_width.unwrap_or(px(0.));
-        if state.mode.is_single_line() || !state.soft_wrap || lines.len() > 1 {
+        // 1. Single line
+        // 2. Multi-line with soft wrap disabled.
+        if state.mode.is_single_line() || !state.soft_wrap {
             let longest_row = state.text_wrapper.longest_row.row;
             let longest_line: SharedString = state.text.slice_line(longest_row).to_string().into();
             longest_line_width = window


### PR DESCRIPTION
Fixes #1589

Before:
https://github.com/user-attachments/assets/ae1dd1c4-de97-4336-94ab-e545a1e97047



After:
https://github.com/user-attachments/assets/62b5cf08-0782-426e-b2ee-dc018f140149

