### PR TITLE
docs: Add `anyhow` dependency to Getting Started.

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,6 +16,7 @@ gpui = "{{ GPUI_VERSION }}"
 gpui-component = "{{ VERSION }}"
 # Optional, for default bundled assets
 gpui-component-assets = "{{ VERSION }}"
+anyhow = "1.0"
 ```
 
 :::tip


### PR DESCRIPTION
add anyhow,because  example use it.
<img width="1024" height="660" alt="Clip_2025-12-09_14-58-48" src="https://github.com/user-attachments/assets/36fc715c-d1a8-40d6-ba6e-3f9b0322a9e4" />
