### PR TITLE
window_border: Set cursor style to Arrow inside window.

### DIFF
--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -1,9 +1,9 @@
 // From:
 // https://github.com/zed-industries/zed/blob/56daba28d40301ee4c05546fadb691d070b7b2b6/crates/gpui/examples/window_shadow.rs
 use gpui::{
-    canvas, div, point, prelude::FluentBuilder as _, px, AnyElement, App, Bounds, CursorStyle,
-    Decorations, Edges, HitboxBehavior, Hsla, InteractiveElement as _, IntoElement, MouseButton,
-    ParentElement, Pixels, Point, RenderOnce, ResizeEdge, Size, Styled as _, Window,
+    AnyElement, App, Bounds, CursorStyle, Decorations, Edges, HitboxBehavior, Hsla,
+    InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce,
+    ResizeEdge, Size, Styled as _, Window, canvas, div, point, prelude::FluentBuilder as _, px,
 };
 
 use crate::ActiveTheme;
@@ -137,7 +137,7 @@ impl RenderOnce for WindowBorder {
             .size_full()
             .child(
                 div()
-                    .cursor(CursorStyle::Arrow)
+                    .cursor(CursorStyle::default())
                     .map(|div| match decorations {
                         Decorations::Server => div,
                         Decorations::Client { tiling } => div


### PR DESCRIPTION
## Description

Currently cursor style doesn't change back to `Arrow` after covering over window border with CSD enabled. I copied modification from GPUI example linked at the top of the window_border.rs. I didn't include this change: https://github.com/zed-industries/zed/blob/56daba28d40301ee4c05546fadb691d070b7b2b6/crates/gpui/examples/window_shadow.rs#L79 because I didn't know why/if it's needed.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="590" height="373" alt="изображение" src="https://github.com/user-attachments/assets/48b91b0c-19f2-4419-9aab-79bc73aa8ff8" />  | <img width="631" height="355" alt="изображение" src="https://github.com/user-attachments/assets/570a01a8-4964-4300-86f8-638610b3a7af" /> |

## How to Test

I used this code to test it:
```rust
use gpui::*;
use gpui_component::{button::*, *, Theme};

pub struct HelloWorld;
impl Render for HelloWorld {
    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
        v_flex()
            .bg(Rgba{r: 0.5, g: 0f32, b: 0.5, a: 0.0})
            .size_full()
            .child(
                TitleBar::new()
                    .bg(Rgba{r: 0.5, g: 0.0, b: 0.6, a: 1.0})
            )
            .child(
                v_flex()
                    .bg(Rgba{r: 0.5, g: 0f32, b: 0.5, a: 0.0})
                    .size_full()
                    .gap_2()
                    .items_center()
                    .justify_center()
                    .child("Hello, World!")
                    .child(
                        Button::new("ok")
                            .primary()
                            .label("Let's Go!")
                            .on_click(|_, _, _| println!("Clicked!")),
                    )
            )
    }
}

fn main() {
    let app = Application::new();

    app.run(move |cx| {
        // This must be called before using any GPUI Component features.
        gpui_component::init(cx);
        // Theme::sync_system_appearance(None, cx);

        cx.spawn(async move |cx| {
            let window_options = WindowOptions {
                titlebar: Some(TitlebarOptions::default()),
                window_decorations: Some(WindowDecorations::Client),
                
                ..Default::default()
            };
            
            cx.open_window(window_options, |window, cx| {
                // change_color_mode(cx.theme().mode, window, cx);
                // window.
                let view = cx.new(|_| HelloWorld);
                // This first level on the window, should be a Root.
                cx.new(|cx| Root::new(view, window, cx))
            })?;

            Ok::<_, anyhow::Error>(())
        })
        .detach();
    });
}
```

1. Hover over bottom right corner.
2. Move cursor inside the window
3. Observe that cursor style didn't change to `Arrow`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
