### PR TITLE
dialog, sheet: Support window dragging when overlay popup

### DIFF
--- a/crates/ui/src/dialog.rs
+++ b/crates/ui/src/dialog.rs
@@ -3,8 +3,8 @@ use std::{rc::Rc, time::Duration};
 use gpui::{
     Animation, AnimationExt as _, AnyElement, App, Bounds, BoxShadow, ClickEvent, Edges,
     FocusHandle, Hsla, InteractiveElement, IntoElement, KeyBinding, MouseButton, ParentElement,
-    Pixels, Point, RenderOnce, SharedString, StyleRefinement, Styled, Window, anchored, div, hsla,
-    point, prelude::FluentBuilder, px, relative,
+    Pixels, Point, RenderOnce, SharedString, StyleRefinement, Styled, Window, WindowControlArea,
+    anchored, div, hsla, point, prelude::FluentBuilder, px, relative,
 };
 use rust_i18n::t;
 
@@ -85,7 +85,6 @@ pub struct Dialog {
     width: Pixels,
     max_width: Option<Pixels>,
     margin_top: Option<Pixels>,
-    overlay_top: Option<Pixels>,
 
     on_close: Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>,
     on_ok: Option<Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) -> bool + 'static>>,
@@ -132,8 +131,6 @@ impl Dialog {
             button_props: DialogButtonProps::default(),
             close_button: true,
             overlay_closable: true,
-            // Cover the title bar bottom border.
-            overlay_top: Some(TITLE_BAR_HEIGHT - px(1.)),
         }
     }
 
@@ -231,14 +228,6 @@ impl Dialog {
     /// Set the top offset of the dialog, defaults to None, will use the 1/10 of the viewport height.
     pub fn margin_top(mut self, margin_top: impl Into<Pixels>) -> Self {
         self.margin_top = Some(margin_top.into());
-        self
-    }
-
-    /// Set the top offset of the overlay
-    ///
-    /// When not using [`TitleBar`] set your own value, for System title bar it should be `0.0`.
-    pub fn overlay_top(mut self, overlay_top: impl Into<Pixels>) -> Self {
-        self.overlay_top = Some(overlay_top.into());
         self
     }
 
@@ -365,8 +354,7 @@ impl RenderOnce for Dialog {
             }
         });
 
-        let mut window_paddings = crate::window_border::window_paddings(window);
-        window_paddings.top += self.overlay_top.unwrap_or_default();
+        let window_paddings = crate::window_border::window_paddings(window);
         let view_size = window.viewport_size()
             - gpui::size(
                 window_paddings.left + window_paddings.right,
@@ -423,19 +411,23 @@ impl RenderOnce for Dialog {
                             return this;
                         }
 
-                        this.on_any_mouse_down({
-                            let on_cancel = on_cancel.clone();
-                            let on_close = on_close.clone();
-                            move |event, window, cx| {
-                                cx.stop_propagation();
+                        this.window_control_area(WindowControlArea::Drag)
+                            .on_any_mouse_down({
+                                let on_cancel = on_cancel.clone();
+                                let on_close = on_close.clone();
+                                move |event, window, cx| {
+                                    if event.position.y < TITLE_BAR_HEIGHT {
+                                        return;
+                                    }
 
-                                if self.overlay_closable && event.button == MouseButton::Left {
-                                    on_cancel(&ClickEvent::default(), window, cx);
-                                    on_close(&ClickEvent::default(), window, cx);
-                                    window.close_dialog(cx);
+                                    cx.stop_propagation();
+                                    if self.overlay_closable && event.button == MouseButton::Left {
+                                        on_cancel(&ClickEvent::default(), window, cx);
+                                        on_close(&ClickEvent::default(), window, cx);
+                                        window.close_dialog(cx);
+                                    }
                                 }
-                            }
-                        })
+                            })
                     })
                     .child(
                         v_flex()

--- a/crates/ui/src/title_bar.rs
+++ b/crates/ui/src/title_bar.rs
@@ -1,13 +1,12 @@
 use std::rc::Rc;
 
 use crate::{
-    ActiveTheme, Icon, IconName, InteractiveElementExt as _, Sizable as _, StyledExt, WindowExt,
-    h_flex,
+    ActiveTheme, Icon, IconName, InteractiveElementExt as _, Sizable as _, StyledExt, h_flex,
 };
 use gpui::{
     AnyElement, App, ClickEvent, Context, Decorations, Hsla, InteractiveElement, IntoElement,
     MouseButton, ParentElement, Pixels, Render, RenderOnce, StatefulInteractiveElement as _,
-    StyleRefinement, Styled, TitlebarOptions, Window, WindowControlArea, deferred, div,
+    StyleRefinement, Styled, TitlebarOptions, Window, WindowControlArea, div,
     prelude::FluentBuilder as _, px,
 };
 use smallvec::SmallVec;
@@ -257,7 +256,6 @@ impl RenderOnce for TitleBar {
         let is_macos = cfg!(target_os = "macos");
 
         let state = window.use_state(cx, |_, _| TitleBarState { should_move: false });
-        let is_disabled = window.has_active_dialog(cx) || window.has_active_sheet(cx);
 
         div().flex_shrink_0().child(
             div()
@@ -308,9 +306,6 @@ impl RenderOnce for TitleBar {
                         .justify_between()
                         .flex_shrink_0()
                         .flex_1()
-                        .when(is_disabled, |this| {
-                            this.child(deferred(div().absolute().size_full().occlude()))
-                        })
                         .when(is_linux && is_client_decorated, |this| {
                             this.child(
                                 div()


### PR DESCRIPTION
## Breaking change
Remove `overlay_top` because window dragging is now supported when the overlay is shown.

## Dialog
https://github.com/user-attachments/assets/27e2b846-9001-4756-8a4a-4fefaf4110fc

## Sheet
https://github.com/user-attachments/assets/93a8eb4a-f205-4dd9-a98b-df1bede8e60a

