### PR TITLE
menu: fix app menu action routing after hover switching

### DIFF
--- a/crates/ui/src/menu/app_menu_bar.rs
+++ b/crates/ui/src/menu/app_menu_bar.rs
@@ -7,7 +7,7 @@ use crate::{
     menu::PopupMenu,
 };
 use gpui::{
-    App, AppContext as _, ClickEvent, Context, DismissEvent, Entity, Focusable,
+    App, AppContext as _, ClickEvent, Context, DismissEvent, Entity, FocusHandle, Focusable,
     InteractiveElement as _, IntoElement, KeyBinding, MouseButton, OwnedMenu, ParentElement,
     Render, SharedString, StatefulInteractiveElement, Styled, Subscription, Window, anchored,
     deferred, div, prelude::FluentBuilder, px,
@@ -26,6 +26,7 @@ pub fn init(cx: &mut App) {
 pub struct AppMenuBar {
     menus: Vec<Entity<AppMenu>>,
     selected_index: Option<usize>,
+    action_context: Option<FocusHandle>,
 }
 
 impl AppMenuBar {
@@ -34,6 +35,7 @@ impl AppMenuBar {
         cx.new(|cx| {
             let mut this = Self {
                 selected_index: None,
+                action_context: None,
                 menus: Vec::new(),
             };
             this.reload(cx);
@@ -55,6 +57,7 @@ impl AppMenuBar {
             .map(|(ix, menu)| AppMenu::new(ix, menu, menu_bar.clone(), cx))
             .collect();
         self.selected_index = None;
+        self.action_context = None;
         cx.notify();
     }
 
@@ -88,7 +91,21 @@ impl AppMenuBar {
         self.set_selected_index(None, window, cx);
     }
 
-    fn set_selected_index(&mut self, ix: Option<usize>, _: &mut Window, cx: &mut Context<Self>) {
+    fn set_selected_index(
+        &mut self,
+        ix: Option<usize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_index.is_none() && ix.is_some() {
+            self.action_context = window.focused(cx);
+        } else if ix.is_none() {
+            if let Some(action_context) = self.action_context.as_ref() {
+                action_context.focus(window, cx);
+            }
+            self.action_context = None;
+        }
+
         self.selected_index = ix;
         cx.notify();
     }
@@ -148,23 +165,28 @@ impl AppMenu {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<PopupMenu> {
+        let action_context = self.menu_bar.read(cx).action_context.clone();
         let popup_menu = match self.popup_menu.as_ref() {
             None => {
                 let items = self.menu.items.clone();
                 let popup_menu = PopupMenu::build(window, cx, |menu, window, cx| {
-                    menu.when_some(window.focused(cx), |this, handle| {
-                        this.action_context(handle)
-                    })
-                    .with_menu_items(items, window, cx)
+                    menu.with_menu_items(items, window, cx)
                 });
-                popup_menu.read(cx).focus_handle(cx).focus(window, cx);
+                popup_menu.update(cx, |menu, cx| {
+                    menu.set_action_context(action_context.clone(), cx);
+                });
                 self._subscription =
                     Some(cx.subscribe_in(&popup_menu, window, Self::handle_dismiss));
                 self.popup_menu = Some(popup_menu.clone());
 
                 popup_menu
             }
-            Some(menu) => menu.clone(),
+            Some(menu) => {
+                menu.update(cx, |menu, cx| {
+                    menu.set_action_context(action_context.clone(), cx);
+                });
+                menu.clone()
+            }
         };
 
         let focus_handle = popup_menu.read(cx).focus_handle(cx);
@@ -257,5 +279,71 @@ impl Render for AppMenu {
                         ),
                 ))
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use gpui::TestAppContext;
+
+    struct TestRoot {
+        menu_bar: Entity<AppMenuBar>,
+        first_focus: FocusHandle,
+        second_focus: FocusHandle,
+    }
+
+    impl Render for TestRoot {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .child(div().id("first").track_focus(&self.first_focus))
+                .child(div().id("second").track_focus(&self.second_focus))
+                .child(self.menu_bar.clone())
+        }
+    }
+
+    #[gpui::test]
+    fn preserves_action_context_while_switching_menus(cx: &mut TestAppContext) {
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let first_focus = cx.focus_handle();
+            let second_focus = cx.focus_handle();
+            first_focus.focus(window, cx);
+
+            TestRoot {
+                menu_bar: cx.new(|_| AppMenuBar {
+                    menus: Vec::new(),
+                    selected_index: None,
+                    action_context: None,
+                }),
+                first_focus,
+                second_focus,
+            }
+        });
+
+        let (menu_bar, first_focus, second_focus) = root.read_with(cx, |root, _| {
+            (
+                root.menu_bar.clone(),
+                root.first_focus.clone(),
+                root.second_focus.clone(),
+            )
+        });
+
+        menu_bar.update_in(cx, |menu_bar, window, cx| {
+            menu_bar.set_selected_index(Some(0), window, cx);
+            assert_eq!(menu_bar.action_context.as_ref(), Some(&first_focus));
+
+            second_focus.focus(window, cx);
+            menu_bar.set_selected_index(Some(1), window, cx);
+            assert_eq!(menu_bar.action_context.as_ref(), Some(&first_focus));
+
+            menu_bar.set_selected_index(None, window, cx);
+            assert!(menu_bar.action_context.is_none());
+            assert_eq!(window.focused(cx).as_ref(), Some(&first_focus));
+
+            second_focus.focus(window, cx);
+            menu_bar.set_selected_index(Some(0), window, cx);
+            assert_eq!(menu_bar.action_context.as_ref(), Some(&second_focus));
+        });
     }
 }

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -334,6 +334,22 @@ impl PopupMenu {
         self
     }
 
+    pub(crate) fn set_action_context(
+        &mut self,
+        action_context: Option<FocusHandle>,
+        cx: &mut Context<Self>,
+    ) {
+        self.action_context = action_context.clone();
+
+        for item in &self.menu_items {
+            if let PopupMenuItem::Submenu { menu, .. } = item {
+                menu.update(cx, |menu, cx| {
+                    menu.set_action_context(action_context.clone(), cx);
+                });
+            }
+        }
+    }
+
     /// Set min width of the popup menu, default is 120px
     pub fn min_w(mut self, width: impl Into<Pixels>) -> Self {
         self.min_width = Some(width.into());


### PR DESCRIPTION
**Problem:**
Menu items could sometimes do nothing after switching between top-level menus by hovering. The menu was using the current focus when each popup opened. After the first popup opened, focus moved into that popup. When the user hovered to another menu, the new popup could accidentally remember the old popup as the place to send actions. That old popup was no longer active, so the selected menu item had nowhere useful to go.

**Reproduce:**

1. Select Editor in Story
2. Select any text
3. Click the Help menu
4. Move to the Edit menu and select Cut

Nothing happens.

**Solution:**
The menu bar now remembers the focused area once, when the menu interaction starts. It keeps using that same target while the user switches between menus, and clears it when the menu closes. Popup menus, including submenus and reused popups, now receive this stored target instead of reading focus again.

This keeps menu actions routed to the view that was active before the menu opened, even after hover-switching between menus.

> Implemented-by: Codex GPT-5.5 High
> Reviewed-by: Claude Opus 4.7 High & Human
> Tested-by: Human

**Tests run using Story:**

- Click menu A, click an item in menu A.
- Click menu A, hover menu B, click an item in B.
- Click menu A, hover B, hover C, click an item in C.
- Open with click, switch menus with left/right arrow keys, press Enter on an item.
- Open a menu, press Escape. Confirm focus returns to the original widget.
- Open a menu, click outside it. Confirm focus returns and the menu closes.
- Open a menu from widget 1, dismiss it, focus widget 2, reopen a menu. Confirm actions route to widget 2.
- Use a submenu item, especially after hover-switching top-level menus first.
- Trigger both focus-scoped actions, like copy/paste/delete, and global actions, like about/quit/theme, if present.
- Try from different focused widgets: editor/input, sidebar/tree/list, and no obvious focused widget.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)

---

Hello - and thank you for this toolkit.