### PR TITLE
dialog: Fix top padding to match the other edges when not has title.

### DIFF
--- a/crates/ui/src/dialog.rs
+++ b/crates/ui/src/dialog.rs
@@ -398,7 +398,7 @@ impl RenderOnce for Dialog {
 
         if !has_title {
             // When no title, reduce the top padding to fix line-height effect.
-            paddings.top -= px(4.);
+            paddings.top -= px(6.);
         }
 
         let animation = Animation::new(Duration::from_secs_f64(0.25))


### PR DESCRIPTION
Close #1800

| Before | After |
| --- | --- |
| <img width="524" height="155" alt="image" src="https://github.com/user-attachments/assets/2a1d677f-02e0-4331-b56e-6f2ceae3d528" /> | <img width="512" height="140" alt="image" src="https://github.com/user-attachments/assets/e41e70d6-9b0d-4810-84fe-a7de030bd838" /> |