### PR TITLE
scrollbar: Remove `Scrollbar::uniform_scroll`, use `Scrollbar::vertical` instead.

### DIFF
--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -550,7 +550,7 @@ where
                 }
             })
             .when(scrollbar_visible, |this| {
-                this.child(Scrollbar::uniform_scroll(&scroll_state, &scroll_handle))
+                this.child(Scrollbar::vertical(&scroll_state, &scroll_handle))
             })
     }
 }

--- a/crates/ui/src/scroll/scrollbar.rs
+++ b/crates/ui/src/scroll/scrollbar.rs
@@ -359,14 +359,6 @@ impl Scrollbar {
         Self::new(ScrollbarAxis::Vertical, state, scroll_handle)
     }
 
-    /// Create vertical scrollbar for uniform list.
-    pub fn uniform_scroll(
-        state: &ScrollbarState,
-        scroll_handle: &(impl ScrollHandleOffsetable + Clone + 'static),
-    ) -> Self {
-        Self::new(ScrollbarAxis::Vertical, state, scroll_handle)
-    }
-
     /// Set the scrollbar show mode [`ScrollbarShow`], if not set use the `cx.theme().scrollbar_show`.
     pub fn scrollbar_show(mut self, scrollbar_show: ScrollbarShow) -> Self {
         self.scrollbar_show = Some(scrollbar_show);

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -1214,11 +1214,8 @@ where
                 .bottom_0()
                 .w(Scrollbar::width())
                 .child(
-                    Scrollbar::uniform_scroll(
-                        &self.vertical_scroll_state,
-                        &self.vertical_scroll_handle,
-                    )
-                    .max_fps(60),
+                    Scrollbar::vertical(&self.vertical_scroll_state, &self.vertical_scroll_handle)
+                        .max_fps(60),
                 ),
         )
     }


### PR DESCRIPTION
## Break Change

- Remove `Scrollbar::uniform_scroll`, use `Scrollbar::vertical` instead.

```diff
- Scrollbar::uniform_scroll(&scroll_state, &scroll_handle)
+ Scrollbar::vertical(&scroll_state, &scroll_handle)
```