### PR TITLE
editor: Add Ocaml syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "tree-sitter-lua",
  "tree-sitter-make",
  "tree-sitter-md",
+ "tree-sitter-ocaml",
  "tree-sitter-php",
  "tree-sitter-proto",
  "tree-sitter-python",
@@ -8061,6 +8062,16 @@ checksum = "ff190c235d2c0106d8d4c567e990f7776b80a2643b7d201a672cae308675424d"
 dependencies = [
  "cc",
  "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ocaml"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d19db582b3855f56b5f9ec484170fbfb9ee60b938ec7720d76d2ee788e8b640"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/crates/story/examples/fixtures/test.ml
+++ b/crates/story/examples/fixtures/test.ml
@@ -1,0 +1,98 @@
+open Printf
+
+(* A variant type representing shapes *)
+type shape =
+  | Circle of float
+  | Rectangle of float * float
+  | Triangle of { base : float; height : float }
+
+(* A record type for configuration *)
+type config = {
+  name : string;
+  debug : bool;
+  retries : int;
+}
+
+(* A polymorphic option helper *)
+let unwrap_or (default : 'a) (opt : 'a option) : 'a =
+  match opt with
+  | Some x -> x
+  | None -> default
+
+(* Compute the area of a shape using pattern matching *)
+let area (s : shape) : float =
+  match s with
+  | Circle r -> Float.pi *. r *. r
+  | Rectangle (w, h) -> w *. h
+  | Triangle { base; height } -> 0.5 *. base *. height
+
+(* A recursive function *)
+let rec factorial (n : int) : int =
+  if n <= 1 then 1
+  else n * factorial (n - 1)
+
+(* Higher-order function with labeled and optional arguments *)
+let greet ~greeting ?(punctuation = "!") name =
+  sprintf "%s, %s%s" greeting name punctuation
+
+(* Module with a signature *)
+module type Printable = sig
+  type t
+  val to_string : t -> string
+end
+
+module ShapePrinter : Printable with type t = shape = struct
+  type t = shape
+
+  let to_string = function
+    | Circle r -> sprintf "Circle(r=%.2f)" r
+    | Rectangle (w, h) -> sprintf "Rectangle(%.2f x %.2f)" w h
+    | Triangle { base; height } ->
+      sprintf "Triangle(base=%.2f, height=%.2f)" base height
+end
+
+(* Exception handling *)
+exception Invalid_input of string
+
+let safe_divide a b =
+  if b = 0.0 then raise (Invalid_input "division by zero")
+  else a /. b
+
+(* List processing with the pipe operator *)
+let process_names names =
+  names
+  |> List.filter (fun name -> String.length name > 0)
+  |> List.map String.uppercase_ascii
+  |> List.sort String.compare
+
+(* For loop and mutable reference *)
+let sum_range (start : int) (stop : int) : int =
+  let total = ref 0 in
+  for i = start to stop do
+    total := !total + i
+  done;
+  !total
+
+(* Async-like computation with result type *)
+let try_parse (s : string) : (int, string) result =
+  try Ok (int_of_string s)
+  with Failure msg -> Error msg
+
+(* Entry point *)
+let () =
+  let shapes = [Circle 3.0; Rectangle (4.0, 5.0); Triangle { base = 6.0; height = 3.0 }] in
+  List.iter (fun s ->
+    let desc = ShapePrinter.to_string s in
+    printf "%s -> area = %.2f\n" desc (area s)
+  ) shapes;
+
+  printf "5! = %d\n" (factorial 5);
+  printf "%s\n" (greet ~greeting:"Hello" "OCaml");
+  printf "sum(1..10) = %d\n" (sum_range 1 10);
+
+  let names = process_names ["alice"; ""; "bob"; "charlie"] in
+  List.iter (printf "  %s\n") names;
+
+  match try_parse "42" with
+  | Ok n -> printf "Parsed: %d\n" n
+  | Error e -> printf "Error: %s\n" e

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -40,6 +40,7 @@ tree-sitter-languages = [
     "dep:tree-sitter-lua",
     "dep:tree-sitter-make",
     "dep:tree-sitter-md",
+    "dep:tree-sitter-ocaml",
     "dep:tree-sitter-php",
     "dep:tree-sitter-proto",
     "dep:tree-sitter-python",
@@ -119,6 +120,7 @@ tree-sitter-kotlin-sg = { version = "0.4.0", optional = true }
 tree-sitter-lua = { version = "0.4.1", optional = true }
 tree-sitter-make = { version = "1.1.1", optional = true }
 tree-sitter-md = { version = "0.5.1", optional = true }
+tree-sitter-ocaml = { version = "0.24.2", optional = true }
 tree-sitter-php = { version = "0.24.2", optional = true }
 tree-sitter-proto = { version = "0.2.0", optional = true }
 tree-sitter-python = { version = "0.23.6", optional = true }

--- a/crates/ui/src/highlighter/languages.rs
+++ b/crates/ui/src/highlighter/languages.rs
@@ -35,6 +35,7 @@ pub enum Language {
     Make,
     Markdown,
     MarkdownInline,
+    Ocaml,
     Php,
     Proto,
     Python,
@@ -92,6 +93,7 @@ impl Language {
             Self::Make => "make",
             Self::Markdown => "markdown",
             Self::MarkdownInline => "markdown_inline",
+            Self::Ocaml => "ocaml",
             Self::Php => "php",
             Self::Proto => "proto",
             Self::Python => "python",
@@ -139,6 +141,7 @@ impl Language {
             "make" | "makefile" => Self::Make,
             "markdown" | "md" | "mdx" => Self::Markdown,
             "markdown_inline" | "markdown-inline" => Self::MarkdownInline,
+            "ml" | "mli" => Self::Ocaml,
             "php" | "php3" | "php4" | "php5" | "phtml" => Self::Php,
             "proto" | "protobuf" => Self::Proto,
             "python" | "py" => Self::Python,
@@ -411,6 +414,12 @@ impl Language {
                 tree_sitter_svelte_next::HIGHLIGHTS_QUERY,
                 tree_sitter_svelte_next::INJECTIONS_QUERY,
                 tree_sitter_svelte_next::LOCALS_QUERY,
+            ),
+            Self::Ocaml => (
+                tree_sitter_ocaml::LANGUAGE_OCAML,
+                tree_sitter_ocaml::HIGHLIGHTS_QUERY,
+                "",
+                tree_sitter_ocaml::LOCALS_QUERY,
             ),
         };
 


### PR DESCRIPTION
## Description

Add Ocaml syntax highlighting to the Editor component.

## Screenshot

<img width="1312" height="862" alt="ocaml" src="https://github.com/user-attachments/assets/0457bc2b-151a-4e8c-9f05-6d4124cc7426" />


## How to Test

1. Run `cargo run -p gpui-component-story --example editor`
2. Open `test.ml`

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [X] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
