### PR TITLE
text: Fix unexpected text overlap on `List`

### DIFF
--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -996,7 +996,7 @@ impl BlockNode {
                                                     }),
                                             )
                                         })
-                                        .child(div().overflow_hidden().child(text)),
+                                        .child(div().flex_1().overflow_hidden().child(text)),
                                 );
                             }
                             BlockNode::List { .. } => {


### PR DESCRIPTION
Closes #1913.

| Before | After |
| - | - |
| <img width="449" height="152" alt="SCR-20260109-ncof" src="https://github.com/user-attachments/assets/e967b70c-b0cf-4f51-8bf7-d5b6892ee7a7" /> | <img width="414" height="154" alt="SCR-20260109-nbvh" src="https://github.com/user-attachments/assets/48ea24d8-eeb9-45a7-a914-aea1003c436f" /> |
