### PR TITLE
docs: fix GPUI dependency instructions to use git source with font-kit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Here is the first application: [Longbridge Pro](https://longbridge.com/desktop),
 ## Usage
 
 ```toml
-gpui = "0.2.2"
-gpui-component = "0.5.1"
+gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```
 
 ### Basic Example
@@ -61,9 +62,7 @@ impl Render for HelloWorld {
 }
 
 fn main() {
-    let app = Application::new();
-
-    app.run(move |cx| {
+    gpui_platform::application().run(move |cx| {
         // This must be called before using any GPUI Component features.
         gpui_component::init(cx);
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,8 +31,9 @@ https://longbridge.github.io/gpui-component/gallery/
 ## Usage
 
 ```toml
-gpui = "0.2.2"
-gpui-component = "0.5.1"
+gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
+gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```
 
 ### Examples
@@ -61,9 +62,7 @@ impl Render for HelloWorld {
 }
 
 fn main() {
-    let app = Application::new();
-
-    app.run(move |cx| {
+    gpui_platform::application().run(move |cx| {
         // 使用任何 GPUI Component 功能之前必须先调用此函数。
         gpui_component::init(cx);
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -13,7 +13,7 @@ Add dependencies to your `Cargo.toml`:
 ```toml
 [dependencies]
 gpui = { git = "https://github.com/zed-industries/zed" }
-gpui_platform = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 # Optional, for default bundled assets
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -43,5 +43,6 @@ To install the `gpui-component` library, you can use Cargo, the Rust package man
 
 ```toml
 gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ The documentation on this site are based on the **Git main branch**, if you use 
 
 ```toml
 gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```
 

--- a/docs/zh-CN/docs/getting-started.md
+++ b/docs/zh-CN/docs/getting-started.md
@@ -13,7 +13,7 @@ order: -2
 ```toml
 [dependencies]
 gpui = { git = "https://github.com/zed-industries/zed" }
-gpui_platform = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 # 可选：使用内置默认资源
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }

--- a/docs/zh-CN/docs/installation.md
+++ b/docs/zh-CN/docs/installation.md
@@ -45,5 +45,6 @@ order: -1
 
 ```toml
 gpui = { git = "https://github.com/zed-industries/zed" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 ```


### PR DESCRIPTION
## Summary

- Replace crates.io version pins (`gpui = "0.2.2"`, `gpui-component = "0.5.1"`) with git source references in README.md and README.zh-CN.md
- Add missing `gpui_platform` dependency with required `features = ["font-kit"]` across all docs and READMEs — without this feature, text will not render
- Update example code to use `gpui_platform::application()` instead of the outdated `Application::new()`

## Files changed

- `README.md` / `README.zh-CN.md`
- `docs/index.md`
- `docs/docs/getting-started.md` / `docs/docs/installation.md`
- `docs/zh-CN/docs/getting-started.md` / `docs/zh-CN/docs/installation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)