### PR TITLE
input: fix multiline placeholder shaping in empty multiline inputs

### DIFF
--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -433,7 +433,10 @@ impl LineLayout {
         for (i, line) in self.wrapped_lines.iter().enumerate() {
             let is_last = i + 1 == self.wrapped_lines.len();
 
-            let matches = if is_last || line_end_affinity {
+            let matches = if line.len == 0 {
+                // Empty visual lines still own their boundary offset.
+                offset == acc_len
+            } else if is_last || line_end_affinity {
                 // Inclusive: cursor can sit at end of this visual line.
                 offset >= acc_len && offset <= acc_len + line.len
             } else {
@@ -580,6 +583,8 @@ impl LineLayout {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::rc::Rc;
+
     use gpui::{Boundary, FontFeatures, FontStyle, FontWeight, px};
 
     #[test]
@@ -789,6 +794,36 @@ mod tests {
         line_layout.set_wrapped_lines(wrapped_lines);
         assert_eq!(line_layout.len(), 150);
         assert_eq!(line_layout.wrapped_lines.len(), 2);
+    }
+
+    #[test]
+    fn test_position_for_index_prefers_first_leading_empty_visual_line() {
+        let mut line_layout = LineLayout::new();
+        line_layout.set_wrapped_lines(smallvec::smallvec![
+            ShapedLine::default(),
+            ShapedLine::default(),
+            ShapedLine::default().with_len(3),
+        ]);
+
+        let last_layout = LastLayout {
+            visible_range: 0..1,
+            visible_buffer_lines: vec![0],
+            visible_line_byte_offsets: vec![0],
+            visible_top: px(0.),
+            visible_range_offset: 0..0,
+            lines: Rc::new(vec![]),
+            line_height: px(20.),
+            wrap_width: None,
+            line_number_width: px(0.),
+            cursor_bounds: None,
+            text_align: TextAlign::Left,
+            content_width: px(0.),
+        };
+
+        assert_eq!(
+            line_layout.position_for_index(0, &last_layout, false),
+            Some(point(px(0.), px(0.)))
+        );
     }
 
     #[test]

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1925,6 +1925,9 @@ fn placeholder_line_runs<'a>(
     result
 }
 
+/// Get the runs for the given range.
+///
+/// The range is the byte range of the wrapped line.
 pub(super) fn runs_for_range(
     runs: &[TextRun],
     line_offset: usize,

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -961,21 +961,24 @@ impl TextElement {
 
         // Empty to use placeholder, the placeholder is not in the wrapper map.
         if state.text.len() == 0 {
-            return display_text
-                .to_string()
-                .split("\n")
-                .map(|line| {
-                    let shaped_line = window.text_system().shape_line(
-                        line.to_string().into(),
-                        font_size,
-                        &runs,
-                        None,
-                    );
-                    LineLayout::new()
-                        .lines(smallvec::smallvec![shaped_line])
-                        .with_whitespaces(whitespace_indicators.clone())
-                })
-                .collect();
+            let placeholder_text = display_text.to_string();
+            let mut placeholder_lines = SmallVec::new();
+
+            for (line, line_runs) in placeholder_line_runs(&placeholder_text, runs) {
+                let shaped_line = window.text_system().shape_line(
+                    line.to_string().into(),
+                    font_size,
+                    &line_runs,
+                    None,
+                );
+                placeholder_lines.push(shaped_line);
+            }
+
+            // Keep placeholder lines in a single layout to stay parallel with visible_* metadata.
+            let line_layout = LineLayout::new()
+                .lines(placeholder_lines)
+                .with_whitespaces(whitespace_indicators);
+            return vec![line_layout];
         }
 
         let mut lines = Vec::with_capacity(last_layout.visible_buffer_lines.len());
@@ -1900,9 +1903,28 @@ impl Element for TextElement {
     }
 }
 
-/// Get the runs for the given range.
-///
-/// The range is the byte range of the wrapped line.
+/// Split placeholder text into display lines and trim runs to each line.
+fn placeholder_line_runs<'a>(
+    display_text: &'a str,
+    runs: &[TextRun],
+) -> Vec<(&'a str, Vec<TextRun>)> {
+    let mut result = Vec::new();
+    let mut line_offset = 0;
+
+    for line in display_text.split('\n') {
+        let line_runs = runs_for_range(runs, line_offset, &(0..line.len()));
+        debug_assert_eq!(
+            line_runs.iter().map(|run| run.len).sum::<usize>(),
+            line.len()
+        );
+        result.push((line, line_runs));
+        // Advance in the whole-placeholder coordinate space, including the separator.
+        line_offset += line.len() + 1;
+    }
+
+    result
+}
+
 pub(super) fn runs_for_range(
     runs: &[TextRun],
     line_offset: usize,
@@ -2061,6 +2083,44 @@ mod tests {
         assert_runs(runs_for_range(&runs, 3, &(0..3)), &[1, 2]);
         assert_runs(runs_for_range(&runs, 3, &(2..10)), &[4, 1, 3]);
         assert_runs(runs_for_range(&runs, 9, &(0..8)), &[1, 7]);
+    }
+
+    #[test]
+    fn test_placeholder_line_runs() {
+        let run = TextRun {
+            len: 0,
+            font: gpui::font(".SystemUIFont"),
+            color: gpui::black(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+
+        let runs = vec![
+            TextRun {
+                len: 2,
+                ..run.clone()
+            },
+            TextRun {
+                len: 2,
+                ..run.clone()
+            },
+            TextRun { len: 1, ..run },
+        ];
+
+        let placeholder_runs = placeholder_line_runs("ab\n\nc", &runs);
+
+        let lines = placeholder_runs
+            .iter()
+            .map(|(line, _)| *line)
+            .collect::<Vec<_>>();
+        assert_eq!(lines, vec!["ab", "", "c"]);
+
+        let run_lengths = placeholder_runs
+            .iter()
+            .map(|(_, line_runs)| line_runs.iter().map(|run| run.len).collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        assert_eq!(run_lengths, vec![vec![2], vec![], vec![1]]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2264

## Description

This PR fixes multiline placeholder shaping for empty multiline inputs.

Previously, when an input was empty and its placeholder contained `\n`, the empty-placeholder layout path split the placeholder into lines but reused `TextRun`s built for the entire placeholder string for each `shape_line(...)` call. That could make the shaping input internally inconsistent and cause empty multiline inputs to fail during initial render.

This change keeps the fix scoped to this single issue:

- slice placeholder runs per visual line before calling `shape_line(...)`
- keep multiline placeholder lines inside a single `LineLayout` so layout metadata stays aligned with the empty buffer
- handle leading empty visual lines correctly when resolving cursor / IME positions

This fixes empty multiline inputs such as textarea- or editor-like fields with multiline placeholders and avoids placeholder-specific layout inconsistencies.

## Screenshot

| Before | After |
| --- | --- |
| Empty multiline input with a multiline placeholder could fail during initial render or show incorrect placeholder layout. | Multiline placeholder lines render correctly in empty multiline inputs, and cursor / IME positioning stays aligned. |

## How to Test

1. Run the focused unit tests:

```bash
cargo test -p gpui-component test_placeholder_line_runs
cargo test -p gpui-component test_position_for_index_prefers_first_leading_empty_visual_line
```
2. Run the story app:

3. Open a multiline input / textarea-style story and use a placeholder such as ab\n\nc.

4. Leave the input empty and confirm:

   * it renders without crashing
   * each placeholder line is displayed correctly
   * leading empty placeholder lines do not move the cursor / IME position to a later visual line
   
   ## Checklist

* [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
* [x] Passed `cargo run` for story tests related to the changes.
* [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)