### PR TITLE
popover: Restore lost `with_priority`

### DIFF
--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -329,6 +329,7 @@ impl Popover {
                 ))
                 .child(div().relative().child(content)),
         )
+        .with_priority(1)
     }
 
     pub(crate) fn render_popover_content(


### PR DESCRIPTION
Cause by #1931.