### PR TITLE
notification: Allow `remove_notification` to dismiss `id1` entries

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -512,6 +512,28 @@ impl NotificationList {
         cx.notify();
     }
 
+    /// Close all notifications whose id matches the given [`TypeId`], regardless of
+    /// whether they were registered via [`Notification::id`] or [`Notification::id1`].
+    pub(crate) fn close_by_type(
+        &mut self,
+        type_id: TypeId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let matched: Vec<_> = self
+            .notifications
+            .iter()
+            .filter(|n| match &n.read(cx).id {
+                NotificationId::Id(t) | NotificationId::IdAndElementId(t, _) => *t == type_id,
+            })
+            .cloned()
+            .collect();
+        for n in matched {
+            n.update(cx, |note, cx| note.dismiss(window, cx));
+        }
+        cx.notify();
+    }
+
     pub fn clear(&mut self, _: &mut Window, cx: &mut Context<Self>) {
         self.notifications.clear();
         cx.notify();
@@ -564,5 +586,179 @@ impl Render for NotificationList {
                 cx.notify()
             }))
             .children(items)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Theme;
+    use gpui::{TestAppContext, VisualTestContext};
+
+    struct FooKind;
+    struct BarKind;
+
+    struct TestRoot {
+        list: Entity<NotificationList>,
+    }
+
+    impl Render for TestRoot {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.list.clone()
+        }
+    }
+
+    fn ids(list: &Entity<NotificationList>, cx: &mut VisualTestContext) -> Vec<NotificationId> {
+        list.read_with(cx, |l, cx| {
+            l.notifications
+                .iter()
+                .map(|n| n.read(cx).id.clone())
+                .collect()
+        })
+    }
+
+    /// Drive the dismiss animation timer + propagate the resulting `DismissEvent`
+    /// so that closed notifications are removed from the list.
+    fn flush_dismiss(cx: &mut VisualTestContext) {
+        cx.background_executor
+            .advance_clock(Duration::from_millis(200));
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn close_by_type_removes_id_and_all_id1_of_same_type(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_global(Theme::default()));
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("plain").id::<FooKind>().autohide(false),
+                window,
+                cx,
+            );
+            list.push(
+                Notification::info("a").id1::<FooKind>(1).autohide(false),
+                window,
+                cx,
+            );
+            list.push(
+                Notification::info("b").id1::<FooKind>(2).autohide(false),
+                window,
+                cx,
+            );
+            list.push(
+                Notification::info("bar").id::<BarKind>().autohide(false),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+        assert_eq!(ids(&list, cx).len(), 4);
+
+        list.update_in(cx, |list, window, cx| {
+            list.close_by_type(TypeId::of::<FooKind>(), window, cx);
+        });
+        flush_dismiss(cx);
+
+        let remaining = ids(&list, cx);
+        assert_eq!(
+            remaining,
+            vec![NotificationId::Id(TypeId::of::<BarKind>())],
+            "only the BarKind notification should survive"
+        );
+    }
+
+    #[gpui::test]
+    fn close_with_id_and_element_id_removes_only_matching_key(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_global(Theme::default()));
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("a").id1::<FooKind>(1).autohide(false),
+                window,
+                cx,
+            );
+            list.push(
+                Notification::info("b").id1::<FooKind>(2).autohide(false),
+                window,
+                cx,
+            );
+            list.push(
+                Notification::info("plain").id::<FooKind>().autohide(false),
+                window,
+                cx,
+            );
+        });
+
+        list.update_in(cx, |list, window, cx| {
+            list.close((TypeId::of::<FooKind>(), ElementId::from(1usize)), window, cx);
+        });
+        flush_dismiss(cx);
+
+        let remaining = ids(&list, cx);
+        assert_eq!(remaining.len(), 2);
+        assert!(remaining.contains(&NotificationId::IdAndElementId(
+            TypeId::of::<FooKind>(),
+            ElementId::from(2usize),
+        )));
+        assert!(remaining.contains(&NotificationId::Id(TypeId::of::<FooKind>())));
+    }
+
+    #[gpui::test]
+    fn close_with_only_type_id_does_not_match_id1_entries(cx: &mut TestAppContext) {
+        // The plain `close(TypeId)` form (used by the legacy code path) must keep
+        // its narrow semantics: it only matches `NotificationId::Id`, not
+        // `NotificationId::IdAndElementId`. The new `close_by_type` is the broad form.
+        cx.update(|cx| cx.set_global(Theme::default()));
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("a").id1::<FooKind>(1).autohide(false),
+                window,
+                cx,
+            );
+        });
+
+        list.update_in(cx, |list, window, cx| {
+            list.close(TypeId::of::<FooKind>(), window, cx);
+        });
+        flush_dismiss(cx);
+
+        assert_eq!(ids(&list, cx).len(), 1, "id1 entry should remain untouched");
+    }
+
+    #[gpui::test]
+    fn close_by_type_with_no_match_is_noop(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_global(Theme::default()));
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("bar").id::<BarKind>().autohide(false),
+                window,
+                cx,
+            );
+        });
+
+        list.update_in(cx, |list, window, cx| {
+            list.close_by_type(TypeId::of::<FooKind>(), window, cx);
+        });
+        flush_dismiss(cx);
+
+        assert_eq!(ids(&list, cx).len(), 1);
     }
 }

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -9,7 +9,7 @@ use crate::{
     window_border,
 };
 use gpui::{
-    Anchor, AnyView, App, AppContext, Context, DefiniteLength, Entity, FocusHandle,
+    Anchor, AnyView, App, AppContext, Context, DefiniteLength, ElementId, Entity, FocusHandle,
     InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Pixels, Render,
     StyleRefinement, Styled, WeakFocusHandle, Window, actions, div, prelude::FluentBuilder as _,
 };
