### PR TITLE
select: Add `menu_max_h` option

### DIFF
--- a/crates/story/src/stories/select_story.rs
+++ b/crates/story/src/stories/select_story.rs
@@ -42,6 +42,7 @@ pub struct SelectStory {
     simple_select1: Entity<SelectState<Vec<&'static str>>>,
     simple_select2: Entity<SelectState<SearchableVec<&'static str>>>,
     simple_select3: Entity<SelectState<Vec<SharedString>>>,
+    menu_max_h_select: Entity<SelectState<Vec<&'static str>>>,
     disabled_select: Entity<SelectState<Vec<SharedString>>>,
     appearance_select: Entity<SelectState<Vec<SharedString>>>,
     input_state: Entity<InputState>,
@@ -147,6 +148,17 @@ impl SelectStory {
                 }),
                 simple_select3: cx
                     .new(|cx| SelectState::new(Vec::<SharedString>::new(), None, window, cx)),
+                menu_max_h_select: cx.new(|cx| {
+                    SelectState::new(
+                        vec![
+                            "GPUI", "Iced", "egui", "Makepad", "Slint", "QT", "ImGui", "Cocoa",
+                            "WinUI",
+                        ],
+                        Some(IndexPath::default()),
+                        window,
+                        cx,
+                    )
+                }),
                 disabled_select: cx
                     .new(|cx| SelectState::new(Vec::<SharedString>::new(), None, window, cx)),
                 appearance_select,
@@ -219,6 +231,16 @@ impl Render for SelectStory {
                         .small()
                         .placeholder("UI")
                         .title_prefix("UI: "),
+                ),
+            )
+            .child(
+                section("Custom Menu Max Height").max_w_128().child(
+                    Select::new(&self.menu_max_h_select)
+                        .disabled(self.disabled)
+                        .small()
+                        .placeholder("UI")
+                        .title_prefix("UI: ")
+                        .menu_max_h(rems(6.)),
                 ),
             )
             .child(

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -1,9 +1,9 @@
 use gpui::{
     AnyElement, App, AppContext, Bounds, ClickEvent, Context, DismissEvent, Edges, ElementId,
     Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding,
-    Length, ParentElement, Pixels, Render, RenderOnce, SharedString, StatefulInteractiveElement,
-    StyleRefinement, Styled, Subscription, Task, WeakEntity, Window, anchored, deferred, div,
-    prelude::FluentBuilder, px, rems,
+    Length, ParentElement, Pixels, Render, RenderOnce, SharedString,
+    StatefulInteractiveElement, StyleRefinement, Styled, Subscription, Task, WeakEntity, Window,
+    anchored, deferred, div, prelude::FluentBuilder, px, rems,
 };
 use rust_i18n::t;
 
@@ -317,6 +317,7 @@ struct SelectOptions {
     search_placeholder: Option<SharedString>,
     empty: Option<AnyElement>,
     menu_width: Length,
+    menu_max_h: Length,
     disabled: bool,
     appearance: bool,
 }
@@ -332,6 +333,7 @@ impl Default for SelectOptions {
             title_prefix: None,
             empty: None,
             menu_width: Length::Auto,
+            menu_max_h: rems(20.).into(),
             disabled: false,
             appearance: true,
             search_placeholder: None,
@@ -902,7 +904,7 @@ where
                                                     },
                                                 )
                                                 .with_size(self.options.size)
-                                                .max_h(rems(20.))
+                                                .max_h(self.options.menu_max_h)
                                                 .paddings(Edges::all(px(4.))),
                                         ),
                                 )
@@ -932,6 +934,12 @@ where
     /// Set the width of the dropdown menu, default: Length::Auto
     pub fn menu_width(mut self, width: impl Into<Length>) -> Self {
         self.options.menu_width = width.into();
+        self
+    }
+
+    /// Set the max height of the dropdown menu, default: 20rem
+    pub fn menu_max_h(mut self, max_h: impl Into<Length>) -> Self {
+        self.options.menu_max_h = max_h.into();
         self
     }
 

--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -174,6 +174,7 @@ Select::new(&state)
 Select::new(&state)
     .w(px(320.))                    // Set dropdown width
     .menu_width(px(400.))           // Set menu popup width
+    .menu_max_h(rems(10.))          // Set menu max height (default: 20rem)
     .appearance(false)              // Remove default styling
     .title_prefix("Country: ")      // Add prefix to selected title
 ```


### PR DESCRIPTION
## Summary

Add `menu_max_h(impl Into<Length>)` builder method to `Select`, allowing callers to customize the dropdown menu's max height. Defaults to `rems(20.)` to preserve existing behavior.

```rust
Select::new(&state).menu_max_h(rems(10.))
Select::new(&state).menu_max_h(px(300.))
```

## Changes

- `crates/ui/src/select.rs`: Add `menu_max_h` field to `SelectOptions` and builder method
- `crates/story/src/stories/select_story.rs`: Add "Custom Menu Max Height" section
- `docs/docs/components/select.md`: Document `menu_max_h` under Custom Appearance

🤖 Generated with [Claude Code](https://claude.ai/code)