### PR TITLE
chore: Fix GPUI `update` method API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -654,7 +654,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -719,8 +719,7 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4deb8f595ce7f00dee3543ebf6fd9a20ea86fc421ab79600dac30876250bdae"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "ash",
  "ash-window",
@@ -754,8 +753,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27142319e2f4c264581067eaccb9f80acccdde60d8b4bf57cc50cd3152f109ca"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -765,8 +763,7 @@ dependencies = [
 [[package]]
 name = "blade-util"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6be3a82c001ba7a17b6f8e413ede5d1004e6047213f8efaf0ffc15b5c4904c"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "blade-graphics",
  "bytemuck",
@@ -1185,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "indexmap",
  "rustc-hash 2.1.1",
@@ -1662,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1997,7 +1994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2789,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2862,6 +2859,7 @@ dependencies = [
  "stacksafe",
  "strum 0.27.2",
  "sum_tree",
+ "swash",
  "taffy",
  "thiserror 2.0.14",
  "usvg",
@@ -3024,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3284,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4289,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -5078,7 +5076,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "collections",
  "serde",
@@ -5602,7 +5600,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5903,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "derive_refineable",
 ]
@@ -6186,7 +6184,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6199,7 +6197,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6267,7 +6265,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6852,7 +6850,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6980,7 +6978,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "arrayvec",
  "log",
@@ -7085,9 +7083,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -7286,7 +7284,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8317,7 +8315,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -8356,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "perf",
  "quote",
@@ -8866,7 +8864,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10002,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10013,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -10024,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#da992374b3a702e1675902325c6fc0870fbbd23a"
+source = "git+https://github.com/zed-industries/zed#1fa9dd628445623793005c73ce807d4da9f58d21"
 
 [[package]]
 name = "zune-core"

--- a/crates/ui/src/input/blink_cursor.rs
+++ b/crates/ui/src/input/blink_cursor.rs
@@ -64,7 +64,7 @@ impl BlinkCursor {
         self._task = cx.spawn(async move |this, cx| {
             Timer::after(INTERVAL).await;
             if let Some(this) = this.upgrade() {
-                this.update(cx, |this, cx| this.blink(epoch, cx)).ok();
+                this.update(cx, |this, cx| this.blink(epoch, cx));
             }
         });
     }
@@ -89,8 +89,7 @@ impl BlinkCursor {
                 this.update(cx, |this, cx| {
                     this.paused = false;
                     this.blink(epoch, cx);
-                })
-                .ok();
+                });
             }
         });
     }


### PR DESCRIPTION
## Description

Remove the `ok()` call since the function in GPUI has been updated in PR zed-industries/zed#45809

 [https://github.com/zed-industries/zed/pull/45809/changes#diff-6c814195beb441cc46c0cd635e07958047fc0e69901e1d52de1e36a0088eef3aL448](url)


