### PR TITLE
dock: Fix active tab item top border in TabPanel.

### DIFF
--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -4,7 +4,7 @@ use gpui::{
 };
 
 use gpui_component::{
-    IconName, Selectable as _, Sizable, Size,
+    ActiveTheme as _, IconName, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
     checkbox::Checkbox,
     h_flex,
@@ -128,6 +128,8 @@ impl Render for TabsStory {
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
                         }))
+                        .border_t_1()
+                        .border_color(cx.theme().border)
                         .prefix(
                             h_flex()
                                 .mx_1()

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -130,7 +130,6 @@ impl TabVariant {
                 fg: cx.theme().tab_foreground,
                 bg: cx.theme().transparent,
                 borders: Edges {
-                    top: px(1.),
                     left: px(1.),
                     right: px(1.),
                     ..Default::default()
@@ -175,7 +174,6 @@ impl TabVariant {
                 fg: cx.theme().tab_foreground,
                 bg: cx.theme().transparent,
                 borders: Edges {
-                    top: px(1.),
                     left: px(1.),
                     right: px(1.),
                     ..Default::default()
@@ -225,7 +223,6 @@ impl TabVariant {
                 fg: cx.theme().tab_active_foreground,
                 bg: cx.theme().tab_active,
                 borders: Edges {
-                    top: px(1.),
                     left: px(1.),
                     right: px(1.),
                     ..Default::default()
@@ -276,7 +273,6 @@ impl TabVariant {
                     cx.theme().transparent
                 },
                 borders: Edges {
-                    top: px(1.),
                     left: px(1.),
                     right: px(1.),
                     ..Default::default()


### PR DESCRIPTION
## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1009" height="923" alt="image" src="https://github.com/user-attachments/assets/b9097a2c-7e6b-4e1f-af01-0220b7646b07" /> | <img width="980" height="856" alt="image" src="https://github.com/user-attachments/assets/02228760-6489-46ab-a627-d4464610f388" /> |
