### PR TITLE
list: Fix `confirm` called twice when pressing Enter

### DIFF
--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -293,13 +293,6 @@ where
                     });
                 });
             }
-            InputEvent::PressEnter { secondary } => self.on_action_confirm(
-                &Confirm {
-                    secondary: *secondary,
-                },
-                window,
-                cx,
-            ),
             _ => {}
         }
     }


### PR DESCRIPTION
Closes #2194.

When a searchable list is open and the user presses Enter, `confirm` was fired twice: once via the `InputEvent::PressEnter` subscription and once via the `Confirm` action.

Remove the redundant `PressEnter` arm from `on_query_input_event`; the action system already handles Enter correctly.