### PR TITLE
description_list: Fix item's layout

### DIFF
--- a/crates/ui/src/description_list.rs
+++ b/crates/ui/src/description_list.rs
@@ -1,6 +1,6 @@
 use gpui::{
     div, prelude::FluentBuilder as _, px, AnyElement, App, Axis, DefiniteLength, IntoElement,
-    ParentElement, RenderOnce, SharedString, Styled, Window,
+    ParentElement, relative, RenderOnce, SharedString, Styled, Window
 };
 
 use crate::{h_flex, text::Text, v_flex, ActiveTheme as _, AxisExt, Sizable, Size};
@@ -298,7 +298,7 @@ impl RenderOnce for DescriptionList {
                             let is_first_col = item_ix == 0;
 
                             match item {
-                                DescriptionItem::Item { label, value, .. } => {
+                                DescriptionItem::Item { label, value, span } => {
                                     let el = if self.layout.is_vertical() {
                                         v_flex()
                                     } else {
@@ -306,6 +306,7 @@ impl RenderOnce for DescriptionList {
                                     };
 
                                     el.flex_1()
+                                        .flex_basis(relative((span as f32) / (self.columns as f32)))
                                         .overflow_x_hidden()
                                         .child(
                                             div()


### PR DESCRIPTION
## Description

Fixes how a description item is laid out, taking the span into account. Before everything was given equal width in a row, ignoring the span value.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1313" height="464" alt="desc_list_before" src="https://github.com/user-attachments/assets/d1c87500-b5f4-4ecb-8aa4-ca8e944fd9fe" /> | <img width="1314" height="465" alt="desc_list_after" src="https://github.com/user-attachments/assets/1e2df88f-2c44-4927-9a87-d16dfa1bd29c" /> |

*Notice the row with Repository and Category. Rather than a 50/50 split in the before, in the after the repository item is spanning 2 columns and the category item is spanning 1.

## How to Test

I only tested by viewing the Description List in the gallery.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
