### PR TITLE
tab: Acitve text color on hover

### DIFF
--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -171,7 +171,7 @@ impl TabVariant {
     fn hovered(&self, selected: bool, cx: &App) -> TabStyle {
         match self {
             TabVariant::Tab => TabStyle {
-                fg: cx.theme().tab_foreground,
+                fg: cx.theme().tab_active_foreground,
                 bg: cx.theme().transparent,
                 borders: Edges {
                     left: px(1.),
@@ -194,7 +194,7 @@ impl TabVariant {
                 ..Default::default()
             },
             TabVariant::Segmented => TabStyle {
-                fg: cx.theme().tab_foreground,
+                fg: cx.theme().tab_active_foreground,
                 bg: cx.theme().transparent,
                 inner_bg: if selected {
                     cx.theme().background


### PR DESCRIPTION
## Description

This PR changes the underline tab bar style to have the tabs text color change to the active color when they are hovered over.

I understand if this isn't something you feel fits into the design goals. But I thought it made it feel more responsive and was an easy change to submit as a PR to get your thoughts.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <video src="https://github.com/user-attachments/assets/9ba376b0-608a-4c42-9093-dbbf9bbac872"> | <video src="https://github.com/user-attachments/assets/ff01c0d8-5b12-45fa-8987-f2026509f2e7"> |

## How to Test

I only tested this by running the gallery and observing the new behavior in the Tabs story.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
