### PR TITLE
bar_chart: Add support for arbitrary fills, e.g. gradients

### DIFF
--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -234,7 +234,7 @@ impl Render for ChartStory {
                         BarChart::new(self.monthly_devices.clone())
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
-                            .fill(move |d| d.color(color)),
+                            .fill(move |d, _, _, _| d.color(color)),
                         false,
                         cx,
                     ))
@@ -258,7 +258,7 @@ impl Render for ChartStory {
                         cx,
                     ))
                     .child(chart_container(
-                        "Bar Chart - Label",
+                        "Bar Chart - Bottom aligned",
                         BarChart::new(self.monthly_devices.clone())
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
@@ -295,7 +295,150 @@ impl Render for ChartStory {
                             .alignment(BarAlignment::Right),
                         false,
                         cx,
-                    )),
+                    ))
+                    .child({
+                        let c = cx.theme().chart_1;
+                        chart_container(
+                            "Bar Chart - Gradient (Bottom)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .fill_gradient(move |_, chart_range, chart_to_bar| {
+                                    [
+                                        linear_color_stop(
+                                            c.opacity(0.3),
+                                            chart_to_bar(*chart_range.start()),
+                                        ),
+                                        linear_color_stop(c, chart_to_bar(*chart_range.end())),
+                                    ]
+                                }),
+                            false,
+                            cx,
+                        )
+                    })
+                    .child({
+                        let c = cx.theme().chart_1;
+                        chart_container(
+                            "Bar Chart - Gradient (Top)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .alignment(BarAlignment::Top)
+                                .fill_gradient(move |_, chart_range, chart_to_bar| {
+                                    [
+                                        linear_color_stop(
+                                            c.opacity(0.3),
+                                            chart_to_bar(*chart_range.start()),
+                                        ),
+                                        linear_color_stop(c, chart_to_bar(*chart_range.end())),
+                                    ]
+                                }),
+                            false,
+                            cx,
+                        )
+                    })
+                    .child({
+                        let c = cx.theme().chart_1;
+                        chart_container(
+                            "Bar Chart - Gradient (Left)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .alignment(BarAlignment::Left)
+                                .fill_gradient(move |_, chart_range, chart_to_bar| {
+                                    [
+                                        linear_color_stop(
+                                            c.opacity(0.3),
+                                            chart_to_bar(*chart_range.start()),
+                                        ),
+                                        linear_color_stop(c, chart_to_bar(*chart_range.end())),
+                                    ]
+                                }),
+                            false,
+                            cx,
+                        )
+                    })
+                    .child({
+                        let c = cx.theme().chart_1;
+                        chart_container(
+                            "Bar Chart - Gradient (Right)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .alignment(BarAlignment::Right)
+                                .fill_gradient(move |_, chart_range, chart_to_bar| {
+                                    [
+                                        linear_color_stop(
+                                            c.opacity(0.3),
+                                            chart_to_bar(*chart_range.start()),
+                                        ),
+                                        linear_color_stop(c, chart_to_bar(*chart_range.end())),
+                                    ]
+                                }),
+                            false,
+                            cx,
+                        )
+                    })
+                    .child({
+                        let c = cx.theme().chart_1;
+                        chart_container(
+                            "Bar Chart - Gradient (Per-bar)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .fill_gradient(move |_, _, _| {
+                                    [
+                                        linear_color_stop(c.opacity(0.3), 0.),
+                                        linear_color_stop(c, 1.),
+                                    ]
+                                }),
+                            false,
+                            cx,
+                        )
+                    })
+                    .child({
+                        let c1 = cx.theme().chart_1;
+                        let c2 = cx.theme().chart_5;
+                        chart_container(
+                            "Bar Chart - Gradient (Diagonal, across bars)",
+                            BarChart::new(self.monthly_devices.clone())
+                                .band(|d| d.month.clone())
+                                .value(|d| d.desktop)
+                                .label(|d| d.desktop.to_string())
+                                .fill(move |_, bar, chart, _| {
+                                    // Project the bar's corners onto the chart's
+                                    // bottom-left → top-right diagonal so each bar
+                                    // shows the slice of a chart-wide diagonal
+                                    // gradient corresponding to its own footprint.
+                                    let w = chart.size.width.max(f32::EPSILON);
+                                    let h = chart.size.height.max(f32::EPSILON);
+                                    let denom = w * w + h * h;
+                                    let project = |x: f32, y: f32| -> f32 {
+                                        (x * w + (h - y) * h) / denom
+                                    };
+                                    let lo = project(bar.origin.x, bar.origin.y + bar.size.height);
+                                    let hi = project(bar.origin.x + bar.size.width, bar.origin.y);
+                                    let lerp = |t: f32| Hsla {
+                                        h: c1.h + (c2.h - c1.h) * t,
+                                        s: c1.s + (c2.s - c1.s) * t,
+                                        l: c1.l + (c2.l - c1.l) * t,
+                                        a: c1.a + (c2.a - c1.a) * t,
+                                    };
+                                    linear_gradient(
+                                        45.,
+                                        linear_color_stop(lerp(lo), 0.),
+                                        linear_color_stop(lerp(hi), 1.),
+                                    )
+                                }),
+                            false,
+                            cx,
+                        )
+                    }),
             )
             .child(Divider::horizontal())
             .child(

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -108,7 +108,7 @@ impl Plot for StackedBarChart {
                 .cross(move |d| x.tick(&d.data.date.clone()))
                 .base(move |d| y0.tick(&(d.y0 as f64)).unwrap_or(height))
                 .value(move |d| y1.tick(&(d.y1 as f64)))
-                .fill(move |_| fill)
+                .fill(move |_, _, _| fill)
                 .paint(&bounds, window, cx);
         }
     }

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -1,6 +1,9 @@
-use std::rc::Rc;
+use std::{ops::RangeInclusive, rc::Rc};
 
