### PR TITLE
notification: Adjust close icon position to avoid covering the action button.

### DIFF
--- a/crates/story/src/stories/notification_story.rs
+++ b/crates/story/src/stories/notification_story.rs
@@ -228,7 +228,6 @@ impl Render for NotificationStory {
                                     .id::<TestNotification>()
                                     .title("Uh oh! Something went wrong.")
                                     .message("There was a problem with your request.")
-                                    .autohide(false)
                                     .action(|_, _, cx| {
                                         Button::new("try-again").primary().label("Retry").on_click(
                                             cx.listener(|this, _, window, cx| {


### PR DESCRIPTION
Closes #1861

| Before | After |
| --- | --- |
| <img width="789" height="440" alt="image" src="https://github.com/user-attachments/assets/cecc1423-287e-4fcc-a7a5-a3b1a9adaf31" /> | <img width="923" height="533" alt="image" src="https://github.com/user-attachments/assets/35ba10a5-e36a-49f3-9d6a-e4b150704f2c" /> |