### PR TITLE
table: Add support for cell selection.

### DIFF
--- a/crates/story/src/stories/table_story.rs
+++ b/crates/story/src/stories/table_story.rs
@@ -896,6 +896,9 @@ impl TableStory {
             TableEvent::SelectCell(row_ix, col_ix) => {
                 println!("Select cell: row={}, col={}", row_ix, col_ix)
             }
+            TableEvent::DoubleClickedCell(row_ix, col_ix) => {
+                println!("Double clicked cell: row={}, col={}", row_ix, col_ix)
+            }
             TableEvent::DoubleClickedRow(ix) => println!("Double clicked row: {}", ix),
             TableEvent::SelectRow(ix) => println!("Select row: {}", ix),
             TableEvent::MoveColumn(origin_idx, target_idx) => {

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -58,6 +58,10 @@ pub enum TableEvent {
     ///
     /// The first `usize` is the row index, and the second `usize` is the column index.
     SelectCell(usize, usize),
+    /// Double click on the cell.
+    ///
+    /// The first `usize` is the row index, and the second `usize` is the column index.
+    DoubleClickedCell(usize, usize),
     /// The column widths have changed.
     ///
     /// The `Vec<Pixels>` contains the new widths of all columns.
@@ -470,6 +474,7 @@ where
 
     fn on_cell_click(
         &mut self,
+        e: &ClickEvent,
         row_ix: usize,
         col_ix: usize,
         _: &mut Window,
@@ -481,6 +486,10 @@ where
 
         cx.stop_propagation();
         self.set_selected_cell(row_ix, col_ix, cx);
+
+        if e.click_count() == 2 {
+            cx.emit(TableEvent::DoubleClickedCell(row_ix, col_ix));
+        }
     }
 
     fn has_selection(&self) -> bool {
@@ -1401,9 +1410,9 @@ where
                                                     )
                                                     .when(self.cell_selectable, |this| {
                                                         this.on_click(cx.listener(
-                                                            move |table, _, window, cx| {
+                                                            move |table, e, window, cx| {
                                                                 table.on_cell_click(
-                                                                    row_ix, col_ix, window, cx,
+                                                                    e, row_ix, col_ix, window, cx,
                                                                 );
                                                             },
                                                         ))
@@ -1522,10 +1531,10 @@ where
                                                         )
                                                         .when(table.cell_selectable, |this| {
                                                             this.on_click(cx.listener(
-                                                                move |table, _, window, cx| {
+                                                                move |table, e, window, cx| {
                                                                     cx.stop_propagation();
                                                                     table.on_cell_click(
-                                                                        row_ix, col_ix, window, cx,
+                                                                        e, row_ix, col_ix, window, cx,
                                                                     );
                                                                 },
                                                             ))


### PR DESCRIPTION
## Summary

Adds comprehensive cell selection functionality to the Table component, enabling users to select individual cells with mouse clicks and navigate between cells using keyboard shortcuts.

<img width="1433" height="1025" alt="image" src="https://github.com/user-attachments/assets/acbfa6ed-3377-4ee5-b49d-58d3d73f236b" />

## Features

### Cell Selection API
- `cell_selectable` configuration option (default: `true`)
- `selected_cell() -> Option<(usize, usize)>` - Get currently selected cell
- `set_selected_cell(row_ix, col_ix)` - Programmatically select a cell
- `SelectCell(row_ix, col_ix)` event emitted on selection

### Visual Feedback
- Selected cells display highlight with `table_active` background and `table_active_border`
- Row and column highlights are automatically hidden when a cell is selected
- Automatic scrolling to bring selected cell into view

### Keyboard Navigation
When in cell selection mode, all keyboard operations work at the cell level:

- **↑↓** - Navigate vertically within the same column
- **←→** - Navigate horizontally within the same row
- **Home/End** - Jump to first/last cell in current row
- **PageUp/PageDown** - Move by page within current column
- **Tab/Shift+Tab** - Cycle through cells
- **Escape** - Clear selection

All navigation respects the `loop_selection` configuration.

### Demo Enhancements
Updated TableStory with:
- "Cell Selectable" toggle checkbox
- Buttons to select specific cells programmatically
- "Clear Selection" button
- Real-time display of selected cell coordinates

## Implementation Details

- Event propagation control (`stop_propagation`) prevents row selection when clicking cells
- Cell IDs use unique formula: `row_ix * 1_000_000 + col_ix`
- Selection state machine supports three modes: Row, Column, and Cell
- Keyboard actions branch based on `selection_state` for mode-specific behavior

## Test Plan

1. Enable "Cell Selectable" in Table story
2. Click any cell to verify selection and visual highlight
3. Use arrow keys to navigate between cells
4. Test Home/End for row-level jumps
5. Test PageUp/PageDown for column-level jumps
6. Verify Escape clears selection
7. Test programmatic selection buttons
8. Verify selected cell coordinates display in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)