### PR TITLE
input: Fix Input may infinite repaint loop in occurs at fractional DPI scale factors (e.g. 125%, 150%).

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -107,13 +107,16 @@ impl TextElement {
         let mut cursor_bounds = None;
 
         // If the input has a fixed height (Otherwise is auto-grow), we need to add a bottom margin to the input.
+        // Cap to bounds height: taffy edge-rounding can shrink bounds.height below
+        // line_height, and an uncapped margin would falsely trigger scroll adjustments.
         let top_bottom_margin = if state.mode.is_auto_grow() {
             line_height
         } else if visible_range.len() < BOTTOM_MARGIN_ROWS * 8 {
             line_height
         } else {
             BOTTOM_MARGIN_ROWS * line_height
-        };
+        }
+        .min(bounds.size.height);
 
         // The cursor corresponds to the current cursor position in the text no only the line.
         let mut cursor_pos = None;

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1842,17 +1842,23 @@ impl Element for TextElement {
             cx,
         );
 
+        let scale_factor = window.scale_factor();
         self.state.update(cx, |state, cx| {
             state.last_layout = Some(prepaint.last_layout.clone());
             state.last_bounds = Some(bounds);
             state.last_cursor = Some(state.cursor());
-            state.set_input_bounds(input_bounds, cx);
+            state.set_input_bounds(input_bounds, scale_factor, cx);
             state.last_selected_range = Some(selected_range);
             state.scroll_size = prepaint.scroll_size;
-            state.update_scroll_offset(Some(prepaint.cursor_scroll_offset), cx);
+            state.update_scroll_offset(
+                Some(prepaint.cursor_scroll_offset),
+                scale_factor,
+                cx,
+            );
             state.deferred_scroll_offset = None;
-
-            cx.notify();
+            // No unconditional cx.notify() here — paint is a read-only observation endpoint.
+            // set_input_bounds and update_scroll_offset notify internally only when
+            // values truly change at physical-pixel granularity.
         });
 
         if let Some(hitbox) = prepaint.hover_definition_hitbox.as_ref() {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1555,6 +1555,10 @@ impl InputState {
         } else {
             line_height
         };
+        // Cap margin to viewport height: taffy edge-rounding can shrink bounds.height
+        // below line_height (e.g. 34.5 phys → 34 phys at 1.5× scale), and an
+        // uncapped margin would falsely trigger scroll on every cursor movement.
+        let edge_height = edge_height.min(bounds.size.height);
         if row_offset_y - edge_height + line_height < -scroll_offset.y {
             // Scroll up
             scroll_offset.y = -row_offset_y + edge_height - line_height;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1442,7 +1442,7 @@ impl InputState {
         let delta = event.delta.pixel_delta(line_height);
 
         let old_offset = self.scroll_handle.offset();
-        self.update_scroll_offset(Some(old_offset + delta), cx);
+        self.update_scroll_offset(Some(old_offset + delta), window.scale_factor(), cx);
 
         // Only stop propagation if the offset actually changed
         if self.scroll_handle.offset() != old_offset {
@@ -1455,6 +1455,7 @@ impl InputState {
     pub(super) fn update_scroll_offset(
         &mut self,
         offset: Option<Point<Pixels>>,
+        scale_factor: f32,
         cx: &mut Context<Self>,
     ) {
         let mut offset = offset.unwrap_or(self.scroll_handle.offset());
@@ -1476,8 +1477,16 @@ impl InputState {
             offset.y.clamp(safe_y_range.start, safe_y_range.end)
         };
         offset.x = offset.x.clamp(safe_x_range.start, safe_x_range.end);
+
+        // Compare at physical-pixel granularity to avoid sub-pixel oscillation
+        // that would cause a perpetual notify→repaint loop.
+        let old = self.scroll_handle.offset();
         self.scroll_handle.set_offset(offset);
-        cx.notify();
+
+        let snap = |v: Pixels| (v.as_f32() * scale_factor).round() as i32;
+        if snap(old.x) != snap(offset.x) || snap(old.y) != snap(offset.y) {
+            cx.notify();
+        }
     }
 
     /// Scroll to make the given offset visible.
@@ -1979,8 +1988,17 @@ impl InputState {
         cx.notify();
     }
 
-    pub(super) fn set_input_bounds(&mut self, new_bounds: Bounds<Pixels>, cx: &mut Context<Self>) {
-        let wrap_width_changed = self.input_bounds.size.width != new_bounds.size.width;
+    pub(super) fn set_input_bounds(
+        &mut self,
+        new_bounds: Bounds<Pixels>,
+        scale_factor: f32,
+        cx: &mut Context<Self>,
+    ) {
+        // Compare at physical-pixel granularity to avoid sub-pixel float noise
+        // from taffy rounding causing a perpetual notify→repaint loop.
+        let snap = |v: Pixels| (v.as_f32() * scale_factor).round() as i32;
+        let wrap_width_changed =
+            snap(self.input_bounds.size.width) != snap(new_bounds.size.width);
         self.input_bounds = new_bounds;
 
         // Update display_map wrap_width if changed.


### PR DESCRIPTION
Fix an infinite repaint loop (perpetual `cx.notify()`) in the Input component
  that occurs at fractional DPI scale factors (e.g. 125%, 150%).

  **Root cause:** taffy's layout rounding produces sub-pixel floating-point
  differences between frames. `paint()` unconditionally called `cx.notify()` at
  the end, and `update_scroll_offset` / `set_input_bounds` also called
  `cx.notify()` without checking whether the value actually changed — creating a
  `paint → notify → repaint → paint → …` infinite loop.

  **Fix (3 commits):**
  1. Add physical-pixel granularity guards to `update_scroll_offset` and
     `set_input_bounds` — only `cx.notify()` when the rounded physical pixel
     value actually changes.
  2. Remove the unconditional `cx.notify()` at the end of `paint()`, since the
     two functions above now notify conditionally.
  3. Cap `edge_height` and `top_bottom_margin` to viewport height, preventing
     false scroll triggers when taffy rounds `bounds.height` below `line_height`.