-use gpui::{App, Bounds, Corners, Hsla, Pixels, SharedString, TextAlign, Window, px};
+use gpui::{
+    App, Background, Bounds, Corners, Hsla, LinearColorStop, Pixels, Point, SharedString, Size, TextAlign,
+    Window, linear_gradient, px,
+};
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive};
 
@@ -26,7 +29,11 @@ where
     data: Vec<T>,
     band: Option<Rc<dyn Fn(&T) -> B>>,
     value: Option<Rc<dyn Fn(&T) -> V>>,
-    fill: Option<Rc<dyn Fn(&T) -> Hsla>>,
+    fill: Option<Rc<dyn Fn(&T, Bounds<f32>, Bounds<f32>, BarAlignment) -> Background>>,
+    #[allow(clippy::type_complexity)]
+    fill_gradient: Option<
+        Rc<dyn Fn(&T, RangeInclusive<f32>, &dyn Fn(f32) -> f32) -> [LinearColorStop; 2]>,
+    >,
     tick_margin: usize,
     label: Option<Rc<dyn Fn(&T) -> SharedString>>,
     label_axis: bool,
@@ -49,6 +56,7 @@ where
             band: None,
             value: None,
             fill: None,
+            fill_gradient: None,
             tick_margin: 1,
             label: None,
             label_axis: true,
@@ -70,11 +78,81 @@ where
         self
     }
 
