### PR TITLE
highlighter: fix editor crash after deleting markdown text

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -988,7 +988,15 @@ fn should_parse_injection_layer(
 }
 
 fn markdown_inline_range_has_trigger(text: &Rope, range: Range<usize>) -> bool {
-    text.slice(range).bytes().any(|byte| {
+    if range.start > range.end || range.end > text.len() {
+        return false;
+    }
+
+    let Ok(slice) = text.try_slice(range) else {
+        return false;
+    };
+
+    slice.bytes().any(|byte| {
         matches!(
             byte,
             b'*' | b'_' | b'`' | b'[' | b']' | b'(' | b')' | b'<' | b'>' | b'!' | b'~' | b'$'
@@ -1353,6 +1361,35 @@ $x = 1;
             1,
             "Markdown inline LaTeX markers should create a markdown_inline layer"
         );
+    }
+
+    #[test]
+    fn test_markdown_inline_trigger_rejects_out_of_bounds_range() {
+        let text = Rope::from_str("-");
+
+        assert!(
+            !markdown_inline_range_has_trigger(&text, 0..2),
+            "stale markdown inline ranges should not panic"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-markdown")]
+    fn test_markdown_inline_stale_edit_range_does_not_panic() {
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &Rope::from_str("-="), None);
+
+        let text = Rope::from_str("-");
+        let stale_edit = InputEdit {
+            start_byte: 1,
+            old_end_byte: 1,
+            new_end_byte: 1,
+            start_position: Point::new(0, 1),
+            old_end_position: Point::new(0, 1),
+            new_end_position: Point::new(0, 1),
+        };
+
+        highlighter.update(Some(stale_edit), &text, None);
     }
 
     #[test]

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -224,6 +224,7 @@ impl InputMode {
     pub(super) fn update_highlighter(
         &mut self,
         selected_range: &Range<usize>,
+        old_text: &Rope,
         text: &Rope,
         new_text: &str,
         force: bool,
@@ -250,29 +251,7 @@ impl InputMode {
                     return None;
                 };
 
-                // When full text changed, the selected_range may be out of bound (The before version).
-                let mut selected_range = selected_range.clone();
-                selected_range.end = selected_range.end.min(text.len());
-
-                // If insert a chart, this is 1.
-                // If backspace or delete, this is -1.
-                // If selected to delete, this is the length of the selected text.
-                // let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let new_end = (selected_range.end as isize + changed_len) as usize;
-
-                let start_pos = text.offset_to_point(selected_range.start);
-                let old_end_pos = text.offset_to_point(selected_range.end);
-                let new_end_pos = text.offset_to_point(new_end);
-
-                let edit = InputEdit {
-                    start_byte: selected_range.start,
-                    old_end_byte: selected_range.end,
-                    new_end_byte: new_end,
-                    start_position: start_pos,
-                    old_end_position: old_end_pos,
-                    new_end_position: new_end_pos,
-                };
+                let edit = replacement_input_edit(old_text, text, selected_range, new_text);
 
                 const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
                 let completed = h.update(Some(edit), text, Some(SYNC_PARSE_TIMEOUT));
@@ -320,14 +299,53 @@ impl InputMode {
     }
 }
 
+/// Builds the tree-sitter edit for a text replacement.
+///
+/// Byte offsets and old positions are measured in `old_text`, while the new
+/// end position is measured in `text`.
+fn replacement_input_edit(
+    old_text: &Rope,
+    text: &Rope,
+    selected_range: &Range<usize>,
+    new_text: &str,
+) -> InputEdit {
+    let start_byte = selected_range.start.min(old_text.len());
+    let old_end_byte = selected_range.end.min(old_text.len()).max(start_byte);
+    let new_end_byte = (start_byte + new_text.len()).min(text.len());
+
+    InputEdit {
+        start_byte,
+        old_end_byte,
+        new_end_byte,
+        start_position: old_text.offset_to_point(start_byte),
+        old_end_position: old_text.offset_to_point(old_end_byte),
+        new_end_position: text.offset_to_point(new_end_byte),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ropey::Rope;
 
+    use super::replacement_input_edit;
     use crate::{
         highlighter::DiagnosticSet,
-        input::{TabSize, mode::InputMode},
+        input::{Point, TabSize, mode::InputMode},
     };
+
+    #[test]
+    fn test_replacement_input_edit_backspace_at_end_uses_old_range() {
+        let old_text = Rope::from_str("-=");
+        let text = Rope::from_str("-");
+        let edit = replacement_input_edit(&old_text, &text, &(1..2), "");
+
+        assert_eq!(edit.start_byte, 1);
+        assert_eq!(edit.old_end_byte, 2);
+        assert_eq!(edit.new_end_byte, 1);
+        assert_eq!(edit.start_position, Point::new(0, 1));
+        assert_eq!(edit.old_end_position, Point::new(0, 2));
+        assert_eq!(edit.new_end_position, Point::new(0, 1));
+    }
 
     #[test]
     fn test_code_editor() {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2364,7 +2364,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2431,7 +2431,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2548,7 +2548,7 @@ impl Render for InputState {
         if self._pending_update {
             let bg = self
                 .mode
-                .update_highlighter(&(0..0), &self.text, "", false, cx);
+                .update_highlighter(&(0..0), &self.text, &self.text, "", false, cx);
             if let Some(bg) = bg {
                 Self::dispatch_background_parse(bg, window, cx);
             }


### PR DESCRIPTION
**Problem:**
Typing a short markdown text and then pressing backspace could crash the editor.

The highlighter was telling tree-sitter about the edit using the new text only. For deletes, this made the old edit range too short. Tree-sitter could then keep an old markdown inline range that no longer fit the current text. When the markdown highlighter checked that old range, Ropey crashed because the range was outside the text.

**Solution:**
The function that builds the edit descriptor now takes both ropes: the start and old end positions are clamped against the rope before the change, and the new end position is clamped against the rope after the change. This yields a correct deletion record even when the change sits at the end of the buffer. As a safety net, the helper that scans an injection range for trigger characters now rejects any range whose end exceeds the rope length before attempting to slice, since the rope library's fallible slice method still panics on inputs that are out of bounds.

**Tests:**
Added regression tests for the backspace edit case and for stale markdown inline ranges.

Manually tested: `cargo run -p gpui-component-story --example markdown`

> Implemented by: Codex GPT-5.5
> Reviewed by: Claude Opus 4.7 and Human

---

Related to my previous PR #2333. I can't believe I didn't catch this in previous testing! Apologies.