### PR TITLE
input: Fix ghost lines offsetting all line numbers

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1495,7 +1495,7 @@ impl Element for TextElement {
                 }
 
                 // Add ghost line height after cursor row for line numbers alignment
-                if !prepaint.ghost_lines.is_empty() && prepaint.current_row.is_some() {
+                if !prepaint.ghost_lines.is_empty() && prepaint.current_row == Some(row) {
                     offset_y += prepaint.ghost_lines_height;
                 }
             }


### PR DESCRIPTION
## Description

When using inline completions the ghost lines would push/offset all line numbers, not just at the current row.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="329" height="318" alt="Screenshot From 2026-01-30 10-42-58" src="https://github.com/user-attachments/assets/38c29ff0-f562-428a-bef5-5c2e87ef1095" /> |  <img width="329" height="318" alt="Screenshot From 2026-01-30 10-59-31" src="https://github.com/user-attachments/assets/5b0cd83d-7fda-4dab-afa3-043e44bb2375" /> |

## How to Test

1. `cargo run --release --example editor` 
2. Type `fn (` to get inline completions

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
