### PR TITLE
popup_menu: Fix separator being invisible when scrollable

### DIFF
--- a/crates/story/src/stories/menu_story.rs
+++ b/crates/story/src/stories/menu_story.rs
@@ -341,6 +341,10 @@ impl Render for MenuStory {
                                     .max_h(px(300.))
                                     .label(format!("Total {} items", 100));
                                 for i in 0..100 {
+                                    if i % 5 == 0 {
+                                        this = this.separator();
+                                    }
+
                                     this = this.menu(
                                         SharedString::from(format!("Item {}", i)),
                                         Box::new(Info(i)),

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -1094,8 +1094,8 @@ impl PopupMenu {
                 .p_0()
                 .my_0p5()
                 .mx_neg_1()
-                .h(px(1.))
-                .bg(cx.theme().border)
+                .border_b(px(2.))
+                .border_color(cx.theme().border)
                 .disabled(true),
             PopupMenuItem::Label(label) => this.disabled(true).cursor_default().child(
                 h_flex()


### PR DESCRIPTION
Closes #2016.

| Before | After |
| - | - |
| <img width="264" height="367" alt="SCR-20260211-oyrx" src="https://github.com/user-attachments/assets/e0746812-70dd-4da7-853d-33f46ba98efe" /> | <img width="264" height="366" alt="SCR-20260211-oygk" src="https://github.com/user-attachments/assets/ec960621-90b9-44f1-8c90-4a0792fa12e2" /> |
