### PR TITLE
slider: Notify on bound update

### DIFF
--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -656,7 +656,17 @@ impl RenderOnce for Slider {
                             .child({
                                 let state = self.state.clone();
                                 canvas(
-                                    move |bounds, _, cx| state.update(cx, |r, _| r.bounds = bounds),
+                                    move |bounds, _, cx| {
+                                        state.update(cx, |r, cx| {
+                                            r.bounds = bounds;
+                                            let entity = cx.entity();
+                                            cx.defer(move |cx| {
+                                                entity.update(cx, |_, cx| {
+                                                    cx.notify();
+                                                });
+                                            });
+                                        })
+                                    },
                                     |_, _, _, _| {},
                                 )
                                 .absolute()


### PR DESCRIPTION
The slider has the same issue that was fixed in #1588. When resizing, the state isn't notified when the bounds change, leading to the slider not updating until it is rendered again:

https://github.com/user-attachments/assets/de79c338-d489-4173-a0be-45af30c8ae95

Again, I believe the defer is necessary here. Only notifying without deferring does not change this behavior. With the deferred notify, this behavior is fixed:


https://github.com/user-attachments/assets/6e77dc52-ec1f-47a8-945f-4a70ce7bd48d

