### PR TITLE
editor: Fix background parse task cancellation and injection layer threading

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, anyhow};
 use gpui::{HighlightStyle, SharedString};
 
 use ropey::{ChunkCursor, Rope};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeSet, HashMap},
@@ -25,7 +26,7 @@ pub struct SyntaxHighlighter {
     language: SharedString,
     query: Option<Query>,
     /// A separate query for injection patterns that have `#set! injection.combined`.
-    combined_injections_query: Option<Query>,
+    combined_injections_query: Option<Arc<Query>>,
     injection_queries: HashMap<SharedString, Query>,
 
     locals_pattern_index: usize,
@@ -53,8 +54,16 @@ pub struct SyntaxHighlighter {
 
 /// A parsed injection layer.
 /// Stores the parsed tree and the ranges it covers.
-struct InjectionLayer {
-    tree: Tree,
+pub(crate) struct InjectionLayer {
+    pub(crate) tree: Tree,
+}
+
+/// Data needed to compute injection layers on a background thread.
+pub(crate) struct InjectionParseData {
+    pub(crate) query: Arc<Query>,
+    pub(crate) content_capture_index: Option<u32>,
+    /// Old injection trees for incremental re-parsing.
+    pub(crate) old_layers: HashMap<SharedString, Tree>,
 }
 
 struct TextProvider<'a>(&'a Rope);
@@ -263,7 +272,7 @@ impl SyntaxHighlighter {
                         ciq.disable_pattern(pattern_index);
                     }
                 }
-                if has_combined_query { Some(ciq) } else { None }
+                if has_combined_query { Some(Arc::new(ciq)) } else { None }
             } else {
                 None
             }
@@ -448,36 +457,38 @@ impl SyntaxHighlighter {
         true
     }
 
