### PR TITLE
menu: Support check state to AppMenuBar.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,6 +2955,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest_client",
+ "rust-i18n",
  "serde",
  "serde_json",
  "smol",

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tree-sitter-navi = "0.2.2"
 unindent = "0.2.3"
+rust-i18n.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18" }

--- a/crates/story/src/app_menus.rs
+++ b/crates/story/src/app_menus.rs
@@ -1,12 +1,40 @@
-use gpui::{App, Menu, MenuItem, SharedString};
-use gpui_component::{ThemeMode, ThemeRegistry};
+use gpui::{App, Entity, Menu, MenuItem, SharedString};
+use gpui_component::{ActiveTheme as _, Theme, ThemeMode, ThemeRegistry, menu::AppMenuBar};
 
 use crate::{
     About, CloseWindow, Open, Quit, SelectLocale, ToggleSearch,
     themes::{SwitchTheme, SwitchThemeMode},
 };
 
-pub fn init(title: impl Into<SharedString>, cx: &mut App) {
+pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Entity<AppMenuBar> {
+    let app_menu_bar = AppMenuBar::new(cx);
+    let title: SharedString = title.into();
+    update_app_menu(title.clone(), app_menu_bar.clone(), cx);
+
+    cx.on_action({
+        let title = title.clone();
+        let app_menu_bar = app_menu_bar.clone();
+        move |s: &SelectLocale, cx: &mut App| {
+            rust_i18n::set_locale(&s.0.as_str());
+            update_app_menu(title.clone(), app_menu_bar.clone(), cx);
+        }
+    });
+
+    // Observe theme changes to update the menu to refresh the checked state
+    cx.observe_global::<Theme>({
+        let title = title.clone();
+        let app_menu_bar = app_menu_bar.clone();
+        move |cx| {
+            update_app_menu(title.clone(), app_menu_bar.clone(), cx);
+        }
+    })
+    .detach();
+
+    app_menu_bar
+}
+
+fn update_app_menu(title: impl Into<SharedString>, app_menu_bar: Entity<AppMenuBar>, cx: &mut App) {
+    let mode = cx.theme().mode;
     cx.set_menus(vec![
         Menu {
             name: title.into(),
@@ -18,8 +46,10 @@ pub fn init(title: impl Into<SharedString>, cx: &mut App) {
                 MenuItem::Submenu(Menu {
                     name: "Appearance".into(),
                     items: vec![
-                        MenuItem::action("Light", SwitchThemeMode(ThemeMode::Light)),
-                        MenuItem::action("Dark", SwitchThemeMode(ThemeMode::Dark)),
+                        MenuItem::action("Light", SwitchThemeMode(ThemeMode::Light))
+                            .checked(!mode.is_dark()),
+                        MenuItem::action("Dark", SwitchThemeMode(ThemeMode::Dark))
+                            .checked(mode.is_dark()),
                     ],
                 }),
                 theme_menu(cx),
@@ -66,25 +96,35 @@ pub fn init(title: impl Into<SharedString>, cx: &mut App) {
             items: vec![MenuItem::action("Open Website", Open)],
         },
     ]);
+
+    app_menu_bar.update(cx, |menu_bar, cx| {
+        menu_bar.reload(cx);
+    })
 }
 
-fn language_menu(_cx: &App) -> MenuItem {
+fn language_menu(_: &App) -> MenuItem {
+    let locale = rust_i18n::locale().to_string();
     MenuItem::Submenu(Menu {
         name: "Language".into(),
         items: vec![
-            MenuItem::action("English", SelectLocale("en".into())),
-            MenuItem::action("简体中文", SelectLocale("zh-CN".into())),
+            MenuItem::action("English", SelectLocale("en".into())).checked(locale == "en"),
+            MenuItem::action("简体中文", SelectLocale("zh-CN".into())).checked(locale == "zh-CN"),
         ],
     })
 }
 
 fn theme_menu(cx: &App) -> MenuItem {
     let themes = ThemeRegistry::global(cx).sorted_themes();
+    let current_name = cx.theme().theme_name();
     MenuItem::Submenu(Menu {
         name: "Theme".into(),
         items: themes
             .iter()
-            .map(|theme| MenuItem::action(theme.name.clone(), SwitchTheme(theme.name.clone())))
+            .map(|theme| {
+                let checked = current_name == &theme.name;
+                MenuItem::action(theme.name.clone(), SwitchTheme(theme.name.clone()))
+                    .checked(checked)
+            })
             .collect(),
     })
 }

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -28,10 +28,8 @@ impl AppTitleBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        app_menus::init(title, cx);
-
+        let app_menu_bar = app_menus::init(title, cx);
         let font_size_selector = cx.new(|cx| FontSizeSelector::new(window, cx));
-        let app_menu_bar = AppMenuBar::new(window, cx);
 
         Self {
             app_menu_bar,

--- a/crates/ui/src/menu/app_menu_bar.rs
+++ b/crates/ui/src/menu/app_menu_bar.rs
@@ -29,22 +29,29 @@ pub struct AppMenuBar {
 
 impl AppMenuBar {
     /// Create a new app menu bar.
-    pub fn new(window: &mut Window, cx: &mut App) -> Entity<Self> {
+    pub fn new(cx: &mut App) -> Entity<Self> {
         cx.new(|cx| {
-            let menu_bar = cx.entity();
-            let menus = cx
-                .get_menus()
-                .unwrap_or_default()
-                .iter()
-                .enumerate()
-                .map(|(ix, menu)| AppMenu::new(ix, menu, menu_bar.clone(), window, cx))
-                .collect();
-
-            Self {
+            let mut this = Self {
                 selected_ix: None,
-                menus,
-            }
+                menus: Vec::new(),
+            };
+            this.reload(cx);
+            this
         })
+    }
+
+    /// Reload the menus from the app.
+    pub fn reload(&mut self, cx: &mut Context<Self>) {
+        let menu_bar = cx.entity();
+        self.menus = cx
+            .get_menus()
+            .unwrap_or_default()
+            .iter()
+            .enumerate()
+            .map(|(ix, menu)| AppMenu::new(ix, menu, menu_bar.clone(), cx))
+            .collect();
+        self.selected_ix = None;
+        cx.notify();
     }
 
     fn on_move_left(&mut self, _: &SelectLeft, window: &mut Window, cx: &mut Context<Self>) {
@@ -119,7 +126,6 @@ impl AppMenu {
         ix: usize,
         menu: &OwnedMenu,
         menu_bar: Entity<AppMenuBar>,
-        _: &mut Window,
         cx: &mut App,
     ) -> Entity<Self> {
         let name = menu.name.clone();

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -674,9 +674,12 @@ impl PopupMenu {
     {
         for item in items {
             match item.into() {
-                OwnedMenuItem::Action { name, action, .. } => {
-                    self = self.menu(name, action.boxed_clone())
-                }
+                OwnedMenuItem::Action {
+                    name,
+                    action,
+                    checked,
+                    ..
+                } => self = self.menu_with_check(name, checked, action.boxed_clone()),
                 OwnedMenuItem::Separator => {
                     self = self.separator();
                 }


### PR DESCRIPTION
<img width="710" height="568" alt="image" src="https://github.com/user-attachments/assets/6a2bbd01-c9c2-4bc5-b631-534eb9a18420" />

## Break Change

- Removed `window` option from `AppMenuBar::new` method, we don't need it.

```diff
- AppMenuBar::new(window, cx);
+ AppMenuBar::new(cx);
```