### PR TITLE
table: make Column return owned

### DIFF
--- a/crates/story/src/stories/dialog_story.rs
+++ b/crates/story/src/stories/dialog_story.rs
@@ -58,8 +58,8 @@ impl TableDelegate for MyTable {
         200
     }
 
-    fn column(&self, col_ix: usize, _: &App) -> &Column {
-        &self.columns[col_ix]
+    fn column(&self, col_ix: usize, _: &App) -> Column {
+        self.columns[col_ix].clone()
     }
 
     fn render_td(

--- a/crates/story/src/stories/table_story.rs
+++ b/crates/story/src/stories/table_story.rs
@@ -352,8 +352,8 @@ impl TableDelegate for StockTableDelegate {
         self.stocks.len()
     }
 
-    fn column(&self, col_ix: usize, _cx: &App) -> &Column {
-        &self.columns[col_ix]
+    fn column(&self, col_ix: usize, _cx: &App) -> Column {
+        self.columns[col_ix].clone()
     }
 
     fn render_th(

--- a/crates/ui/src/table/delegate.rs
+++ b/crates/ui/src/table/delegate.rs
@@ -23,7 +23,7 @@ pub trait TableDelegate: Sized + 'static {
     /// Returns the table column at the given index.
     ///
     /// This only call on Table prepare or refresh.
-    fn column(&self, col_ix: usize, cx: &App) -> &Column;
+    fn column(&self, col_ix: usize, cx: &App) -> Column;
 
     /// Perform sort on the column at the given index.
     fn perform_sort(

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -282,7 +282,7 @@ where
                 ColGroup {
                     width: column.width,
                     bounds: Bounds::default(),
-                    column: column.clone(),
+                    column,
                 }
             })
             .collect();


### PR DESCRIPTION
Closes #1765

## Description

table: Make refs Column as owned ; allows column name to be replaced

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="521" height="198" alt="image" src="https://github.com/user-attachments/assets/485568c2-3035-42d8-8237-1e5f0075639f" /> | <img width="521" height="198" alt="image" src="https://github.com/user-attachments/assets/ae0d7acc-b488-4b47-b932-b9c8cbf365af" /> |

- Change 1

```diff
- fn column(&self, col_ix: usize, cx: &App) -> &Column;
+ fn column(&self, col_ix: usize, cx: &App) -> Column;
```

## How to Test

i could make a reproduction repo, but not worth it for such a small change

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
