### PR TITLE
menu_story: add min_w to popup-menu to avoid resize on shortcut load

### DIFF
--- a/crates/story/src/stories/menu_story.rs
+++ b/crates/story/src/stories/menu_story.rs
@@ -1,5 +1,5 @@
-use gpui::{ Anchor,
-    Action, App, AppContext, Context, Entity, InteractiveElement, IntoElement, KeyBinding,
+use gpui::{
+    Action, Anchor, App, AppContext, Context, Entity, InteractiveElement, IntoElement, KeyBinding,
     ParentElement as _, Render, SharedString, Styled as _, Window, actions, div, px,
 };
 use gpui_component::{
@@ -135,7 +135,8 @@ impl Render for MenuStory {
                             .outline()
                             .label("Edit")
                             .dropdown_menu(move |this, window, cx| {
-                                this.link("About", "https://github.com/longbridge/gpui-component")
+                                this.min_w(250.)
+                                    .link("About", "https://github.com/longbridge/gpui-component")
                                     .check_side(check_side.unwrap_or(Side::Left))
                                     .separator()
                                     .item(PopupMenuItem::new("Handle Click").on_click(


### PR DESCRIPTION
## Description

Keyboard shortcuts in the popup menu caused the component to resize after opening. This change adds a minimum width to prevent the layout shift and keep the popup menu size stable.

## Screenshot

### Before

https://github.com/user-attachments/assets/b535fc43-c1eb-4b93-b108-cc7f01c16371

### After
https://github.com/user-attachments/assets/c5ee83b4-7ff6-4512-a0cb-9098b99cf78e

## Break Changes
None

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
