### PR TITLE
context_menu: Prevent mouse events when menu popped out

### DIFF
--- a/crates/ui/src/menu/context_menu.rs
+++ b/crates/ui/src/menu/context_menu.rs
@@ -1,10 +1,10 @@
 use std::{cell::RefCell, rc::Rc};
 
 use gpui::{
-    anchored, deferred, div, prelude::FluentBuilder, px, AnyElement, App, Context, Corner,
-    DismissEvent, Element, ElementId, Entity, Focusable, GlobalElementId, InspectorElementId,
-    InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
-    StyleRefinement, Styled, Subscription, Window,
+    AnyElement, App, Context, Corner, DismissEvent, Element, ElementId, Entity, Focusable,
+    GlobalElementId, InspectorElementId, InteractiveElement, IntoElement, MouseButton,
+    MouseDownEvent, ParentElement, Pixels, Point, StyleRefinement, Styled, Subscription, Window,
+    anchored, deferred, div, prelude::FluentBuilder, px,
 };
 
 use crate::menu::PopupMenu;
@@ -168,18 +168,29 @@ impl<E: ParentElement + Styled + IntoElement + 'static> Element for ContextMenu<
                     if has_menu_item {
                         menu_element = Some(
                             deferred(
-                                anchored()
-                                    .position(position)
-                                    .snap_to_window_with_margin(px(8.))
-                                    .anchor(anchor)
-                                    .when_some(menu_view, |this, menu| {
-                                        // Focus the menu, so that can be handle the action.
-                                        if !menu.focus_handle(cx).contains_focused(window, cx) {
-                                            menu.focus_handle(cx).focus(window);
-                                        }
+                                anchored().child(
+                                    div()
+                                        .w(window.bounds().size.width)
+                                        .h(window.bounds().size.height)
+                                        .occlude()
+                                        .child(
+                                            anchored()
+                                                .position(position)
+                                                .snap_to_window_with_margin(px(8.))
+                                                .anchor(anchor)
+                                                .when_some(menu_view, |this, menu| {
+                                                    // Focus the menu, so that can be handle the action.
+                                                    if !menu
+                                                        .focus_handle(cx)
+                                                        .contains_focused(window, cx)
+                                                    {
+                                                        menu.focus_handle(cx).focus(window);
+                                                    }
 
-                                        this.child(div().occlude().child(menu.clone()))
-                                    }),
+                                                    this.child(menu.clone())
+                                                }),
+                                        ),
+                                ),
                             )
                             .with_priority(1)
                             .into_any(),


### PR DESCRIPTION
## Before
https://github.com/user-attachments/assets/6cb5a767-d888-43f1-b5cc-1f3c5748389d

## After
https://github.com/user-attachments/assets/0846d0e2-2311-47d1-8d5b-2e7bbc347fe3

