### PR TITLE
chart: Add `grid` option.

### DIFF
--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -27,7 +27,7 @@ where
     stroke_styles: Vec<StrokeStyle>,
     fills: Vec<Background>,
     tick_margin: usize,
-    show_grid: bool,
+    grid: bool,
 }
 
 impl<T, X, Y> AreaChart<T, X, Y>
@@ -47,7 +47,7 @@ where
             tick_margin: 1,
             x: None,
             y: vec![],
-            show_grid: true,
+            grid: true,
         }
     }
 
@@ -91,8 +91,8 @@ where
         self
     }
 
-    pub fn hide_grid(mut self) -> Self {
-        self.show_grid = false;
+    pub fn grid(mut self, grid: bool) -> Self {
+        self.grid = grid;
         self
     }
 }
@@ -156,7 +156,7 @@ where
             .paint(&bounds, window, cx);
 
         // Draw grid
-        if self.show_grid {
+        if self.grid {
             Grid::new()
                 .y((0..=3).map(|i| height * i as f32 / 4.0).collect())
                 .stroke(cx.theme().border)

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -27,7 +27,7 @@ where
     fill: Option<Rc<dyn Fn(&T) -> Hsla>>,
     tick_margin: usize,
     label: Option<Rc<dyn Fn(&T) -> SharedString>>,
-    show_grid: bool,
+    grid: bool,
 }
 
 impl<T, X, Y> BarChart<T, X, Y>
@@ -46,7 +46,7 @@ where
             fill: None,
             tick_margin: 1,
             label: None,
-            show_grid: true,
+            grid: true,
         }
     }
 
@@ -81,8 +81,8 @@ where
         self
     }
 
-    pub fn hide_grid(mut self) -> Self {
-        self.show_grid = false;
+    pub fn grid(mut self, grid: bool) -> Self {
+        self.grid = grid;
         self
     }
 }
@@ -139,7 +139,7 @@ where
             .paint(&bounds, window, cx);
 
         // Draw grid
-        if self.show_grid {
+        if self.grid {
             Grid::new()
                 .y((0..=3).map(|i| height * i as f32 / 4.0).collect())
                 .stroke(cx.theme().border)

--- a/crates/ui/src/chart/candlestick_chart.rs
+++ b/crates/ui/src/chart/candlestick_chart.rs
@@ -27,7 +27,7 @@ where
     close: Option<Rc<dyn Fn(&T) -> Y>>,
     tick_margin: usize,
     body_width_ratio: f32,
-    show_grid: bool,
+    grid: bool,
 }
 
 impl<T, X, Y> CandlestickChart<T, X, Y>
@@ -48,7 +48,7 @@ where
             close: None,
             tick_margin: 1,
             body_width_ratio: 0.8,
-            show_grid: true,
+            grid: true,
         }
     }
 
@@ -87,8 +87,8 @@ where
         self
     }
 
-    pub fn hide_grid(mut self) -> Self {
-        self.show_grid = false;
+    pub fn grid(mut self, grid: bool) -> Self {
+        self.grid = grid;
         self
     }
 }
@@ -149,7 +149,7 @@ where
             .paint(&bounds, window, cx);
 
         // Draw grid
-        if self.show_grid {
+        if self.grid {
             Grid::new()
                 .y((0..=3).map(|i| height * i as f32 / 4.0).collect())
                 .stroke(cx.theme().border)

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -27,7 +27,7 @@ where
     stroke_style: StrokeStyle,
     dot: bool,
     tick_margin: usize,
-    show_grid: bool,
+    grid: bool,
 }
 
 impl<T, X, Y> LineChart<T, X, Y>
@@ -47,7 +47,7 @@ where
             x: None,
             y: None,
             tick_margin: 1,
-            show_grid: true,
+            grid: true,
         }
     }
 
@@ -91,8 +91,8 @@ where
         self
     }
 
-    pub fn hide_grid(mut self) -> Self {
-        self.show_grid = false;
+    pub fn grid(mut self, grid: bool) -> Self {
+        self.grid = grid;
         self
     }
 }
@@ -153,7 +153,7 @@ where
             .paint(&bounds, window, cx);
 
         // Draw grid
-        if self.show_grid {
+        if self.grid {
             Grid::new()
                 .y((0..=3).map(|i| height * i as f32 / 4.0).collect())
                 .stroke(cx.theme().border)


### PR DESCRIPTION
## Description

Allows hiding the `grid` for Area, Line, Bar and Candlestick charts. The grid is shown by default, but it gives the option to hide it.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
|  <img width="325" height="410" alt="Screenshot 2026-02-25 at 20 22 30" src="https://github.com/user-attachments/assets/e83c5aa3-659b-494f-a610-72228fb781f3" /> | <img width="327" height="409" alt="Screenshot 2026-02-25 at 20 21 43" src="https://github.com/user-attachments/assets/0dca87bc-878b-4fa2-9765-a1e88dea2c3c" /> |
| <img width="323" height="407" alt="Screenshot 2026-02-25 at 20 24 57" src="https://github.com/user-attachments/assets/7f6cb30b-7bf3-47fd-8534-e7277ec45ed2" /> | <img width="325" height="415" alt="Screenshot 2026-02-25 at 20 17 13" src="https://github.com/user-attachments/assets/4591d4c2-12a8-4805-a1fa-be0c8bffaa4b" /> |
| <img width="324" height="409" alt="Screenshot 2026-02-25 at 20 27 15" src="https://github.com/user-attachments/assets/26596658-c166-426e-94f2-0d8fb5747062" /> | <img width="325" height="408" alt="Screenshot 2026-02-25 at 20 17 43" src="https://github.com/user-attachments/assets/717fa26e-a06c-4d34-930d-83086e6c15df" /> |
| <img width="327" height="410" alt="Screenshot 2026-02-25 at 20 28 12" src="https://github.com/user-attachments/assets/83983257-e75f-43e9-bde4-1eb615dbda1d" /> | <img width="324" height="409" alt="Screenshot 2026-02-25 at 20 17 31" src="https://github.com/user-attachments/assets/6ac43715-0562-4f0a-a781-a7641cf200af" /> |




## Break Changes

N/A

## How to Test

Simply use the charts as

```rs
CandlestickChart::new(data).grid(false)
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
