### PR TITLE
sidebar: Add click_to_toggle functionality to SidebarMenuItem

### DIFF
--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -97,6 +97,7 @@ pub struct SidebarMenuItem {
     default_open: bool,
     click_to_open: bool,
     collapsed: bool,
+    click_to_toggle: bool,
     children: Vec<Self>,
     suffix: Option<Rc<dyn Fn(&mut Window, &mut App) -> AnyElement + 'static>>,
     disabled: bool,
@@ -114,6 +115,7 @@ impl SidebarMenuItem {
             collapsed: false,
             default_open: false,
             click_to_open: false,
+            click_to_toggle: false,
             children: Vec::new(),
             suffix: None,
             disabled: false,
@@ -163,6 +165,16 @@ impl SidebarMenuItem {
     /// If `false` we only handle open/close via the caret button.
     pub fn click_to_open(mut self, click_to_open: bool) -> Self {
         self.click_to_open = click_to_open;
+        self
+    }
+
+    /// Set whether clicking the menu item toggles the submenu.
+    ///
+    /// If click_to_open is `true`, this has no effect.
+    ///
+    /// Default is `false`.
+    pub fn click_to_toggle(mut self, click_to_toggle: bool) -> Self {
+        self.click_to_toggle = click_to_toggle;
         self
     }
 
@@ -224,6 +236,7 @@ impl SidebarItem for SidebarMenuItem {
         cx: &mut App,
     ) -> impl IntoElement {
         let click_to_open = self.click_to_open;
+        let click_to_toggle = self.click_to_toggle;
         let default_open = self.default_open;
         let id = id.into();
         let is_submenu = self.is_submenu();
@@ -329,8 +342,14 @@ impl SidebarItem for SidebarMenuItem {
                                             cx.notify();
                                         });
                                     }
+                                } else if click_to_toggle {
+                                    if let Some(ref s) = open_state {
+                                        s.update(cx, |is_open: &mut bool, cx| {
+                                            *is_open = !*is_open;
+                                            cx.notify();
+                                        });
+                                    }
                                 }
-
                                 handler(ev, window, cx)
                             }
                         })


### PR DESCRIPTION

## Description

This adds click_to_toggle to SidebarMenuItem, letting submenu items toggle their open state when the user clicks the item itself.

Previously, submenu open state was internal and not writable from user code, so implementing toggle behavior externally was not possible (at least I was not able to do it). With this change, the sidebar can support user-facing toggle interactions without exposing internal state.

click_to_open still takes precedence, and the existing caret-only behavior remains unchanged unless toggle behavior is enabled.

I wasn’t entirely sure whether exposing open_state is the right approach. If click_to_toggle isn’t aligned with the preferred direction, I’m happy to open another PR following a different pattern. Also, if there’s already a way to achieve this behavior without introducing this change, I’d really appreciate any guidance.

Breaking Changes
None.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
