### PR TITLE
select: Fix `perform_search` to call `SelectItem::matches`

### DIFF
--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -428,7 +428,7 @@ impl<I: SelectItem> SelectDelegate for SearchableVec<I> {
         self.matched_items = self
             .items
             .iter()
-            .filter(|item| item.title().to_lowercase().contains(&query.to_lowercase()))
+            .filter(|item| item.matches(query))
             .cloned()
             .collect();
 


### PR DESCRIPTION
Previously, `SearchableVec::perform_search` used hardcoded title matching, which prevented users from implementing custom search logic.
