### PR TITLE
menu: Fix icon width to tidy indent in `PopupMenuItem`.

### DIFF
--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -970,26 +970,17 @@ impl PopupMenu {
         _: &mut Window,
         _: &mut Context<Self>,
     ) -> Option<impl IntoElement> {
-        let icon_placeholder = if has_icon { Some(Icon::empty()) } else { None };
-
         if !has_icon {
             return None;
         }
 
-        let icon = h_flex()
-            .w_3p5()
-            .h_3p5()
-            .justify_center()
-            .text_sm()
-            .map(|this| {
-                if let Some(icon) = icon {
-                    this.child(icon.clone().xsmall())
-                } else {
-                    this.children(icon_placeholder.clone())
-                }
-            });
+        let icon = if let Some(icon) = icon {
+            icon.clone()
+        } else {
+            Icon::empty()
+        };
 
-        Some(icon)
+        Some(icon.xsmall())
     }
 
     #[inline]
@@ -1070,7 +1061,7 @@ impl PopupMenu {
                     .items_center()
                     .gap_x_1()
                     .children(Self::render_icon(has_icon, None, window, cx))
-                    .child(label.clone()),
+                    .child(div().flex_1().child(label.clone())),
             ),
             PopupMenuItem::ElementItem {
                 render,


### PR DESCRIPTION
Fix the issue of alignment after selection.

| Before | After |
| - | - |
| <img width="291" height="299" alt="image" src="https://github.com/user-attachments/assets/ed1237dc-d4b9-4934-b2f1-1e5b558c757c" /> | <img width="292" height="297" alt="SCR-20251117-kjik" src="https://github.com/user-attachments/assets/200071c2-717e-4033-bf1a-906b43c77f19" /> |