### PR TITLE
notification: Change the close button layout from `absolute` to `v_flex`.

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -328,10 +328,8 @@ impl Render for Notification {
                 }))
             })
             .child(
-                h_flex()
-                    .absolute()
-                    .top_3p5()
-                    .right_3p5()
+                v_flex()
+                    .h_full()
                     .invisible()
                     .group_hover("", |this| this.visible())
                     .child(


### PR DESCRIPTION
## Description

- Absolute layout may cover the content.
- Parent's padding top may changed.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1016" height="363" alt="2025-12-27 22 29 38" src="https://github.com/user-attachments/assets/6482956a-5d55-49c0-b188-403446e64867" /> | <img width="1013" height="325" alt="2025-12-27 22 31 13" src="https://github.com/user-attachments/assets/9f951b52-2e3f-41e9-b5c4-48e66eac9f1c" /> |
