### PR TITLE
chart: Add support to set stroke color on line chart

### DIFF
--- a/crates/story/src/chart_story.rs
+++ b/crates/story/src/chart_story.rs
@@ -261,7 +261,8 @@ impl Render for ChartStory {
                         LineChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .dot(),
+                            .dot()
+                            .stroke(cx.theme().chart_5),
                         false,
                         cx,
                     )),

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -59,6 +59,11 @@ where
         self
     }
 
+    pub fn stroke(mut self, stroke: impl Into<Hsla>) -> Self {
+        self.stroke = Some(stroke.into());
+        self
+    }
+
     pub fn natural(mut self) -> Self {
         self.stroke_style = StrokeStyle::Natural;
         self


### PR DESCRIPTION
Close #1625.

<img width="335" height="422" alt="image" src="https://github.com/user-attachments/assets/f2235b42-9a3e-4ed7-88ae-b694ee579faf" />
