### PR TITLE
popover: Fix race condition when restoring focus on close

### DIFF
--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -280,7 +280,9 @@ impl PopoverState {
             self._dismiss_subscription = None;
             // Restore focus to the element that was focused before the popover opened.
             if let Some(prev) = self.previous_focus_handle.take() {
-                prev.focus(window, cx);
+                if self.focus_handle.contains_focused(window, cx) {
+                    prev.focus(window, cx);
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #2187.

When the popover closes, it previously always restored focus to the previously focused element. This could cause a race condition: if another element had already taken focus (e.g., a second popover opening), the restore would incorrectly steal focus back.

Fix: only restore the previous focus handle if the popover's focus handle still contains focus at the time of closing.

```diff
  if let Some(prev) = self.previous_focus_handle.take() {
+     if self.focus_handle.contains_focused(window, cx) {
          prev.focus(window, cx);
+     }
  }
```