### PR TITLE
input: Allow setting custom context menu

### DIFF
--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -27,6 +27,7 @@ pub struct InputStory {
     mask_input2: Entity<InputState>,
     currency_input: Entity<InputState>,
     custom_input: Entity<InputState>,
+    custom_menu_input: Entity<InputState>,
     code_input: Entity<InputState>,
     color_input: Entity<InputState>,
 
@@ -97,6 +98,9 @@ impl InputStory {
                 .context_menu(false)
         });
 
+        let custom_menu_input = cx
+            .new(|cx| InputState::new(window, cx).placeholder("Input with custom context menu..."));
+
         let color_input = cx.new(|cx| {
             InputState::new(window, cx)
                 .placeholder("Type something...")
@@ -149,6 +153,7 @@ impl InputStory {
             mask_input2,
             currency_input,
             custom_input,
+            custom_menu_input,
             code_input,
             color_input,
             input_text_centered,
@@ -307,6 +312,14 @@ impl Render for InputStory {
                         .child(Input::new(&self.custom_input).appearance(false)),
                 ),
             )
+            .child(section("Custom Context Menu").max_w_md().child(
+                Input::new(&self.custom_menu_input).context_menu(|menu, _, _| {
+                    menu.menu("Custom Action", Box::new(input::SelectAll))
+                        .separator()
+                        .menu("Copy", Box::new(input::Copy))
+                        .menu("Paste", Box::new(input::Paste))
+                }),
+            ))
             .child(
                 section("Custom Text Color")
                     .max_w_md()

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -1,13 +1,16 @@
+use std::rc::Rc;
+
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AnyElement, App, DefiniteLength, Edges, EdgesRefinement, Entity, Hsla, InteractiveElement as _,
-    IntoElement, IsZero, MouseButton, ParentElement as _, Rems, RenderOnce, StyleRefinement,
-    Styled, TextAlign, Window, div, px, relative,
+    AnyElement, App, Context, DefiniteLength, Edges, EdgesRefinement, Entity, Hsla,
+    InteractiveElement as _, IntoElement, IsZero, MouseButton, ParentElement as _, Rems,
+    RenderOnce, StyleRefinement, Styled, TextAlign, Window, div, px, relative,
 };
 
 use crate::button::{Button, ButtonVariants as _};
 use crate::input::clear_button;
 use crate::input::element::{LINE_NUMBER_RIGHT_MARGIN, RIGHT_MARGIN};
+use crate::menu::PopupMenu;
 use crate::scroll::Scrollbar;
 use crate::spinner::Spinner;
 use crate::{ActiveTheme, Colorize, v_flex};
@@ -46,6 +49,12 @@ pub struct Input {
     focus_bordered: bool,
     tab_index: isize,
     selected: bool,
+
+    /// An optional context menu builder to allow a custom context menu on the input.
+    ///
+    /// If set, this will override the built-in context menu.
+    context_menu_builder:
+        Option<Rc<dyn Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu>>,
 }
 
 impl Sizable for Input {
@@ -84,6 +93,7 @@ impl Input {
             focus_bordered: true,
             tab_index: 0,
             selected: false,
+            context_menu_builder: None,
         }
     }
 
@@ -148,6 +158,15 @@ impl Input {
     /// Set the tab index for the input, default is 0.
     pub fn tab_index(mut self, index: isize) -> Self {
         self.tab_index = index;
+        self
+    }
+
+    /// Sets the context menu for the input.
+    pub fn context_menu(
+        mut self,
+        f: impl Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu + 'static,
+    ) -> Self {
+        self.context_menu_builder = Some(Rc::new(f));
         self
     }
 
@@ -253,8 +272,10 @@ impl RenderOnce for Input {
         let text_align = self.style.text.text_align.unwrap_or(TextAlign::Left);
 
         self.state.update(cx, |state, _| {
+            state.context_menu_builder = self.context_menu_builder.clone();
             state.disabled = self.disabled;
             state.size = self.size;
+
             // Only for single line mode
             if state.mode.is_single_line() {
                 state.text_align = text_align;

--- a/crates/ui/src/input/popovers/context_menu.rs
+++ b/crates/ui/src/input/popovers/context_menu.rs
@@ -58,29 +58,33 @@ impl InputState {
         self.context_menu.update(cx, |this, cx| {
             this.mouse_position = event.position;
             this.menu.update(cx, |menu, cx| {
-                let new_menu = PopupMenu::new(cx)
-                    .when(is_code_editor, |m| {
-                        m.menu_with_enable(
-                            t!("Input.Go to Definition"),
-                            Box::new(input::GoToDefinition),
-                            has_goto_definition,
-                        )
+                let new_menu = if let Some(builder) = &self.context_menu_builder {
+                    builder(PopupMenu::new(cx), window, cx)
+                } else {
+                    PopupMenu::new(cx)
+                        .when(is_code_editor, |m| {
+                            m.menu_with_enable(
+                                t!("Input.Go to Definition"),
+                                Box::new(input::GoToDefinition),
+                                has_goto_definition,
+                            )
+                            .menu_with_enable(
+                                t!("Input.Show Code Actions"),
+                                Box::new(input::ToggleCodeActions),
+                                has_code_action,
+                            )
+                            .separator()
+                        })
                         .menu_with_enable(
-                            t!("Input.Show Code Actions"),
-                            Box::new(input::ToggleCodeActions),
-                            has_code_action,
+                            t!("Input.Cut"),
+                            Box::new(input::Cut),
+                            is_enable && is_selected,
                         )
+                        .menu_with_enable(t!("Input.Copy"), Box::new(input::Copy), is_selected)
+                        .menu_with_enable(t!("Input.Paste"), Box::new(input::Paste), has_paste)
                         .separator()
-                    })
-                    .menu_with_enable(
-                        t!("Input.Cut"),
-                        Box::new(input::Cut),
-                        is_enable && is_selected,
-                    )
-                    .menu_with_enable(t!("Input.Copy"), Box::new(input::Copy), is_selected)
-                    .menu_with_enable(t!("Input.Paste"), Box::new(input::Paste), has_paste)
-                    .separator()
-                    .menu(t!("Input.Select All"), Box::new(input::SelectAll));
+                        .menu(t!("Input.Select All"), Box::new(input::SelectAll))
+                };
 
                 menu.menu_items = new_menu.menu_items;
                 menu.action_context = Some(action_context);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -37,6 +37,7 @@ use crate::input::{
     popovers::{ContextMenu, DiagnosticPopover, HoverPopover, InputContextMenu},
     search::{self, SearchPanel},
 };
+use crate::menu::PopupMenu;
 use crate::{Root, history::History};
 
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
@@ -345,6 +346,16 @@ pub struct InputState {
     /// Completion/CodeAction context menu
     pub(super) context_menu_content: Option<ContextMenu>,
     pub(super) context_menu: Entity<InputContextMenu>,
+
+    /// An optional context menu builder to allow a custom context menu on the input.
+    ///
+    /// If set, this will override the built-in context menu and ignore the value set in [`Self::enable_context_menu`].
+    pub(super) context_menu_builder:
+        Option<Rc<dyn Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu>>,
+
+    /// Whether the context menu that shows on right-click is enabled.
+    ///
+    /// This value will be ignored if a context menu builder is defined in [`Self::context_menu_builder`].
     pub(super) enable_context_menu: bool,
 
     /// A flag to indicate if we are currently inserting a completion item.
@@ -443,6 +454,7 @@ impl InputState {
             diagnostic_popover: None,
             context_menu_content: None,
             context_menu: mouse_context_menu,
+            context_menu_builder: None,
             enable_context_menu: true,
             completion_inserting: false,
             hover_popover: None,
@@ -502,6 +514,7 @@ impl InputState {
     /// Sets whether the context menu that shows on right-click is enabled.
     ///
     /// The context menu is enabled by default.
+    /// This value will be ignored if a custom context menu is defined on the input.
     pub fn context_menu(mut self, enable: bool) -> Self {
         self.enable_context_menu = enable;
         self
@@ -1377,7 +1390,7 @@ impl InputState {
 
         // Show Mouse context menu
         if event.button == MouseButton::Right {
-            if self.enable_context_menu {
+            if self.enable_context_menu || self.context_menu_builder.is_some() {
                 self.handle_right_click_menu(event, offset, window, cx);
             }
             return;

--- a/docs/docs/components/input.md
+++ b/docs/docs/components/input.md
@@ -193,6 +193,25 @@ div()
     .child(Input::new(&input).appearance(false))
 ```
 
+### Context Menu
+
+```rust
+// The built-in context menu can be disabled.
+let input = cx.new(|cx| InputState::new(window, cx).context_menu(false));
+
+// Or you can define a custom context menu.
+Input::new(&input).context_menu(|menu, window, cx| {
+    // You can define your own actions and even utilize
+    // built-in actions (cut, copy, paste, etc.)
+    // to avoid having to re-implement that functionality.
+    menu.menu("Custom Action", Box::new(CustomAction))
+        .separator()
+        .menu("Cut", Box::new(input::Cut))
+        .menu("Copy", Box::new(input::Copy))
+        .menu("Paste", Box::new(input::Paste))
+})
+```
+
 ## Examples
 
 ### Search Input


### PR DESCRIPTION
## Description

Following #2235 and #2236, this is what I came up with for allowing custom context menus to be set on input components. This allows both custom actions as well as still utilizing the built-in input actions (as they're public structs), so the user doesn't have to re-implement basic functionality such as copying and pasting if they wanted a custom context menu.

Also I tried to document everything that was added, let me know if anything needs to be changed there.

## Screenshot

<img width="545" height="166" alt="image" src="https://github.com/user-attachments/assets/be73c6b0-c658-48e6-aa7c-408ff70be64c" />

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
