### PR TITLE
popover: Fix first-frame flash in top-left when default-open is enabled

### DIFF
--- a/crates/ui/src/anchored.rs
+++ b/crates/ui/src/anchored.rs
@@ -1,5 +1,7 @@
 //! This is a fork of gpui's anchored element that adds support for offsetting
 //! https://github.com/zed-industries/zed/blob/b06f4088a3565c5e30663106ff79c1ced645d87a/crates/gpui/src/elements/anchored.rs
+use std::rc::Rc;
+
 use gpui::{
     AnyElement, App, Axis, Bounds, Display, Edges, Element, GlobalElementId, Half,
     InspectorElementId, IntoElement, LayoutId, ParentElement, Pixels, Point, Position, Size, Style,
@@ -21,6 +23,7 @@ pub(crate) struct Anchored {
     anchor_corner: Anchor,
     fit_mode: AnchoredFitMode,
     anchor_position: Option<Point<Pixels>>,
+    anchor_position_fn: Option<Rc<dyn Fn() -> Point<Pixels>>>,
     position_mode: AnchoredPositionMode,
     offset: Option<Point<Pixels>>,
 }
@@ -33,6 +36,7 @@ pub(crate) fn anchored() -> Anchored {
         anchor_corner: Anchor::TopLeft,
         fit_mode: AnchoredFitMode::SwitchAnchor,
         anchor_position: None,
+        anchor_position_fn: None,
         position_mode: AnchoredPositionMode::Window,
         offset: None,
     }
@@ -50,6 +54,14 @@ impl Anchored {
     /// (otherwise the location the anchored element is rendered is used)
     pub fn position(mut self, anchor: Point<Pixels>) -> Self {
         self.anchor_position = Some(anchor);
+        self
+    }
+
+    /// Sets a closure that will be called at prepaint time to get the position.
+    /// This takes precedence over [`Anchored::position`] when set, and is useful
+    /// when the position is not yet known at render time.
+    pub fn position_fn(mut self, f: impl Fn() -> Point<Pixels> + 'static) -> Self {
+        self.anchor_position_fn = Some(Rc::new(f));
         self
     }
 
@@ -145,8 +157,14 @@ impl Element for Anchored {
         }
         let size: Size<Pixels> = (child_max - child_min).into();
 
+        let anchor_position = self
+            .anchor_position_fn
+            .as_ref()
+            .map(|f| f())
+            .or(self.anchor_position);
+
         let (origin, mut desired) = self.position_mode.get_position_and_bounds(
-            self.anchor_position,
+            anchor_position,
             self.anchor_corner,
             size,
             bounds,

--- a/crates/ui/src/hover_card.rs
+++ b/crates/ui/src/hover_card.rs
@@ -3,7 +3,7 @@ use gpui::{
     ParentElement, Pixels, Render, RenderOnce, StatefulInteractiveElement, StyleRefinement, Styled,
     Task, Window, div, prelude::FluentBuilder as _,
 };
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 use instant::Duration;
 
 use crate::{Anchor, ElementExt, StyledExt as _, popover::Popover};
@@ -276,6 +276,9 @@ impl RenderOnce for HoverCard {
             return div().id("empty");
         };
 
+        let anchor = self.anchor;
+        let position = Rc::new(Cell::new(Popover::resolved_corner(anchor, trigger_bounds)));
+
         let root = div().id(self.id).child(
             div()
                 .id("trigger")
@@ -285,7 +288,9 @@ impl RenderOnce for HoverCard {
                 }))
                 .on_prepaint({
                     let state = state.clone();
+                    let position = position.clone();
                     move |bounds, _, cx| {
+                        position.set(Popover::resolved_corner(anchor, bounds));
                         state.update(cx, |state, _| {
                             state.trigger_bounds = bounds;
                         });
@@ -311,7 +316,7 @@ impl RenderOnce for HoverCard {
 
         root.child(Popover::render_popover(
             self.anchor,
-            trigger_bounds,
+            position,
             popover_content,
             window,
             cx,

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -4,7 +4,7 @@ use gpui::{
     ParentElement, Pixels, Point, Render, RenderOnce, Stateful, StyleRefinement, Styled,
     Subscription, Window, deferred, div, prelude::FluentBuilder as _, px,
 };
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 
 use crate::{
     Anchor, ElementExt, Selectable, StyledExt as _, actions::Cancel, anchored,
@@ -170,7 +170,7 @@ impl Popover {
         self
     }
 
-    fn resolved_corner(anchor: Anchor, trigger_bounds: Bounds<Pixels>) -> Point<Pixels> {
+    pub(crate) fn resolved_corner(anchor: Anchor, trigger_bounds: Bounds<Pixels>) -> Point<Pixels> {
         let offset = if anchor.is_center() {
             gpui::point(trigger_bounds.size.width.half(), px(0.))
         } else {
@@ -314,7 +314,7 @@ impl EventEmitter<DismissEvent> for PopoverState {}
 impl Popover {
     pub(crate) fn render_popover<E>(
         anchor: Anchor,
-        trigger_bounds: Bounds<Pixels>,
+        position: Rc<Cell<Point<Pixels>>>,
         content: E,
         _: &mut Window,
         _: &mut App,
@@ -326,7 +326,7 @@ impl Popover {
             anchored()
                 .snap_to_window_with_margin(px(8.))
                 .anchor(anchor)
-                .position(Self::resolved_corner(anchor, trigger_bounds))
+                .position_fn(move || position.get())
                 .child(div().relative().child(content)),
         )
         .with_priority(1)
@@ -379,6 +379,10 @@ impl RenderOnce for Popover {
 
         let parent_view_id = window.current_view();
 
+        // Shared cell so the deferred Anchored element can read the real trigger bounds at
+        // prepaint time (after trigger's on_prepaint has already fired with the correct bounds).
+        let position = Rc::new(Cell::new(Self::resolved_corner(self.anchor, trigger_bounds)));
+
         let el = div()
             .id(self.id)
             .child((trigger)(open, window, cx))
@@ -397,10 +401,15 @@ impl RenderOnce for Popover {
             })
             .on_prepaint({
                 let state = state.clone();
+                let position = position.clone();
+                let anchor = self.anchor;
                 move |bounds, _, cx| {
+                    // Update the shared cell so the deferred Anchored element reads the correct
+                    // position when its prepaint runs (deferred prepaint happens after this).
+                    position.set(Self::resolved_corner(anchor, bounds));
                     state.update(cx, |state, _| {
                         state.trigger_bounds = bounds;
-                    })
+                    });
                 }
             });
 
@@ -432,7 +441,7 @@ impl RenderOnce for Popover {
 
         el.child(Self::render_popover(
             self.anchor,
-            trigger_bounds,
+            position,
             popover_content,
             window,
             cx,


### PR DESCRIPTION
## Before
https://github.com/user-attachments/assets/de9c7fd9-26c5-4775-9a58-05680494c5a6


## After
https://github.com/user-attachments/assets/c7cf8d1f-c273-415f-8e60-a5842b5ae495

