### PR TITLE
text_view: Fix clipped markdown hit testing

### DIFF
--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -5,13 +5,13 @@ use std::{
 };
 
 use gpui::{
-    point, px, quad, App, BorderStyle, Bounds, CursorStyle, Edges, Element, ElementId,
-    GlobalElementId, Half, HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement,
-    LayoutId, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, StyledText, TextLayout,
-    Window,
+    App, BorderStyle, Bounds, CursorStyle, Edges, Element, ElementId, GlobalElementId, Half,
+    HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId,
+    MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, StyledText, TextLayout, Window,
+    point, px, quad,
 };
 
-use crate::{global_state::GlobalState, input::Selection, text::node::LinkMark, ActiveTheme};
+use crate::{ActiveTheme, global_state::GlobalState, input::Selection, text::node::LinkMark};
 
 /// A inline element used to render a inline text and support selectable.
 ///
@@ -129,13 +129,8 @@ impl Inline {
                 }
             }
 
-            if point_in_text_selection(
-                pos,
-                char_width,
-                selection_start,
-                selection_end,
-                line_height,
-            ) {
+            if point_in_text_selection(pos, char_width, selection_start, selection_end, line_height)
+            {
                 if selection.is_none() {
                     selection = Some((offset..offset).into());
                 }
@@ -354,9 +349,10 @@ impl Element for Inline {
             window.on_mouse_event({
                 let links = self.links.clone();
                 let text_layout = text_layout.clone();
+                let hitbox = hitbox.clone();
 
-                move |event: &MouseUpEvent, phase, _, cx| {
-                    if !bounds.contains(&event.position) || !phase.bubble() {
+                move |event: &MouseUpEvent, phase, window, cx| {
+                    if !phase.bubble() || !hitbox.is_hovered(window) {
                         return;
                     }
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AnyElement, App, Bounds, Element, ElementId, Entity, GlobalElementId, InspectorElementId,
-    InteractiveElement, IntoElement, LayoutId, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
+    AnyElement, App, Bounds, Element, ElementId, Entity, GlobalElementId, Hitbox, HitboxBehavior,
+    InspectorElementId, InteractiveElement, IntoElement, LayoutId, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
 };
 
 use crate::StyledExt;
@@ -159,7 +159,7 @@ pub struct TextViewLayoutState {
 
 impl Element for TextView {
     type RequestLayoutState = TextViewLayoutState;
-    type PrepaintState = ();
+    type PrepaintState = Hitbox;
 
     fn id(&self) -> Option<ElementId> {
         Some(self.id.clone())
@@ -230,21 +230,22 @@ impl Element for TextView {
         &mut self,
         _: Option<&GlobalElementId>,
         _: Option<&InspectorElementId>,
-        _: Bounds<Pixels>,
+        bounds: Bounds<Pixels>,
         request_layout: &mut Self::RequestLayoutState,
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
         request_layout.element.prepaint(window, cx);
+        window.insert_hitbox(bounds, HitboxBehavior::Normal)
     }
 
     fn paint(
         &mut self,
         _: Option<&GlobalElementId>,
         _: Option<&InspectorElementId>,
-        bounds: Bounds<Pixels>,
+        _bounds: Bounds<Pixels>,
         request_layout: &mut Self::RequestLayoutState,
-        _: &mut Self::PrepaintState,
+        hitbox: &mut Self::PrepaintState,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -262,9 +263,9 @@ impl Element for TextView {
 
             window.on_mouse_event({
                 let state = state.clone();
-
-                move |event: &MouseDownEvent, phase, _, cx| {
-                    if !bounds.contains(&event.position) || !phase.bubble() {
+                let hitbox = hitbox.clone();
+                move |event: &MouseDownEvent, phase, window, cx| {
+                    if !phase.bubble() || !hitbox.is_hovered(window) {
                         return;
                     }
 
@@ -311,8 +312,9 @@ impl Element for TextView {
                 // down outside to clear selection
                 window.on_mouse_event({
                     let state = state.clone();
-                    move |event: &MouseDownEvent, _, _, cx| {
-                        if bounds.contains(&event.position) {
+                    let hitbox = hitbox.clone();
+                    move |_: &MouseDownEvent, _, window, cx| {
+                        if hitbox.is_hovered(window) {
                             return;
                         }
 
@@ -324,5 +326,84 @@ impl Element for TextView {
                 });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TextView;
+    use crate::text::TextViewState;
+    use gpui::{
+        AppContext as _, Context, Entity, IntoElement, Modifiers, MouseButton, ParentElement as _,
+        Render, Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
+    };
+
+    struct TextViewTestRoot {
+        text_view: Entity<TextViewState>,
+    }
+
+    impl TextViewTestRoot {
+        fn new(text: &str, cx: &mut Context<Self>) -> Self {
+            let text = text.to_string();
+            let text_view = cx.new(|cx| TextViewState::markdown(&text, cx));
+            Self { text_view }
+        }
+    }
+
+    impl Render for TextViewTestRoot {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(160.))
+                .child(
+                    div()
+                        .h(px(24.))
+                        .overflow_hidden()
+                        .child(TextView::new(&self.text_view).selectable(true)),
+                )
+                .child(div().h(px(40.)).child("footer"))
+        }
+    }
+
+    #[gpui::test]
+    fn clipped_markdown_link_does_not_open(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, cx| {
+            TextViewTestRoot::new("visible\n\n[hidden](https://example.com)", cx)
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.simulate_click(point(px(10.), px(34.)), Modifiers::default());
+
+        assert_eq!(cx.opened_url(), None);
+    }
+
+    #[gpui::test]
+    fn clipped_markdown_cannot_start_selection(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (view, cx) = cx
+            .add_window_view(|_, cx| TextViewTestRoot::new("visible\n\nhidden selection text", cx));
+        let cx: &mut VisualTestContext = cx;
+
+        cx.simulate_mouse_down(
+            point(px(10.), px(34.)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_move(
+            point(px(90.), px(34.)),
+            Some(MouseButton::Left),
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_up(
+            point(px(90.), px(34.)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+
+        let selected_text = view.read_with(cx, |root, cx| root.text_view.read(cx).selected_text());
+        assert!(
+            selected_text.is_empty(),
+            "unexpected selection: {selected_text:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #2155

## Description

Fix clipped-region hit testing for markdown content rendered by `TextView`. `TextView` now uses a hitbox-aware check when starting or clearing selection, and `Inline` link clicks use the same clipped-region-aware hit testing instead of raw bounds checks. This prevents hidden markdown from remaining interactive when it is clipped by `overflow_hidden()` or covered by sibling content.

## Screenshot

### Before 

https://github.com/user-attachments/assets/77d5a9f1-53c3-47c3-a958-bc1806630dcd

### After 

https://github.com/user-attachments/assets/67144c0f-08ad-4c90-9636-9a68ab8934bd

## How to Test

Run:

```bash
cargo test -p gpui-component clipped_markdown_ -- --nocapture
```

Then verify that clicking or dragging over a visually clipped markdown region no longer starts selection or opens a link.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
