### PR TITLE
editor: Fix cursor direction not resetting after mouseup

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1232,6 +1232,9 @@ impl InputState {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) {
+        if self.selected_range.is_empty() {
+            self.selection_reversed = false;
+        }
         self.selecting = false;
         self.selected_word_range = None;
     }


### PR DESCRIPTION
## Description

This PR fixes an issue where the editor's "reverse cursor" state was not reset
after completing a text selection. Because the flag remained `true`, the cursor
could appear on the wrong side of the selection when the next interaction
started.

## Screenshot

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/308c5119-52da-4bdb-9a94-36617d957c63" controls width="360"></video> | <video src="https://github.com/user-attachments/assets/bf9328b4-96d8-48df-9cc0-99fccaced7c5" controls width="360"></video> |

## How to Test

`cargo run --example editor`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
