### PR TITLE
tabs: Fix tab bottom border in TabPanel on Windows.

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -690,7 +690,6 @@ impl TabPanel {
         let tabs_count = self.panels.len();
 
         TabBar::new("tab-bar")
-            .tab_item_top_offset(-px(1.))
             .track_scroll(&self.tab_bar_scroll_handle)
             .when(has_extend_dock_button, |this| {
                 this.prefix(

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -1,7 +1,7 @@
 use gpui::{
     AnyElement, App, Corner, Div, Edges, ElementId, InteractiveElement, IntoElement, ParentElement,
-    Pixels, RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement as _, StyleRefinement,
-    Styled, Window, div, prelude::FluentBuilder as _, px,
+    RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement as _, StyleRefinement, Styled,
+    Window, div, prelude::FluentBuilder as _, px,
 };
 use smallvec::SmallVec;
 use std::rc::Rc;
@@ -26,8 +26,6 @@ pub struct TabBar {
     size: Size,
     menu: bool,
     on_click: Option<Rc<dyn Fn(&usize, &mut Window, &mut App) + 'static>>,
-    /// Special for internal TabPanel to remove the top border.
-    tab_item_top_offset: Pixels,
 }
 
 impl TabBar {
@@ -46,7 +44,6 @@ impl TabBar {
             selected_index: None,
             on_click: None,
             menu: false,
-            tab_item_top_offset: px(0.),
         }
     }
 
@@ -136,11 +133,6 @@ impl TabBar {
         F: Fn(&usize, &mut Window, &mut App) + 'static,
     {
         self.on_click = Some(Rc::new(on_click));
-        self
-    }
-
-    pub(crate) fn tab_item_top_offset(mut self, offset: impl Into<Pixels>) -> Self {
-        self.tab_item_top_offset = offset.into();
         self
     }
 }
@@ -251,7 +243,6 @@ impl RenderOnce for TabBar {
                         child
                             .ix(ix)
                             .tab_bar_prefix(tab_bar_prefix)
-                            .mt(self.tab_item_top_offset)
                             .with_variant(self.variant)
                             .with_size(self.size)
                             .when_some(self.selected_index, |this, selected_ix| {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="236" height="136" alt="image" src="https://github.com/user-attachments/assets/6c44cf43-8631-489e-9e1f-0b7c3dc1fefa" /> | <img width="233" height="128" alt="after" src="https://github.com/user-attachments/assets/b7512d05-48b9-4e43-a63a-0707fd2e1f7e" /> |
