### PR TITLE
number_input: Use input border on the buttons

### DIFF
--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -160,6 +160,7 @@ impl RenderOnce for NumberInput {
                     .compact()
                     .tab_stop(false)
                     .disabled(self.disabled)
+                    .border_color(cx.theme().input)
                     .border_corners(Corners {
                         top_left: true,
                         top_right: false,
@@ -197,6 +198,7 @@ impl RenderOnce for NumberInput {
                     .compact()
                     .tab_stop(false)
                     .disabled(self.disabled)
+                    .border_color(cx.theme().input)
                     .border_corners(Corners {
                         top_left: false,
                         top_right: true,


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="268" height="114" alt="SCR-20251118-nasx" src="https://github.com/user-attachments/assets/d66d4178-d6f9-4f00-b3ad-94d1aee3a262" /> | <img width="268" height="112" alt="SCR-20251118-nazg" src="https://github.com/user-attachments/assets/df1bdc1d-ee8b-4249-b301-4479145f393a" /> |