### PR TITLE
docs: Fix functional usage in accordion.md example code

### DIFF
--- a/docs/docs/components/accordion.md
+++ b/docs/docs/components/accordion.md
@@ -121,7 +121,7 @@ Accordion::new("my-accordion")
 Accordion::new("outer")
     .item(|item| {
         item.title("Parent Section")
-            .content(
+            .child(
                 Accordion::new("inner")
                     .item(|item| item.title("Child 1").child("Content"))
                     .item(|item| item.title("Child 2").child("Content"))


### PR DESCRIPTION
## Before

According to the documentation, a compilation error occurred in version 0.5.1.

<img width="1974" height="652" alt="7c89ce4919f1360e3299cd630a2e397d" src="https://github.com/user-attachments/assets/279b20c7-c434-4dc2-89c3-a2510185bf41" />

## After 

Fix functional usage in accordion.md example code

<img width="1678" height="750" alt="image" src="https://github.com/user-attachments/assets/6c39ba02-3a80-4b35-96d8-f1d465aee34a" />