### PR TITLE
context_menu: Fix context menu shadow.

### DIFF
--- a/crates/story/src/stories/menu_story.rs
+++ b/crates/story/src/stories/menu_story.rs
@@ -302,6 +302,31 @@ impl Render for MenuStory {
                                     .menu("Item 1", Box::new(Info(1)))
                                 }
                             }),
+                    )
+                    .child(
+                        div()
+                            .id("other1")
+                            .flex()
+                            .w_full()
+                            .p_4()
+                            .items_center()
+                            .justify_center()
+                            .min_h_20()
+                            .rounded_lg()
+                            .border_2()
+                            .border_dashed()
+                            .border_color(cx.theme().border)
+                            .child("ContextMenu area 1")
+                            .context_menu({
+                                move |this, _, _| {
+                                    this.link(
+                                        "About",
+                                        "https://github.com/longbridge/gpui-component",
+                                    )
+                                    .separator()
+                                    .menu("Item 1", Box::new(Info(1)))
+                                }
+                            }),
                     ),
             )
             .child(

--- a/crates/ui/src/menu/context_menu.rs
+++ b/crates/ui/src/menu/context_menu.rs
@@ -18,8 +18,14 @@ pub trait ContextMenuExt: ParentElement + Styled {
     fn context_menu(
         self,
         f: impl Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu + 'static,
-    ) -> ContextMenu<Self> {
-        ContextMenu::new("context-menu", self).menu(f)
+    ) -> ContextMenu<Self>
+    where
+        Self: Sized,
+    {
+        // Generate a unique ID based on the element's memory address to ensure
+        // each context menu has its own state and doesn't share with others
+        let id = format!("context-menu-{:p}", &self as *const _);
+        ContextMenu::new(id, self).menu(f)
     }
 }
 


### PR DESCRIPTION
Closes #1860

| Before |  After |
| --- | --- |
| <img width="402" height="337" alt="image" src="https://github.com/user-attachments/assets/2c54af02-5519-48e2-8aab-d3472ab5d1f8" /> | <img width="416" height="330" alt="image" src="https://github.com/user-attachments/assets/eb49275d-2807-46a7-8b70-e18344a54664" /> |
