### PR TITLE
chore: Upgrade rust-i18n from 3 to 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,7 +5121,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6652,12 +6652,11 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n"
-version = "3.1.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+checksum = "21031bf5e6f2c0ae745d831791c403608e99a8bd3776c7e5e5535acd70c3b7ba"
 dependencies = [
  "globwalk",
- "once_cell",
  "regex",
  "rust-i18n-macro",
  "rust-i18n-support",
@@ -6666,12 +6665,11 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-macro"
-version = "3.1.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+checksum = "51fe5295763b358606f7ca26a564e20f4469775a57ec1f09431249a33849ff52"
 dependencies = [
  "glob",
- "once_cell",
  "proc-macro2",
  "quote",
  "rust-i18n-support",
@@ -6683,9 +6681,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-support"
-version = "3.1.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+checksum = "69bcc115c8eea2803aa3d85362e339776f4988a0349f2f475af572e497443f6f"
 dependencies = [
  "arc-swap",
  "base62",
@@ -6693,7 +6691,6 @@ dependencies = [
  "itertools 0.11.0",
  "lazy_static",
  "normpath",
- "once_cell",
  "proc-macro2",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ropey = { version = "=2.0.0-beta.1", features = [
     "metric_lines_lf",
     "metric_utf16",
 ] }
-rust-i18n = "3"
+rust-i18n = "4"
 schemars = "1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
- Upgrade `rust-i18n` from v3 to v4 in workspace `Cargo.toml`
- v4 brings significant performance improvements: reduced memory allocations via `Cow<'static, str>`, and replaces `once_cell` with `std::sync::LazyLock`
- No code changes needed — the project uses only standard APIs (`t!`, `i18n!`, `locale()`, `set_locale()`) which are unchanged in v4

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy -- --deny warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)