### PR TITLE
table: Virtualize header leaf-column rendering to fix FPS drop with large column counts

### DIFF
--- a/crates/story/src/stories/data_table_story.rs
+++ b/crates/story/src/stories/data_table_story.rs
@@ -188,6 +188,8 @@ fn random_stocks(size: usize) -> Vec<Stock> {
 struct StockTableDelegate {
     stocks: Vec<Stock>,
     columns: Vec<Column>,
+    /// Number of extra "Column N" columns appended after the built-in columns.
+    extra_columns_count: usize,
     size: Size,
     loading: bool,
     lazy_load: bool,
@@ -265,6 +267,7 @@ impl StockTableDelegate {
                 Column::new("day_120_ranking", "120d Ranking"),
                 Column::new("day_250_ranking", "250d Ranking"),
             ],
+            extra_columns_count: 0,
             loading: false,
             full_loading: false,
             show_group_headers: true,
@@ -329,7 +332,7 @@ impl StockTableDelegate {
 
 impl TableDelegate for StockTableDelegate {
     fn columns_count(&self, _: &App) -> usize {
-        self.columns.len()
+        self.columns.len() + self.extra_columns_count
     }
 
     fn rows_count(&self, _: &App) -> usize {
@@ -337,7 +340,12 @@ impl TableDelegate for StockTableDelegate {
     }
 
     fn column(&self, col_ix: usize, _cx: &App) -> Column {
-        self.columns[col_ix].clone()
+        if let Some(col) = self.columns.get(col_ix) {
+            col.clone()
+        } else {
+            let n = col_ix - self.columns.len() + 1;
+            Column::new(format!("extra_{n}"), format!("Column {n}"))
+        }
     }
 
     fn group_headers(&self, cx: &App) -> Option<Vec<Vec<ColumnGroup>>> {
@@ -380,9 +388,9 @@ impl TableDelegate for StockTableDelegate {
         &mut self,
         col_ix: usize,
         _: &mut Window,
-        _: &mut Context<TableState<Self>>,
+        cx: &mut Context<TableState<Self>>,
     ) -> impl IntoElement {
-        let col = self.columns.get(col_ix).unwrap();
+        let col = self.column(col_ix, cx);
 
         div()
             .child(col.name.clone())
@@ -442,7 +450,9 @@ impl TableDelegate for StockTableDelegate {
         cx: &mut Context<TableState<Self>>,
     ) -> impl IntoElement {
         let stock = self.stocks.get(row_ix).unwrap();
-        let col = self.columns.get(col_ix).unwrap();
+        let Some(col) = self.columns.get(col_ix) else {
+            return div().child("--").into_any_element();
+        };
 
         match col.key.as_ref() {
             "id" => div()
@@ -665,6 +675,7 @@ impl TableDelegate for StockTableDelegate {
 pub struct DataTableStory {
     table: Entity<TableState<StockTableDelegate>>,
     num_stocks_input: Entity<InputState>,
+    num_extra_cols_input: Entity<InputState>,
     stripe: bool,
     refresh_data: bool,
     size: Size,
@@ -703,12 +714,19 @@ impl DataTableStory {
     }
 
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        // Create the number input field with validation for positive integers
         let num_stocks_input = cx.new(|cx| {
             let mut input = InputState::new(window, cx)
                 .placeholder("Enter number of Stocks to display")
                 .validate(|s, _| s.parse::<usize>().is_ok());
             input.set_value("5000", window, cx);
+            input
+        });
+
+        let num_extra_cols_input = cx.new(|cx| {
+            let mut input = InputState::new(window, cx)
+                .placeholder("Extra columns")
+                .validate(|s, _| s.parse::<usize>().is_ok());
+            input.set_value("0", window, cx);
             input
         });
 
@@ -718,7 +736,7 @@ impl DataTableStory {
         let _subscriptions = vec![
             cx.subscribe_in(&table, window, Self::on_table_event),
             cx.subscribe_in(&num_stocks_input, window, Self::on_num_stocks_input_change),
-            // Spawn a background to random refresh the list
+            cx.subscribe_in(&num_extra_cols_input, window, Self::on_num_extra_cols_input_change),
         ];
 
         let _load_task = cx.spawn(async move |this, cx| {
@@ -750,6 +768,7 @@ impl DataTableStory {
         Self {
             table,
             num_stocks_input,
+            num_extra_cols_input,
             stripe: false,
             refresh_data: false,
             size: Size::default(),
@@ -777,6 +796,28 @@ impl DataTableStory {
 
                     self.table.update(cx, |table, _| {
                         table.delegate_mut().update_stocks(total_count);
+                    });
+                    cx.notify();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_num_extra_cols_input_change(
+        &mut self,
+        _: &Entity<InputState>,
+        event: &InputEvent,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            InputEvent::PressEnter { .. } | InputEvent::Blur => {
+                let text = self.num_extra_cols_input.read(cx).value().to_string();
+                if let Ok(count) = text.parse::<usize>() {
+                    self.table.update(cx, |table, cx| {
+                        table.delegate_mut().extra_columns_count = count;
+                        table.refresh(cx);
                     });
                     cx.notify();
                 }
@@ -1149,11 +1190,18 @@ impl Render for DataTableStory {
                             h_flex()
                                 .gap_2()
                                 .flex_1()
-                                .child(Label::new("Number of Stocks:"))
+                                .child(Label::new("Stocks:"))
                                 .child(
                                     h_flex()
-                                        .min_w_32()
+                                        .min_w_24()
                                         .child(Input::new(&self.num_stocks_input).small())
+                                        .into_any_element(),
+                                )
+                                .child(Label::new("Extra Columns:"))
+                                .child(
+                                    h_flex()
+                                        .min_w_24()
+                                        .child(Input::new(&self.num_extra_cols_input).small())
                                         .into_any_element(),
                                 )
                                 .when(delegate.loading, |this| {

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -1379,6 +1379,64 @@ where
             })
     }
 
+    /// Compute the visible non-fixed leaf-column range for header rendering.
+    ///
+    /// Returns `(visible_range, left_spacer_width)` where:
+    /// - `visible_range` is the column-index range that should be rendered.
+    /// - `left_spacer_width` is the total width of the off-screen left columns,
+    ///   used as a spacer div to keep visible columns at the correct position.
+    ///
+    /// On the first frame `self.bounds` is zero, so a fallback that covers all
+    /// columns is returned to avoid a blank header on initial paint.
+    fn calculate_visible_leaf_col_range(
+        &self,
+        left_columns_count: usize,
+    ) -> (Range<usize>, Pixels) {
+        let total_cols = self.col_groups.len();
+
+        if self.bounds.size.width == px(0.) {
+            return (left_columns_count..total_cols, px(0.));
+        }
+
+        let fixed_width = self.fixed_head_cols_bounds.size.width;
+        let available_width = (self.bounds.size.width - fixed_width).max(px(0.));
+        // The scroll handle offset is negative when scrolled right; negate it
+        // to obtain a positive distance from the left edge of the scroll area.
+        let scroll_x = (-self.horizontal_scroll_handle.offset().x).max(px(0.));
+
+        // Walk left-to-right through non-fixed columns to find the first one
+        // whose right edge enters the viewport. The accumulated width of the
+        // skipped columns becomes the left spacer width.
+        let mut range_start = left_columns_count;
+        let mut left_spacer = px(0.);
+        let mut cumulative = px(0.);
+        for i in left_columns_count..total_cols {
+            let right_edge = cumulative + self.col_groups[i].width;
+            if right_edge > scroll_x {
+                range_start = i;
+                left_spacer = cumulative;
+                break;
+            }
+            cumulative = right_edge;
+        }
+
+        // Continue from `range_start` (skipping already-scanned columns) to
+        // find the last column still within the viewport. The 200 px overdraw
+        // buffer prevents a visible flash when the user scrolls quickly.
+        let right_bound = scroll_x + available_width + px(200.);
+        let mut range_end = total_cols;
+        let mut cumulative = left_spacer; // already summed widths before `range_start`
+        for i in range_start..total_cols {
+            cumulative += self.col_groups[i].width;
+            if cumulative > right_bound {
+                range_end = (i + 1).min(total_cols);
+                break;
+            }
+        }
+
+        (range_start..range_end, left_spacer)
+    }
+
     fn render_table_header(
         &mut self,
         left_columns_count: usize,
@@ -1388,44 +1446,22 @@ where
         let view = cx.entity().clone();
         let horizontal_scroll_handle = self.horizontal_scroll_handle.clone();
 
-        // Compute the visible leaf-column range to avoid rendering off-screen columns.
-        // On the first frame bounds are zero, so we fall back to rendering everything.
+        // Header leaf-column virtualization.
+        //
+        // `render_th` creates interactive elements with resize-handle listeners.
+        // Calling it for every column every frame is O(n) in column count; with
+        // 1000+ columns this alone drops FPS below 60 even in release mode.
+        //
+        // We restrict rendering to the columns currently visible inside the
+        // overflow-scroll viewport, surrounding them with inert spacer divs:
+        //
+        //   [left_spacer] [visible columns…] [right_spacer] [last_empty_col]
+        //
+        // The spacers preserve the flex container's total content width so that
+        // the scrollbar range stays correct.
         let total_cols = self.col_groups.len();
-        let (vis_start, vis_end, left_spacer) = if self.bounds.size.width > px(0.) {
-            let fixed_width = self.fixed_head_cols_bounds.size.width;
-            let available_width = (self.bounds.size.width - fixed_width).max(px(0.));
-            let scroll_x = (-self.horizontal_scroll_handle.offset().x).max(px(0.));
-
-            // Find the first visible non-fixed column.
-            let mut start = left_columns_count;
-            let mut spacer = px(0.);
-            let mut cumulative = px(0.);
-            for i in left_columns_count..total_cols {
-                let next = cumulative + self.col_groups[i].width;
-                if next > scroll_x {
-                    start = i;
-                    spacer = cumulative;
-                    break;
-                }
-                cumulative = next;
-            }
-
-            // Find the last visible non-fixed column (with a small buffer).
-            let right_bound = scroll_x + available_width + px(200.);
-            let mut end = total_cols;
-            let mut cumulative = px(0.);
-            for i in left_columns_count..total_cols {
-                cumulative += self.col_groups[i].width;
-                if cumulative > right_bound {
-                    end = (i + 1).min(total_cols);
-                    break;
-                }
-            }
-
-            (start, end, spacer)
-        } else {
-            (left_columns_count, total_cols, px(0.))
-        };
+        let (visible_col_range, left_spacer) =
+            self.calculate_visible_leaf_col_range(left_columns_count);
 
         let layout_len = self.header_layout.len();
 
@@ -1526,47 +1562,35 @@ where
                                 .border_color(cx.theme().border)
                                 .map(|this| {
                                     if is_leaf_row {
-                                        // Leaf row: only render columns within the visible range.
-                                        // A left spacer fills the space of off-screen left columns
-                                        // so remaining cells are positioned correctly inside the
-                                        // CSS overflow-scroll container.
+                                        // Leaf row: apply the spacer virtualization pattern.
+                                        // Only columns in `visible_range` are rendered; the two
+                                        // spacer divs preserve the container's total content width
+                                        // so the scrollbar range stays correct.
                                         this.when(left_spacer > px(0.), |r| {
-                                            r.child(
-                                                div()
-                                                    .w(left_spacer)
-                                                    .h_full()
-                                                    .flex_shrink_0(),
-                                            )
+                                            r.child(div().w(left_spacer).h_full().flex_shrink_0())
                                         })
                                         .children(row_cells.iter().filter_map(|cell| {
                                             if cell.is_leaf {
                                                 let ix = cell.leaf_col_ix?;
-                                                if ix < vis_start || ix >= vis_end {
+                                                if !visible_col_range.contains(&ix) {
                                                     return None;
                                                 }
-                                                return Some(
-                                                    self.render_th(ix, window, cx)
-                                                        .into_any_element(),
-                                                );
+                                                Some(self.render_th(ix, window, cx).into_any_element())
+                                            } else {
+                                                None
                                             }
-                                            None
                                         }))
-                                        .when(vis_end < total_cols, |r| {
-                                            let right_spacer: Pixels = self.col_groups
-                                                [vis_end..total_cols]
+                                        .when(visible_col_range.end < total_cols, |r| {
+                                            let right_spacer: Pixels = self.col_groups[visible_col_range.end..total_cols]
                                                 .iter()
                                                 .map(|g| g.width)
                                                 .sum();
-                                            r.child(
-                                                div()
-                                                    .w(right_spacer)
-                                                    .h_full()
-                                                    .flex_shrink_0(),
-                                            )
+                                            r.child(div().w(right_spacer).h_full().flex_shrink_0())
                                         })
                                         .child(self.delegate.render_last_empty_col(window, cx))
                                     } else {
-                                        // Group header rows: few cells, render all.
+                                        // Group header rows have far fewer cells (one per group),
+                                        // so the cost of rendering all of them is negligible.
                                         this.children(row_cells.iter().filter_map(|cell| {
                                             if cell.start_leaf_col_ix >= left_columns_count {
                                                 if cell.is_leaf {
@@ -2089,15 +2113,15 @@ where
                                 render_rows_count,
                                 cx.processor(
                                     move |table, visible_range: Range<usize>, window, cx| {
+                                        // Use `col.width` (always up-to-date) rather than
+                                        // `col.bounds.size.width`, which is only set after
+                                        // prepaint and is therefore zero on the first frame.
                                         let col_sizes: Rc<Vec<gpui::Size<Pixels>>> = Rc::new(
                                             table
                                                 .col_groups
                                                 .iter()
                                                 .skip(left_columns_count)
-                                                .map(|col| gpui::Size {
-                                                    width: col.width,
-                                                    height: px(0.),
-                                                })
+                                                .map(|col| gpui::Size { width: col.width, height: px(0.) })
                                                 .collect(),
                                         );
 

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -1388,6 +1388,47 @@ where
         let view = cx.entity().clone();
         let horizontal_scroll_handle = self.horizontal_scroll_handle.clone();
 
+        // Compute the visible leaf-column range to avoid rendering off-screen columns.
+        // On the first frame bounds are zero, so we fall back to rendering everything.
+        let total_cols = self.col_groups.len();
+        let (vis_start, vis_end, left_spacer) = if self.bounds.size.width > px(0.) {
+            let fixed_width = self.fixed_head_cols_bounds.size.width;
+            let available_width = (self.bounds.size.width - fixed_width).max(px(0.));
+            let scroll_x = (-self.horizontal_scroll_handle.offset().x).max(px(0.));
+
+            // Find the first visible non-fixed column.
+            let mut start = left_columns_count;
+            let mut spacer = px(0.);
+            let mut cumulative = px(0.);
+            for i in left_columns_count..total_cols {
+                let next = cumulative + self.col_groups[i].width;
+                if next > scroll_x {
+                    start = i;
+                    spacer = cumulative;
+                    break;
+                }
+                cumulative = next;
+            }
+
+            // Find the last visible non-fixed column (with a small buffer).
+            let right_bound = scroll_x + available_width + px(200.);
+            let mut end = total_cols;
+            let mut cumulative = px(0.);
+            for i in left_columns_count..total_cols {
+                cumulative += self.col_groups[i].width;
+                if cumulative > right_bound {
+                    end = (i + 1).min(total_cols);
+                    break;
+                }
+            }
+
+            (start, end, spacer)
+        } else {
+            (left_columns_count, total_cols, px(0.))
+        };
+
+        let layout_len = self.header_layout.len();
+
         // Reset fixed head columns bounds, if no fixed columns are present
         if left_columns_count == 0 {
             self.fixed_head_cols_bounds = Bounds::default();
@@ -1476,38 +1517,84 @@ where
                     .track_scroll(&horizontal_scroll_handle)
                     .bg(cx.theme().table_head)
                     .child(
-                        v_flex().min_w_full().flex_shrink_0().children(layout.iter().enumerate().map(|(_row_ix, row_cells)| {
+                        v_flex().min_w_full().flex_shrink_0().children(layout.iter().enumerate().map(|(row_ix, row_cells)| {
+                            let is_leaf_row = row_ix + 1 == layout_len;
                             h_flex()
                                 .min_w_full()
                                 .h(self.options.size.table_row_height())
                                 .border_b_1()
                                 .border_color(cx.theme().border)
-                                .children(row_cells.iter().filter_map(|cell| {
-                                    if cell.start_leaf_col_ix >= left_columns_count {
-                                        if cell.is_leaf {
-                                            if let Some(ix) = cell.leaf_col_ix {
+                                .map(|this| {
+                                    if is_leaf_row {
+                                        // Leaf row: only render columns within the visible range.
+                                        // A left spacer fills the space of off-screen left columns
+                                        // so remaining cells are positioned correctly inside the
+                                        // CSS overflow-scroll container.
+                                        this.when(left_spacer > px(0.), |r| {
+                                            r.child(
+                                                div()
+                                                    .w(left_spacer)
+                                                    .h_full()
+                                                    .flex_shrink_0(),
+                                            )
+                                        })
+                                        .children(row_cells.iter().filter_map(|cell| {
+                                            if cell.is_leaf {
+                                                let ix = cell.leaf_col_ix?;
+                                                if ix < vis_start || ix >= vis_end {
+                                                    return None;
+                                                }
                                                 return Some(
                                                     self.render_th(ix, window, cx)
                                                         .into_any_element(),
                                                 );
                                             }
-                                        } else {
-                                            return Some(
-                                                self.delegate_mut()
-                                                    .render_group_th(
-                                                        &cell.label,
-                                                        cell.col_span,
-                                                        cell.width,
-                                                        window,
-                                                        cx,
-                                                    )
-                                                    .into_any_element(),
-                                            );
-                                        }
+                                            None
+                                        }))
+                                        .when(vis_end < total_cols, |r| {
+                                            let right_spacer: Pixels = self.col_groups
+                                                [vis_end..total_cols]
+                                                .iter()
+                                                .map(|g| g.width)
+                                                .sum();
+                                            r.child(
+                                                div()
+                                                    .w(right_spacer)
+                                                    .h_full()
+                                                    .flex_shrink_0(),
+                                            )
+                                        })
+                                        .child(self.delegate.render_last_empty_col(window, cx))
+                                    } else {
+                                        // Group header rows: few cells, render all.
+                                        this.children(row_cells.iter().filter_map(|cell| {
+                                            if cell.start_leaf_col_ix >= left_columns_count {
+                                                if cell.is_leaf {
+                                                    if let Some(ix) = cell.leaf_col_ix {
+                                                        return Some(
+                                                            self.render_th(ix, window, cx)
+                                                                .into_any_element(),
+                                                        );
+                                                    }
+                                                } else {
+                                                    return Some(
+                                                        self.delegate_mut()
+                                                            .render_group_th(
+                                                                &cell.label,
+                                                                cell.col_span,
+                                                                cell.width,
+                                                                window,
+                                                                cx,
+                                                            )
+                                                            .into_any_element(),
+                                                    );
+                                                }
+                                            }
+                                            None
+                                        }))
+                                        .child(self.delegate.render_last_empty_col(window, cx))
                                     }
-                                    None
-                                }))
-                                .child(self.delegate.render_last_empty_col(window, cx))
+                                })
                         }))
                     ),
             )
@@ -2002,14 +2089,15 @@ where
                                 render_rows_count,
                                 cx.processor(
                                     move |table, visible_range: Range<usize>, window, cx| {
-                                        // We must calculate the col sizes here, because the col sizes
-                                        // need render_th first, then that method will set the bounds of each col.
                                         let col_sizes: Rc<Vec<gpui::Size<Pixels>>> = Rc::new(
                                             table
                                                 .col_groups
                                                 .iter()
                                                 .skip(left_columns_count)
-                                                .map(|col| col.bounds.size)
+                                                .map(|col| gpui::Size {
+                                                    width: col.width,
+                                                    height: px(0.),
+                                                })
                                                 .collect(),
                                         );
 


### PR DESCRIPTION
## Summary

Fixes #2281.

With 1000 columns, `render_table_header` was calling `render_th` for every column every frame, even those off-screen, causing FPS to drop to ~45 in release mode.

- **Header virtualization**: Compute the visible leaf-column range from the current horizontal scroll position. Only `render_th` for columns within that range. A left spacer and a right spacer are inserted around the visible cells so the `overflow-scroll` container still measures the correct total content width, keeping the scrollbar accurate.
- **Fix first-frame `col_sizes`**: Body row rendering previously used `col.bounds.size` for column widths, which is zero on the first frame (set only after prepaint). Changed to use `col_group.width`, which is always up to date.

## Test

https://github.com/user-attachments/assets/ce849a75-f29d-4121-8390-67306f5de434

I also tested on 10K columns, it stable works on 120 FPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)