### PR TITLE
bar_chart: Add `corner_radii: Corners<Pixels>` support to `Bar` and `BarChart`

### DIFF
--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -248,6 +248,16 @@ impl Render for ChartStory {
                         )
                     })
                     .child(chart_container(
+                        "Bar Chart - Rounded corners",
+                        BarChart::new(self.monthly_devices.clone())
+                            .band(|d| d.month.clone())
+                            .value(|d| d.desktop)
+                            .label(|d| d.desktop.to_string())
+                            .corner_radii(px(8.)),
+                        false,
+                        cx,
+                    ))
+                    .child(chart_container(
                         "Bar Chart - Label",
                         BarChart::new(self.monthly_devices.clone())
                             .band(|d| d.month.clone())

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use gpui::{App, Bounds, Hsla, Pixels, SharedString, TextAlign, Window, px};
+use gpui::{App, Bounds, Corners, Hsla, Pixels, SharedString, TextAlign, Window, px};
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive};
 
@@ -32,6 +32,7 @@ where
     label_axis: bool,
     grid: bool,
     alignment: BarAlignment,
+    corner_radii: Corners<Pixels>,
 }
 
 impl<T, B, V> BarChart<T, B, V>
@@ -53,6 +54,7 @@ where
             label_axis: true,
             grid: true,
             alignment: BarAlignment::default(),
+            corner_radii: Corners::all(px(0.)),
         }
     }
 
@@ -107,6 +109,15 @@ where
     /// Default is [`BarAlignment::Bottom`].
     pub fn alignment(mut self, alignment: BarAlignment) -> Self {
         self.alignment = alignment;
+        self
+    }
+
+    /// Set the corner radii applied to every bar rectangle.
+    ///
+    /// Use [`Corners::all`] for uniform rounding, or construct [`Corners`] manually
+    /// to round only specific corners (e.g. just the tip end of each bar).
+    pub fn corner_radii(mut self, corner_radii: impl Into<Corners<Pixels>>) -> Self {
+        self.corner_radii = corner_radii.into();
         self
     }
 }
@@ -273,6 +284,7 @@ where
             .cross(move |d| band_scale.tick(&band_fn_cloned(d)))
             .base(move |_| baseline)
             .value(move |d| value_scale.tick(&value_fn_cloned(d)))
