### PR TITLE
color_picker: Add radius on focus border

### DIFF
--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -398,6 +398,7 @@ impl RenderOnce for ColorPicker {
                     .items_center()
                     .input_text_size(self.size)
                     .line_height(relative(1.))
+                    .rounded(cx.theme().radius)
                     .refine_style(&self.style)
                     .when_some(self.icon.clone(), |this, icon| {
                         this.child(
@@ -417,7 +418,6 @@ impl RenderOnce for ColorPicker {
                                 .border_1()
                                 .m_1()
                                 .border_color(cx.theme().input)
-                                .rounded(cx.theme().radius)
                                 .shadow_xs()
                                 .rounded(cx.theme().radius)
                                 .overflow_hidden()
@@ -470,7 +470,6 @@ impl RenderOnce for ColorPicker {
                                     .border_1()
                                     .border_color(cx.theme().border)
                                     .shadow_lg()
-                                    .rounded(cx.theme().radius)
                                     .bg(cx.theme().background)
                                     .child(self.render_colors(window, cx))
                                     .on_mouse_up_out(


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="143" height="51" alt="SCR-20251121-jwmj" src="https://github.com/user-attachments/assets/69693a83-dbf8-44ea-b46e-bd88c3c2f1f3" /> | <img width="135" height="45" alt="SCR-20251121-jvol" src="https://github.com/user-attachments/assets/177a90fc-8400-4df7-9ee2-3b4f32633c4b" /> |