-    pub fn fill<H>(mut self, fill: impl Fn(&T) -> H + 'static) -> Self
+    /// Set a per-datum verbatim fill.
+    ///
+    /// The closure receives:
+    ///
+    /// 1. the datum,
+    /// 2. the **bar's bounds** in pixel space, expressed relative to the
+    ///    chart's origin (i.e. the bar's painted rectangle within the chart),
+    /// 3. the **chart's bounds** in pixel space with origin `(0, 0)` and size
+    ///    equal to the full chart extent, and
+    /// 4. the bar's [`BarAlignment`] (so callers can branch on orientation,
+    ///    e.g. flip a gradient angle).
+    ///
+    /// Both rectangles share the same coordinate system, so callers can
+    /// implement arbitrary chart-aware backgrounds — bar-local gradients,
+    /// chart-wide gradients, patterns, sampled colormaps, etc. — without any
+    /// help from the library.
+    ///
+    /// Accepts any type convertible to [`Background`]. Setting this clears any
+    /// previously set [`BarChart::fill_gradient`].
+    pub fn fill<Bg>(
+        mut self,
+        fill: impl Fn(&T, Bounds<f32>, Bounds<f32>, BarAlignment) -> Bg + 'static,
+    ) -> Self
     where
-        H: Into<Hsla> + 'static,
+        Bg: Into<Background> + 'static,
     {
-        self.fill = Some(Rc::new(move |t| fill(t).into()));
+        self.fill = Some(Rc::new(move |t, bar_bounds, chart_bounds, alignment| {
+            fill(t, bar_bounds, chart_bounds, alignment).into()
+        }));
+        self.fill_gradient = None;
+        self
+    }
+
+    /// Set a per-datum auto-oriented linear gradient fill.
+    ///
+    /// The closure receives the datum, the chart's full data range
+    /// (`chart_range`, derived from all data values), and a `chart_to_bar`
+    /// remap helper that maps a chart-value coordinate to a bar-local
+    /// gradient position (where `0.0` is the bar's base and `1.0` is its tip).
+    ///
+    /// Use bar-local positions directly for per-bar gradients (every bar
+    /// looks the same regardless of its value):
+    ///
+    /// ```ignore
+    /// .fill_gradient(|_, _, _| [
+    ///     linear_color_stop(c.opacity(0.3), 0.0),
+    ///     linear_color_stop(c, 1.0),
+    /// ])
+    /// ```
+    ///
+    /// Or use `chart_to_bar` to position stops at chart-relative values, so
+    /// each bar shows the slice of a chart-wide gradient corresponding to
+    /// its own `[base, value]` span:
+    ///
+    /// ```ignore
+    /// .fill_gradient(|_, chart_range, chart_to_bar| [
+    ///     linear_color_stop(c.opacity(0.3), chart_to_bar(*chart_range.start())),
+    ///     linear_color_stop(c,              chart_to_bar(*chart_range.end())),
+    /// ])
+    /// ```
+    ///
+    /// Stop positions returned outside `[0, 1]` are clipped to the bar; the
+    /// library interpolates colors at the clip points so the on-bar gradient
+    /// still matches the chart-wide one.
+    ///
+    /// The gradient angle is derived from [`BarAlignment`] so stop-0 is at the
+    /// base and stop-1 at the tip. Setting this clears any previously set
+    /// [`BarChart::fill`].
+    pub fn fill_gradient(
+        mut self,
+        fill: impl Fn(&T, RangeInclusive<f32>, &dyn Fn(f32) -> f32) -> [LinearColorStop; 2]
+            + 'static,
+    ) -> Self {
+        self.fill_gradient = Some(Rc::new(fill));
+        self.fill = None;
         self
     }
 
@@ -247,15 +325,17 @@ where
         }
         axis.paint(&bounds, window, cx);
 
