### PR TITLE
table: pass click modifiers through SelectRow event

### DIFF
--- a/crates/story/src/stories/data_table_story.rs
+++ b/crates/story/src/stories/data_table_story.rs
@@ -882,7 +882,7 @@ impl DataTableStory {
                 println!("Double clicked cell: row={}, col={}", row_ix, col_ix)
             }
             TableEvent::DoubleClickedRow(ix) => println!("Double clicked row: {}", ix),
-            TableEvent::SelectRow(ix) => println!("Select row: {}", ix),
+            TableEvent::SelectRow(ix, _) => println!("Select row: {}", ix),
             TableEvent::MoveColumn(origin_idx, target_idx) => {
                 println!("Move col index: {} -> {}", origin_idx, target_idx);
             }

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -49,7 +49,8 @@ impl SelectionMode {
 #[derive(Clone)]
 pub enum TableEvent {
     /// Single click or move to selected row.
-    SelectRow(usize),
+    /// Contains the row index and the keyboard modifiers held during the click.
+    SelectRow(usize, gpui::Modifiers),
     /// Double click on the row.
     DoubleClickedRow(usize),
     /// Selected column.
@@ -365,8 +366,13 @@ where
         self.selected_row
     }
 
-    /// Sets the selected row to the given index.
+    /// Sets the selected row to the given index with default (no) modifiers.
     pub fn set_selected_row(&mut self, row_ix: usize, cx: &mut Context<Self>) {
+        self.set_selected_row_with_modifiers(row_ix, gpui::Modifiers::default(), cx);
+    }
+
+    /// Sets the selected row to the given index with the specified modifiers.
+    pub fn set_selected_row_with_modifiers(&mut self, row_ix: usize, modifiers: gpui::Modifiers, cx: &mut Context<Self>) {
         let is_down = match self.selected_row {
             Some(selected_row) => row_ix > selected_row,
             None => true,
@@ -382,7 +388,7 @@ where
                 if is_down { ScrollStrategy::Bottom } else { ScrollStrategy::Top },
             );
         }
-        cx.emit(TableEvent::SelectRow(row_ix));
+        cx.emit(TableEvent::SelectRow(row_ix, modifiers));
         cx.emit(TableEvent::RightClickedRow(None));
         cx.notify();
     }
@@ -627,7 +633,7 @@ where
             return;
         }
 
-        self.set_selected_row(row_ix, cx);
+        self.set_selected_row_with_modifiers(row_ix, e.modifiers(), cx);
 
         if e.click_count() == 2 {
             cx.emit(TableEvent::DoubleClickedRow(row_ix));


### PR DESCRIPTION
Fixes #2228

## Summary

- Changes `SelectRow(usize)` to `SelectRow(usize, Modifiers)` to carry keyboard modifiers from the click event
- Adds `set_selected_row_with_modifiers()` alongside the existing `set_selected_row()` (which passes default modifiers)
- Enables consumers to implement Cmd+click / Shift+click multi-row selection without intercepting mouse events on the row div (which breaks `on_drag` on child elements)

## AI Disclosure

This code was generated with AI assistance (Claude). The implementation has been manually tested in a production GPUI application with multi-row selection and native macOS drag.