### PR TITLE
theme: Fix theme sorting

### DIFF
--- a/crates/ui/src/theme/mod.rs
+++ b/crates/ui/src/theme/mod.rs
@@ -223,7 +223,7 @@ impl From<&ThemeColor> for Theme {
 }
 
 #[derive(
-    Debug, Clone, Copy, Default, PartialEq, PartialOrd, Eq, Hash, Serialize, Deserialize, JsonSchema,
+    Debug, Clone, Copy, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeMode {

--- a/crates/ui/src/theme/registry.rs
+++ b/crates/ui/src/theme/registry.rs
@@ -129,6 +129,7 @@ impl ThemeRegistry {
         themes.sort_by(|a, b| {
             b.is_default
                 .cmp(&a.is_default)
+                .then(a.mode.cmp(&b.mode))
                 .then(a.name.to_lowercase().cmp(&b.name.to_lowercase()))
         });
         themes


### PR DESCRIPTION
## Description

Derive `Ord` for `ThemeMode` and include mode in the sorting logic of `ThemeRegistry::sorted_themes`.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="200" alt="before" src="https://github.com/user-attachments/assets/376e0abb-be27-49fd-b84d-dd0f2ee906ae" /> | <img width="200" alt="after" src="https://github.com/user-attachments/assets/2fd559ab-4ed4-4619-bcc7-fb1dd5364bdc" /> |