@@ -367,14 +367,29 @@ impl Root {
         cx.notify();
     }
 
+    /// Removes all notifications whose id matches `T`, including ones registered with
+    /// either [`Notification::id`] or [`Notification::id1`] (any key).
     pub fn remove_notification<T: Sized + 'static>(
         &mut self,
         window: &mut Window,
         cx: &mut Context<'_, Root>,
     ) {
         self.notification.update(cx, |view, cx| {
-            let id = TypeId::of::<T>();
-            view.close(id, window, cx);
+            view.close_by_type(TypeId::of::<T>(), window, cx);
+        });
+        cx.notify();
+    }
+
+    /// Removes the notification matching the given type and element id (paired with [`Notification::id1`]).
+    pub fn remove_notification1<T: Sized + 'static>(
+        &mut self,
+        key: impl Into<ElementId>,
+        window: &mut Window,
+        cx: &mut Context<'_, Root>,
+    ) {
+        let key = key.into();
+        self.notification.update(cx, |view, cx| {
+            view.close((TypeId::of::<T>(), key), window, cx);
         });
         cx.notify();
     }

--- a/crates/ui/src/window_ext.rs
+++ b/crates/ui/src/window_ext.rs
@@ -5,7 +5,7 @@ use crate::{
     notification::Notification,
     sheet::Sheet,
 };
-use gpui::{App, Entity, Window};
+use gpui::{App, ElementId, Entity, Window};
 use std::rc::Rc;
 
 /// Extension trait for [`Window`] to add dialog, sheet .. functionality.
@@ -64,8 +64,12 @@ pub trait WindowExt: Sized {
     /// Pushes a notification to the notification list.
     fn push_notification(&mut self, note: impl Into<Notification>, cx: &mut App);
 
-    /// Removes the notification with the given id.
+    /// Removes all notifications whose id matches `T`, including ones registered with
+    /// either `Notification::id` or `Notification::id1` (any key).
     fn remove_notification<T: Sized + 'static>(&mut self, cx: &mut App);
+
+    /// Removes a single notification matching the given type `T` and `key` (paired with `Notification::id1`).
+    fn remove_notification1<T: Sized + 'static>(&mut self, key: impl Into<ElementId>, cx: &mut App);
 
     /// Clears all notifications.
     fn clear_notifications(&mut self, cx: &mut App);
@@ -161,6 +165,18 @@ impl WindowExt for Window {
     fn remove_notification<T: Sized + 'static>(&mut self, cx: &mut App) {
         Root::update(self, cx, |root, window, cx| {
             root.remove_notification::<T>(window, cx);
+        })
+    }
+
+    #[inline]
+    fn remove_notification1<T: Sized + 'static>(
+        &mut self,
+        key: impl Into<ElementId>,
+        cx: &mut App,
+    ) {
+        let key = key.into();
+        Root::update(self, cx, |root, window, cx| {
+            root.remove_notification1::<T>(key, window, cx);
         })
     }
 


### PR DESCRIPTION
- `remove_notification::<T>` now removes both `id::<T>()` and any `id1::<T>(key)` notifications of the same type. 
- Adds a companion `remove_notification1::<T>(key)` for precise per-key removal.
