### PR TITLE
dock: Render title bar based on visible panels

### DIFF
--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -8,9 +8,10 @@ mod tiles;
 
 use anyhow::Result;
 use gpui::{
-    actions, canvas, div, prelude::FluentBuilder, AnyElement, AnyView, App, AppContext, Axis,
-    Bounds, Context, Edges, Entity, EntityId, EventEmitter, InteractiveElement as _, IntoElement,
-    ParentElement as _, Pixels, Render, SharedString, Styled, Subscription, WeakEntity, Window,
+    AnyElement, AnyView, App, AppContext, Axis, Bounds, Context, Edges, Entity, EntityId,
+    EventEmitter, InteractiveElement as _, IntoElement, ParentElement as _, Pixels, Render,
+    SharedString, Styled, Subscription, WeakEntity, Window, actions, canvas, div,
+    prelude::FluentBuilder,
 };
 use std::sync::Arc;
 
@@ -463,7 +464,7 @@ impl DockArea {
             right_dock: None,
             bottom_dock: None,
             locked: false,
-            panel_style: PanelStyle::Default,
+            panel_style: PanelStyle::default(),
             _subscriptions: vec![],
         };
 

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -8,7 +8,7 @@ use gpui::{
 
 use rust_i18n::t;
 
-use super::{invalid_panel::InvalidPanel, DockArea, PanelInfo, PanelState};
+use super::{DockArea, PanelInfo, PanelState, invalid_panel::InvalidPanel};
 
 pub enum PanelEvent {
     ZoomIn,
@@ -16,10 +16,11 @@ pub enum PanelEvent {
     LayoutChanged,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PanelStyle {
     /// Display the TabBar when there are multiple tabs, otherwise display the simple title.
-    Default,
+    #[default]
+    Auto,
     /// Always display the tab bar.
     TabBar,
 }

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -601,7 +601,6 @@ impl TabPanel {
         let Some(dock_area) = self.dock_area.upgrade() else {
             return div().into_any_element();
         };
-        let panel_style = dock_area.read(cx).panel_style;
 
         let left_dock_button = self.render_dock_toggle_button(DockPlacement::Left, window, cx);
         let bottom_dock_button = self.render_dock_toggle_button(DockPlacement::Bottom, window, cx);
@@ -609,8 +608,15 @@ impl TabPanel {
 
         let is_bottom_dock = bottom_dock_button.is_some();
 
-        if self.panels.len() == 1 && panel_style == PanelStyle::Default {
-            let panel = self.panels.get(0).unwrap();
+        let panel_style = dock_area.read(cx).panel_style;
+        let visible_panels = self
+            .panels
+            .iter()
+            .filter(|panel| panel.visible(cx))
+            .collect::<Vec<_>>();
+
+        if visible_panels.len() == 1 && panel_style == PanelStyle::default() {
+            let panel = visible_panels.get(0).unwrap();
 
             if !panel.visible(cx) {
                 return div().into_any_element();
@@ -655,7 +661,7 @@ impl TabPanel {
                         .when(state.draggable, |this| {
                             this.on_drag(
                                 DragPanel {
-                                    panel: panel.clone(),
+                                    panel: (**panel).clone(),
                                     tab_panel: view,
                                 },
                                 |drag, _, _, cx| {


### PR DESCRIPTION
Display the title when only one panel is visible.

## Breaking change
```diff
pub enum PanelStyle {
-   Default,
+   #[default]
+   Auto,
    TabBar,
}

- dock_area.panel_style(PanelStyle::Default)
+ dock_area.panel_style(PanelStyle::Auto)
```