### PR TITLE
setting: Add icon support

### DIFF
--- a/crates/story/src/stories/settings_story.rs
+++ b/crates/story/src/stories/settings_story.rs
@@ -131,6 +131,7 @@ impl SettingsStory {
             SettingPage::new("General")
                 .resettable(resettable)
                 .default_open(true)
+                .icon(Icon::new(IconName::Settings2))
                 .groups(vec![
                     SettingGroup::new().title("Appearance").items(vec![
                         SettingItem::new(
@@ -333,6 +334,7 @@ impl SettingsStory {
                 ]),
             SettingPage::new("Software Update")
                 .resettable(resettable)
+                .icon(Icon::new(IconName::Cpu))
                 .groups(vec![SettingGroup::new().title("Updates").items(vec![
                     SettingItem::new(
                         "Enable Notifications",
@@ -359,6 +361,7 @@ impl SettingsStory {
                 ])]),
             SettingPage::new("About")
                 .resettable(resettable)
+                .icon(Icon::new(IconName::Info))
                 .group(
                     SettingGroup::new().item(SettingItem::render(|_options, _, cx| {
                         v_flex()

--- a/crates/ui/src/setting/page.rs
+++ b/crates/ui/src/setting/page.rs
@@ -1,11 +1,12 @@
 use gpui::{
-    App, Entity, InteractiveElement as _, IntoElement, ListAlignment, ListState, StyleRefinement,
-    ParentElement as _, SharedString, Styled, Window, div, list, prelude::FluentBuilder as _, px,
+    App, Entity, InteractiveElement as _, IntoElement, ListAlignment, ListState,
+    ParentElement as _, SharedString, StyleRefinement, Styled, Window, div, list,
+    prelude::FluentBuilder as _, px,
 };
 use rust_i18n::t;
 
 use crate::{
-    ActiveTheme, IconName, Sizable, StyledExt,
+    ActiveTheme, Icon, IconName, Sizable, StyledExt,
     button::{Button, ButtonVariants},
     h_flex,
     label::Label,
@@ -17,6 +18,7 @@ use crate::{
 /// A setting page that can contain multiple setting groups.
 #[derive(Clone)]
 pub struct SettingPage {
+    pub(super) icon: Option<Icon>,
     resettable: bool,
     pub(super) default_open: bool,
     pub(super) title: SharedString,
@@ -28,6 +30,7 @@ pub struct SettingPage {
 impl SettingPage {
     pub fn new(title: impl Into<SharedString>) -> Self {
         Self {
+            icon: None,
             resettable: true,
             default_open: false,
             title: title.into(),
@@ -40,6 +43,12 @@ impl SettingPage {
     /// Set the title of the setting page.
     pub fn title(mut self, title: impl Into<SharedString>) -> Self {
         self.title = title.into();
+        self
+    }
+
+    /// Set the icon of the setting page.
+    pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
+        self.icon = Some(icon.into());
         self
     }
 

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -175,6 +175,7 @@ impl Settings {
                     let is_page_active =
                         selected_index.page_ix == page_ix && selected_index.group_ix.is_none();
                     SidebarMenuItem::new(page.title.clone())
+                        .when_some(page.icon.clone(), |this, icon| this.icon(icon))
                         .default_open(page.default_open)
                         .active(is_page_active)
                         .on_click({

--- a/docs/docs/components/settings.md
+++ b/docs/docs/components/settings.md
@@ -119,6 +119,14 @@ SettingPage::new("General")
     ])
 ```
 
+### Icon
+
+```rust
+SettingPage::new("General")
+    .icon(IconName::Settings)
+    .groups(vec![...])
+```
+
 ### Default Open
 
 ```rust


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1055" height="725" alt="Before" src="https://github.com/user-attachments/assets/df016ac0-bdbe-446a-9b60-a38c29414140" /> | <img width="1055" height="726" alt="After" src="https://github.com/user-attachments/assets/db8389bd-26cb-4fb4-a464-aa194ed78772" /> |