### PR TITLE
input: Hide focus styling when disabled

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -253,7 +253,7 @@ impl RenderOnce for Input {
         });
 
         let state = self.state.read(cx);
-        let focused = state.focus_handle.is_focused(window);
+        let focused = state.focus_handle.is_focused(window) && !state.disabled;
         let gap_x = match self.size {
             Size::Small => px(4.),
             Size::Large => px(8.),

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1720,6 +1720,7 @@ impl InputState {
     /// Returns the true to let InputElement to render cursor, when Input is focused and current BlinkCursor is visible.
     pub(crate) fn show_cursor(&self, window: &Window, cx: &App) -> bool {
         (self.focus_handle.is_focused(window) || self.is_context_menu_open(cx))
+            && !self.disabled
             && self.blink_cursor.read(cx).visible()
             && window.is_window_active()
     }


### PR DESCRIPTION
## Description

Improve styling of disabled input elements by hiding focus border & blinking cursor.
This is consistent with how disabled inputs in HTML look.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="176" height="50" alt="image" src="https://github.com/user-attachments/assets/5d033a53-17fe-486c-a779-32b0a4fcceca" /> | <img width="175" height="52" alt="image" src="https://github.com/user-attachments/assets/3007dc14-d390-4afa-a3c5-8672bf431e0b" /> |

For comparison, this is how it looks in HTML:

<img width="175" height="47" alt="image" src="https://github.com/user-attachments/assets/3d3d4004-51a1-41b7-a040-6432da279d55" />

## How to Test

Select text in the Input story.

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
