### PR TITLE
resizable: Support style overrides on ResizablePanel

### DIFF
--- a/crates/story/src/stories/resizable_story.rs
+++ b/crates/story/src/stories/resizable_story.rs
@@ -4,12 +4,16 @@ use gpui::{
 };
 use gpui_component::{
     ActiveTheme,
+    button::Button,
+    h_flex,
     resizable::{h_resizable, resizable_panel, v_resizable},
     v_flex,
 };
 
 pub struct ResizableStory {
     focus_handle: FocusHandle,
+    show_left: bool,
+    use_flex_none: bool,
 }
 
 impl super::Story for ResizableStory {
@@ -40,6 +44,8 @@ impl ResizableStory {
     fn new(_: &mut Window, cx: &mut App) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
+            show_left: true,
+            use_flex_none: true,
         }
     }
 }
@@ -106,6 +112,83 @@ impl Render for ResizableStory {
                                     .child(panel_box("Left 2", cx)),
                             )
                             .child(panel_box("Right (Grow)", cx)),
+                    ),
+            )
+            // Demonstrates `.flex_none()`. Toggle the left panel's
+            // visibility while watching the right panel's width:
+            //
+            // - `Use flex_none = true` (default): right panel holds
+            //   its width; the center flex panel absorbs the freed
+            //   space.
+            // - `Use flex_none = false`: right panel inherits the
+            //   internal `flex_grow: 1` and absorbs half of the
+            //   freed slack alongside the center.
+            //
+            // Use the two buttons to record before/after for the same
+            // layout in a single session.
+            .child(
+                v_flex()
+                    .gap_2()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("toggle-left")
+                                    .outline()
+                                    .label(if self.show_left {
+                                        "Hide Left"
+                                    } else {
+                                        "Show Left"
+                                    })
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.show_left = !this.show_left;
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(
+                                Button::new("toggle-flex-none")
+                                    .outline()
+                                    .label(if self.use_flex_none {
+                                        "Use flex_none: ON"
+                                    } else {
+                                        "Use flex_none: OFF"
+                                    })
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.use_flex_none = !this.use_flex_none;
+                                        cx.notify();
+                                    })),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .h(px(200.))
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .child(
+                                h_resizable("resizable-flex-none")
+                                    .child({
+                                        let mut p = resizable_panel()
+                                            .visible(self.show_left)
+                                            .size(px(200.))
+                                            .size_range(px(150.)..px(400.))
+                                            .child(panel_box("Left", cx));
+                                        if self.use_flex_none {
+                                            p = p.flex_none();
+                                        }
+                                        p
+                                    })
+                                    .child(panel_box("Center", cx))
+                                    .child({
+                                        let mut p = resizable_panel()
+                                            .size(px(280.))
+                                            .size_range(px(200.)..px(400.))
+                                            .child(panel_box("Right", cx));
+                                        if self.use_flex_none {
+                                            p = p.flex_none();
+                                        }
+                                        p
+                                    }),
+                            ),
                     ),
             )
     }

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -6,10 +6,11 @@ use std::{
 use gpui::{
     Along, AnyElement, App, AppContext, Axis, Bounds, Context, Element, ElementId, Empty, Entity,
     EventEmitter, InteractiveElement as _, IntoElement, IsZero as _, MouseMoveEvent, MouseUpEvent,
-    ParentElement, Pixels, Render, RenderOnce, Style, Styled, Window, div, prelude::FluentBuilder,
+    ParentElement, Pixels, Render, RenderOnce, Style, StyleRefinement, Styled, Window, div,
+    prelude::FluentBuilder,
 };
 
-use crate::{AxisExt, ElementExt, h_flex, resizable::PANEL_MIN_SIZE, v_flex};
+use crate::{AxisExt, ElementExt, h_flex, resizable::PANEL_MIN_SIZE, styled::StyledExt as _, v_flex};
 
 use super::{ResizableState, resizable_panel, resize_handle};
 
@@ -177,6 +178,32 @@ impl RenderOnce for ResizablePanelGroup {
 }
 
 /// A resizable panel inside a [`ResizablePanelGroup`].
+///
+/// Implements [`Styled`], so call sites can override the panel's
+/// rendered styles. User overrides are applied **between** the panel's
+/// flex defaults and its size management — the caller can override the
+/// internal `flex_grow: 1` (e.g. via `.flex_none()`) and add their own
+/// padding / colors / borders, while the panel's runtime size
+/// constraints (`min_w`/`max_w`/`flex_basis` driven by `ResizableState`)
+/// always win.
+///
+/// A common override is `.flex_none()`: the panel sets `flex_grow: 1`
+/// internally, so a sized panel that should hold its width when a
+/// sibling collapses needs to opt out of growth via `.flex_none()`.
+///
+/// ```ignore
+/// h_resizable("layout")
+///     .child(resizable_panel().size(px(220.)).flex_none().child(sidebar))
+///     .child(resizable_panel().child(content))                // flex
+///     .child(resizable_panel().size(px(280.)).flex_none().child(metadata))
+/// ```
+///
+/// **Reserved styles**: do not call these from outside — they fight the
+/// panel's own layout management:
+/// - `.flex_basis(...)` — driven by `ResizableState`, not by the caller.
+/// - `.absolute()` — would remove the panel from the resizable's flex flow.
+/// - `.overflow_hidden()` — may clip the resize handle, which is positioned
+///   absolute at `left: -4px` of each panel after the first.
 #[derive(IntoElement)]
 pub struct ResizablePanel {
     axis: Axis,
@@ -188,6 +215,7 @@ pub struct ResizablePanel {
     size_range: Range<Pixels>,
     children: Vec<AnyElement>,
     visible: bool,
+    style: StyleRefinement,
 }
 
 impl ResizablePanel {
@@ -201,6 +229,7 @@ impl ResizablePanel {
             axis: Axis::Horizontal,
             children: vec![],
             visible: true,
+            style: StyleRefinement::default(),
         }
     }
 
@@ -222,6 +251,12 @@ impl ResizablePanel {
     pub fn size_range(mut self, range: impl Into<Range<Pixels>>) -> Self {
         self.size_range = range.into();
         self
+    }
+}
+
+impl Styled for ResizablePanel {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
     }
 }
 
@@ -253,6 +288,14 @@ impl RenderOnce for ResizablePanel {
             .flex_grow()
             .size_full()
             .relative()
+            // Apply caller style overrides here — between the flex defaults
+            // above and the size management below. This lets callers cancel
+            // the unconditional `.flex_grow()` (via `.flex_none()`, the load-
+            // bearing case for sized panels next to a collapsing sibling) and
+            // add their own padding / colors / borders, while keeping the
+            // panel's runtime size constraints (min/max + `flex_basis` driven
+            // by `ResizableState`) authoritative.
+            .refine_style(&self.style)
             .when(self.axis.is_vertical(), |this| {
                 this.min_h(size_range.start).max_h(size_range.end)
             })


### PR DESCRIPTION
## Description

`ResizablePanel` does not currently implement `Styled`, so call sites
cannot override the panel's rendered styles. The load-bearing case is
flex behavior: the panel sets `flex_grow: 1` unconditionally in its
render, so a sized panel inherits growth and absorbs slack from
siblings — most visibly when a sibling toggles its `.visible()`.

This PR adopts the same pattern `Button` and `Input` use:

- `style: StyleRefinement` field on `ResizablePanel`
- `impl Styled for ResizablePanel`
- `.refine_style(&self.style)` applied last in render so call-site
  overrides win over internal flex defaults

The internal `flex_grow: 1` is unchanged — there is **no behavior
change for existing call sites**. To opt out of growth, write
`.flex_none()` in the chain. It overrides `flex_grow` / `flex_shrink`
while leaving `flex_basis` (managed by `ResizableState`) untouched.

The struct doc enumerates reserved styles to avoid (`flex_basis`,
`absolute`, `overflow_hidden`).

## Screenshot

The Resizable story gains a third demo with two buttons:
**Hide Left** (toggles a sibling's `.visible()`) and **Use flex_none**
(toggles the override on the same layout). Recording shows the same
layout under both states.


https://github.com/user-attachments/assets/eb8b6662-4989-4917-95ca-4dc5572681cb



## Break Changes

None. The default `StyleRefinement::default()` is empty, so render
output is byte-identical for any caller that does not invoke `Styled`
methods.

## How to Test

Open the **Resizable** story. The new demo at the bottom has two
buttons next to a 3-panel `h_resizable`:

1. With **Use flex_none: ON** → click **Hide Left**. The right panel
   should hold its width; the center flex panel absorbs the freed
   space.
2. Click **Show Left** to reset, then click **Use flex_none: OFF** →
   click **Hide Left** again. The right panel grows by half of the
   freed space.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR. AI assistance noted in the
      commit body and below; the foot-gun list and story example
      were authored deliberately, and the whole branch was reviewed
      against the story before commit.
- [x] Passed the Resizable story for the new demo.

## AI assistance

Iterated with Claude Code: implementation, story example, doc comment.
Each step reviewed and tested locally.
