### PR TITLE
Add `Iconify` component.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1720,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2904,8 +2933,10 @@ version = "0.5.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "blake3",
  "chrono",
  "core-text",
+ "directories",
  "enum-iterator",
  "gpui",
  "gpui-component-macros",
@@ -3407,6 +3438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "iconify"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "gpui-component",
+ "reqwest_client",
+ "rust-embed",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "examples/webview",
     "examples/system_monitor",
     "examples/focus_trap",
+    "examples/iconify",
 ]
 resolver = "2"
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -125,6 +125,10 @@ tree-sitter-typescript = { version = "0.23.2", optional = true }
 tree-sitter-yaml = { version = "0.7.1", optional = true }
 tree-sitter-zig = { version = "1.1.2", optional = true }
 
+# Iconify
+blake3 = "1.8.3"
+directories = "6.0.0"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "=21.0.0"
 

--- a/crates/ui/src/iconify.rs
+++ b/crates/ui/src/iconify.rs
@@ -1,0 +1,373 @@
+use crate::{ActiveTheme, Sizable};
+use directories::BaseDirs;
+use gpui::{
+    AnyElement, App, Asset, Bounds, Element, ElementId, GlobalElementId, InspectorElementId,
+    IntoElement, LayoutId, Negate, Pixels, Point, Radians, Refineable, SharedString, Size, Style,
+    StyleRefinement, Styled, TransformationMatrix, Window,
+    http_client::{Uri, Url},
+    point, px, radians, size,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use smol::{future::Future, io::AsyncReadExt};
+use std::{env, fs, panic::Location, path::PathBuf};
+
+/// The settings for Iconify.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IconifySettings {
+    /// The URL of the Iconify API, default is [https://api.iconify.design](https://iconify.design/docs/api).
+    pub api_url: Option<SharedString>,
+    /// The cache directory for Iconify, keep same with [iconify-rs](https://github.com/wrapperup/iconify-rs).
+    pub cache_dir: Option<PathBuf>,
+}
+
+impl Default for IconifySettings {
+    fn default() -> Self {
+        Self {
+            api_url: Some(iconify_url().into()),
+            cache_dir: Some(iconify_cache()),
+        }
+    }
+}
+
+/// Copied from [iconify-rs](https://github.com/wrapperup/iconify-rs/blob/314561148b29fb1498cee3437ef70c77add036aa/src/svg.rs#L233).
+fn iconify_url() -> String {
+    env::var("ICONIFY_URL").unwrap_or("https://api.iconify.design".into())
+}
+/// Copied from [iconify-rs](https://github.com/wrapperup/iconify-rs/blob/314561148b29fb1498cee3437ef70c77add036aa/src/svg.rs#L238).
+fn iconify_cache() -> PathBuf {
+    if let Ok(dir) = env::var("ICONIFY_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+
+    let dir = if cfg!(target_family = "unix") {
+        // originally we used cache_dir for all non-Windows platforms but that returns
+        // a path that's not writable in cross-rs Docker. /tmp should always work
+        PathBuf::from("/tmp")
+    } else if cfg!(target_os = "windows") {
+        // I didn't like the idea of having a cache dir in the root of %LOCALAPPDATA%.
+        PathBuf::from(BaseDirs::new().unwrap().cache_dir()).join("cache")
+    } else {
+        PathBuf::from(BaseDirs::new().unwrap().cache_dir())
+    };
+
+    dir.join("iconify-rs")
+}
+
+/// A convenience function to create an Iconify element.
+///
+/// # Example
+/// ```
+/// use gpui_component::iconify;
+///
+/// let icon = iconify().path("lucide:smile");
+/// let icon = iconify().path("lucide/smile");
+/// let icon = iconify().path("lucide/smile.svg");
+/// ```
+/// # Note
+/// The additional query parameters such as `?size=24`, `?color=red` etc. will be ignored.
+#[track_caller]
+pub fn iconify() -> Iconify {
+    Iconify::new()
+}
+
+/// An element to render an icon from Iconify API or a cached path if exists.
+///
+/// # Example
+/// ```
+/// use gpui_component::Iconify;
+///
+/// let icon = Iconify::new().path("lucide:smile");
+/// let icon = Iconify::new().path("lucide/smile");
+/// let icon = Iconify::new().path("lucide/smile.svg");
+/// ```
+/// # Note
+/// The additional query parameters such as `?size=24`, `?color=red` etc. will be ignored.
+pub struct Iconify {
+    path: Option<SharedString>,
+    data: Option<SharedString>,
+    scale: Size<f32>,
+    translate: Point<Pixels>,
+    rotate: Radians,
+    style: StyleRefinement,
+}
+
+impl Iconify {
+    pub fn new() -> Self {
+        Self {
+            path: None,
+            data: None,
+            scale: size(1.0, 1.0),
+            translate: point(px(0.0), px(0.0)),
+            rotate: radians(0.0),
+            style: StyleRefinement::default().flex_none().size_4(),
+        }
+    }
+
+    pub fn path(mut self, path: impl Into<SharedString>) -> Self {
+        self.path = Some(Self::convert_path(path));
+        self
+    }
+
+    /// Set the svg data for the icon.
+    /// # Example
+    /// ```
+    /// use gpui_component::Iconify;
+    ///
+    /// let icon = Iconify::new().data(r#"<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2s4-2 4-2M9 9h.01M15 9h.01"/></g></svg>"#);
+    /// ```
+    pub fn data(mut self, data: impl Into<SharedString>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    /// Set the scale for the svg, same as [`gpui::Transformation`] for [`gpui::Svg`].
+    pub fn scale(mut self, scale: Size<f32>) -> Self {
+        self.scale = scale;
+        self
+    }
+
+    /// Set the translate for the svg, same as [`gpui::Transformation`] for [`gpui::Svg`].
+    pub fn translate(mut self, translate: Point<Pixels>) -> Self {
+        self.translate = translate;
+        self
+    }
+
+    /// Set the rotate for the svg, same as [`gpui::Transformation`] for [`gpui::Svg`].
+    pub fn rotate(mut self, rotate: impl Into<Radians>) -> Self {
+        self.rotate = rotate.into();
+        self
+    }
+
+    /// Convert to a valid path for Iconify API, ignored the query params and add .svg if not exists.
+    fn convert_path(path: impl Into<SharedString>) -> SharedString {
+        let mut path = path.into().replace(":", "/");
+        path.insert(0, '/');
+
+        if let Ok(url) = path.parse::<Uri>() {
+            path = url.path().to_string();
+        }
+        if !path.ends_with(".svg") {
+            path.push_str(".svg");
+        }
+        path = path.trim_start_matches('/').into();
+
+        path.into()
+    }
+
+    fn into_matrix(
+        center: Point<Pixels>,
+        factor: f32,
+        scale: Size<f32>,
+        translate: Point<Pixels>,
+        rotate: Radians,
+    ) -> TransformationMatrix {
+        TransformationMatrix::unit()
+            .translate(center.scale(factor) + translate.scale(factor))
+            .rotate(rotate)
+            .scale(scale)
+            .translate(center.scale(factor).negate())
+    }
+}
+
+impl IntoElement for Iconify {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Styled for Iconify {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl From<Iconify> for AnyElement {
+    fn from(val: Iconify) -> Self {
+        val.into_any_element()
+    }
+}
+
+impl Sizable for Iconify {
+    fn with_size(mut self, size: impl Into<crate::styled::Size>) -> Self {
+        let style = StyleRefinement::default();
+        let style = match size.into() {
+            crate::styled::Size::Size(px) => style.size(px),
+            crate::styled::Size::XSmall => style.size_3(),
+            crate::styled::Size::Small => style.size_3p5(),
+            crate::styled::Size::Medium => style.size_4(),
+            crate::styled::Size::Large => style.size_6(),
+        };
+        self.style.refine(&style);
+        self
+    }
+}
+
+impl Element for Iconify {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.refine(&self.style);
+        (window.request_layout(style, None, cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) where
+        Self: Sized,
+    {
+        let color = self.style.text.color.unwrap_or_default();
+
+        let data = if let Some(data) = self.data.as_ref() {
+            Some(data.as_bytes().to_vec())
+        } else if let Some(path) = &self.path {
+            window
+                .use_asset::<IconifyAsset>(path, cx)
+                .and_then(|asset| asset)
+        } else {
+            None
+        };
+
+        let path = data
+            .as_ref()
+            .map(|d| blake3::hash(&d).to_string().into())
+            .unwrap_or_else(|| self.path.clone().unwrap_or_default());
+
+        let transformation = Self::into_matrix(
+            bounds.center(),
+            window.scale_factor(),
+            self.scale,
+            self.translate,
+            self.rotate,
+        );
+
+        window
+            .paint_svg(bounds, path, data.as_deref(), transformation, color, cx)
+            .ok();
+    }
+}
+
+enum IconifyAsset {}
+
+impl Asset for IconifyAsset {
+    type Source = SharedString;
+    type Output = Option<Vec<u8>>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        // Without setting `cx.http_client`, this will fail but no panic.
+        let client = cx.http_client();
+
+        let path = cx
+            .theme()
+            .iconify
+            .cache_dir
+            .as_ref()
+            .map(|p| p.join(source.as_ref()));
+
+        let url = cx
+            .theme()
+            .iconify
+            .api_url
+            .as_ref()
+            .and_then(|u| Url::parse(u).and_then(|u| u.join(source.as_ref())).ok());
+
+        async move {
+            // If cached, just return it.
+            if let Some(path) = &path
+                && path.exists()
+                && let Ok(bytes) = fs::read(path)
+            {
+                return Some(bytes);
+            }
+
+            let mut bytes = Vec::new();
+
+            // If not cached, download from iconify api.
+            if let Some(url) = url
+                && let Ok(mut resp) = client.get(url.as_ref(), ().into(), true).await
+                && resp.status().is_success()
+                && resp.body_mut().read_to_end(&mut bytes).await.is_ok()
+                && !bytes.is_empty()
+            {
+                // Try to cache the svg.
+                if let Some(path) = path {
+                    if let Some(parent) = path.parent()
+                        && !parent.exists()
+                    {
+                        fs::create_dir_all(parent).ok();
+                    }
+                    fs::write(&path, &bytes).ok();
+                }
+
+                return Some(bytes);
+            }
+
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_convert_path() {
+        let paths = vec![
+            "lucide:smile",
+            "lucide:angry?width=24",
+            "mdi/smiley-outline",
+            "mdi/emoticon-angry-outline?height=32",
+            "icon-park-outline/slightly-smiling-face.svg",
+            "icon-park-outline/angry-face.svg?rotate=180deg",
+        ];
+        let expected = vec![
+            "lucide/smile.svg",
+            "lucide/angry.svg",
+            "mdi/smiley-outline.svg",
+            "mdi/emoticon-angry-outline.svg",
+            "icon-park-outline/slightly-smiling-face.svg",
+            "icon-park-outline/angry-face.svg",
+        ];
+        for (i, path) in paths.into_iter().enumerate() {
+            assert_eq!(super::Iconify::convert_path(path), expected[i]);
+        }
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -8,6 +8,7 @@ mod focus_trap;
 mod geometry;
 mod global_state;
 mod icon;
+mod iconify;
 mod index_path;
 #[cfg(any(feature = "inspector", debug_assertions))]
 mod inspector;
@@ -81,6 +82,7 @@ pub use event::InteractiveElementExt;
 pub use focus_trap::FocusTrapElement;
 pub use geometry::*;
 pub use icon::*;
+pub use iconify::*;
 pub use index_path::IndexPath;
 pub use input::{Rope, RopeExt, RopeLines};
 #[cfg(any(feature = "inspector", debug_assertions))]

--- a/examples/iconify/Cargo.toml
+++ b/examples/iconify/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "iconify"
+description = "Example to load icons from assets folder or Iconify."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+gpui-component = { workspace = true }
+rust-embed = { version = "8", features = ["interpolate-folder-path"] }
+reqwest_client = { path = "../../crates/reqwest_client" }
+
+[lints]
+workspace = true

--- a/examples/iconify/README.md
+++ b/examples/iconify/README.md
@@ -1,0 +1,87 @@
+## Iconify in GPUI Component
+
+Well, I just feel it's a little boring to manually download and collect icon resources. Is there a way to automatically download icon?
+
+[Iconify](https://iconify.design/) is a awesome project that provides a convenient way to use a rich set of icon resources. So after some searching and inspired from [iconify-rs](https://github.com/wrapperup/iconify-rs), I think it's feasible.
+
+With `Iconify` component we can download icon resources from the Iconify server through [Iconify API](https://iconify.design/docs/api) automatically in develop mode, while in release mode, embeds them into the binary.
+
+Now, we can fetch the icon and render it with `Iconify` component easily when we know the `collection:icon` name, and don't forget to set `cx.http_client` or we will get nothing.
+
+## How to use
+
+First, define `IconAssets` struct, implement `gpui::AssetSource` and `rust_embed::RustEmbed` for it.
+
+```rust
+#[cfg(not(debug_assertions))]
+#[derive(rust_embed::RustEmbed)]
+#[folder = "assets"]
+#[include = "**/*.svg"]
+pub struct IconAssets;
+
+#[cfg(not(debug_assertions))]
+impl gpui::AssetSource for IconAssets {
+    fn load(&self, path: &str) -> anyhow::Result<Option<std::borrow::Cow<'static, [u8]>>> {
+        Self::get(path)
+            .map(|f| Some(f.data))
+            .ok_or_else(|| anyhow::anyhow!("could not find asset at path \"{path}\""))
+    }
+
+    fn list(&self, path: &str) -> anyhow::Result<Vec<gpui::SharedString>> {
+        Ok(Self::iter()
+            .filter_map(|p| p.starts_with(path).then(|| p.into()))
+            .collect())
+    }
+}
+```
+
+Then, set `cx.http_client` in develop mode, and use `IconAssets` to register icon assets in release mode.
+
+```rust
+use gpui::Application;
+
+#[cfg(debug_assertions)]
+let app = Application::new().with_http_client(std::sync::Arc::new(
+    reqwest_client::ReqwestClient::user_agent("gpui-component-example-iconify").unwrap(),
+));
+
+#[cfg(not(debug_assertions))]
+let app = Application::new().with_assets(IconAssets);
+```
+
+Set the different value of `IconifySetting` separately in develop mode and release mode.
+
+```rust
+use gpui_component::theme;
+
+theme::init(cx);
+
+let theme = theme::Theme::global_mut(cx);
+if cfg!(debug_assertions) {
+    // Where to cache the downloaded icons in develop mode and embeded in release mode.
+    theme.iconify.cache_dir = Some("assets".into());
+} else {
+    // Fetch from embeded icon from binary.
+    theme.iconify.api_url = None;
+    theme.iconify.cache_dir = None;
+}
+```
+
+Then just use `Iconify` component to render a icon from `collection:icon` name.
+Note it does not support query parameters for Iconify API, and will be ignored if set.
+
+```rust
+use gpui_component::{Iconify, iconify};
+
+Iconify::new().path("lucide:smile");
+iconify().path("lucide:smile");
+```
+
+
+And it can also render a icon from standard `<svg />` string.
+
+```rust
+use gpui_component::Iconify;
+
+Iconify::new().data(r#"<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 48 48"><g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="4"><path d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20Z"/><path stroke-linecap="round" d="M31 18v1m-14-1v1m14 12s-2 4-7 4s-7-4-7-4"/></g></svg>"#)
+```

--- a/examples/iconify/src/main.rs
+++ b/examples/iconify/src/main.rs
@@ -1,0 +1,87 @@
+use gpui::{
+    App, AppContext, Application, Bounds, Context, IntoElement, ParentElement, Render, Styled,
+    Window, WindowBounds, WindowOptions, div, px, size, white,
+};
+use gpui_component::{Sizable, Theme, amber_500, green_500, iconify, red_500, theme};
+
+#[cfg(not(debug_assertions))]
+#[derive(rust_embed::RustEmbed)]
+#[folder = "assets"]
+#[include = "**/*.svg"]
+pub struct IconAssets;
+
+#[cfg(not(debug_assertions))]
+impl gpui::AssetSource for IconAssets {
+    fn load(&self, path: &str) -> anyhow::Result<Option<std::borrow::Cow<'static, [u8]>>> {
+        Self::get(path)
+            .map(|f| Some(f.data))
+            .ok_or_else(|| anyhow::anyhow!("could not find asset at path \"{path}\""))
+    }
+
+    fn list(&self, path: &str) -> anyhow::Result<Vec<gpui::SharedString>> {
+        Ok(Self::iter()
+            .filter_map(|p| p.starts_with(path).then(|| p.into()))
+            .collect())
+    }
+}
+
+fn main() {
+    #[cfg(debug_assertions)]
+    let app = Application::new().with_http_client(std::sync::Arc::new(
+        reqwest_client::ReqwestClient::user_agent("gpui-component-example-iconify").unwrap(),
+    ));
+
+    #[cfg(not(debug_assertions))]
+    let app = Application::new().with_assets(IconAssets);
+
+    app.run(|cx: &mut App| {
+        theme::init(cx);
+
+        let theme = Theme::global_mut(cx);
+        if cfg!(debug_assertions) {
+            theme.iconify.cache_dir = Some("assets".into());
+        } else {
+            theme.iconify.api_url = None;
+            theme.iconify.cache_dir = None;
+        }
+
+        let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| IconExample),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}
+
+struct IconExample;
+
+impl Render for IconExample {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .justify_center()
+            .gap_8()
+            .bg(white())
+            .child(
+                div()
+                    .flex()
+                    .justify_center()
+                    .items_center()
+                    .gap_8()
+                    .child(iconify().path("mdi:smiley-outline").text_color(red_500()))
+                    .child(
+                    iconify().path("lucide/smile").text_color(amber_500()).large(),
+                    )
+                    .child(
+                        iconify().data(r#"<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 48 48"><g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="4"><path d="M24 44c11.046 0 20-8.954 20-20S35.046 4 24 4S4 12.954 4 24s8.954 20 20 20Z"/><path stroke-linecap="round" d="M31 18v1m-14-1v1m14 12s-2 4-7 4s-7-4-7-4"/></g></svg>"#).text_color(green_500()).size_8(),
+                    )
+            )
+    }
+}


### PR DESCRIPTION
Manually download and collect icon resources is a little bit boring.

Add a new component `Iconify` that download svg from [Iconify](https://iconify.design) through Iconify API and cache them locally to embed in binary.