### PR TITLE
editor: Adding support for Svelte syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -636,7 +636,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -983,10 +983,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -1999,7 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2130,6 +2131,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -2955,6 +2962,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-sequel",
+ "tree-sitter-svelte-next",
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
@@ -4750,7 +4758,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -5634,7 +5642,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6229,7 +6237,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6242,7 +6250,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6310,7 +6318,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6902,7 +6910,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7336,7 +7344,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7999,9 +8007,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-make"
@@ -8099,6 +8107,16 @@ name = "tree-sitter-sequel"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2550ddbfd7f52da6d7fd4bb145e20dc67f3a0cdfdae068034a2a16101e668b"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f88190d0743e897c3e148a7e241aba0a8844b8afe816943851426e3f7b9753"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/story/examples/fixtures/test.svelte
+++ b/crates/story/examples/fixtures/test.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	// Keep the following line to suppress type checking errors in this example
+	// @ts-nocheck
+	import { fade, slide } from 'svelte/transition';
+
+	let state = $state({
+		count: 0,
+		name: 'World',
+		items: ['Apple', 'Banana', 'Cherry'],
+		newItem: ''
+	});
+
+	// Those lines raise a warning in the IDE, uncomment in the editor example to see them highlighted
+	// let summary = $derived(
+	// 	`Hello ${state.name}! Count: ${state.count}, Items: ${state.items.length}`
+	// );
+	// $effect(() => {
+	// 	console.log(`State updated:`, state);
+	// });
+
+	function increment() {
+		state.count++;
+	}
+
+	function decrement() {
+		state.count--;
+	}
+
+	function reset() {
+		state.count = 0;
+		state.name = 'World';
+	}
+
+	function addItem() {
+		if (state.newItem.trim()) {
+			state.items.push(state.newItem.trim());
+			state.newItem = '';
+		}
+	}
+
+	function removeItem(index: number) {
+		state.items.splice(index, 1);
+	}
+
+	async function asyncIncrement() {
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		state.count++;
+	}
+</script>
+
+<main class="p-6 max-w-2xl mx-auto">
+	<h1 class="text-3xl font-bold mb-6">Svelte 5 Features</h1>
+
+	<section class="mb-6 p-4 border rounded">
+		<h2 class="text-xl font-semibold mb-3">Counter</h2>
+		<p class="mb-4">Count: <strong>{state.count}</strong></p>
+
+		<div class="flex gap-2">
+			<button onclick={increment} class="px-4 py-2 bg-blue-500 text-white rounded">
+				Increment
+			</button>
+			<button onclick={decrement} class="px-4 py-2 bg-red-500 text-white rounded">
+				Decrement
+			</button>
+			<button onclick={asyncIncrement} class="px-4 py-2 bg-green-500 text-white rounded">
+				Async +1
+			</button>
+			<button onclick={reset} class="px-4 py-2 bg-gray-500 text-white rounded">Reset</button>
+		</div>
+	</section>
+
+	<section class="mb-6 p-4 border rounded">
+		<h2 class="text-xl font-semibold mb-3">Input Binding</h2>
+		<input
+			type="text"
+			bind:value={state.name}
+			placeholder="Enter your name"
+			class="px-3 py-2 border rounded w-full"
+		/>
+	</section>
+
+	<section class="mb-6 p-4 border rounded">
+		<h2 class="text-xl font-semibold mb-3">List Management</h2>
+
+		<div class="flex gap-2 mb-4">
+			<input
+				type="text"
+				bind:value={state.newItem}
+				placeholder="Add item"
+				class="px-3 py-2 border rounded grow"
+				onkeydown={(e) => e.key === 'Enter' && addItem()}
+			/>
+			<button onclick={addItem} class="px-4 py-2 bg-blue-500 text-white rounded">Add</button>
+		</div>
+
+		{#if state.items.length === 0}
+			<p class="text-gray-500" transition:fade>No items yet. Add some!</p>
+		{:else}
+			<ul class="space-y-2">
+				{#each state.items as item, i (item)}
+					<li
+						class="flex justify-between items-center p-2 bg-gray-100 rounded"
+						transition:slide
+					>
+						<span>{item}</span>
+						<button
+							onclick={() => removeItem(i)}
+							class="px-2 py-1 bg-red-500 text-white rounded text-sm"
+						>
+							Remove
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+</main>

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -48,6 +48,7 @@ tree-sitter-languages = [
     "dep:tree-sitter-swift",
     "dep:tree-sitter-toml-ng",
     "dep:tree-sitter-typescript",
+    "dep:tree-sitter-svelte-next",
     "dep:tree-sitter-yaml",
     "dep:tree-sitter-zig",
 ]
@@ -121,6 +122,7 @@ tree-sitter-ruby = { version = "0.23.1", optional = true }
 tree-sitter-rust = { version = "0.24.0", optional = true }
 tree-sitter-scala = { version = "0.23.4", optional = true }
 tree-sitter-sequel = { version = "0.3.8", optional = true }
+tree-sitter-svelte-next = { version = "0.1.1", optional = true }
 tree-sitter-swift = { version = "0.7.0", optional = true }
 tree-sitter-toml-ng = { version = "0.7.0", optional = true }
 tree-sitter-typescript = { version = "0.23.2", optional = true }

--- a/crates/ui/src/highlighter/languages.rs
+++ b/crates/ui/src/highlighter/languages.rs
@@ -40,6 +40,7 @@ pub enum Language {
     Rust,
     Scala,
     Sql,
+    Svelte,
     Swift,
     Toml,
     Tsx,
@@ -94,6 +95,7 @@ impl Language {
             Self::Rust => "rust",
             Self::Scala => "scala",
             Self::Sql => "sql",
+            Self::Svelte => "svelte",
             Self::Swift => "swift",
             Self::Toml => "toml",
             Self::Tsx => "tsx",
@@ -138,6 +140,7 @@ impl Language {
             "rust" | "rs" => Self::Rust,
             "scala" => Self::Scala,
             "sql" => Self::Sql,
+            "svelte" => Self::Svelte,
             "swift" => Self::Swift,
             "toml" => Self::Toml,
             "tsx" => Self::Tsx,
@@ -180,6 +183,7 @@ impl Language {
                 "jsdoc",
                 "graphql",
             ],
+            Self::Svelte => vec!["svelte", "html", "css", "typescript"],
             _ => vec![],
         }
         .into_iter()
@@ -382,6 +386,12 @@ impl Language {
                 include_str!("languages/kotlin/highlights.scm"),
                 "",
                 "",
+            ),
+            Self::Svelte => (
+                tree_sitter_svelte_next::LANGUAGE,
+                tree_sitter_svelte_next::HIGHLIGHTS_QUERY,
+                tree_sitter_svelte_next::INJECTIONS_QUERY,
+                tree_sitter_svelte_next::LOCALS_QUERY,
             ),
         };
 


### PR DESCRIPTION
## Description

Adds support for Svelte syntax highlighting.

## Screenshot

<img width="1312" height="862" alt="svelte" src="https://github.com/user-attachments/assets/c93ccef8-2097-4ffe-9365-61ea5b6e0559" />

## How to Test

1. Run `cargo run -p gpui-component-story --example editor`
2. Open `test.svelte`

Due to the fact that some Svelte keywords start with a `#`character (e.g. `#each`), the current implementation of setting a matching background color to color codes in the code editor (e.g. #eac) will wrongfully set a background color to #each. This is not an issue of this fix.

A few lines are commented in the `test.svelte`file as they raise warnings in the IDE. They can be uncommented in the editor story. I've added them as they cover key features of Svelte 5.

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [N/A] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
