### PR TITLE
docs: Keep the doc version in sync with the package official version

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,8 +1,9 @@
 name: Release Docs
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["Release Crate"]
+    types:
+      - completed
   workflow_dispatch:
 permissions:
   contents: read
@@ -12,9 +13,12 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: oven-sh/setup-bun@v1
       - name: Install
         working-directory: docs


### PR DESCRIPTION
Closes #1947

## Description

The `Release Docs` action is currently triggered by a tag, but this can cause it to become unsynchronized with the official package version if the package fails to publish.

To address this, change the `Release Docs` action to be triggered by the `Release Crate` workflow. Once that workflow completes successfully, it will trigger the documentation release, ensuring that the doc version stays in sync with the official package version.