+        // Far edge of the value axis in pixel space (opposite the baseline).
+        let far = match alignment {
+            BarAlignment::Bottom => 10.,
+            BarAlignment::Top => value_dim - 10.,
+            BarAlignment::Left => value_dim - value_end_gap,
+            BarAlignment::Right => value_end_gap,
+        };
+
         // Draw grid: lines perpendicular to the value axis, evenly spaced
         // across the value range and excluding the line at the baseline.
         if self.grid {
-            let far = match alignment {
-                BarAlignment::Bottom => 10.,
-                BarAlignment::Top => value_dim - 10.,
-                BarAlignment::Left => value_dim - value_end_gap,
-                BarAlignment::Right => value_end_gap,
-            };
             let grid_steps: Vec<f32> = (0..4)
                 .map(|i| far + (baseline - far) * i as f32 / 4.0)
                 .collect();
@@ -273,9 +353,32 @@ where
         // Draw bars.
         let band_fn_cloned = band_fn.clone();
         let value_fn_cloned = value_fn.clone();
-        let default_fill = cx.theme().chart_2;
+        let default_fill: Background = cx.theme().chart_2.into();
         let fill = self.fill.clone();
+        let fill_gradient = self.fill_gradient.clone();
         let label_color = cx.theme().foreground;
+
+        // Chart bounds in pixel space, with origin (0, 0) and size equal to
+        // the full chart extent. Passed to user `fill` closures so they can
+        // position chart-wide backgrounds (gradients, patterns, etc.).
+        let chart_bounds: Bounds<f32> = Bounds {
+            origin: Point::new(0., 0.),
+            size: Size::new(total_width, total_height),
+        };
+
+        // Chart data range in f32 — passed to `fill_gradient` callers and used
+        // by the `chart_to_bar` remap helper.
+        let chart_range = {
+            let mut lo = 0.0_f32;
+            let mut hi = 0.0_f32;
+            for v in &self.data {
+                if let Some(f) = value_fn(v).to_f32() {
+                    lo = lo.min(f);
+                    hi = hi.max(f);
+                }
+            }
+            lo..=hi
+        };
 
         let mut bar = Bar::new()
             .data(&self.data)
@@ -284,8 +387,29 @@ where
             .cross(move |d| band_scale.tick(&band_fn_cloned(d)))
             .base(move |_| baseline)
             .value(move |d| value_scale.tick(&value_fn_cloned(d)))
-            .corner_radii(self.corner_radii)
-            .fill(move |d| fill.as_ref().map(|f| f(d)).unwrap_or(default_fill));
+            .corner_radii(self.corner_radii);
+
+        bar = match (fill, fill_gradient) {
+            (_, Some(fg)) => {
+                let value_fn_for_grad = value_fn.clone();
+                bar.fill(move |d, _frame, alignment| {
+                    let v = value_fn_for_grad(d).to_f32().unwrap_or(0.);
+                    let base_v = 0.0_f32;
+                    let bar_lo = base_v.min(v);
+                    let bar_hi = base_v.max(v);
+                    let bar_span = (bar_hi - bar_lo).max(f32::EPSILON);
+                    let chart_to_bar = |chart_value: f32| (chart_value - bar_lo) / bar_span;
+                    let stops = fg(d, chart_range.clone(), &chart_to_bar);
+                    let [s0, s1] = clip_stops_to_bar(stops);
+                    let bg: Background = linear_gradient(alignment.gradient_angle(), s0, s1);
+                    bg
+                })
+            }
+            (Some(f), _) => {
+                bar.fill(move |d, frame, alignment| f(d, frame, chart_bounds, alignment))
+            }
+            _ => bar.fill(move |_, _, _| default_fill),
+        };
 
         if let Some(label) = self.label.as_ref() {
             let label = label.clone();
@@ -300,4 +424,53 @@ where
 
         bar.paint(&bounds, window, cx);
     }
+}
+
+/// Clip a two-stop gradient to bar-local `[0, 1]`, interpolating colors at the
+/// clip points so the on-bar gradient matches the (possibly broader) gradient
+/// the caller defined.
+///
+/// When a stop position falls outside `[0, 1]` (e.g. because `chart_to_bar`
+/// returned a value past the bar's edge for a chart-relative gradient),
+/// gpui's renderer would clamp the position and lose the gradient effect.
+/// This function instead replaces such a stop with the color sampled along
+/// the line through both stops at position `0.0` or `1.0`, preserving the
+/// visual slice.
+fn clip_stops_to_bar(stops: [LinearColorStop; 2]) -> [LinearColorStop; 2] {
+    let [a, b] = stops;
+    let p0 = a.percentage;
+    let p1 = b.percentage;
+    let lerp = |t: f32| -> Hsla {
+        Hsla {
+            h: a.color.h + (b.color.h - a.color.h) * t,
+            s: a.color.s + (b.color.s - a.color.s) * t,
+            l: a.color.l + (b.color.l - a.color.l) * t,
+            a: a.color.a + (b.color.a - a.color.a) * t,
+        }
+    };
+    let span = p1 - p0;
+    let sample = |target: f32| -> Hsla {
+        if span.abs() < f32::EPSILON {
+            a.color
+        } else {
+            lerp((target - p0) / span)
+        }
+    };
+    let new_a = if (0. ..=1.).contains(&p0) {
+        a
+    } else {
+        LinearColorStop {
+            color: sample(p0.clamp(0., 1.)),
+            percentage: p0.clamp(0., 1.),
+        }
+    };
+    let new_b = if (0. ..=1.).contains(&p1) {
+        b
+    } else {
+        LinearColorStop {
+            color: sample(p1.clamp(0., 1.)),
+            percentage: p1.clamp(0., 1.),
+        }
+    };
+    [new_a, new_b]
 }

