### PR TITLE
date_picker: Fix incorrect placeholder text color

### DIFF
--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -415,7 +415,15 @@ impl RenderOnce for DatePicker {
                             .items_center()
                             .justify_between()
                             .gap_1()
-                            .child(div().w_full().overflow_hidden().child(display_title))
+                            .child(
+                                div()
+                                    .w_full()
+                                    .overflow_hidden()
+                                    .when(!state.date.is_some(), |this| {
+                                        this.text_color(cx.theme().muted_foreground)
+                                    })
+                                    .child(display_title),
+                            )
                             .when(!self.disabled, |this| {
                                 this.when(show_clean, |this| {
                                     this.child(clear_button(cx).on_click(


### PR DESCRIPTION
Closes #1944.

| Before | After |
| - | - |
| <img width="1055" height="759" alt="SCR-20260115-rfpd" src="https://github.com/user-attachments/assets/02c39b6d-d64c-4a8e-a5fd-2849f3225aba" /> |  <img width="1008" height="761" alt="After" src="https://github.com/user-attachments/assets/9d77b3aa-9295-4f46-b7aa-8c3fe71b67f8" /> |
