### PR TITLE
dialog: Fix events failing due to duplicate focus trap IDs

### DIFF
--- a/crates/ui/src/dialog.rs
+++ b/crates/ui/src/dialog.rs
@@ -441,7 +441,7 @@ impl RenderOnce for Dialog {
                         v_flex()
                             .id(layer_ix)
                             .track_focus(&self.focus_handle)
-                            .focus_trap("dialog", &self.focus_handle)
+                            .focus_trap(format!("dialog-{}", layer_ix), &self.focus_handle)
                             .bg(cx.theme().background)
                             .border_1()
                             .border_color(cx.theme().border)


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/ba7038fd-9b37-4939-ada2-4384a2ade1ee

## After

https://github.com/user-attachments/assets/44f9e2c3-4ab3-4c88-95c4-41aa5c804eaa