### PR TITLE
input: Fix resetting highlighting for single line code editor

### DIFF
--- a/crates/story/src/input_story.rs
+++ b/crates/story/src/input_story.rs
@@ -1,10 +1,12 @@
 use gpui::{
-    App, AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement as _,
-    Render, Styled, Subscription, Window, div,
+    App, AppContext as _, ClickEvent, Context, Entity, InteractiveElement, IntoElement,
+    ParentElement as _, Render, Styled, Subscription, Window, div,
 };
 
 use crate::section;
 use gpui_component::{button::*, input::*, *};
+
+const CODE_EXAMPLE: &str = r#"{"single_line":"code editor"}"#;
 
 pub fn init(_: &mut App) {}
 
@@ -93,7 +95,7 @@ impl InputStory {
             InputState::new(window, cx)
                 .code_editor("json")
                 .multi_line(false)
-                .default_value(r#"{"single_line":"code editor"}"#)
+                .default_value(CODE_EXAMPLE)
         });
 
         let _subscriptions = vec![
@@ -150,6 +152,12 @@ impl InputStory {
             InputEvent::Focus => println!("Focus"),
             InputEvent::Blur => println!("Blur"),
         };
+    }
+
+    fn on_click_reset(&mut self, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
+        self.code_input.update(cx, |input_state, cx| {
+            input_state.set_value(CODE_EXAMPLE, window, cx);
+        });
     }
 }
 
@@ -262,9 +270,15 @@ impl Render for InputStory {
                 ),
             )
             .child(
-                section("Single line code editor")
-                    .max_w_md()
-                    .child(Input::new(&self.code_input)),
+                section("Single line code editor").max_w_md().child(
+                    Input::new(&self.code_input).suffix(
+                        Button::new("code-reset")
+                            .ghost()
+                            .label("Reset")
+                            .xsmall()
+                            .on_click(cx.listener(Self::on_click_reset)),
+                    ),
+                ),
             )
     }
 }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -606,15 +606,19 @@ impl InputState {
         self.replace_text(value, window, cx);
         self.disabled = was_disabled;
         self.history.ignore = false;
+
         // Ensure cursor to start when set text
         if self.mode.is_single_line() {
             self.selected_range = (self.text.len()..self.text.len()).into();
         } else {
             self.selected_range.clear();
+        }
 
+        if self.mode.is_code_editor() {
             self._pending_update = true;
             self.lsp.reset();
         }
+
         // Move scroll to top
         self.scroll_handle.set_offset(point(px(0.), px(0.)));
 


### PR DESCRIPTION
## Description

When using `set_value` with a `code_editor("lang").multi_line(false)` the highlighting and lsp will not be reset.

## Video

### Before
https://github.com/user-attachments/assets/5fef5b6e-478e-4233-a911-e087f889040a

### After
https://github.com/user-attachments/assets/3ea99060-8dba-4604-9d3f-c151b3aadcf2

## How to Test

`cargo run --release -- input`, enter some text in "Single line code editor", click "Reset"

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
