### PR TITLE
switch: Add color option for custom checked background

### DIFF
--- a/crates/story/src/stories/switch_story.rs
+++ b/crates/story/src/stories/switch_story.rs
@@ -14,6 +14,8 @@ pub struct SwitchStory {
     switch1: bool,
     switch2: bool,
     switch3: bool,
+    switch4: bool,
+    switch5: bool,
 }
 
 impl super::Story for SwitchStory {
@@ -41,6 +43,8 @@ impl SwitchStory {
             switch1: true,
             switch2: false,
             switch3: true,
+            switch4: true,
+            switch5: false,
         }
     }
 }
@@ -127,6 +131,39 @@ impl Render for SwitchStory {
                                 println!("Switch value changed: {:?}", ev);
                             }),
                     ),
+            )
+            .child(
+                section("Custom Color").child(
+                    h_flex()
+                        .gap_4()
+                        .child(
+                            Switch::new("switch4")
+                                .checked(self.switch4)
+                                .label("Success")
+                                .color(theme.success)
+                                .on_click(cx.listener(|view, checked, _, cx| {
+                                    view.switch4 = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(
+                            Switch::new("switch5")
+                                .checked(self.switch5)
+                                .label("Destructive")
+                                .color(theme.danger)
+                                .on_click(cx.listener(|view, checked, _, cx| {
+                                    view.switch5 = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(
+                            Switch::new("switch4_disabled")
+                                .checked(true)
+                                .label("Disabled")
+                                .color(theme.success)
+                                .disabled(true),
+                        ),
+                ),
             )
             .child(
                 section("Small Size").child(

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -2,7 +2,7 @@ use crate::{
     h_flex, text::Text, tooltip::Tooltip, ActiveTheme, Disableable, Side, Sizable, Size, StyledExt,
 };
 use gpui::{
-    div, prelude::FluentBuilder as _, px, Animation, AnimationExt as _, App, ElementId,
+    div, prelude::FluentBuilder as _, px, Animation, AnimationExt as _, App, ElementId, Hsla,
     InteractiveElement, IntoElement, ParentElement as _, RenderOnce, SharedString,
     StatefulInteractiveElement, StyleRefinement, Styled, Window,
 };
@@ -19,6 +19,7 @@ pub struct Switch {
     label_side: Side,
     on_click: Option<Rc<dyn Fn(&bool, &mut Window, &mut App)>>,
     size: Size,
+    color: Option<Hsla>,
     tooltip: Option<SharedString>,
 }
 
@@ -35,6 +36,7 @@ impl Switch {
             on_click: None,
             label_side: Side::Right,
             size: Size::Medium,
+            color: None,
             tooltip: None,
         }
     }
@@ -57,6 +59,13 @@ impl Switch {
         F: Fn(&bool, &mut Window, &mut App) + 'static,
     {
         self.on_click = Some(Rc::new(handler));
+        self
+    }
+
+    /// Set the background color of the switch when checked.
+    /// Defaults to `cx.theme().primary`.
+    pub fn color(mut self, color: impl Into<Hsla>) -> Self {
+        self.color = Some(color.into());
         self
     }
 
@@ -93,8 +102,9 @@ impl RenderOnce for Switch {
         let on_click = self.on_click.clone();
         let toggle_state = window.use_keyed_state(self.id.clone(), cx, |_, _| checked);
 
+        let checked_bg = self.color.unwrap_or(cx.theme().primary);
         let (bg, toggle_bg) = match checked {
-            true => (cx.theme().primary, cx.theme().switch_thumb),
+            true => (checked_bg, cx.theme().switch_thumb),
             false => (cx.theme().switch, cx.theme().switch_thumb),
         };
 

--- a/docs/docs/components/switch.md
+++ b/docs/docs/components/switch.md
@@ -89,6 +89,31 @@ Switch::new("disabled-on")
     .checked(true)
 ```
 
+### Custom Color
+
+Use `.color()` to override the checked-state background color. The disabled alpha is applied automatically on top of the custom color.
+
+```rust
+// Success color when checked
+Switch::new("switch")
+    .label("Success")
+    .checked(true)
+    .color(cx.theme().success)
+
+// Danger color when checked
+Switch::new("switch")
+    .label("Danger")
+    .checked(true)
+    .color(cx.theme().danger)
+
+// Custom color + disabled: color is shown at 50% opacity
+Switch::new("switch")
+    .label("Disabled")
+    .checked(true)
+    .color(cx.theme().success)
+    .disabled(true)
+```
+
 ### With Tooltip
 
 ```rust
@@ -110,6 +135,7 @@ Switch::new("switch")
 | `label_side(side)` | Position label (Side::Left or Side::Right)                  |
 | `disabled(bool)`   | Set disabled state                                          |
 | `tooltip(text)`    | Add tooltip text                                            |
+| `color(color)`     | Set background color when checked (default: `theme.primary`) |
 | `on_click(fn)`     | Callback when clicked, receives `&bool` (new checked state) |
 
 ### Styling


### PR DESCRIPTION
## Summary

Add `color(impl Into<Hsla>)` builder method to `Switch`, allowing callers to customize the background color when the switch is checked. Defaults to `theme.primary` to preserve existing behavior.

```rust
Switch::new("id")
    .checked(true)
    .color(cx.theme().success)  // green

Switch::new("id")
    .checked(true)
    .color(cx.theme().danger)   // red
```

## Preview
<img width="676" height="104" alt="image" src="https://github.com/user-attachments/assets/b1422295-e463-4075-b2f2-475c71ef7ac9" />

## Changes

- `crates/ui/src/switch.rs`: Add `color` field and builder method
- `crates/story/src/stories/switch_story.rs`: Add "Custom Color" section
- `docs/docs/components/switch.md`: Document `color` method