### PR TITLE
button: Fix the button's text color when hovered

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -135,7 +135,7 @@ impl ButtonCustomVariant {
     }
 }
 
-/// The veriant of the Button.
+/// The variant of the Button.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum ButtonVariant {
     Primary,
@@ -552,12 +552,12 @@ impl RenderOnce for Button {
                         return;
                     }
 
-                    (on_click)(event, window, cx);
+                    on_click(event, window, cx);
                 })
             })
             .when_some(self.on_hover.filter(|_| hoverable), |this, on_hover| {
                 this.on_hover(move |hovered, window, cx| {
-                    (on_hover)(hovered, window, cx);
+                    on_hover(hovered, window, cx);
                 })
             })
             .child({


### PR DESCRIPTION
Closes #1840

## Description

All button text turns pink when the button is hovered over.  

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="558" height="372" alt="CleanShot20251222111644" src="https://github.com/user-attachments/assets/45e065d4-f853-4aad-8d91-ec5b3aa286e7" />| <img width="568" height="360" alt="CleanShot20251222111718" src="https://github.com/user-attachments/assets/a83164e6-8153-434d-83fc-a451d2420c36" /> |

