### PR TITLE
docs: Fix code block syntax in settings.md

### DIFF
--- a/docs/docs/components/settings.md
+++ b/docs/docs/components/settings.md
@@ -344,7 +344,7 @@ You may have a complex field that you want to reuse, you may want split the elem
 
 In this case, the [SettingFieldElement] trait can help you to create a custom field element.
 
-````rust
+```rust
 use gpui_component::setting::{SettingFieldElement, RenderOptions};
 
 struct OpenURLSettingField {
@@ -496,4 +496,3 @@ Settings::new("app-settings")
 [NumberFieldOptions]: https://docs.rs/gpui-component/latest/gpui_component/setting/struct.NumberFieldOptions.html
 [GroupBox]: ./group-box.md
 [Sizable]: https://docs.rs/gpui-component/latest/gpui_component/trait.Sizable.html
-````


### PR DESCRIPTION
## Before

<img width="1760" height="8020" alt="before" src="https://github.com/user-attachments/assets/7d31377a-c91c-4baf-92cf-3814562895ed" />

## After
<img width="1602" height="7815" alt="after" src="https://github.com/user-attachments/assets/6f5b736d-cc64-4524-8de5-b9a997f402be" />
