### PR TITLE
resizable: Expose `resize_panel` method for programmatic resize

### DIFF
--- a/crates/story/src/stories/resizable_story.rs
+++ b/crates/story/src/stories/resizable_story.rs
@@ -3,10 +3,10 @@ use gpui::{
     ParentElement as _, Pixels, Render, SharedString, Styled, Window, div, px,
 };
 use gpui_component::{
-    ActiveTheme,
+    ActiveTheme, Sizable as _,
     button::Button,
     h_flex,
-    resizable::{h_resizable, resizable_panel, v_resizable},
+    resizable::{ResizableState, h_resizable, resizable_panel, v_resizable},
     v_flex,
 };
 
@@ -14,6 +14,7 @@ pub struct ResizableStory {
     focus_handle: FocusHandle,
     show_left: bool,
     use_flex_none: bool,
+    programmatic_state: Entity<ResizableState>,
 }
 
 impl super::Story for ResizableStory {
@@ -46,6 +47,7 @@ impl ResizableStory {
             focus_handle: cx.focus_handle(),
             show_left: true,
             use_flex_none: true,
+            programmatic_state: cx.new(|_| ResizableState::default()),
         }
     }
 }
@@ -188,6 +190,79 @@ impl Render for ResizableStory {
                                         }
                                         p
                                     }),
+                            ),
+                    ),
+            )
+            // Programmatic resize: drive panel sizes via
+            // `ResizableState::resize_panel(ix, size, window, cx)`. Buttons
+            // mutate the shared state; subscribers (none here) would observe
+            // a `ResizablePanelEvent::Resized` just like a drag-finish.
+            .child(
+                v_flex()
+                    .gap_2()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("compact-left")
+                                    .small()
+                                    .label("Compact left → 100")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.programmatic_state.update(cx, |state, cx| {
+                                            state.resize_panel(0, px(100.), window, cx);
+                                        });
+                                    })),
+                            )
+                            .child(
+                                Button::new("reset-left")
+                                    .small()
+                                    .label("Reset left → 200")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.programmatic_state.update(cx, |state, cx| {
+                                            state.resize_panel(0, px(200.), window, cx);
+                                        });
+                                    })),
+                            )
+                            .child(
+                                Button::new("compact-right")
+                                    .small()
+                                    .label("Compact right → 80")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.programmatic_state.update(cx, |state, cx| {
+                                            state.resize_panel(2, px(80.), window, cx);
+                                        });
+                                    })),
+                            )
+                            .child(
+                                Button::new("reset-right")
+                                    .small()
+                                    .label("Reset right → 200")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.programmatic_state.update(cx, |state, cx| {
+                                            state.resize_panel(2, px(200.), window, cx);
+                                        });
+                                    })),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .h(px(200.))
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .child(
+                                h_resizable("resizable-programmatic")
+                                    .with_state(&self.programmatic_state)
+                                    .child(
+                                        resizable_panel()
+                                            .size(px(200.))
+                                            .child(panel_box("Left", cx)),
+                                    )
+                                    .child(panel_box("Center (grow)", cx))
+                                    .child(
+                                        resizable_panel()
+                                            .size(px(200.))
+                                            .child(panel_box("Right", cx)),
+                                    ),
                             ),
                     ),
             )

--- a/crates/ui/src/resizable/mod.rs
+++ b/crates/ui/src/resizable/mod.rs
@@ -55,6 +55,37 @@ impl ResizableState {
         &self.sizes
     }
 
+    /// Programmatically resize the panel at `ix` to `size`, redistributing
+    /// space among siblings using the same logic as a drag.
+    ///
+    /// Sizes are clamped to the panel's `size_range` and to the container.
+    /// Emits `ResizablePanelEvent::Resized` so subscribers (e.g. preference
+    /// persistence) see the change just as if the user had dragged a handle.
+    ///
+    /// Out-of-range indices are a no-op. For the last panel, space is taken
+    /// from the previous sibling (the last panel has no handle of its own).
+    pub fn resize_panel(
+        &mut self,
+        ix: usize,
+        size: Pixels,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if ix >= self.sizes.len() {
+            return;
+        }
+        if ix + 1 < self.sizes.len() {
+            self.resize_panel_at_handle(ix, size, window, cx);
+        } else if ix > 0 {
+            // Last panel: drive its size by resizing the previous sibling so
+            // the freed space lands here.
+            let delta = self.sizes[ix] - size;
+            let prev = self.sizes[ix - 1];
+            self.resize_panel_at_handle(ix - 1, prev + delta, window, cx);
+        }
+        self.done_resizing(cx);
+    }
+
     pub(crate) fn insert_panel(
         &mut self,
         size: Option<Pixels>,
@@ -192,9 +223,19 @@ impl ResizableState {
         }
     }
 