+            .corner_radii(self.corner_radii)
             .fill(move |d| fill.as_ref().map(|f| f(d)).unwrap_or(default_fill));
 
         if let Some(label) = self.label.as_ref() {

--- a/crates/ui/src/plot/shape/bar.rs
+++ b/crates/ui/src/plot/shape/bar.rs
@@ -1,4 +1,6 @@
-use gpui::{App, Bounds, Hsla, PaintQuad, Pixels, Point, Window, fill, point, px};
+use gpui::{
+    App, Bounds, Corners, Hsla, PaintQuad, Pixels, Point, Window, fill, point, px,
+};
 
 use crate::plot::{
     label::{PlotLabel, TEXT_GAP, TEXT_HEIGHT, TEXT_SIZE, Text},
@@ -40,6 +42,7 @@ pub struct Bar<T> {
     value: Box<dyn Fn(&T) -> Option<f32>>,
     fill: Box<dyn Fn(&T) -> Hsla>,
     label: Option<Box<dyn Fn(&T, Point<Pixels>) -> Vec<Text>>>,
+    corner_radii: Corners<Pixels>,
 }
 
 impl<T> Default for Bar<T> {
@@ -53,6 +56,7 @@ impl<T> Default for Bar<T> {
             value: Box::new(|_| None),
             fill: Box::new(|_| gpui::black()),
             label: None,
+            corner_radii: Corners::all(px(0.)),
         }
     }
 }
@@ -134,6 +138,15 @@ impl<T> Bar<T> {
         self
     }
 
+    /// Set the corner radii applied to every bar rectangle.
+    ///
+    /// Use [`Corners::all`] for uniform rounding, or construct `Corners` manually to
+    /// round only specific corners (e.g. just the tip end of each bar).
+    pub fn corner_radii(mut self, corner_radii: impl Into<Corners<Pixels>>) -> Self {
+        self.corner_radii = corner_radii.into();
+        self
+    }
+
     fn path(&self, bounds: &Bounds<Pixels>) -> (Vec<PaintQuad>, PlotLabel) {
         let origin = bounds.origin;
         let mut graph = vec![];
@@ -170,7 +183,7 @@ impl<T> Bar<T> {
             };
 
             let color = (self.fill)(v);
-            graph.push(fill(Bounds::from_corners(p1, p2), color));
+            graph.push(fill(Bounds::from_corners(p1, p2), color).corner_radii(self.corner_radii));
 
             if let Some(label) = &self.label {
                 let label_origin = label_origin(self.alignment, cross, base, value, bw);

--- a/docs/docs/components/chart.md
+++ b/docs/docs/components/chart.md
@@ -160,6 +160,33 @@ BarChart::new(data)
     .alignment(BarAlignment::Right)
 ```
 
+#### Bar Chart Corner Radii
+
+Round the bar rectangles. Pass any value convertible into `Corners<Pixels>` —
+use a single `px(..)` for uniform rounding, or construct `Corners` manually to
+round only specific corners (e.g. just the tip end of each bar).
+
+```rust
+use gpui::{px, Corners};
+
+// Uniform 4px rounded corners on every bar
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .corner_radii(px(4.))
+
+// Round only the top corners (tip end for bottom-aligned bars)
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .corner_radii(Corners {
+        top_left: px(4.),
+        top_right: px(4.),
+        bottom_left: px(0.),
+        bottom_right: px(0.),
+    })
+```
+
 ### AreaChart
 
 An area chart displays quantitative data visually, similar to a line chart but with the area below the line filled.

--- a/docs/zh-CN/docs/components/chart.md
+++ b/docs/zh-CN/docs/components/chart.md
@@ -153,6 +153,33 @@ BarChart::new(data)
     .alignment(BarAlignment::Right)
 ```
 
+#### 柱状图圆角
+
+为柱状条形设置圆角。可传入任意可转换为 `Corners<Pixels>` 的值——
+使用单个 `px(..)` 表示四角统一圆角，或手动构造 `Corners`
+仅对特定角进行圆角处理（例如仅对柱顶一端进行圆角）。
+
+```rust
+use gpui::{px, Corners};
+
+// 所有柱条统一 4px 圆角
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .corner_radii(px(4.))
+
+// 仅顶部圆角（适用于底部对齐柱状图的柱顶一端）
+BarChart::new(data)
+    .band(|d| d.category.clone())
+    .value(|d| d.value)
+    .corner_radii(Corners {
+        top_left: px(4.),
+        top_right: px(4.),
+        bottom_left: px(0.),
+        bottom_right: px(0.),
+    })
+```
+
 ### AreaChart
 
 面积图类似折线图，但会填充曲线下方的区域。


### PR DESCRIPTION
## Description

Adds `corner_radii` support to the low-level `Bar` shape and the high-level `BarChart` component, allowing bar rectangles to be rendered with rounded corners. The radii are applied to the underlying `PaintQuad` so they work uniformly across all four `BarAlignment` orientations (`Bottom`, `Top`, `Left`, `Right`).

The new builder accepts anything convertible into `Corners<Pixels>`, so callers can pass a single `px(..)` value for uniform rounding or construct a `Corners` manually to round only specific corners (e.g. just the tip end of each bar).

A "Bar Chart - Rounded corners" example was added to the chart story to exercise the new option, and the chart documentation was updated in both the English and Chinese locales (⚠️  mandarin needs proof-reading ❗ ).

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="401" height="416" alt="image" src="https://github.com/user-attachments/assets/eaa26d0e-b628-42b1-931c-46c1254142f7" /> | <img width="396" height="416" alt="image" src="https://github.com/user-attachments/assets/c2bd18fa-210f-4ec2-ad95-cba3eb826d0f" /> |

## Break Changes

n/a

## How to Test

1. Run the story gallery: `cargo run`
2. Navigate to the **Chart** story.
3. Verify the new "Bar Chart - Rounded corners" example renders bars with uniform 4px rounded corners.
4. Other bar chart examples (alignment variants, gradients, stacked) should be unchanged visually.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
