### PR TITLE
table: Add `set_right_clicked_row` method.

### DIFF
--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -392,6 +392,15 @@ where
         self.right_clicked_row
     }
 
+    /// Set or clear the right-clicked row state.
+    ///
+    /// Pass `None` to clear — useful when opening a header context menu
+    /// to prevent the row context menu from appearing simultaneously.
+    pub fn set_right_clicked_row(&mut self, row: Option<usize>, cx: &mut Context<Self>) {
+        self.right_clicked_row = row;
+        cx.notify();
+    }
+
     /// Returns the selected column index.
     pub fn selected_col(&self) -> Option<usize> {
         self.selected_col


### PR DESCRIPTION
Fixes #2214

## Summary

- Adds `clear_right_clicked_row()` public method to `TableState`
- Allows delegates to clear the row right-click state from `render_header`, preventing row and header context menus from appearing simultaneously

## AI Disclosure

This code was generated with AI assistance (Claude). The implementation has been manually tested in a production GPUI application.