### PR TITLE
Switch gpui dependencies from zed to gpuix repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ gpui-component-macros = { path = "crates/macros", version = "0.5.1" }
 gpui-component-assets = { path = "crates/assets", version = "0.5.1" }
 story = { path = "crates/story" }
 
-gpui = { git = "https://github.com/zed-industries/zed" }
-gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
-gpui_web = { git = "https://github.com/zed-industries/zed" }
-gpui_macros = { git = "https://github.com/zed-industries/zed" }
-reqwest_client = { git = "https://github.com/zed-industries/zed" }
+gpui = { git = "https://github.com/AzureZee/gpuix.git" }
+gpui_platform = { git = "https://github.com/AzureZee/gpuix.git", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
+gpui_web = { git = "https://github.com/AzureZee/gpuix.git" }
+gpui_macros = { git = "https://github.com/AzureZee/gpuix.git" }
+reqwest_client = { git = "https://github.com/AzureZee/gpuix.git" }
 sum-tree = { version = "0.2.0", package = "zed-sum-tree" }
 # reqwest = { version = "0.12.15-zed", package = "zed-reqwest" }
 reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "c15662463bda39148ba154100dd44d3fba5873a4", default-features = false, features = [


### PR DESCRIPTION
## Description

### Summary
This PR updates all `gpui`-related dependencies to use the standalone `gpuix` repository instead of the original `zed-industries/zed` monorepo.

### Motivation
The original `gpui` crates are embedded inside the large zed repository. Depending on them requires cloning the entire monorepo, which significantly increases dependency size and slows down CI and local builds.  
The `gpuix` repository extracts `gpui` and related crates into an independent, lightweight repository, making it more suitable for projects that only need the UI runtime.

### Changes
Updated the following dependencies in `Cargo.toml`:

| Crate | Old Source | New Source |
|-------|------------|------------|
| gpui | zed-industries/zed | AzureZee/gpuix |
| gpui_platform | zed-industries/zed | AzureZee/gpuix |
| gpui_web | zed-industries/zed | AzureZee/gpuix |
| gpui_macros | zed-industries/zed | AzureZee/gpuix |
| reqwest_client | zed-industries/zed | AzureZee/gpuix |

No other functional changes are included.

### Benefits
- Reduces dependency size by avoiding the full zed monorepo  
- Faster CI and local builds  
- Improves modularity and maintainability  
- Keeps the API identical since `gpuix` is a direct extraction

### Compatibility
`gpuix` preserves the original `gpui` APIs. This change should be fully backward compatible.

The test failed before (#2184) was merged.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
