### PR TITLE
docs: Use git dependencies instead of crates.io versions

### DIFF
--- a/docs/docs/assets.md
+++ b/docs/docs/assets.md
@@ -17,10 +17,10 @@ The [gpui-component-assets] crate provides a default bundled assets implementati
 
 To use the default bundled assets, you need to add the `gpui-component-assets` crate as a dependency in your `Cargo.toml`:
 
-```toml-vue
+```toml
 [dependencies]
-gpui-component = "{{ VERSION }}"
-gpui-component-assets = "{{ VERSION }}"
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
+gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }
 ```
 
 Then we need call the `with_assets` method when creating the GPUI application to register the asset source:

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -10,12 +10,13 @@ order: -2
 
 Add dependencies to your `Cargo.toml`:
 
-```toml-vue
+```toml
 [dependencies]
-gpui = "{{ GPUI_VERSION }}"
-gpui-component = "{{ VERSION }}"
+gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed" }
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 # Optional, for default bundled assets
-gpui-component-assets = "{{ VERSION }}"
+gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }
 anyhow = "1.0"
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -27,10 +27,10 @@ GPUI Component is a comprehensive UI component library for building fantastic de
 
 Add `gpui` and `gpui-component` to your `Cargo.toml`:
 
-```toml-vue
+```toml
 [dependencies]
-gpui = "{{ VERSION }}"
-gpui-component = "{{ VERSION }}"
+gpui = { git = "https://github.com/zed-industries/zed" }
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```
 
 Then create a simple "Hello, World!" application with a button:
@@ -59,9 +59,7 @@ impl Render for HelloWorld {
 }
 
 fn main() {
-    let app = Application::new();
-
-    app.run(move |cx| {
+    gpui_platform::application().run(move |cx| {
         // This must be called before using any GPUI Component features.
         gpui_component::init(cx);
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -41,7 +41,7 @@ We use Rust programming language to build the `gpui-component` library. Make sur
 
 To install the `gpui-component` library, you can use Cargo, the Rust package manager. Add the following line to your `Cargo.toml` file under the `[dependencies]` section:
 
-```toml-vue
-gpui = "{{ GPUI_VERSION }}"
-gpui-component = "{{ VERSION }}"
+```toml
+gpui = { git = "https://github.com/zed-industries/zed" }
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,16 +28,9 @@ GPUI and GPUI Component are under active development, recently GPUI have some ne
 
 The documentation on this site are based on the **Git main branch**, if you use the crates.io version, there may be some differences.
 
-```toml-vue
+```toml
 gpui = { git = "https://github.com/zed-industries/zed" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
-```
-
-If you prefer to use the versions on crates.io. Please visit [docs.rs](https://docs.rs/gpui-component/latest/gpui_component/) to check the API differences.
-
-```toml-vue
-gpui = "{{ GPUI_VERSION }}"
-gpui-component = "{{ VERSION }}"
 ```
 
 ## Hello World
@@ -68,9 +61,7 @@ impl Render for HelloWorld {
 }
 
 fn main() {
-    let app = Application::new();
-
-    app.run(move |cx| {
+    gpui_platform::application().run(move |cx| {
         // This must be called before using any GPUI Component features.
         gpui_component::init(cx);
 


### PR DESCRIPTION
## Summary
- Replace all `{{ VERSION }}` / `{{ GPUI_VERSION }}` template-based crates.io dependencies with git dependencies across documentation
- Fix code examples to use `gpui_platform::application()` instead of the deprecated `Application::new()`
- Add missing `gpui_platform` dependency in Getting Started guide
- Remove crates.io fallback section from homepage

Closes #2246

🤖 Generated with [Claude Code](https://claude.com/claude-code)