### PR TITLE
input: Rename `mouse_context_menu` to `context_menu`

### DIFF
--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -92,7 +92,9 @@ impl InputStory {
             })
         });
         let custom_input = cx.new(|cx| {
-            InputState::new(window, cx).placeholder("Custom Input use monospace, 0123456789.")
+            InputState::new(window, cx)
+                .placeholder("Custom Input use monospace, 0123456789.")
+                .context_menu(false)
         });
 
         let color_input = cx.new(|cx| {

--- a/crates/ui/src/input/lsp/code_actions.rs
+++ b/crates/ui/src/input/lsp/code_actions.rs
@@ -4,8 +4,8 @@ use lsp_types::CodeAction;
 use std::ops::Range;
 
 use crate::input::{
-    popovers::{CodeActionItem, CodeActionMenu, ContextMenu},
     InputState, ToggleCodeActions,
+    popovers::{CodeActionItem, CodeActionMenu, ContextMenu},
 };
 
 pub trait CodeActionProvider {
@@ -53,7 +53,7 @@ impl InputState {
         cx: &mut Context<Self>,
     ) {
         let providers = self.lsp.code_action_providers.clone();
-        let menu = match self.context_menu.as_ref() {
+        let menu = match self.context_menu_content.as_ref() {
             Some(ContextMenu::CodeAction(menu)) => Some(menu),
             _ => None,
         };
@@ -62,7 +62,7 @@ impl InputState {
             Some(menu) => menu.clone(),
             None => {
                 let menu = CodeActionMenu::new(cx.entity(), window, cx);
-                self.context_menu = Some(ContextMenu::CodeAction(menu.clone()));
+                self.context_menu_content = Some(ContextMenu::CodeAction(menu.clone()));
                 menu
             }
         };

--- a/crates/ui/src/input/lsp/completions.rs
+++ b/crates/ui/src/input/lsp/completions.rs
@@ -130,7 +130,7 @@ impl InputState {
             return;
         }
 
-        let menu = match self.context_menu.as_ref() {
+        let menu = match self.context_menu_content.as_ref() {
             Some(ContextMenu::Completion(menu)) => Some(menu),
             _ => None,
         };
@@ -140,7 +140,7 @@ impl InputState {
             Some(menu) => menu.clone(),
             None => {
                 let menu = CompletionMenu::new(cx.entity(), window, cx);
-                self.context_menu = Some(ContextMenu::Completion(menu.clone()));
+                self.context_menu_content = Some(ContextMenu::Completion(menu.clone()));
                 menu
             }
         };

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -112,7 +112,7 @@ impl InputState {
                     handled = menu.handle_action(action, window, cx)
                 });
             }
-            ContextMenu::MouseContext(..) => {}
+            ContextMenu::RightClick(..) => {}
         };
 
         handled

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -73,13 +73,13 @@ impl Lsp {
 
 impl InputState {
     pub(crate) fn hide_context_menu(&mut self, cx: &mut Context<Self>) {
-        self.context_menu = None;
+        self.context_menu_content = None;
         self._context_menu_task = Task::ready(Ok(()));
         cx.notify();
     }
 
     pub(crate) fn is_context_menu_open(&self, cx: &App) -> bool {
-        let Some(menu) = self.context_menu.as_ref() else {
+        let Some(menu) = self.context_menu_content.as_ref() else {
             return false;
         };
 
@@ -95,7 +95,7 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(menu) = self.context_menu.as_ref() else {
+        let Some(menu) = self.context_menu_content.as_ref() else {
             return false;
         };
 

--- a/crates/ui/src/input/popovers/context_menu.rs
+++ b/crates/ui/src/input/popovers/context_menu.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Context menu for mouse right clicks.
-pub(crate) struct MouseContextMenu {
+pub(crate) struct InputContextMenu {
     editor: Entity<InputState>,
     menu: Entity<PopupMenu>,
     mouse_position: Point<Pixels>,
@@ -41,7 +41,7 @@ impl InputState {
             self.move_to(offset, None, cx);
         }
 
-        self.context_menu_content = Some(ContextMenu::MouseContext(self.context_menu.clone()));
+        self.context_menu_content = Some(ContextMenu::RightClick(self.context_menu.clone()));
 
         let is_code_editor = self.mode.is_code_editor();
         if is_code_editor {
@@ -94,7 +94,7 @@ impl InputState {
     }
 }
 
-impl MouseContextMenu {
+impl InputContextMenu {
     pub(crate) fn new(
         editor: Entity<InputState>,
         window: &mut Window,
@@ -133,7 +133,7 @@ impl MouseContextMenu {
     }
 }
 
-impl Render for MouseContextMenu {
+impl Render for InputContextMenu {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if !self.open {
             return div().into_any_element();

--- a/crates/ui/src/input/popovers/context_menu.rs
+++ b/crates/ui/src/input/popovers/context_menu.rs
@@ -41,7 +41,7 @@ impl InputState {
             self.move_to(offset, None, cx);
         }
 
-        self.context_menu = Some(ContextMenu::MouseContext(self.mouse_context_menu.clone()));
+        self.context_menu_content = Some(ContextMenu::MouseContext(self.context_menu.clone()));
 
         let is_code_editor = self.mode.is_code_editor();
         if is_code_editor {
@@ -55,7 +55,7 @@ impl InputState {
         let has_paste = is_enable && cx.read_from_clipboard().is_some();
 
         let action_context = self.focus_handle.clone();
-        self.mouse_context_menu.update(cx, |this, cx| {
+        self.context_menu.update(cx, |this, cx| {
             this.mouse_position = event.position;
             this.menu.update(cx, |menu, cx| {
                 let new_menu = PopupMenu::new(cx)

--- a/crates/ui/src/input/popovers/mod.rs
+++ b/crates/ui/src/input/popovers/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 pub(crate) enum ContextMenu {
     Completion(Entity<CompletionMenu>),
     CodeAction(Entity<CodeActionMenu>),
-    MouseContext(Entity<MouseContextMenu>),
+    RightClick(Entity<InputContextMenu>),
 }
 
 impl ContextMenu {
@@ -31,7 +31,7 @@ impl ContextMenu {
         match self {
             ContextMenu::Completion(menu) => menu.read(cx).is_open(),
             ContextMenu::CodeAction(menu) => menu.read(cx).is_open(),
-            ContextMenu::MouseContext(menu) => menu.read(cx).is_open(),
+            ContextMenu::RightClick(menu) => menu.read(cx).is_open(),
         }
     }
 
@@ -39,7 +39,7 @@ impl ContextMenu {
         match self {
             ContextMenu::Completion(menu) => menu.clone().into_any_element(),
             ContextMenu::CodeAction(menu) => menu.clone().into_any_element(),
-            ContextMenu::MouseContext(menu) => menu.clone().into_any_element(),
+            ContextMenu::RightClick(menu) => menu.clone().into_any_element(),
         }
     }
 }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -343,9 +343,9 @@ pub struct InputState {
     /// Popover
     diagnostic_popover: Option<Entity<DiagnosticPopover>>,
     /// Completion/CodeAction context menu
-    pub(super) context_menu: Option<ContextMenu>,
-    pub(super) mouse_context_menu: Entity<MouseContextMenu>,
-    pub(super) enable_mouse_context_menu: bool,
+    pub(super) context_menu_content: Option<ContextMenu>,
+    pub(super) context_menu: Entity<MouseContextMenu>,
+    pub(super) enable_context_menu: bool,
 
     /// A flag to indicate if we are currently inserting a completion item.
     pub(super) completion_inserting: bool,
@@ -441,9 +441,9 @@ impl InputState {
             text_align: TextAlign::Left,
             lsp: Lsp::default(),
             diagnostic_popover: None,
-            context_menu: None,
-            mouse_context_menu,
-            enable_mouse_context_menu: true,
+            context_menu_content: None,
+            context_menu: mouse_context_menu,
+            enable_context_menu: true,
             completion_inserting: false,
             hover_popover: None,
             hover_definition: HoverDefinition::default(),
@@ -499,11 +499,11 @@ impl InputState {
         self
     }
 
-    /// Sets whether the mouse context menu that shows on right-click is enabled.
+    /// Sets whether the context menu that shows on right-click is enabled.
     ///
-    /// The mouse context menu is enabled by default.
-    pub fn mouse_context_menu(mut self, enable: bool) -> Self {
-        self.enable_mouse_context_menu = enable;
+    /// The context menu is enabled by default.
+    pub fn context_menu(mut self, enable: bool) -> Self {
+        self.enable_context_menu = enable;
         self
     }
 
@@ -1377,7 +1377,7 @@ impl InputState {
 
         // Show Mouse context menu
         if event.button == MouseButton::Right {
-            if self.enable_mouse_context_menu {
+            if self.enable_context_menu {
                 self.handle_right_click_menu(event, offset, window, cx);
             }
             return;
@@ -1719,8 +1719,7 @@ impl InputState {
                 let local_index = line_layout.closest_index_for_x(pos.x, last_layout);
                 let index = line_start_offset + local_index;
                 return if self.masked {
-                    self.text
-                        .char_index_to_offset(index / MASK_CHAR.len_utf8())
+                    self.text.char_index_to_offset(index / MASK_CHAR.len_utf8())
                 } else {
                     index.min(self.text.len())
                 };
@@ -1730,8 +1729,7 @@ impl InputState {
             if let Some(local_index) = line_layout.closest_index_for_position(pos, last_layout) {
                 let index = line_start_offset + local_index;
                 return if self.masked {
-                    self.text
-                        .char_index_to_offset(index / MASK_CHAR.len_utf8())
+                    self.text.char_index_to_offset(index / MASK_CHAR.len_utf8())
                 } else {
                     index.min(self.text.len())
                 };
@@ -1890,7 +1888,7 @@ impl InputState {
 
         self.hover_popover = None;
         self.diagnostic_popover = None;
-        self.context_menu = None;
+        self.context_menu_content = None;
         self.clear_inline_completion(cx);
         self.blink_cursor.update(cx, |cursor, cx| {
             cursor.stop(cx);
@@ -2505,7 +2503,7 @@ impl Render for InputState {
             .overflow_x_hidden()
             .child(TextElement::new(cx.entity().clone()).placeholder(self.placeholder.clone()))
             .children(self.diagnostic_popover.clone())
-            .children(self.context_menu.as_ref().map(|menu| menu.render()))
+            .children(self.context_menu_content.as_ref().map(|menu| menu.render()))
             .children(self.hover_popover.clone())
     }
 }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -34,7 +34,7 @@ use crate::input::{
     HoverDefinition, InlineCompletion, Lsp, Position, RopeExt as _, Selection,
     display_map::LineLayout,
     element::RIGHT_MARGIN,
-    popovers::{ContextMenu, DiagnosticPopover, HoverPopover, MouseContextMenu},
+    popovers::{ContextMenu, DiagnosticPopover, HoverPopover, InputContextMenu},
     search::{self, SearchPanel},
 };
 use crate::{Root, history::History};
@@ -344,7 +344,7 @@ pub struct InputState {
     diagnostic_popover: Option<Entity<DiagnosticPopover>>,
     /// Completion/CodeAction context menu
     pub(super) context_menu_content: Option<ContextMenu>,
-    pub(super) context_menu: Entity<MouseContextMenu>,
+    pub(super) context_menu: Entity<InputContextMenu>,
     pub(super) enable_context_menu: bool,
 
     /// A flag to indicate if we are currently inserting a completion item.
@@ -403,7 +403,7 @@ impl InputState {
         ];
 
         let text_style = window.text_style();
-        let mouse_context_menu = MouseContextMenu::new(cx.entity(), window, cx);
+        let mouse_context_menu = InputContextMenu::new(cx.entity(), window, cx);
 
         Self {
             focus_handle: focus_handle.clone(),


### PR DESCRIPTION
Continue #2235.

Adjusted some poorly named variables in the input state.

cc @jstnd 