### PR TITLE
notification: Dismiss on middle-mouse button click

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -345,6 +345,11 @@ impl Render for Notification {
                     on_click(event, window, cx);
                 }))
             })
+            .on_aux_click(cx.listener(move |view, event: &ClickEvent, window, cx| {
+                if event.is_middle_click() {
+                    view.dismiss(window, cx);
+                }
+            }))
             .with_animation(
                 ElementId::NamedInteger("slide-down".into(), closing as u64),
                 Animation::new(Duration::from_secs_f64(0.25))


### PR DESCRIPTION
## Description

Close notifications by pressing on them with the middle-mouse button.
This is a fairly common shortcut in various desktop environments/applications, such as Windows.
A user of one of my applications requested this functionality: https://github.com/Moulberry/PandoraLauncher/issues/189

## Screenshot

No visual difference

## How to Test

Open a notification and click on it with the middle mouse button to dismiss it

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
