### PR TITLE
input: Add `selected_value` to InputState

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -865,6 +865,12 @@ impl InputState {
         SharedString::new(self.text.to_string())
     }
 
+    /// Return the portion of the value within the input field that
+    /// is selected by the user
+    pub fn selected_value(&self) -> SharedString {
+        SharedString::new(self.selected_text().to_string())
+    }
+
     /// Return the value without mask.
     pub fn unmask_value(&self) -> SharedString {
         self.mask_pattern.unmask(&self.text.to_string()).into()


### PR DESCRIPTION

## Description

Adds a `selected_value` function to `InputState` obtain the portion of the input value that is currently selected as a `SharedString` which is not currently something that can be done with the available (public) functions

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Manually tested, change is simple so I just edited one of the stories to ensure that the value coming back was correct and it is.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
