### PR TITLE
root: Add `window_shadow_size` option.

### DIFF
--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -9,9 +9,9 @@ use gpui::{
 use crate::ActiveTheme;
 
 #[cfg(not(target_os = "linux"))]
-const SHADOW_SIZE: Pixels = px(0.0);
+pub(crate) const SHADOW_SIZE: Pixels = px(0.0);
 #[cfg(target_os = "linux")]
-const SHADOW_SIZE: Pixels = px(12.0);
+pub(crate) const SHADOW_SIZE: Pixels = px(12.0);
 const BORDER_SIZE: Pixels = px(1.0);
 pub(crate) const BORDER_RADIUS: Pixels = px(0.0);
 
@@ -41,9 +41,11 @@ impl WindowBorder {
         Self::default()
     }
 
-    /// Set the shadow size in pixels. Use `px(12.0)` for typical Linux client-side decorations.
-    pub fn shadow_size(mut self, size: Pixels) -> Self {
-        self.shadow_size = size;
+    /// Set the shadow size for typical Linux client-side decorations.
+    ///
+    /// Default: [`SHADOW_SIZE`]
+    pub fn shadow_size(mut self, size: impl Into<Pixels>) -> Self {
+        self.shadow_size = size.into();
         self
     }
 }


### PR DESCRIPTION
## Description

Recently, i made an adaption for gpui that can run in OpenHarmony/HarmonyNext. And i use gpui and gpui-component to make some applications. I find the soft keyboard will effect the dialog mask offset.

Is it possiable for us to add some cfg feature for ohos? Thanks.

## Screenshot

Keyboard hide:
<img width="700" height="366" alt="image" src="https://github.com/user-attachments/assets/58d45085-0e94-4ca9-9bd4-fa876433d600" />

Keyboard show:
<img width="778" height="276" alt="image" src="https://github.com/user-attachments/assets/4eea7cf9-7283-45c6-8557-a7a35217d80a" />


## Break Changes
- No breaking

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
