### PR TITLE
input: Fix clear button showing in disabled state

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -272,8 +272,11 @@ impl RenderOnce for Input {
 
         let prefix = self.prefix;
         let suffix = self.suffix;
-        let show_clear_button =
-            self.cleanable && !state.loading && state.text.len() > 0 && state.mode.is_single_line();
+        let show_clear_button = self.cleanable
+            && !state.disabled
+            && !state.loading
+            && state.text.len() > 0
+            && state.mode.is_single_line();
         let has_suffix = suffix.is_some() || state.loading || self.mask_toggle || show_clear_button;
 
         div()


### PR DESCRIPTION
## Description

Hide clear button when the input is disabled.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="341" height="327" alt="image" src="https://github.com/user-attachments/assets/0d3377ed-32ff-41f9-ae68-fbff5af8b26c" /> | <img width="360" height="338" alt="image" src="https://github.com/user-attachments/assets/48f1b9c1-1210-4861-998c-476389ccd44f" /> |

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
