### PR TITLE
tree: Add context menu support with right-click highlight

### DIFF
--- a/crates/story/src/stories/tree_story.rs
+++ b/crates/story/src/stories/tree_story.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use autocorrect::ignorer::Ignorer;
 use gpui::{
     App, AppContext, Context, Entity, InteractiveElement, KeyBinding, ParentElement, Render,
-    Styled, Window, actions, px,
+    Styled, Window, actions, prelude::FluentBuilder as _, px,
 };
 
 use gpui_component::{
@@ -20,7 +20,7 @@ use rand::seq::SliceRandom as _;
 
 use crate::{Story, section};
 
-actions!(story, [Rename]);
+actions!(story, [Rename, OpenFile, Delete]);
 
 const CONTEXT: &str = "TreeStory";
 pub(crate) fn init(cx: &mut App) {
@@ -101,7 +101,20 @@ impl TreeStory {
         if let Some(entry) = self.tree_state.read(cx).selected_entry() {
             let item = entry.item();
             println!("Renaming item: {} ({})", item.label, item.id);
-            // Here you could implement actual renaming logic
+        }
+    }
+
+    fn on_action_open(&mut self, _: &OpenFile, _: &mut Window, cx: &mut gpui::Context<Self>) {
+        if let Some(entry) = self.tree_state.read(cx).selected_entry() {
+            let item = entry.item();
+            println!("Opening item: {} ({})", item.label, item.id);
+        }
+    }
+
+    fn on_action_delete(&mut self, _: &Delete, _: &mut Window, cx: &mut gpui::Context<Self>) {
+        if let Some(entry) = self.tree_state.read(cx).selected_entry() {
+            let item = entry.item();
+            println!("Deleting item: {} ({})", item.label, item.id);
         }
     }
 }
@@ -133,6 +146,8 @@ impl Render for TreeStory {
             .id("tree-story")
             .key_context(CONTEXT)
             .on_action(cx.listener(Self::on_action_rename))
+            .on_action(cx.listener(Self::on_action_open))
+            .on_action(cx.listener(Self::on_action_delete))
             .child(
                 h_flex().gap_3().child(
                     Button::new("select-item")
@@ -149,7 +164,7 @@ impl Render for TreeStory {
             )
             .child(
                 section("File tree")
-                    .sub_title("Press `space` to select, `enter` to rename.")
+                    .sub_title("Press `enter` to rename. Right-click for context menu.")
                     .v_flex()
                     .max_w_md()
                     .child(
@@ -186,6 +201,13 @@ impl Render for TreeStory {
                                 })
                             },
                         )
+                        .context_menu(|_ix, entry, menu, _window, _cx| {
+                            let is_folder = entry.is_folder();
+                            menu.when(!is_folder, |m| m.menu("Open", Box::new(OpenFile)))
+                                .menu("Rename", Box::new(Rename))
+                                .separator()
+                                .menu("Delete", Box::new(Delete))
+                        })
                         .p_1()
                         .border_1()
                         .border_color(cx.theme().border)

--- a/crates/story/src/stories/tree_story.rs
+++ b/crates/story/src/stories/tree_story.rs
@@ -7,7 +7,7 @@ use gpui::{
 };
 
 use gpui_component::{
-    ActiveTheme as _, IconName, StyledExt as _,
+    ActiveTheme as _, IconName,
     button::Button,
     dock::PanelControl,
     h_flex,
@@ -165,71 +165,74 @@ impl Render for TreeStory {
             .child(
                 section("File tree")
                     .sub_title("Press `enter` to rename. Right-click for context menu.")
-                    .v_flex()
                     .max_w_md()
                     .child(
-                        tree(
-                            &self.tree_state,
-                            move |ix, entry, _selected, _window, cx| {
-                                view.update(cx, |_, cx| {
-                                    let item = entry.item();
-                                    let icon = if !entry.is_folder() {
-                                        IconName::File
-                                    } else if entry.is_expanded() {
-                                        IconName::FolderOpen
-                                    } else {
-                                        IconName::Folder
-                                    };
+                        v_flex()
+                            .gap_4()
+                            .child(
+                                tree(
+                                    &self.tree_state,
+                                    move |ix, entry, _selected, _window, cx| {
+                                        view.update(cx, |_, cx| {
+                                            let item = entry.item();
+                                            let icon = if !entry.is_folder() {
+                                                IconName::File
+                                            } else if entry.is_expanded() {
+                                                IconName::FolderOpen
+                                            } else {
+                                                IconName::Folder
+                                            };
 
-                                    ListItem::new(ix)
-                                        .w_full()
-                                        .rounded(cx.theme().radius)
-                                        .px_3()
-                                        .pl(px(16.) * entry.depth() + px(12.))
-                                        .child(
-                                            h_flex().gap_2().child(icon).child(item.label.clone()),
-                                        )
-                                        .on_click(cx.listener({
-                                            let item = item.clone();
-                                            move |_, _, _window, _| {
-                                                println!(
-                                                    "Clicked on item: {} ({})",
-                                                    item.label, item.id
-                                                );
-                                            }
-                                        }))
+                                            ListItem::new(ix)
+                                                .w_full()
+                                                .rounded(cx.theme().radius)
+                                                .px_3()
+                                                .pl(px(16.) * entry.depth() + px(12.))
+                                                .child(
+                                                    h_flex()
+                                                        .gap_2()
+                                                        .child(icon)
+                                                        .child(item.label.clone()),
+                                                )
+                                                .on_click(cx.listener({
+                                                    let item = item.clone();
+                                                    move |_, _, _window, _| {
+                                                        println!(
+                                                            "Clicked on item: {} ({})",
+                                                            item.label, item.id
+                                                        );
+                                                    }
+                                                }))
+                                        })
+                                    },
+                                )
+                                .context_menu(|_ix, entry, menu, _window, _cx| {
+                                    let is_folder = entry.is_folder();
+                                    menu.when(!is_folder, |m| m.menu("Open", Box::new(OpenFile)))
+                                        .menu("Rename", Box::new(Rename))
+                                        .separator()
+                                        .menu("Delete", Box::new(Delete))
                                 })
-                            },
-                        )
-                        .context_menu(|_ix, entry, menu, _window, _cx| {
-                            let is_folder = entry.is_folder();
-                            menu.when(!is_folder, |m| m.menu("Open", Box::new(OpenFile)))
-                                .menu("Rename", Box::new(Rename))
-                                .separator()
-                                .menu("Delete", Box::new(Delete))
-                        })
-                        .p_1()
-                        .border_1()
-                        .border_color(cx.theme().border)
-                        .rounded(cx.theme().radius)
-                        .h(px(540.)),
-                    )
-                    .child(
-                        h_flex()
-                            .w_full()
-                            .justify_between()
-                            .gap_3()
-                            .children(
-                                self.tree_state
-                                    .read(cx)
-                                    .selected_index()
-                                    .map(|ix| format!("Selected Index: {}", ix)),
+                                .p_1()
+                                .border_1()
+                                .border_color(cx.theme().border)
+                                .rounded(cx.theme().radius)
+                                .h(px(540.)),
                             )
-                            .children(
-                                self.tree_state
-                                    .read(cx)
-                                    .selected_item()
-                                    .map(|item| Label::new("Selected:").secondary(item.id.clone())),
+                            .child(
+                                h_flex()
+                                    .w_full()
+                                    .justify_between()
+                                    .gap_3()
+                                    .children(
+                                        self.tree_state
+                                            .read(cx)
+                                            .selected_index()
+                                            .map(|ix| format!("Selected Index: {}", ix)),
+                                    )
+                                    .children(self.tree_state.read(cx).selected_item().map(
+                                        |item| Label::new("Selected:").secondary(item.id.clone()),
+                                    )),
                             ),
                     ),
             )

--- a/crates/story/src/stories/tree_story.rs
+++ b/crates/story/src/stories/tree_story.rs
@@ -168,6 +168,7 @@ impl Render for TreeStory {
                     .max_w_md()
                     .child(
                         v_flex()
+                            .w_full()
                             .gap_4()
                             .child(
                                 tree(

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -1,5 +1,4 @@
 use crate::{ActiveTheme, Disableable, Icon, Selectable, Sizable as _, StyledExt, h_flex};
-use std::collections::HashMap;
 use gpui::{
     AnyElement, App, ClickEvent, Div, ElementId, InteractiveElement, IntoElement, MouseButton,
     MouseDownEvent, MouseMoveEvent, ParentElement, RenderOnce, Stateful,
@@ -7,6 +6,7 @@ use gpui::{
     prelude::FluentBuilder as _,
 };
 use smallvec::SmallVec;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum ListItemMode {
@@ -33,7 +33,8 @@ pub struct ListItem {
     confirmed: bool,
     check_icon: Option<Icon>,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
-    on_mouse_down: HashMap<MouseButton, Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>>,
+    on_mouse_down:
+        HashMap<MouseButton, Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>>,
     on_mouse_enter: Option<Box<dyn Fn(&MouseMoveEvent, &mut Window, &mut App) + 'static>>,
     suffix: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyElement + 'static>>,
     children: SmallVec<[AnyElement; 2]>,
@@ -163,7 +164,7 @@ impl ParentElement for ListItem {
 
 impl RenderOnce for ListItem {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let is_active = self.confirmed || self.selected;
+        let is_active = self.confirmed || self.selected || self.secondary_selected;
 
         let corner_radii = self.style.corner_radii.clone();
 
@@ -231,19 +232,20 @@ impl RenderOnce for ListItem {
                         cx.theme().accent
                     };
 
-                    this.bg(bg).when(cx.theme().list.active_highlight, |this| {
-                        this.child(
-                            div()
-                                .absolute()
-                                .top_0()
-                                .left_0()
-                                .right_0()
-                                .bottom_0()
-                                .border_1()
-                                .border_color(cx.theme().list_active_border)
-                                .refine_style(&selected_style),
-                        )
-                    })
+                    this.when(!self.secondary_selected, |this| this.bg(bg))
+                        .when(cx.theme().list.active_highlight, |this| {
+                            this.child(
+                                div()
+                                    .absolute()
+                                    .top_0()
+                                    .left_0()
+                                    .right_0()
+                                    .bottom_0()
+                                    .border_1()
+                                    .border_color(cx.theme().list_active_border)
+                                    .refine_style(&selected_style),
+                            )
+                        })
                 } else {
                     this
                 }

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -330,6 +330,7 @@ impl TreeState {
         }
 
         entry.item.state.borrow_mut().expanded = !entry.is_expanded();
+        self.right_clicked_ix = None;
         self.rebuild_entries();
     }
 

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -199,8 +199,9 @@ pub struct TreeState {
     selected_ix: Option<usize>,
     right_clicked_ix: Option<usize>,
     render_item: Rc<dyn Fn(usize, &TreeEntry, bool, &mut Window, &mut App) -> ListItem>,
-    context_menu_builder:
-        Option<Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>>,
+    context_menu_builder: Option<
+        Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>,
+    >,
 }
 
 impl TreeState {
@@ -421,7 +422,7 @@ impl TreeState {
 impl Render for TreeState {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let render_item = self.render_item.clone();
-        let entity = cx.entity().clone();
+        let state = cx.entity().clone();
 
         let right_clicked_ix = self.right_clicked_ix;
 
@@ -430,21 +431,23 @@ impl Render for TreeState {
             .size_full()
             .relative()
             .context_menu({
-                let entity = entity.clone();
+                let state = state.clone();
                 move |menu, window, cx: &mut Context<PopupMenu>| {
-                    if entity.read(cx).context_menu_builder.is_none() {
+                    if state.read(cx).context_menu_builder.is_none() {
                         return menu;
                     }
+
                     let (ix, entry) = {
-                        let state = entity.read(cx);
+                        let state = state.read(cx);
                         let ix = state.right_clicked_ix;
                         let entry = ix.and_then(|ix| state.entries.get(ix).cloned());
                         (ix, entry)
                     };
+
                     if let (Some(ix), Some(entry)) = (ix, entry) {
-                        entity.update(cx, |state, cx| {
-                            if let Some(cm) = state.context_menu_builder.clone() {
-                                cm(ix, &entry, menu, window, cx)
+                        state.update(cx, |state, cx| {
+                            if let Some(build) = state.context_menu_builder.clone() {
+                                build(ix, &entry, menu, window, cx)
                             } else {
                                 menu
                             }
@@ -511,8 +514,9 @@ pub struct Tree {
     state: Entity<TreeState>,
     style: StyleRefinement,
     render_item: Rc<dyn Fn(usize, &TreeEntry, bool, &mut Window, &mut App) -> ListItem>,
-    context_menu_builder:
-        Option<Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>>,
+    context_menu_builder: Option<
+        Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>,
+    >,
 }
 
 impl Tree {

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -8,9 +8,10 @@ use gpui::{
 };
 
 use crate::{
-    StyledExt,
+    Selectable as _, StyledExt,
     actions::{Confirm, SelectDown, SelectLeft, SelectRight, SelectUp},
     list::ListItem,
+    menu::{ContextMenuExt as _, PopupMenu},
     scroll::ScrollableElement,
 };
 
@@ -196,7 +197,10 @@ pub struct TreeState {
     entries: Vec<TreeEntry>,
     scroll_handle: UniformListScrollHandle,
     selected_ix: Option<usize>,
+    right_clicked_ix: Option<usize>,
     render_item: Rc<dyn Fn(usize, &TreeEntry, bool, &mut Window, &mut App) -> ListItem>,
+    context_menu_builder:
+        Option<Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>>,
 }
 
 impl TreeState {
@@ -204,10 +208,12 @@ impl TreeState {
     pub fn new(cx: &mut App) -> Self {
         Self {
             selected_ix: None,
+            right_clicked_ix: None,
             focus_handle: cx.focus_handle(),
             scroll_handle: UniformListScrollHandle::default(),
             entries: Vec::new(),
             render_item: Rc::new(|_, _, _, _, _| ListItem::new(0)),
+            context_menu_builder: None,
         }
     }
 
@@ -229,6 +235,7 @@ impl TreeState {
             self.add_entry(item, 0);
         }
         self.selected_ix = None;
+        self.right_clicked_ix = None;
         cx.notify();
     }
 
@@ -414,42 +421,86 @@ impl TreeState {
 impl Render for TreeState {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let render_item = self.render_item.clone();
+        let entity = cx.entity().clone();
 
-        div().id("tree-state").size_full().relative().child(
-            uniform_list("entries", self.entries.len(), {
-                cx.processor(move |state, visible_range: Range<usize>, window, cx| {
-                    let mut items = Vec::with_capacity(visible_range.len());
-                    for ix in visible_range {
-                        let entry = &state.entries[ix];
-                        let selected = Some(ix) == state.selected_ix;
-                        let item = (render_item)(ix, entry, selected, window, cx);
+        let right_clicked_ix = self.right_clicked_ix;
 
-                        let el = div()
-                            .id(ix)
-                            .child(item.disabled(entry.item().is_disabled()).selected(selected))
-                            .when(!entry.item().is_disabled(), |this| {
-                                this.on_mouse_down(
-                                    MouseButton::Left,
-                                    cx.listener({
-                                        move |this, _, window, cx| {
-                                            this.on_entry_click(ix, window, cx);
-                                        }
-                                    }),
-                                )
-                            });
-
-                        items.push(el)
-                    }
-
-                    items
-                })
-            })
-            .flex_grow()
+        div()
+            .id("tree-state")
             .size_full()
-            .track_scroll(&self.scroll_handle)
-            .with_sizing_behavior(ListSizingBehavior::Auto)
-            .into_any_element(),
-        )
+            .relative()
+            .context_menu({
+                let entity = entity.clone();
+                move |menu, window, cx: &mut Context<PopupMenu>| {
+                    if entity.read(cx).context_menu_builder.is_none() {
+                        return menu;
+                    }
+                    let (ix, entry) = {
+                        let state = entity.read(cx);
+                        let ix = state.right_clicked_ix;
+                        let entry = ix.and_then(|ix| state.entries.get(ix).cloned());
+                        (ix, entry)
+                    };
+                    if let (Some(ix), Some(entry)) = (ix, entry) {
+                        entity.update(cx, |state, cx| {
+                            if let Some(cm) = state.context_menu_builder.clone() {
+                                cm(ix, &entry, menu, window, cx)
+                            } else {
+                                menu
+                            }
+                        })
+                    } else {
+                        menu
+                    }
+                }
+            })
+            .child(
+                uniform_list("entries", self.entries.len(), {
+                    cx.processor(move |state, visible_range: Range<usize>, window, cx| {
+                        let mut items = Vec::with_capacity(visible_range.len());
+                        for ix in visible_range {
+                            let entry = &state.entries[ix];
+                            let selected = Some(ix) == state.selected_ix;
+                            let right_clicked = right_clicked_ix == Some(ix);
+                            let item = (render_item)(ix, entry, selected, window, cx);
+
+                            let el = div()
+                                .id(ix)
+                                .child(
+                                    item.disabled(entry.item().is_disabled())
+                                        .selected(selected)
+                                        .secondary_selected(right_clicked),
+                                )
+                                .when(!entry.item().is_disabled(), |this| {
+                                    this.on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener({
+                                            move |this, _, window, cx| {
+                                                this.on_entry_click(ix, window, cx);
+                                            }
+                                        }),
+                                    )
+                                    .on_mouse_down(
+                                        MouseButton::Right,
+                                        cx.listener(move |this, _, _, cx| {
+                                            this.right_clicked_ix = Some(ix);
+                                            cx.notify();
+                                        }),
+                                    )
+                                });
+
+                            items.push(el)
+                        }
+
+                        items
+                    })
+                })
+                .flex_grow()
+                .size_full()
+                .track_scroll(&self.scroll_handle)
+                .with_sizing_behavior(ListSizingBehavior::Auto)
+                .into_any_element(),
+            )
     }
 }
 
@@ -460,6 +511,8 @@ pub struct Tree {
     state: Entity<TreeState>,
     style: StyleRefinement,
     render_item: Rc<dyn Fn(usize, &TreeEntry, bool, &mut Window, &mut App) -> ListItem>,
+    context_menu_builder:
+        Option<Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>>,
 }
 
 impl Tree {
@@ -474,7 +527,23 @@ impl Tree {
             render_item: Rc::new(move |ix, item, selected, window, app| {
                 render_item(ix, item, selected, window, app)
             }),
+            context_menu_builder: None,
         }
+    }
+
+    /// Add a context menu to the tree.
+    ///
+    /// The closure receives:
+    /// - `ix`: the index of the right-clicked entry
+    /// - `entry`: the right-clicked tree entry
+    /// - `menu`: the popup menu builder
+    pub fn context_menu<F>(mut self, f: F) -> Self
+    where
+        F: Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu
+            + 'static,
+    {
+        self.context_menu_builder = Some(Rc::new(f));
+        self
     }
 }
 
@@ -489,8 +558,10 @@ impl RenderOnce for Tree {
         let focus_handle = self.state.read(cx).focus_handle.clone();
         let scroll_handle = self.state.read(cx).scroll_handle.clone();
 
-        self.state
-            .update(cx, |state, _| state.render_item = self.render_item);
+        self.state.update(cx, |state, _| {
+            state.render_item = self.render_item;
+            state.context_menu_builder = self.context_menu_builder;
+        });
 
         div()
             .id(self.id)

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -424,8 +424,6 @@ impl Render for TreeState {
         let render_item = self.render_item.clone();
         let state = cx.entity().clone();
 
-        let right_clicked_ix = self.right_clicked_ix;
-
         div()
             .id("tree-state")
             .size_full()
@@ -439,9 +437,10 @@ impl Render for TreeState {
 
                     let (ix, entry) = {
                         let state = state.read(cx);
-                        let ix = state.right_clicked_ix;
-                        let entry = ix.and_then(|ix| state.entries.get(ix).cloned());
-                        (ix, entry)
+                        let entry = state
+                            .right_clicked_ix
+                            .and_then(|ix| state.entries.get(ix).cloned());
+                        (state.right_clicked_ix, entry)
                     };
 
                     if let (Some(ix), Some(entry)) = (ix, entry) {
@@ -464,7 +463,7 @@ impl Render for TreeState {
                         for ix in visible_range {
                             let entry = &state.entries[ix];
                             let selected = Some(ix) == state.selected_ix;
-                            let right_clicked = right_clicked_ix == Some(ix);
+                            let right_clicked = Some(ix) == state.right_clicked_ix;
                             let item = (render_item)(ix, entry, selected, window, cx);
 
                             let el = div()


### PR DESCRIPTION
Closes #2296

## Summary

- Add `context_menu` builder method to `Tree`, following the same single-menu-on-container pattern as `DataTable`
- Each item's wrapper div registers `on_mouse_down(Right)` to track which item was right-clicked — no per-item overhead
- Right-clicked item is highlighted via `ListItem::secondary_selected` (accent background)
- Story demo wires up Open (files only) / Rename / Delete menu entries

<img width="1164" height="1164" alt="image" src="https://github.com/user-attachments/assets/f5edc54d-8da3-41a1-ae9e-9104d31f481c" />

## Test plan

- [ ] Run `cargo run` and navigate to the Tree story
- [ ] Right-click a file: verify "Open", "Rename", "Delete" menu appears with highlight on clicked item
- [ ] Right-click a folder: verify only "Rename", "Delete" appear (no "Open")
- [ ] Click elsewhere to dismiss menu and verify highlight clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)