### PR TITLE
chore: Bump tree-sitter to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8604,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-navi"
 version = "0.2.3"
-source = "git+https://github.com/hewigovens/tree-sitter-navi?branch=tree-sitter-0.26#c579359fbacfdc1575c9ea462a79d5fb49ef924c"
+source = "git+https://github.com/navi-language/tree-sitter-navi#0abb11ca9afafd932b277467371c3c7158f7aa88"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-component"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5121,7 +5121,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8373,9 +8373,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
 dependencies = [
  "cc",
  "regex",
@@ -8603,9 +8603,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-navi"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff190c235d2c0106d8d4c567e990f7776b80a2643b7d201a672cae308675424d"
+version = "0.2.3"
+source = "git+https://github.com/hewigovens/tree-sitter-navi?branch=tree-sitter-0.26#c579359fbacfdc1575c9ea462a79d5fb49ef924c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,5 +126,4 @@ ignored = ["log", "anyhow", "serde"]
 [patch.crates-io]
 # Use stacker's psm version which may have better WASM support
 psm = { git = "https://github.com/rust-lang/stacker", branch = "master" }
-# wait for https://github.com/navi-language/tree-sitter-navi/pull/3
-tree-sitter-navi = { git = "https://github.com/hewigovens/tree-sitter-navi", branch = "tree-sitter-0.26" }
+tree-sitter-navi = { git = "https://github.com/navi-language/tree-sitter-navi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ publish = false
 edition = "2024"
 
 [workspace.dependencies]
-gpui-component = { path = "crates/ui", version = "0.5.1" }
+gpui-component = { path = "crates/ui", version = "0.5.2" }
 gpui-component-macros = { path = "crates/macros", version = "0.5.1" }
 gpui-component-assets = { path = "crates/assets", version = "0.5.1" }
 story = { path = "crates/story" }
@@ -126,3 +126,5 @@ ignored = ["log", "anyhow", "serde"]
 [patch.crates-io]
 # Use stacker's psm version which may have better WASM support
 psm = { git = "https://github.com/rust-lang/stacker", branch = "master" }
+# wait for https://github.com/navi-language/tree-sitter-navi/pull/3
+tree-sitter-navi = { git = "https://github.com/hewigovens/tree-sitter-navi", branch = "tree-sitter-0.26" }

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -36,7 +36,7 @@ dirs = "6.0.0"
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 reqwest_client.workspace = true
 smol.workspace = true
-tree-sitter-navi = "0.2.2"
+tree-sitter-navi = "0.2.3"
 color-lsp = "0.2.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/gpui-component"
 homepage = "https://longbridge.github.io/gpui-component"
 repository = "https://github.com/longbridge/gpui-component"
 readme = "../../README.md"
-version = "0.5.1"
+version = "0.5.2"
 publish = true
 edition.workspace = true
 
@@ -146,7 +146,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 # Native-only dependencies (not available on WASM)
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 smol.workspace = true
-tree-sitter = "0.25.4"
+tree-sitter = "0.26"
 tree-sitter-astro-next = { version="0.1.1", optional = true }
 tree-sitter-bash = { version = "0.23.3", optional = true }
 tree-sitter-c = { version = "0.24.1", optional = true }

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeSet, HashMap},
-    ops::Range,
+    ops::{ControlFlow, Range},
     usize,
 };
 use tree_sitter::{
@@ -216,7 +216,7 @@ impl SyntaxHighlighter {
 
     /// Build the combined injections query for the given language.
     ///
-    /// https://github.com/tree-sitter/tree-sitter/blob/v0.25.5/highlight/src/lib.rs#L336
+    /// https://github.com/tree-sitter/tree-sitter/blob/v0.26.8/crates/highlight/src/highlight.rs#L339
     fn build_combined_injections_query(lang: &str) -> Result<Self> {
         let Some(config) = LanguageRegistry::singleton().language(&lang) else {
             return Err(anyhow!(
@@ -416,17 +416,17 @@ impl SyntaxHighlighter {
 
         let mut timed_out = false;
         let start = Instant::now();
-        let mut progress = |_: &tree_sitter::ParseState| -> bool {
+        let mut progress = |_: &tree_sitter::ParseState| -> ControlFlow<()> {
             let Some(budget) = timeout else {
-                return false;
+                return ControlFlow::Continue(());
             };
 
             if start.elapsed() > budget {
                 timed_out = true;
-                return true; // Cancel execution
+                return ControlFlow::Break(()); // Cancel execution
             }
 
-            false
+            ControlFlow::Continue(())
         };
 
         let options = ParseOptions::new().progress_callback(&mut progress);

--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -88,7 +88,7 @@ impl LanguageConfig {
 
 /// Theme for Tree-sitter Highlight
 ///
-/// https://docs.rs/tree-sitter-highlight/0.25.4/tree_sitter_highlight/
+/// https://docs.rs/tree-sitter-highlight/0.26.8/tree_sitter_highlight/
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, JsonSchema, Serialize, Deserialize)]
 pub struct SyntaxColors {
     pub attribute: Option<ThemeStyle>,


### PR DESCRIPTION
## Description

Bumps `tree-sitter` from 0.25 to 0.26 for `gpui-component`, updates the highlighter progress callback to the 0.26 `ControlFlow` API, and points `tree-sitter-navi` at at upstream main branch (0.2.3). This avoids forcing downstream workspaces that already use `tree-sitter` 0.26 to downgrade.

## Screenshot

Not applicable. This is a dependency and parser API compatibility change with no UI changes.

## How to Test

Ran:

```bash
cargo check -p gpui-component -p gpui-component-story
cargo check -p gpui-component-story --example editor
```

Also verified the dependency graph resolves to a single `tree-sitter v0.26.8` with `tree-sitter-navi v0.2.3`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
