### PR TITLE
linux: Fix window resize cursor shown incorrectly when maximized on Linux

### DIFF
--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -83,15 +83,15 @@ impl ParentElement for WindowBorder {
 impl RenderOnce for WindowBorder {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let decorations = window.window_decorations();
-        let effective_shadow_size = match decorations {
+        let shadow_size = match decorations {
             Decorations::Client { tiling }
                 if tiling.top && tiling.bottom && tiling.left && tiling.right =>
             {
                 px(0.0)
             }
-            _ => SHADOW_SIZE,
+            _ => self.shadow_size,
         };
-        window.set_client_inset(effective_shadow_size);
+        window.set_client_inset(shadow_size);
 
         div()
             .id("window-backdrop")
@@ -120,7 +120,7 @@ impl RenderOnce for WindowBorder {
                                 if tiling.top && tiling.bottom && tiling.left && tiling.right {
                                     return;
                                 }
-                                let Some(edge) = resize_edge(mouse, SHADOW_SIZE, size) else {
+                                let Some(edge) = resize_edge(mouse, shadow_size, size) else {
                                     return;
                                 };
                                 window.set_cursor_style(


### PR DESCRIPTION
Similar fix to #1466 but simple.

## Description

On Linux with client-side decorations, the window resize cursor was incorrectly
shown when the window was maximized or snapped to a screen edge. Clicking in
those areas would also attempt to start a window resize.

The root cause was that `set_client_inset` was called unconditionally with
`SHADOW_SIZE` (12px) every frame, even when the window was fully tiled
(maximized). This told the platform layer to always reserve a 12px resize
grab zone, which on a maximized window falls inside the actual content area.

The fix checks the `tiling` state each frame and zeroes the inset when all
four edges are tiled. The resize hitbox cursor and mouse-down handler are also
guarded with the same check.

## How to Test

1. Build on Linux with `WindowDecorations::Client`
2. Open a window, maximize it or snap it to fill the screen
3. Verify the resize cursor no longer appears anywhere in the window
4. Verify resizing and shadow still work correctly on a normal (non-maximized) window

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested Linux platform performance.
