### PR TITLE
story: Ensure the example has focus at startup

### DIFF
--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -713,6 +713,14 @@ impl Example {
 
             editor
         });
+
+        // Focus the editor on startup so that actions (e.g. Open) can bubble
+        // up through this view's element tree and reach their handlers.
+        let focus_handle = editor.focus_handle(cx);
+        window.defer(cx, move |window, cx| {
+            focus_handle.focus(window, cx);
+        });
+
         let go_to_line_state = cx.new(|cx| InputState::new(window, cx));
 
         let tree_state = cx.new(|cx| TreeState::new(cx));

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -34,6 +34,13 @@ impl Example {
                 .default_value(EXAMPLE)
         });
 
+        // Focus the input on startup so that actions (e.g. Open) can bubble
+        // up through this view's element tree and reach their handlers.
+        let focus_handle = input_state.focus_handle(cx);
+        window.defer(cx, move |window, cx| {
+            focus_handle.focus(window, cx);
+        });
+
         let _subscriptions = vec![cx.subscribe(&input_state, |_, _, _: &InputEvent, _| {})];
 
         Self {

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -132,7 +132,9 @@ pub fn create_new_window_with_size<F, E>(
                 // Set focus to the StoryRoot to enable it's actions.
                 let focus_handle = story_root.focus_handle(cx);
                 window.defer(cx, move |window, cx| {
-                    focus_handle.focus(window, cx);
+                    if window.focused(cx).is_none() {
+                        focus_handle.focus(window, cx);
+                    }
                 });
 
                 cx.new(|cx| Root::new(story_root, window, cx))


### PR DESCRIPTION
Closes #2240.

Ensure that the example has focus when it starts, because the execution of gpui actions depends on focus.