-    /// The `ix`` is the index of the panel to resize,
-    /// and the `size` is the new size for the panel.
-    fn resize_panel(&mut self, ix: usize, size: Pixels, _: &mut Window, cx: &mut Context<Self>) {
+    /// Resize the panel at `ix` by treating `ix` as the drag-handle position
+    /// (the handle that sits between panel `ix` and panel `ix + 1`). Returns
+    /// early on the last panel since there is no handle below it.
+    ///
+    /// This is the worker behind drag interactions and the public
+    /// [`Self::resize_panel`] API.
+    fn resize_panel_at_handle(
+        &mut self,
+        ix: usize,
+        size: Pixels,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let old_sizes = self.sizes.clone();
 
         let mut ix = ix;

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -417,12 +417,18 @@ impl Element for ResizePanelGroupElement {
                     let panel = state.panels.get(ix).expect("BUG: invalid panel index");
 
                     match axis {
-                        Axis::Horizontal => {
-                            state.resize_panel(ix, e.position.x - panel.bounds.left(), window, cx)
-                        }
-                        Axis::Vertical => {
-                            state.resize_panel(ix, e.position.y - panel.bounds.top(), window, cx);
-                        }
+                        Axis::Horizontal => state.resize_panel_at_handle(
+                            ix,
+                            e.position.x - panel.bounds.left(),
+                            window,
+                            cx,
+                        ),
+                        Axis::Vertical => state.resize_panel_at_handle(
+                            ix,
+                            e.position.y - panel.bounds.top(),
+                            window,
+                            cx,
+                        ),
                     }
                     cx.notify();
                 })


### PR DESCRIPTION
## Summary

`ResizableState` exposes only the `sizes()` getter — `self.sizes` can be mutated solely by user-driven handle drags. The two existing patterns documented for layout work fine on their own:

- **Initial layout from preferences** — `ResizablePanel::size(...)` is honored on first render (while the slot is still at `PANEL_MIN_SIZE`).
- **Persisting user drags** — subscribe to `ResizablePanelEvent::Resized`.

What's missing is **imperative resize after init**:

- "Compact / expand" toggle that snaps a panel to a fixed size on click.
- "Reset to default layout" action.
- Syncing a panel's size to non-drag input (a number input, an action, another panel's state).

All of these currently require forking.

### Change

- New public `pub fn resize_panel(&mut self, ix, size, window, cx)`.
  Out-of-range indices no-op. Non-last panels go through the existing handle-walk redistribution; the last panel is driven by resizing its predecessor so the freed space lands on it. Emits the same `ResizablePanelEvent::Resized` as a drag-finish so subscribers see the change uniformly.
- The previous private `fn resize_panel(...)` is renamed `fn resize_panel_at_handle(...)` since its `ix` parameter is the drag-handle index, not the panel index. The two internal call sites in `panel.rs` are updated.
- `ResizableStory` gains a fourth demo block: four buttons (*Compact left → 100*, *Reset left → 200*, *Compact right → 80*, *Reset right → 200*) drive a 3-panel `h_resizable` via `ResizableState::resize_panel`, exercising both the non-last and last-panel paths.

The public name matches the verb-first convention of the rest of `ResizableState`'s mutators (`insert_panel`, `remove_panel`, `replace_panel`).

## Test plan

- [x] `cargo check -p gpui-component-story` passes locally.
- [x] Drag-resize behavior in the resizable story is unchanged (the rename is the only thing that touches the drag path).
- [x] Calling `state.resize_panel(ix, size, window, cx)` from a host app moves the panel to `size`, redistributes among siblings, and fires `ResizablePanelEvent::Resized`. Verified end-to-end against a "compact panel" toggle in a downstream app — round-trip 250 → 60 → 250 produced clean `[layout, waveform]` sizes at every step.
- [x] Last-panel resize drives the previous sibling rather than silently doing nothing.