-    /// Apply a tree that was parsed on a background thread.
-    pub(crate) fn apply_background_tree(&mut self, tree: Tree, text: &Rope) {
-        // Only apply if the text still matches what was parsed.
-        if !self.text.eq(text) {
-            return;
-        }
-
-        self.tree = Some(tree.clone());
-        self.parse_combined_injections(&tree);
+    /// Returns the data needed to compute injection layers on a background thread.
+    /// Returns `None` if this language has no combined injections.
+    pub(crate) fn injection_parse_data(&self) -> Option<InjectionParseData> {
+        let query = self.combined_injections_query.clone()?;
+        Some(InjectionParseData {
+            query,
+            content_capture_index: self.combined_injection_content_capture_index,
+            old_layers: self
+                .injection_layers
+                .iter()
+                .map(|(k, v)| (k.clone(), v.tree.clone()))
+                .collect(),
+        })
     }
 
-    /// Parse all combined injections after main tree is updated.
-    /// pattern: parse once in update, query many times in render.
-    fn parse_combined_injections(&mut self, tree: &Tree) {
-        let Some(combined_query) = &self.combined_injections_query else {
-            return;
-        };
-
-        // Note: Tree edit history is handled in update() via parser.parse_with_options(old_tree)
-
+    /// Compute injection layers from a freshly-parsed main tree.
+    /// This is pure computation with no side effects and is safe to run on a
+    /// background thread.
+    pub(crate) fn compute_injection_layers(
+        data: InjectionParseData,
+        tree: &Tree,
+        text: &Rope,
+    ) -> HashMap<SharedString, InjectionLayer> {
         let root_node = tree.root_node();
         let mut cursor = QueryCursor::new();
-        let mut matches = cursor.matches(combined_query, root_node, TextProvider(&self.text));
+        let mut matches = cursor.matches(&data.query, root_node, TextProvider(text));
 
-        // Group ranges by injection language
         let mut combined_ranges: HashMap<SharedString, Vec<tree_sitter::Range>> = HashMap::new();
         while let Some(query_match) = matches.next() {
             let mut language_name: Option<SharedString> = None;
-
-            if let Some(prop) = combined_query
+            if let Some(prop) = data
+                .query
                 .property_settings(query_match.pattern_index)
                 .iter()
                 .find(|prop| prop.key.as_ref() == "injection.language")
@@ -487,15 +498,13 @@ impl SyntaxHighlighter {
                     .as_ref()
                     .map(|v| SharedString::from(v.to_string()));
             }
-
             let Some(language_name) = language_name else {
                 continue;
             };
-
             for capture in query_match
                 .captures
                 .iter()
-                .filter(|cap| Some(cap.index) == self.combined_injection_content_capture_index)
+                .filter(|cap| Some(cap.index) == data.content_capture_index)
             {
                 combined_ranges
                     .entry(language_name.clone())
@@ -504,16 +513,14 @@ impl SyntaxHighlighter {
             }
         }
 
-        // Parse each combined language group with incremental parsing
+        let mut new_layers = HashMap::new();
         for (language_name, ranges) in combined_ranges {
             if ranges.is_empty() {
                 continue;
             }
-
             let Some(config) = LanguageRegistry::singleton().language(&language_name) else {
                 continue;
             };
-
             let mut parser = Parser::new();
             if parser.set_language(&config.language).is_err() {
                 continue;
@@ -521,19 +528,13 @@ impl SyntaxHighlighter {
             if parser.set_included_ranges(&ranges).is_err() {
                 continue;
             }
-
-            // Try to reuse old tree for incremental parsing
-            let old_tree = self
-                .injection_layers
-                .get(&language_name)
-                .map(|layer| &layer.tree);
-
+            let old_tree = data.old_layers.get(&language_name);
             let Some(new_tree) = parser.parse_with_options(
                 &mut |offset, _| {
-                    if offset >= self.text.len() {
+                    if offset >= text.len() {
                         ""
                     } else {
-                        let (chunk, chunk_byte_ix) = self.text.chunk(offset);
+                        let (chunk, chunk_byte_ix) = text.chunk(offset);
                         &chunk[offset - chunk_byte_ix..]
                     }
                 },
@@ -542,11 +543,39 @@ impl SyntaxHighlighter {
             ) else {
                 continue;
             };
-
-            // Store the parsed layer
-            self.injection_layers
-                .insert(language_name, InjectionLayer { tree: new_tree });
+            new_layers.insert(language_name, InjectionLayer { tree: new_tree });
         }
+        new_layers
+    }
+
+    /// Apply a tree that was parsed on a background thread.
+    ///
+    /// `injection_layers` must also be pre-computed in the background via
+    /// [`compute_injection_layers`] to avoid blocking the main thread.
+    pub(crate) fn apply_background_tree(
+        &mut self,
+        tree: Tree,
+        text: &Rope,
+        injection_layers: HashMap<SharedString, InjectionLayer>,
+    ) {
+        // Only apply if the text still matches what was parsed.
+        if !self.text.eq(text) {
+            return;
+        }
+
+        self.tree = Some(tree);
+        self.injection_layers = injection_layers;
+    }
+
+    /// Parse all combined injections after main tree is updated.
+    /// pattern: parse once in update, query many times in render.
+    /// Parse all combined injections after main tree is updated.
+    /// pattern: parse once in update, query many times in render.
+    fn parse_combined_injections(&mut self, tree: &Tree) {
+        let Some(data) = self.injection_parse_data() else {
+            return;
+        };
+        self.injection_layers = Self::compute_injection_layers(data, tree, &self.text.clone());
     }
 
     /// Match the visible ranges of nodes in the Tree for highlighting.

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -408,12 +408,15 @@ impl SyntaxHighlighter {
         let mut timed_out = false;
         let start = Instant::now();
         let mut progress = |_: &tree_sitter::ParseState| -> bool {
-            if let Some(budget) = timeout {
-                if start.elapsed() > budget {
-                    timed_out = true;
-                    return true; // Cancel execution
-                }
+            let Some(budget) = timeout else {
+                return false;
+            };
+
+            if start.elapsed() > budget {
+                timed_out = true;
+                return true; // Cancel execution
             }
+
             false
         };
 
@@ -446,7 +449,7 @@ impl SyntaxHighlighter {
     }
 
     /// Apply a tree that was parsed on a background thread.
-    pub fn apply_background_tree(&mut self, tree: Tree, text: &Rope) {
+    pub(crate) fn apply_background_tree(&mut self, tree: Tree, text: &Rope) {
         // Only apply if the text still matches what was parsed.
         if !self.text.eq(text) {
             return;

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -4,12 +4,19 @@ use anyhow::{Context, Result, anyhow};
 use gpui::{HighlightStyle, SharedString};
 
 use ropey::{ChunkCursor, Rope};
+use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeSet, HashMap},
     ops::Range,
     usize,
 };
-use tree_sitter::{InputEdit, Parser, Point, Query, QueryCursor, StreamingIterator, Tree};
+use tree_sitter::{
+    InputEdit, ParseOptions, Parser, Point, Query, QueryCursor, StreamingIterator, Tree,
+};
+
+/// When a node spans more than this many bytes beyond the requested query
+/// range, we recurse into its children instead of querying it directly.
+const LARGE_NODE_THRESHOLD: usize = 8 * 1024;
 
 /// A syntax highlighter that supports incremental parsing, multiline text,
 /// and caching of highlight results.
@@ -355,12 +362,32 @@ impl SyntaxHighlighter {
         self.tree.as_ref()
     }
 
+    /// Returns the language name for this highlighter.
+    pub fn language(&self) -> &SharedString {
+        &self.language
+    }
+
+    /// Returns a reference to the current text.
+    pub fn text(&self) -> &Rope {
+        &self.text
+    }
+
     /// Highlight the given text, returning a map from byte ranges to highlight captures.
     ///
     /// Uses incremental parsing by `edit` to efficiently update the highlighter's state.
-    pub fn update(&mut self, edit: Option<InputEdit>, text: &Rope) {
+    /// When `timeout` is `Some`, aborts if parsing exceeds the given duration
+    /// and returns `false`. On timeout the old tree is preserved so highlighting
+    /// still works with stale data, but `self.text` is updated so that the
+    /// caller can send the current text to a background parse.
+    /// When `timeout` is `None`, parsing runs to completion and always returns `true`.
+    pub fn update(
+        &mut self,
+        edit: Option<InputEdit>,
+        text: &Rope,
+        timeout: Option<Duration>,
+    ) -> bool {
         if self.text.eq(text) {
-            return;
+            return true;
         }
 
         let edit = edit.unwrap_or(InputEdit {
@@ -378,6 +405,19 @@ impl SyntaxHighlighter {
             .unwrap_or(self.parser.parse("", None).unwrap());
         old_tree.edit(&edit);
 
+        let mut timed_out = false;
+        let start = Instant::now();
+        let mut progress = |_: &tree_sitter::ParseState| -> bool {
+            if let Some(budget) = timeout {
+                if start.elapsed() > budget {
+                    timed_out = true;
+                    return true; // Cancel execution
+                }
+            }
+            false
+        };
+
+        let options = ParseOptions::new().progress_callback(&mut progress);
         let new_tree = self.parser.parse_with_options(
             &mut move |offset, _| {
                 if offset >= text.len() {
@@ -388,16 +428,32 @@ impl SyntaxHighlighter {
                 }
             },
             Some(&old_tree),
-            None,
+            Some(options),
         );
 
-        let Some(new_tree) = new_tree else {
-            return;
-        };
+        if timed_out || new_tree.is_none() {
+            // Restore the old tree so highlighting continues with stale data.
+            self.tree = Some(old_tree);
+            self.text = text.clone();
+            return false;
+        }
 
+        let new_tree = new_tree.unwrap();
         self.tree = Some(new_tree.clone());
         self.text = text.clone();
         self.parse_combined_injections(&new_tree);
+        true
+    }
+
+    /// Apply a tree that was parsed on a background thread.
+    pub fn apply_background_tree(&mut self, tree: Tree, text: &Rope) {
+        // Only apply if the text still matches what was parsed.
+        if !self.text.eq(text) {
+            return;
+        }
+
+        self.tree = Some(tree.clone());
+        self.parse_combined_injections(&tree);
     }
 
     /// Parse all combined injections after main tree is updated.
@@ -536,36 +592,41 @@ impl SyntaxHighlighter {
             }
         }
 
-        let mut cursor = QueryCursor::new();
-        cursor.set_byte_range(range);
-        let mut matches = cursor.matches(&query, root_node, TextProvider(&source));
+        let query_nodes = collect_query_nodes(root_node, &range);
 
-        while let Some(query_match) = matches.next() {
-            for cap in query_match.captures {
-                let node = cap.node;
+        for query_node in &query_nodes {
+            let mut query_cursor = QueryCursor::new();
+            query_cursor.set_byte_range(range.clone());
 
-                let Some(highlight_name) = query.capture_names().get(cap.index as usize) else {
-                    continue;
-                };
+            let mut matches = query_cursor.matches(&query, *query_node, TextProvider(&source));
 
-                let node_range: Range<usize> = node.start_byte()..node.end_byte();
-                let highlight_name = SharedString::from(highlight_name.to_string());
+            while let Some(query_match) = matches.next() {
+                for cap in query_match.captures {
+                    let node = cap.node;
 
-                // Merge near range and same highlight name
-                let last_item = highlights.last();
-                let last_range = last_item.map(|item| &item.range).unwrap_or(&(0..0));
-                let last_highlight_name = last_item.map(|item| item.name.clone());
+                    let Some(highlight_name) = query.capture_names().get(cap.index as usize) else {
+                        continue;
+                    };
 
-                if last_range == &node_range {
-                    // case:
-                    // last_range: 213..220, last_highlight_name: Some("property")
-                    // last_range: 213..220, last_highlight_name: Some("string")
-                    highlights.push(HighlightItem::new(
-                        node_range,
-                        last_highlight_name.unwrap_or(highlight_name),
-                    ));
-                } else {
-                    highlights.push(HighlightItem::new(node_range, highlight_name.clone()));
+                    let node_range: Range<usize> = node.start_byte()..node.end_byte();
+                    let highlight_name = SharedString::from(highlight_name.to_string());
+
+                    // Merge near range and same highlight name
+                    let last_item = highlights.last();
+                    let last_range = last_item.map(|item| &item.range).unwrap_or(&(0..0));
+                    let last_highlight_name = last_item.map(|item| item.name.clone());
+
+                    if last_range == &node_range {
+                        // case:
+                        // last_range: 213..220, last_highlight_name: Some("property")
+                        // last_range: 213..220, last_highlight_name: Some("string")
+                        highlights.push(HighlightItem::new(
+                            node_range,
+                            last_highlight_name.unwrap_or(highlight_name),
+                        ));
+                    } else {
+                        highlights.push(HighlightItem::new(node_range, highlight_name.clone()));
+                    }
                 }
             }
         }
@@ -595,7 +656,7 @@ impl SyntaxHighlighter {
     /// let code = "fn main() {\n    println!(\"Hello\");\n}";
     /// let rope = Rope::from_str(code);
     /// let mut highlighter = SyntaxHighlighter::new("rust");
-    /// highlighter.update(None, &rope);
+    /// highlighter.update(None, &rope, None);
     ///
     /// let theme = HighlightTheme::default_dark();
     /// let range = 0..code.len();
@@ -732,6 +793,57 @@ pub(crate) fn unique_styles(
     merged
 }
 
+/// Walk the tree and collect nodes suitable for querying, skipping subtrees
+/// that fall entirely outside the byte range. Nodes much larger than the
+/// query range are recursed into so that `QueryCursor` only visits the
+/// relevant portion of the tree.
+fn collect_query_nodes<'a>(
+    root: tree_sitter::Node<'a>,
+    range: &Range<usize>,
+) -> Vec<tree_sitter::Node<'a>> {
+    let mut nodes = Vec::new();
+    collect_query_nodes_inner(root, range, &mut nodes);
+    if nodes.is_empty() {
+        nodes.push(root);
+    }
+    nodes
+}
+
+fn collect_query_nodes_inner<'a>(
+    node: tree_sitter::Node<'a>,
+    range: &Range<usize>,
+    out: &mut Vec<tree_sitter::Node<'a>>,
+) {
+    // Skip nodes entirely outside the range.
+    if node.end_byte() <= range.start || node.start_byte() >= range.end {
+        return;
+    }
+
+    let node_span = node.end_byte() - node.start_byte();
+    let range_span = range.end - range.start;
+
+    // Use `goto_first_child_for_byte` to seek directly to the first
+    // overlapping child instead of iterating all children from the start.
+    if node_span > range_span + LARGE_NODE_THRESHOLD && node.child_count() > 0 {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child_for_byte(range.start).is_some() {
+            loop {
+                let child = cursor.node();
+                if child.start_byte() >= range.end {
+                    break;
+                }
+                collect_query_nodes_inner(child, range, out);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
+    out.push(node);
+}
+
 /// Merge other style (Other on top)
 fn merge_highlight_style(style: &mut HighlightStyle, other: &HighlightStyle) {
     if let Some(color) = other.color {
@@ -835,7 +947,7 @@ $x = 1;
 
         let rope = Rope::from_str(php_code);
         let mut highlighter = SyntaxHighlighter::new("php");
-        highlighter.update(None, &rope);
+        highlighter.update(None, &rope, None);
 
         assert!(
             highlighter.combined_injections_query.is_some(),

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -5,6 +5,7 @@
 
 use gpui::{HighlightStyle, SharedString};
 use std::ops::Range;
+use std::time::Duration;
 
 // Syntax highlighter stub
 pub struct SyntaxHighlighter;
@@ -26,12 +27,32 @@ impl SyntaxHighlighter {
         Vec::new()
     }
 
-    pub fn update(&mut self, _edit: Option<crate::input::InputEdit>, _text: &ropey::Rope) {
+    pub fn update(
+        &mut self,
+        _edit: Option<crate::input::InputEdit>,
+        _text: &ropey::Rope,
+        _timeout: Option<Duration>,
+    ) -> bool {
         // No-op in WASM
+        true
+    }
+
+    pub fn language(&self) -> &SharedString {
+        static EMPTY: SharedString = SharedString::new_static("");
+        &EMPTY
+    }
+
+    pub fn text(&self) -> &ropey::Rope {
+        static EMPTY_ROPE: LazyLock<ropey::Rope> = LazyLock::new(ropey::Rope::new);
+        &EMPTY_ROPE
     }
 
     pub fn tree(&self) -> Option<&crate::input::Tree> {
         None
+    }
+
+    pub fn apply_background_tree(&mut self, _tree: crate::input::Tree, _text: &ropey::Rope) {
+        // No-op in WASM
     }
 }
 

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -50,10 +50,6 @@ impl SyntaxHighlighter {
     pub fn tree(&self) -> Option<&crate::input::Tree> {
         None
     }
-
-    pub(crate) fn apply_background_tree(&mut self, _tree: crate::input::Tree, _text: &ropey::Rope) {
-        // No-op in WASM
-    }
 }
 
 // Language enum stub

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -51,7 +51,7 @@ impl SyntaxHighlighter {
         None
     }
 
-    pub fn apply_background_tree(&mut self, _tree: crate::input::Tree, _text: &ropey::Rope) {
+    pub(crate) fn apply_background_tree(&mut self, _tree: crate::input::Tree, _text: &ropey::Rope) {
         // No-op in WASM
     }
 }

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1030,19 +1030,34 @@ impl TextElement {
 
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
 
-        for &buffer_line in visible_buffer_lines {
-            let line_start = text.line_start_offset(buffer_line);
-            let line = text.slice_line(buffer_line);
-            let line_len = if is_multi_line {
-                // +1 for `\n`
-                line.len() + 1
-            } else {
-                line.len()
-            };
+        // Group contiguous visible lines into ranges and call styles() once per range
+        let mut visible_iter = visible_buffer_lines.iter().peekable();
+        let mut range_start: Option<usize> = None;
 
-            let range = line_start..line_start + line_len;
-            let line_styles = highlighter.styles(&range, &cx.theme().highlight_theme);
-            styles = gpui::combine_highlights(styles, line_styles).collect();
+        while let Some(&line) = visible_iter.next() {
+            range_start.get_or_insert(line);
+
+            // Check if next line is contiguous, if so keep accumulating
+            if visible_iter
+                .peek()
+                .map(|&&next| next == line + 1)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            // Flush the contiguous range
+            let start_line = range_start.take().unwrap();
+            let byte_start = text.line_start_offset(start_line);
+            let byte_end = if is_multi_line {
+                // +1 for `\n`
+                text.line_start_offset(line + 1)
+            } else {
+                text.line_end_offset(line)
+            };
+            let range_styles =
+                highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme);
+            styles = gpui::combine_highlights(styles, range_styles).collect();
         }
 
         let diagnostic_styles = diagnostics.styles_for_range(&visible_byte_range, cx);

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -1,13 +1,22 @@
 use std::rc::Rc;
+use std::time::Duration;
 use std::{cell::RefCell, ops::Range};
 
-use gpui::{App, SharedString};
+use gpui::{App, SharedString, Task};
 use ropey::Rope;
 
 use super::display_map::DisplayMap;
 use crate::highlighter::DiagnosticSet;
 use crate::highlighter::SyntaxHighlighter;
 use crate::input::{InputEdit, RopeExt as _, TabSize};
+
+#[allow(dead_code)]
+pub(super) struct PendingBackgroundParse {
+    pub highlighter: Rc<RefCell<Option<SyntaxHighlighter>>>,
+    pub parse_task: Rc<RefCell<Option<Task<()>>>>,
+    pub language: SharedString,
+    pub text: Rope,
+}
 
 #[derive(Clone)]
 pub(crate) enum InputMode {
@@ -35,6 +44,7 @@ pub(crate) enum InputMode {
         folding: bool,
         highlighter: Rc<RefCell<Option<SyntaxHighlighter>>>,
         diagnostics: DiagnosticSet,
+        parse_task: Rc<RefCell<Option<Task<()>>>>,
     },
 }
 
@@ -67,6 +77,7 @@ impl InputMode {
             indent_guides: true,
             folding: true,
             diagnostics: DiagnosticSet::new(&Rope::new()),
+            parse_task: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -205,6 +216,11 @@ impl InputMode {
         }
     }
 
+    /// Update the syntax highlighter with new text.
+    ///
+    /// Returns `Some(PendingBackgroundParse)` when the synchronous parse
+    /// timed out and the caller should dispatch a background parse.
+    /// Returns `None` when parsing completed (or no highlighter is active).
     pub(super) fn update_highlighter(
         &mut self,
         selected_range: &Range<usize>,
@@ -212,25 +228,26 @@ impl InputMode {
         new_text: &str,
         force: bool,
         cx: &mut App,
-    ) {
+    ) -> Option<PendingBackgroundParse> {
         match &self {
             InputMode::CodeEditor {
                 language,
                 highlighter,
+                parse_task,
                 ..
             } => {
                 if !force && highlighter.borrow().is_some() {
-                    return;
+                    return None;
                 }
 
-                let mut highlighter = highlighter.borrow_mut();
-                if highlighter.is_none() {
+                let mut highlighter_ref = highlighter.borrow_mut();
+                if highlighter_ref.is_none() {
                     let new_highlighter = SyntaxHighlighter::new(language);
-                    highlighter.replace(new_highlighter);
+                    highlighter_ref.replace(new_highlighter);
                 }
 
-                let Some(highlighter) = highlighter.as_mut() else {
-                    return;
+                let Some(h) = highlighter_ref.as_mut() else {
+                    return None;
                 };
 
                 // When full text changed, the selected_range may be out of bound (The before version).
@@ -257,9 +274,25 @@ impl InputMode {
                     new_end_position: new_end_pos,
                 };
 
-                highlighter.update(Some(edit), text);
+                const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
+                let completed = h.update(Some(edit), text, Some(SYNC_PARSE_TIMEOUT));
+                if completed {
+                    // Sync parse succeeded, cancel any pending background parse.
+                    parse_task.borrow_mut().take();
+                    None
+                } else {
+                    // Timed out. Return the data needed for background parsing.
+                    let pending = PendingBackgroundParse {
+                        language: h.language().clone(),
+                        text: text.clone(),
+                        highlighter: highlighter.clone(),
+                        parse_task: parse_task.clone(),
+                    };
+                    drop(highlighter_ref);
+                    Some(pending)
+                }
             }
-            _ => {}
+            _ => None,
         }
     }
 
@@ -318,6 +351,7 @@ mod tests {
             language: "rust".into(),
             highlighter: Default::default(),
             diagnostics: DiagnosticSet::new(&Rope::new()),
+            parse_task: Default::default(),
         };
         assert_eq!(mode.is_code_editor(), true);
         assert_eq!(mode.is_multi_line(), false);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -581,10 +581,12 @@ impl InputState {
             InputMode::CodeEditor {
                 language,
                 highlighter,
+                parse_task,
                 ..
             } => {
                 *language = new_language.into();
                 *highlighter.borrow_mut() = None;
+                parse_task.borrow_mut().take();
             }
             _ => {}
         }
@@ -593,8 +595,13 @@ impl InputState {
 
     fn reset_highlighter(&mut self, cx: &mut Context<Self>) {
         match &mut self.mode {
-            InputMode::CodeEditor { highlighter, .. } => {
+            InputMode::CodeEditor {
+                highlighter,
+                parse_task,
+                ..
+            } => {
                 *highlighter.borrow_mut() = None;
+                parse_task.borrow_mut().take();
             }
             _ => {}
         }
@@ -2074,9 +2081,16 @@ impl InputState {
             .as_ref()
             .and_then(|h| h.tree().cloned());
 
+        // Extract injection parse data on the main thread before spawning, so that
+        // compute_injection_layers can also run on the background thread.
+        let injection_data = highlighter_rc
+            .borrow()
+            .as_ref()
+            .and_then(|h| h.injection_parse_data());
+
         let text_for_apply = text.clone();
         let task = cx.spawn_in(window, async move |entity, cx| {
-            let new_tree = cx
+            let result = cx
                 .background_executor()
                 .spawn(async move {
                     let Some(config) = LanguageRegistry::singleton().language(&language) else {
@@ -2088,7 +2102,7 @@ impl InputState {
                         return None;
                     }
 
-                    parser.parse_with_options(
+                    let new_tree = parser.parse_with_options(
                         &mut |offset, _| {
                             if offset >= text.len() {
                                 ""
@@ -2099,13 +2113,25 @@ impl InputState {
                         },
                         old_tree.as_ref(),
                         None,
-                    )
+                    )?;
+
+                    // Compute injection layers in the background to avoid blocking the
+                    // main thread with combined-injection parsing (e.g. PHP, HTML+JS/CSS).
+                    let injection_layers = if let Some(data) = injection_data {
+                        crate::highlighter::SyntaxHighlighter::compute_injection_layers(
+                            data, &new_tree, &text,
+                        )
+                    } else {
+                        Default::default()
+                    };
+
+                    Some((new_tree, injection_layers))
                 })
                 .await;
 
-            if let Some(new_tree) = new_tree {
+            if let Some((new_tree, injection_layers)) = result {
                 if let Some(h) = highlighter_rc.borrow_mut().as_mut() {
-                    h.apply_background_tree(new_tree, &text_for_apply);
+                    h.apply_background_tree(new_tree, &text_for_apply, injection_layers);
                 }
 
                 // Trigger re-render so the new highlights are displayed.

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -26,6 +26,8 @@ use super::{
 use crate::Size;
 use crate::actions::{SelectDown, SelectLeft, SelectRight, SelectUp};
 use crate::highlighter::DiagnosticSet;
+#[cfg(not(target_family = "wasm"))]
+use crate::highlighter::LanguageRegistry;
 use crate::input::blink_cursor::CURSOR_WIDTH;
 use crate::input::movement::MoveDirection;
 use crate::input::{
@@ -2051,6 +2053,79 @@ impl InputState {
             &self.text,
         );
     }
+
+    /// Spawn a background parse after the synchronous parse timed out.
+    ///
+    /// Dropping the returned `Task` (stored in `parse_task`) cancels the
+    /// parse, which naturally debounces rapid edits.
+    #[cfg(not(target_family = "wasm"))]
+    fn dispatch_background_parse(
+        pending: super::mode::PendingBackgroundParse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let highlighter_rc = pending.highlighter;
+        let parse_task_rc = pending.parse_task;
+        let language = pending.language;
+        let text = pending.text;
+
+        let old_tree = highlighter_rc
+            .borrow()
+            .as_ref()
+            .and_then(|h| h.tree().cloned());
+
+        let text_for_apply = text.clone();
+        let task = cx.spawn_in(window, async move |entity, cx| {
+            let new_tree = cx
+                .background_executor()
+                .spawn(async move {
+                    let Some(config) = LanguageRegistry::singleton().language(&language) else {
+                        return None;
+                    };
+
+                    let mut parser = tree_sitter::Parser::new();
+                    if parser.set_language(&config.language).is_err() {
+                        return None;
+                    }
+
+                    parser.parse_with_options(
+                        &mut |offset, _| {
+                            if offset >= text.len() {
+                                ""
+                            } else {
+                                let (chunk, chunk_byte_ix) = text.chunk(offset);
+                                &chunk[offset - chunk_byte_ix..]
+                            }
+                        },
+                        old_tree.as_ref(),
+                        None,
+                    )
+                })
+                .await;
+
+            if let Some(new_tree) = new_tree {
+                if let Some(h) = highlighter_rc.borrow_mut().as_mut() {
+                    h.apply_background_tree(new_tree, &text_for_apply);
+                }
+
+                // Trigger re-render so the new highlights are displayed.
+                _ = entity.update(cx, |_, cx| {
+                    cx.notify();
+                });
+            }
+        });
+
+        parse_task_rc.borrow_mut().replace(task);
+    }
+
+    #[cfg(target_family = "wasm")]
+    fn dispatch_background_parse(
+        _pending: super::mode::PendingBackgroundParse,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        // No-op
+    }
 }
 
 impl EntityInputHandler for InputState {
@@ -2149,8 +2224,14 @@ impl EntityInputHandler for InputState {
             .adjust_folds_for_edit(&old_text, &range, new_text);
         self.display_map
             .on_text_changed(&self.text, &range, &Rope::from(new_text), cx);
-        self.mode
+
+        let bg = self
+            .mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
+        if let Some(bg) = bg {
+            Self::dispatch_background_parse(bg, window, cx);
+        }
+
         self.update_fold_candidates_incremental(&range, new_text);
         self.lsp.update(&self.text, window, cx);
         self.selected_range = (new_offset..new_offset).into();
@@ -2208,8 +2289,14 @@ impl EntityInputHandler for InputState {
             .adjust_folds_for_edit(&old_text, &range, new_text);
         self.display_map
             .on_text_changed(&self.text, &range, &Rope::from(new_text), cx);
-        self.mode
+
+        let bg = self
+            .mode
             .update_highlighter(&range, &self.text, &new_text, true, cx);
+        if let Some(bg) = bg {
+            Self::dispatch_background_parse(bg, window, cx);
+        }
+
         self.update_fold_candidates_incremental(&range, new_text);
         self.lsp.update(&self.text, window, cx);
         if new_text.is_empty() {
@@ -2316,8 +2403,13 @@ impl Focusable for InputState {
 impl Render for InputState {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if self._pending_update {
-            self.mode
+            let bg = self
+                .mode
                 .update_highlighter(&(0..0), &self.text, "", false, cx);
+            if let Some(bg) = bg {
+                Self::dispatch_background_parse(bg, window, cx);
+            }
+
             self.update_fold_candidates();
             self.lsp.update(&self.text, window, cx);
             self._pending_update = false;

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -523,7 +523,7 @@ impl CodeBlock {
         let mut styles = vec![];
         if let Some(lang) = &lang {
             let mut highlighter = SyntaxHighlighter::new(&lang);
-            highlighter.update(None, &Rope::from_str(code.as_str()));
+            highlighter.update(None, &Rope::from_str(code.as_str()), None);
             styles = highlighter.styles(&(0..code.len()), highlight_theme);
         };
 


### PR DESCRIPTION
## Summary

- **Cancel `parse_task` on language change**: `set_highlighter()` and `reset_highlighter()` now drop the pending background parse task, preventing spurious `cx.notify()` calls and concurrent stale parses when switching languages rapidly.

- **Move injection layer parsing to background thread**: `combined_injections_query` is now wrapped in `Arc<Query>` so a reference can be shared with the background executor. A new `InjectionParseData` struct captures all data needed for injection parsing before the background task is spawned. The new `SyntaxHighlighter::compute_injection_layers` associated function performs the full injection parse on the background thread alongside the main tree parse. `apply_background_tree` now accepts the pre-computed layers and only does cheap field assignments on the main thread — avoiding UI jank for languages with heavy injections such as PHP and HTML+JS/CSS.

## Test plan

- [ ] Open a PHP or HTML file with embedded JS/CSS in the editor and verify no UI jank after a background parse completes
- [ ] Switch languages via `set_highlighter()` rapidly and verify no stale highlights or spurious re-renders from the old language's background parse

🤖 Generated with [Claude Code](https://claude.ai/code)