### PR TITLE
docs: Fix description list example

### DIFF
--- a/docs/docs/components/description-list.md
+++ b/docs/docs/components/description-list.md
@@ -19,9 +19,9 @@ use gpui_component::description_list::{DescriptionList, DescriptionItem, Descrip
 
 ```rust
 DescriptionList::new()
-    .child("Name", "GPUI Component", 1)
-    .child("Version", "0.1.0", 1)
-    .child("License", "Apache-2.0", 1)
+    .item("Name", "GPUI Component", 1)
+    .item("Version", "0.1.0", 1)
+    .item("License", "Apache-2.0", 1)
 ```
 
 ### Using DescriptionItem Builder


### PR DESCRIPTION
Fix `DescriptionList` example to use the correct `item` method.
