### PR TITLE
input: Allow insert on input state when disabled

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -619,10 +619,7 @@ impl InputState {
         cx: &mut Context<Self>,
     ) {
         self.history.ignore = true;
-        let was_disabled = self.disabled;
-        self.disabled = false;
         self.replace_text(value, window, cx);
-        self.disabled = was_disabled;
         self.history.ignore = false;
 
         // Ensure cursor to start when set text


### PR DESCRIPTION
Closes #1983

## Description

Set `InputState.disabled` to false during `InputState::insert` and restore before returning. 

## Break Changes

Users who relied on the text to not update when `InputState::insert` is called if the `Input` is disabled. Not sure why someone would be doing this though.

- Change 1

```diff
    pub fn insert(
        &mut self,
        text: impl Into<SharedString>,
        window: &mut Window,
        cx: &mut Context<Self>,
    ) {
+       let was_disabled = self.disabled;
+       self.disabled = false;
        let text: SharedString = text.into();
        let range_utf16 = self.range_to_utf16(&(self.cursor()..self.cursor()));
        self.replace_text_in_range_silent(Some(range_utf16), &text, window, cx);
        self.selected_range = (self.selected_range.end..self.selected_range.end).into();
+       self.disabled = was_disabled;
    }
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
