### PR TITLE
otp_input: Support full-width digit input

### DIFF
--- a/crates/story/src/stories/theme_story/color_theme_story.rs
+++ b/crates/story/src/stories/theme_story/color_theme_story.rs
@@ -117,7 +117,7 @@ impl ThemeColorsStory {
         let registry = ThemeRegistry::global(cx);
         let mut themes = registry.sorted_themes();
 
-        themes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        themes.sort_by_key(|a| a.name.to_lowercase());
 
         let active_theme_name = cx.theme().theme_name().clone();
         let items: Vec<ThemeItem> = themes

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -99,6 +99,17 @@ impl OtpState {
         window.focus(&self.focus_handle, cx);
     }
 
+    /// Try to extract an ASCII digit char from a string.
+    /// Supports both half-width ('0'-'9') and full-width ('0'-'9') digits.
+    fn to_digit_char(s: &str) -> Option<char> {
+        let c = s.chars().next()?;
+        c.to_digit(10).map(|_| c).or_else(|| {
+            // Full-width digits: '0' (U+FF10)..='9' (U+FF19)
+            let digit = (c as u32).checked_sub('０' as u32)?;
+            char::from_digit(digit, 10)
+        })
+    }
+
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
         let mut chars: Vec<char> = self.value.chars().collect();
         let ix = chars.len();
@@ -116,10 +127,17 @@ impl OtpState {
                 cx.stop_propagation();
             }
             _ => {
-                let c = key.chars().next().unwrap();
-                if !matches!(c, '0'..='9') {
+                let c = Self::to_digit_char(key).or_else(|| {
+                    event
+                        .keystroke
+                        .key_char
+                        .as_deref()
+                        .and_then(Self::to_digit_char)
+                });
+
+                let Some(c) = c else {
                     return;
-                }
+                };
                 if ix >= self.length {
                     return;
                 }


### PR DESCRIPTION
Fix `OtpInput` unable to accept input when the IME is in full-width mode on Windows.

Previously, `on_key_down` only checked `keystroke.key` for ASCII digits `'0'–'9'`. In full-width mode, the IME may place the character in `keystroke.key_char` or produce a full-width digit (`'０'–'９'`), both of which were silently rejected.

This PR adds a `to_digit_char` helper that:
- Accepts half-width digits `'0'–'9'` as-is
- Normalizes full-width digits `'０'–'９'` (U+FF10–U+FF19) to their ASCII equivalents

The handler now falls back to `key_char` if `key` yields no digit.