--- a/crates/ui/src/plot/shape/bar.rs
+++ b/crates/ui/src/plot/shape/bar.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    App, Bounds, Corners, Hsla, PaintQuad, Pixels, Point, Window, fill, point, px,
+    App, Background, Bounds, Corners, PaintQuad, Pixels, Point, Size, Window, fill, point, px,
 };
 
 use crate::plot::{
@@ -30,6 +30,20 @@ impl BarAlignment {
     pub fn is_vertical(self) -> bool {
         !self.is_horizontal()
     }
+
+    /// Linear-gradient angle (in degrees) that runs from the bar's base to its
+    /// tip for this alignment.
+    ///
+    /// gpui convention: `0°` points upward (stop-0 at bottom, stop-1 at top);
+    /// angles increase clockwise.
+    pub fn gradient_angle(self) -> f32 {
+        match self {
+            Self::Bottom => 0.,
+            Self::Top => 180.,
+            Self::Left => 90.,
+            Self::Right => 270.,
+        }
+    }
 }
 
 #[allow(clippy::type_complexity)]
@@ -40,7 +54,7 @@ pub struct Bar<T> {
     band_width: f32,
     base: Box<dyn Fn(&T) -> f32>,
     value: Box<dyn Fn(&T) -> Option<f32>>,
-    fill: Box<dyn Fn(&T) -> Hsla>,
+    fill: Box<dyn Fn(&T, Bounds<f32>, BarAlignment) -> Background>,
     label: Option<Box<dyn Fn(&T, Point<Pixels>) -> Vec<Text>>>,
     corner_radii: Corners<Pixels>,
 }
@@ -54,7 +68,7 @@ impl<T> Default for Bar<T> {
             band_width: 0.,
             base: Box::new(|_| 0.),
             value: Box::new(|_| None),
-            fill: Box::new(|_| gpui::black()),
+            fill: Box::new(|_, _, _| gpui::black().into()),
             label: None,
             corner_radii: Corners::all(px(0.)),
         }
@@ -119,13 +133,23 @@ impl<T> Bar<T> {
         self
     }
 
-    /// Set the fill color of the Bar.
-    pub fn fill<F, C>(mut self, fill: F) -> Self
+    /// Set the fill of each bar.
+    ///
+    /// The closure receives the datum, the bar's painted frame (`Bounds<f32>`)
+    /// in raw pixel coordinates relative to the plot bounds origin, and the
+    /// bar's [`BarAlignment`] (so callers can branch on orientation, e.g. flip
+    /// a gradient angle). Callers wishing to derive normalized or chart-relative
+    /// coordinates from this frame should do so themselves.
+    ///
+    /// Accepts any type convertible to [`Background`], including solid colors and
+    /// fully-specified [`gpui::linear_gradient`] values. The background is used
+    /// verbatim — the gradient angle is not adjusted for bar orientation.
+    pub fn fill<F, B>(mut self, fill: F) -> Self
     where
-        F: Fn(&T) -> C + 'static,
-        C: Into<Hsla>,
+        F: Fn(&T, Bounds<f32>, BarAlignment) -> B + 'static,
+        B: Into<Background>,
     {
-        self.fill = Box::new(move |v| fill(v).into());
+        self.fill = Box::new(move |v, frame, alignment| fill(v, frame, alignment).into());
         self
     }
 
@@ -162,12 +186,17 @@ impl<T> Bar<T> {
             let base = (self.base)(v);
 
             let bw = self.band_width;
-            let (p1, p2) = if self.alignment.is_vertical() {
+            let (frame, p1, p2) = if self.alignment.is_vertical() {
                 let x0 = cross;
                 let x1 = cross + bw;
                 let y_min = value.min(base);
                 let y_max = value.max(base);
+                let frame = Bounds {
+                    origin: Point::new(x0, y_min),
+                    size: Size::new(x1 - x0, y_max - y_min),
+                };
                 (
+                    frame,
                     origin_point(px(x0), px(y_min), origin),
                     origin_point(px(x1), px(y_max), origin),
                 )
@@ -176,14 +205,19 @@ impl<T> Bar<T> {
                 let y1 = cross + bw;
                 let x_min = value.min(base);
                 let x_max = value.max(base);
+                let frame = Bounds {
+                    origin: Point::new(x_min, y0),
+                    size: Size::new(x_max - x_min, y1 - y0),
+                };
                 (
+                    frame,
                     origin_point(px(x_min), px(y0), origin),
                     origin_point(px(x_max), px(y1), origin),
                 )
             };
 
-            let color = (self.fill)(v);
-            graph.push(fill(Bounds::from_corners(p1, p2), color).corner_radii(self.corner_radii));
+            let bg = (self.fill)(v, frame, self.alignment);
+            graph.push(fill(Bounds::from_corners(p1, p2), bg).corner_radii(self.corner_radii));
 
             if let Some(label) = &self.label {
                 let label_origin = label_origin(self.alignment, cross, base, value, bw);

--- a/docs/docs/components/chart.md
+++ b/docs/docs/components/chart.md
@@ -104,10 +104,15 @@ BarChart::new(data)
 
 ```rust
 // Custom fill colors
+//
+// The `fill` closure receives the datum, the bar's bounds (in pixel space,
+// relative to the chart), the chart's bounds, and the bar's `BarAlignment`.
+// Any value convertible to `Background` may be returned (solid color, gradient,
+// pattern, etc.).
 BarChart::new(data)
     .band(|d| d.category.clone())
     .value(|d| d.value)
-    .fill(|d| d.color)
+    .fill(|d, _bar_bounds, _chart_bounds, _alignment| d.color)
 
 // With value labels on bars
 BarChart::new(data)
@@ -127,6 +132,43 @@ BarChart::new(data)
     .value(|d| d.value)
     .label_axis(false)
 ```
+
+#### Bar Chart Gradient Fills
+
+For gradient fills aligned to the bar's orientation, use `fill_gradient`. The closure receives the datum, the chart's full data range, and a `chart_to_bar` helper that maps a chart-value coordinate to a bar-local gradient position (`0.0` is the bar's base, `1.0` is its tip). The gradient angle is derived from the bar's `BarAlignment` so stop-0 sits at the base and stop-1 at the tip.
+
+```rust
+use gpui::linear_color_stop;
+
+// Per-bar gradient: every bar fades from a translucent base to its full color
+// at the tip, regardless of its value.
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .fill_gradient(|d, _chart_range, _chart_to_bar| {
+        let c = d.color;
+        [
+            linear_color_stop(c.opacity(0.3), 0.0),
+            linear_color_stop(c, 1.0),
+        ]
+    })
+
+// Chart-wide gradient: each bar shows the slice of a single gradient
+// spanning the chart's full data range. Stops outside `[0, 1]` are clipped
+// to the bar with colors interpolated at the clip points.
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .fill_gradient(|d, chart_range, chart_to_bar| {
+        let c = d.color;
+        [
+            linear_color_stop(c.opacity(0.3), chart_to_bar(*chart_range.start())),
+            linear_color_stop(c,              chart_to_bar(*chart_range.end())),
+        ]
+    })
+```
+
+`fill` and `fill_gradient` are mutually exclusive — setting one clears the other.
 
 #### Bar Chart Alignment
 
@@ -499,7 +541,7 @@ fn sales_dashboard(data: Vec<SalesData>, cx: &mut Context<Self>) -> impl IntoEle
                 BarChart::new(data)
                     .band(|d| d.region.clone())
                     .value(|d| d.revenue)
-                    .fill(|d| match d.region.as_str() {
+                    .fill(|d, _, _, _| match d.region.as_str() {
                         "North" => cx.theme().chart_1,
                         "South" => cx.theme().chart_2,
                         "East" => cx.theme().chart_3,
@@ -613,7 +655,7 @@ fn stock_chart(ohlc_data: Vec<StockOHLC>, price_data: Vec<StockData>, cx: &mut C
                 BarChart::new(price_data)
                     .band(|d| d.date.clone())
                     .value(|d| d.volume as f64)
-                    .fill(|d| {
+                    .fill(|d, _, _, _| {
                         if d.volume > 1000000 {
                             cx.theme().chart_1
                         } else {
@@ -651,7 +693,7 @@ let colors = [
 BarChart::new(data)
     .band(|d| d.category.clone())
     .value(|d| d.value)
-    .fill(|d| colors[d.category_index % colors.len()])
+    .fill(|d, _, _, _| colors[d.category_index % colors.len()])
 ```
 
 ### Responsive Design

--- a/docs/zh-CN/docs/components/chart.md
+++ b/docs/zh-CN/docs/components/chart.md
@@ -97,10 +97,14 @@ BarChart::new(data)
 
 ```rust
 // 自定义填充颜色
+//
+// `fill` 闭包接收四个参数：数据项、柱子的像素边界（相对于图表原点）、
+// 图表的像素边界，以及柱子的 `BarAlignment`。返回值可以是任何能转换为
+// `Background` 的类型（纯色、渐变、图案等）。
 BarChart::new(data)
     .band(|d| d.category.clone())
     .value(|d| d.value)
-    .fill(|d| d.color)
+    .fill(|d, _bar_bounds, _chart_bounds, _alignment| d.color)
 
 // 显示数值标签
 BarChart::new(data)
@@ -120,6 +124,43 @@ BarChart::new(data)
     .value(|d| d.value)
     .label_axis(false)
 ```
+
+#### 柱状图渐变填充
+
+如需让渐变方向跟随柱子方向，请使用 `fill_gradient`。闭包接收三个参数：数据项、图表的完整数据范围（`chart_range`），以及一个 `chart_to_bar` 辅助函数（将图表数值坐标映射为柱子局部的渐变位置，其中 `0.0` 表示柱子的基线端，`1.0` 表示尖端）。渐变方向由柱子的 `BarAlignment` 推导，使 stop-0 始终位于基线端、stop-1 位于尖端。
+
+```rust
+use gpui::linear_color_stop;
+
+// 单柱渐变：每个柱子都从半透明基线渐变到完全不透明的尖端，
+// 与该柱子的具体数值无关。
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .fill_gradient(|d, _chart_range, _chart_to_bar| {
+        let c = d.color;
+        [
+            linear_color_stop(c.opacity(0.3), 0.0),
+            linear_color_stop(c, 1.0),
+        ]
+    })
+
+// 跨图表渐变：每根柱子展示同一条覆盖整个图表数值范围的渐变中
+// 对应自身值域的那一段。超出 `[0, 1]` 的 stop 会被裁剪到柱子内，
+// 颜色会在裁剪点处插值，使整体效果保持连续。
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .fill_gradient(|d, chart_range, chart_to_bar| {
+        let c = d.color;
+        [
+            linear_color_stop(c.opacity(0.3), chart_to_bar(*chart_range.start())),
+            linear_color_stop(c,              chart_to_bar(*chart_range.end())),
+        ]
+    })
+```
+
+`fill` 与 `fill_gradient` 互斥——设置其中一个会清空另一个。
 
 #### 柱状图对齐方式
 
@@ -470,7 +511,7 @@ fn sales_dashboard(data: Vec<SalesData>, cx: &mut Context<Self>) -> impl IntoEle
                 BarChart::new(data)
                     .band(|d| d.region.clone())
                     .value(|d| d.revenue)
-                    .fill(|d| match d.region.as_str() {
+                    .fill(|d, _, _, _| match d.region.as_str() {
                         "North" => cx.theme().chart_1,
                         "South" => cx.theme().chart_2,
                         "East" => cx.theme().chart_3,
@@ -584,7 +625,7 @@ fn stock_chart(ohlc_data: Vec<StockOHLC>, price_data: Vec<StockData>, cx: &mut C
                 BarChart::new(price_data)
                     .band(|d| d.date.clone())
                     .value(|d| d.volume as f64)
-                    .fill(|d| {
+                    .fill(|d, _, _, _| {
                         if d.volume > 1000000 {
                             cx.theme().chart_1
                         } else {
@@ -620,7 +661,7 @@ let colors = [
 BarChart::new(data)
     .band(|d| d.category.clone())
     .value(|d| d.value)
-    .fill(|d| colors[d.category_index % colors.len()])
+    .fill(|d, _, _, _| colors[d.category_index % colors.len()])
 ```
 
 ### 响应式容器


### PR DESCRIPTION
## Description

Adds support for arbitrary fills (solid colors, gradients, patterns) in `BarChart` and the underlying `Bar` plot shape.

`BarChart::fill` now accepts any type convertible to `gpui::Background`, and its closure receives the bar's painted frame (in pixel space, relative to the chart's origin), the chart's full bounds, and the bar's `BarAlignment`. This lets callers compose chart-aware backgrounds: bar-local gradients, chart-wide gradients, patterns, sampled colormaps, without library help.

A new `BarChart::fill_gradient` convenience builder is added for the common case of per-datum auto-oriented linear gradients. The closure receives the datum, the chart's data range, and a `chart_to_bar` remap helper that maps chart-value coordinates to bar-local positions (`0.0` = base, `1.0` = tip). The gradient angle is derived from `BarAlignment` so stop-0 is always at the base and stop-1 at the tip; stop positions outside `[0, 1]` are clipped to the bar with colors interpolated at the clip points so the on-bar gradient still matches a (possibly broader) chart-wide one.

`fill` and `fill_gradient` are mutually exclusive: setting one clears the other.

The lower-level `plot::shape::Bar::fill` follows the same pattern, accepting any `Into<Background>` and exposing the bar's frame and alignment to the closure. A new `BarAlignment::gradient_angle()` helper returns the linear-gradient angle (in gpui's convention) from base to tip for a given alignment.

The Story Gallery's chart story has been extended with examples demonstrating per-bar gradients, chart-wide diagonal gradients, and orientation-aware gradient fills.

Documentation in `docs/docs/components/chart.md` and `docs/zh-CN/docs/components/chart.md` (⚠️  I don't speak mandarin, needs proof-reading ❗) has been updated to cover the new APIs.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="931" height="829" alt="image" src="https://github.com/user-attachments/assets/5c9e2ed0-d7bc-4dc5-b87c-f79742ef4710" /> | <img width="934" height="832" alt="image" src="https://github.com/user-attachments/assets/ecd2ffca-6e9c-4e19-9b63-7751195a0860" /> |
| n/a |  <img width="937" height="417" alt="image" src="https://github.com/user-attachments/assets/a41741ef-d53c-4fa5-8f2b-303825e854c9" /> |

## Break Changes

The signatures of `BarChart::fill` and `plot::shape::Bar::fill` have changed. Existing callers must update their closures to accept the new positional parameters and may now return any `Into<Background>` instead of just `Hsla`.

- `BarChart::fill` closure signature changed from `Fn(&T) -> Hsla` to `Fn(&T, Bounds<f32>, Bounds<f32>, BarAlignment) -> impl Into<Background>`.

```diff
  BarChart::new(data)
      .band(|d| d.category.clone())
      .value(|d| d.value)
-     .fill(|d| d.color)
+     .fill(|d, _bar_bounds, _chart_bounds, _alignment| d.color)
```

- `plot::shape::Bar::fill` closure signature changed from `Fn(&T) -> Hsla` to `Fn(&T, Bounds<f32>, BarAlignment) -> impl Into<Background>`.

```diff
  Bar::new()
      .data(&data)
-     .fill(|d| d.color)
+     .fill(|d, _frame, _alignment| d.color)
```

## How to Test

1. Run `cargo run` and open the **Chart** story in the Story Gallery.
2. Verify the bar chart examples render correctly, including:
   - Plain solid-fill bar chart (regression check).
   - Per-bar auto-oriented gradient (`fill_gradient` with bar-local stops).
   - Chart-wide gradient (`fill_gradient` with `chart_to_bar`-remapped stops) — the gradient should appear continuous across bars and clip correctly at each bar's edges.
   - Diagonal chart-wide gradient using the verbatim `fill` API (bottom-left → top-right).
   - Stacked bar chart (regression check after the `Bar::fill` signature change).
3. Check `cargo clippy -- --deny warnings` and `cargo fmt --check` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
