### PR TITLE
plot: Rename `Label` and `Axis` include `Plot` prefix

### DIFF
--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -8,7 +8,7 @@ use crate::{
     plot::{
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Area,
-        Axis, AxisText, Grid, Plot, StrokeStyle, AXIS_GAP,
+        AxisText, Grid, Plot, PlotAxis, StrokeStyle, AXIS_GAP,
     },
     ActiveTheme, PixelsExt,
 };
@@ -142,7 +142,7 @@ where
             }
         });
 
-        Axis::new()
+        PlotAxis::new()
             .x(height)
             .x_label(x_label)
             .stroke(cx.theme().border)

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -9,7 +9,7 @@ use crate::{
         label::Text,
         scale::{Scale, ScaleBand, ScaleLinear, Sealed},
         shape::Bar,
-        Axis, AxisText, Grid, Plot, AXIS_GAP,
+        PlotAxis, AxisText, Grid, Plot, AXIS_GAP,
     },
     ActiveTheme, PixelsExt,
 };
@@ -125,7 +125,7 @@ where
             }
         });
 
-        Axis::new()
+        PlotAxis::new()
             .x(height)
             .x_label(x_label)
             .stroke(cx.theme().border)

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -8,7 +8,7 @@ use crate::{
     plot::{
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Line,
-        Axis, AxisText, Grid, Plot, StrokeStyle, AXIS_GAP,
+        AxisText, Grid, Plot, PlotAxis, StrokeStyle, AXIS_GAP,
     },
     ActiveTheme, PixelsExt,
 };
@@ -134,7 +134,7 @@ where
             }
         });
 
-        Axis::new()
+        PlotAxis::new()
             .x(height)
             .x_label(x_label)
             .stroke(cx.theme().border)

--- a/crates/ui/src/plot/axis.rs
+++ b/crates/ui/src/plot/axis.rs
@@ -3,7 +3,7 @@ use gpui::{
     Window,
 };
 
-use super::{label::Label, label::Text, label::TEXT_GAP, label::TEXT_SIZE, origin_point};
+use super::{label::PlotLabel, label::Text, label::TEXT_GAP, label::TEXT_SIZE, origin_point};
 
 pub const AXIS_GAP: f32 = 18.;
 
@@ -38,17 +38,17 @@ impl AxisText {
 }
 
 #[derive(Default)]
-pub struct Axis {
+pub struct PlotAxis {
     x: Option<Pixels>,
-    x_label: Label,
+    x_label: PlotLabel,
     show_x_axis: bool,
     y: Option<Pixels>,
-    y_label: Label,
+    y_label: PlotLabel,
     show_y_axis: bool,
     stroke: Hsla,
 }
 
-impl Axis {
+impl PlotAxis {
     pub fn new() -> Self {
         Self {
             show_x_axis: true,

--- a/crates/ui/src/plot/label.rs
+++ b/crates/ui/src/plot/label.rs
@@ -56,7 +56,7 @@ impl Text {
     }
 }
 
-impl<I> From<I> for Label
+impl<I> From<I> for PlotLabel
 where
     I: Iterator<Item = Text>,
 {
@@ -66,9 +66,9 @@ where
 }
 
 #[derive(Default)]
-pub struct Label(Vec<Text>);
+pub struct PlotLabel(Vec<Text>);
 
-impl Label {
+impl PlotLabel {
     pub fn new(items: Vec<Text>) -> Self {
         Self(items)
     }

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -13,9 +13,9 @@ use gpui::{point, px, App, Bounds, IntoElement, Path, PathBuilder, Pixels, Point
 
 use crate::PixelsExt;
 
-pub use axis::{Axis, AxisText, AXIS_GAP};
+pub use axis::{AxisText, PlotAxis, AXIS_GAP};
 pub use grid::Grid;
-pub use label::Label;
+pub use label::PlotLabel;
 
 pub trait Plot: IntoElement {
     fn paint(&mut self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut App);

--- a/crates/ui/src/plot/shape/bar.rs
+++ b/crates/ui/src/plot/shape/bar.rs
@@ -1,7 +1,7 @@
 use gpui::{fill, point, px, App, Bounds, Hsla, PaintQuad, Pixels, Point, Window};
 
 use crate::plot::{
-    label::{Label, Text, TEXT_GAP, TEXT_HEIGHT},
+    label::{PlotLabel, Text, TEXT_GAP, TEXT_HEIGHT},
     origin_point,
 };
 
@@ -93,7 +93,7 @@ impl<T> Bar<T> {
         self
     }
 
-    fn path(&self, bounds: &Bounds<Pixels>) -> (Vec<PaintQuad>, Label) {
+    fn path(&self, bounds: &Bounds<Pixels>) -> (Vec<PaintQuad>, PlotLabel) {
         let origin = bounds.origin;
         let mut graph = vec![];
         let mut labels = vec![];
@@ -136,7 +136,7 @@ impl<T> Bar<T> {
             }
         }
 
-        (graph, Label::new(labels))
+        (graph, PlotLabel::new(labels))
     }
 
     /// Paint the Bar.


### PR DESCRIPTION
## Breaking changes

```diff
- Label::new()
+ PlotLabel::new()

- Axis::new()
+ PlotAxis::new()
```

This is to avoid naming conflicts with `gpui` and `gpui-component`.