### PR TITLE
fix: ButtonCustomVariant styles

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -670,7 +670,7 @@ impl ButtonVariant {
             Self::Info => cx.theme().info,
             Self::Link => cx.theme().link,
             Self::Text => cx.theme().foreground,
-            Self::Custom(colors) => colors.color,
+            Self::Custom(colors) => colors.foreground,
         }
     }
 
@@ -791,13 +791,7 @@ impl ButtonVariant {
                     cx.theme().info.mix_oklab(cx.theme().transparent, 0.3)
                 }
             }
-            Self::Custom(colors) => {
-                if outline {
-                    colors.color.mix_oklab(cx.theme().transparent, 0.2)
-                } else {
-                    colors.color.mix_oklab(cx.theme().transparent, 0.3)
-                }
-            }
+            Self::Custom(colors) => colors.hover,
             Self::Ghost => {
                 if cx.theme().mode.is_dark() {
                     cx.theme().secondary.lighten(0.1).opacity(0.8)
@@ -851,7 +845,7 @@ impl ButtonVariant {
             Self::Warning => cx.theme().warning.mix_oklab(cx.theme().transparent, 0.4),
             Self::Success => cx.theme().success.mix_oklab(cx.theme().transparent, 0.4),
             Self::Info => cx.theme().info.mix_oklab(cx.theme().transparent, 0.4),
-            Self::Custom(colors) => colors.color.mix_oklab(cx.theme().transparent, 0.4),
+            Self::Custom(colors) => colors.active,
             Self::Link => cx.theme().transparent,
             Self::Text => cx.theme().transparent,
         };


### PR DESCRIPTION
Closes #2185

## Description

Fix `ButtonVariant::Custom` to use the `hover`, `active`, and `foreground` fields from `ButtonCustomVariant` 

## Screenshot
Tested on the button story with the hover color:
https://github.com/longbridge/gpui-component/blob/28e826866977b11e84a0ef7bf57be8587fd77efe/crates/story/src/stories/button_story.rs#L89-L93

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="484" height="85" alt="Screenshot 2026-03-26 at 17 11 47" src="https://github.com/user-attachments/assets/4ae0bf9e-dbf2-4796-9275-1f53e2bccd74" /> | <img width="494" height="84" alt="Screenshot 2026-03-26 at 17 12 09" src="https://github.com/user-attachments/assets/b3fff1e7-0d3b-4326-846a-d91b1cba6e51" /> |

## Break Changes

Users relying on the previous behavior where custom buttons derived hover/active colors from `color` will now see their explicitly set `hover`/`active`/`foreground` values applied, default values remain transparent, so buttons without explicit values are unaffected

## How to Test

1. `cargo run`
2. Open the Button story
3. Hover/click the "Custom Button" it should use the magenta hover/active colors defined in the story

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
