### PR TITLE
sheet: Fix losing focus when sheet is opened twice

### DIFF
--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -302,7 +302,11 @@ impl Root {
     ) where
         F: Fn(Sheet, &mut Window, &mut App) -> Sheet + 'static,
     {
-        let previous_focused_handle = window.focused(cx).map(|h| h.downgrade());
+        let previous_focused_handle = self
+            .active_sheet
+            .take()
+            .and_then(|s| s.previous_focused_handle)
+            .or_else(|| window.focused(cx).map(|h| h.downgrade()));
 
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window, cx);


### PR DESCRIPTION
## Description

Fixes a bug where if open_sheet_at is called twice, then when the sheet is closed, the previous_focused_handle will be invalid. This is because the 2nd sheet uses the focus_handle of the previous sheet, which is no longer valid.
This PR fixes the issue by making the 2nd sheet inherit the previous_focused_handle from the currently active sheet.

## How to Test

I tested by adding a keybind for opening a sheet twice. Without this PR, the focus broke and required calling window.close_sheet before window.open_sheet_at.

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
