### PR TITLE
sheet: Fix window drag not working when sheet is opened

### DIFF
--- a/crates/ui/src/sheet.rs
+++ b/crates/ui/src/sheet.rs
@@ -171,23 +171,21 @@ impl RenderOnce for Sheet {
                     .h(size.height)
                     .bg(overlay_color(self.overlay, cx))
                     .when(self.overlay, |this| {
-                        this.when(placement == Placement::Bottom, |this| {
-                            this.window_control_area(WindowControlArea::Drag)
-                        })
-                        .on_any_mouse_down({
-                            let on_close = self.on_close.clone();
-                            move |event, window, cx| {
-                                if event.position.y < top {
-                                    return;
-                                }
+                        this.window_control_area(WindowControlArea::Drag)
+                            .on_any_mouse_down({
+                                let on_close = self.on_close.clone();
+                                move |event, window, cx| {
+                                    if event.position.y < top {
+                                        return;
+                                    }
 
-                                cx.stop_propagation();
-                                if self.overlay_closable && event.button == MouseButton::Left {
-                                    window.close_sheet(cx);
-                                    on_close(&ClickEvent::default(), window, cx);
+                                    cx.stop_propagation();
+                                    if self.overlay_closable && event.button == MouseButton::Left {
+                                        window.close_sheet(cx);
+                                        on_close(&ClickEvent::default(), window, cx);
+                                    }
                                 }
-                            }
-                        })
+                            })
                     })
                     .child(
                         v_flex()


### PR DESCRIPTION
The window drag functionality was not working when sheet was opened because window_control_area was only set for Placement::Bottom.

This change removes the placement check and always sets window_control_area
when overlay is enabled, making the window draggable in all sheet positions.

Fixes #2046

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| ![before](https://github.com/user-attachments/assets/03782b34-161e-41a0-a838-7582fc40f59c) | ![after](https://github.com/user-attachments/assets/807770af-f292-4bf0-92e1-a8d8bb727271) |
