### PR TITLE
highlighter: Add inline markdown syntax highlighting (again)

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -25,8 +25,8 @@ const LARGE_NODE_THRESHOLD: usize = 8 * 1024;
 pub struct SyntaxHighlighter {
     language: SharedString,
     query: Option<Query>,
-    /// A separate query for injection patterns that have `#set! injection.combined`.
-    combined_injections_query: Option<Arc<Query>>,
+    /// The full injections query. This is used to build injection layers during parsing.
+    injections_query: Option<Arc<Query>>,
     injection_queries: HashMap<SharedString, Query>,
 
     locals_pattern_index: usize,
@@ -35,7 +35,6 @@ pub struct SyntaxHighlighter {
     non_local_variable_patterns: Vec<bool>,
     injection_content_capture_index: Option<u32>,
     injection_language_capture_index: Option<u32>,
-    combined_injection_content_capture_index: Option<u32>,
     local_scope_capture_index: Option<u32>,
     local_def_capture_index: Option<u32>,
     local_def_value_capture_index: Option<u32>,
@@ -47,14 +46,17 @@ pub struct SyntaxHighlighter {
     /// The last parsed tree.
     tree: Option<Tree>,
 
-    /// Parsed injection trees (language → tree with ranges).
+    /// Parsed injection trees.
     /// These are built once in update() and queried multiple times in match_styles().
-    injection_layers: HashMap<SharedString, InjectionLayer>,
+    injection_layers: Vec<InjectionLayer>,
 }
 
 /// A parsed injection layer.
 /// Stores the parsed tree and the ranges it covers.
 pub(crate) struct InjectionLayer {
+    pub(crate) language_name: SharedString,
+    pub(crate) ranges: Vec<tree_sitter::Range>,
+    pub(crate) byte_range: Range<usize>,
     pub(crate) tree: Tree,
 }
 
@@ -62,8 +64,15 @@ pub(crate) struct InjectionLayer {
 pub(crate) struct InjectionParseData {
     pub(crate) query: Arc<Query>,
     pub(crate) content_capture_index: Option<u32>,
+    pub(crate) language_capture_index: Option<u32>,
     /// Old injection trees for incremental re-parsing.
-    pub(crate) old_layers: HashMap<SharedString, Tree>,
+    pub(crate) old_layers: Vec<ReusableInjectionLayer>,
+}
+
+pub(crate) struct ReusableInjectionLayer {
+    pub(crate) language_name: SharedString,
+    pub(crate) ranges: Vec<tree_sitter::Range>,
+    pub(crate) tree: Tree,
 }
 
 struct TextProvider<'a>(&'a Rope);
@@ -200,24 +209,24 @@ impl<'a> sum_tree::Dimension<'a, HighlightSummary> for Range<usize> {
 }
 
 impl SyntaxHighlighter {
-    /// Create a new SyntaxHighlighter for HTML.
+    /// Create a new SyntaxHighlighter for the given language.
     pub fn new(lang: &str) -> Self {
-        match Self::build_combined_injections_query(&lang) {
+        match Self::build_for_language(&lang) {
             Ok(result) => result,
             Err(err) => {
                 tracing::warn!(
                     "SyntaxHighlighter init failed, fallback to use `text`, {}",
                     err
                 );
-                Self::build_combined_injections_query("text").unwrap()
+                Self::build_for_language("text").unwrap()
             }
         }
     }
 
-    /// Build the combined injections query for the given language.
+    /// Build the highlighter for the given language.
     ///
     /// https://github.com/tree-sitter/tree-sitter/blob/v0.25.5/highlight/src/lib.rs#L336
-    fn build_combined_injections_query(lang: &str) -> Result<Self> {
+    fn build_for_language(lang: &str) -> Result<Self> {
         let Some(config) = LanguageRegistry::singleton().language(&lang) else {
             return Err(anyhow!(
                 "language {:?} is not registered in `LanguageRegistry`",
@@ -256,37 +265,19 @@ impl SyntaxHighlighter {
             }
         }
 
-        // Separate combined injection patterns into their own query.
-        // Combined injections (e.g., PHP's HTML text nodes) collect all matching
-        // ranges and parse them as a single document, so that opening/closing
-        // tags across injection boundaries are correctly matched.
-        let combined_injections_query = if !config.injections.is_empty() {
-            if let Ok(mut ciq) = Query::new(&config.language, &config.injections) {
-                let mut has_combined_query = false;
-                for pattern_index in 0..locals_pattern_index {
-                    let settings = query.property_settings(pattern_index);
-                    if settings.iter().any(|s| &*s.key == "injection.combined") {
-                        has_combined_query = true;
-                        query.disable_pattern(pattern_index);
-                    } else {
-                        ciq.disable_pattern(pattern_index);
-                    }
-                }
-                if has_combined_query { Some(Arc::new(ciq)) } else { None }
-            } else {
-                None
-            }
+        let injections_query = if !config.injections.is_empty() {
+            Query::new(&config.language, &config.injections)
+                .ok()
+                .map(Arc::new)
         } else {
             None
         };
 
-        let combined_injection_content_capture_index =
-            combined_injections_query.as_ref().and_then(|q| {
-                q.capture_names()
-                    .iter()
-                    .position(|name| *name == "injection.content")
-                    .map(|i| i as u32)
-            });
+        // Injection layers are computed separately during parsing, so do not
+        // emit injection captures from the main highlight query.
+        for pattern_index in 0..locals_pattern_index {
+            query.disable_pattern(pattern_index);
+        }
 
         // Find all of the highlighting patterns that are disabled for nodes that
         // have been identified as local variables.
@@ -300,8 +291,18 @@ impl SyntaxHighlighter {
             .collect();
 
         // Store the numeric ids for all of the special captures.
-        let mut injection_content_capture_index = None;
-        let mut injection_language_capture_index = None;
+        let injection_content_capture_index = injections_query.as_ref().and_then(|q| {
+            q.capture_names()
+                .iter()
+                .position(|name| *name == "injection.content")
+                .map(|i| i as u32)
+        });
+        let injection_language_capture_index = injections_query.as_ref().and_then(|q| {
+            q.capture_names()
+                .iter()
+                .position(|name| *name == "injection.language")
+                .map(|i| i as u32)
+        });
         let mut local_def_capture_index = None;
         let mut local_def_value_capture_index = None;
         let mut local_ref_capture_index = None;
@@ -309,8 +310,6 @@ impl SyntaxHighlighter {
         for (i, name) in query.capture_names().iter().enumerate() {
             let i = Some(i as u32);
             match *name {
-                "injection.content" => injection_content_capture_index = i,
-                "injection.language" => injection_language_capture_index = i,
                 "local.definition" => local_def_capture_index = i,
                 "local.definition-value" => local_def_value_capture_index = i,
                 "local.reference" => local_ref_capture_index = i,
@@ -342,7 +341,7 @@ impl SyntaxHighlighter {
         Ok(Self {
             language: config.name.clone(),
             query: Some(query),
-            combined_injections_query,
+            injections_query,
             injection_queries,
 
             locals_pattern_index,
@@ -350,7 +349,6 @@ impl SyntaxHighlighter {
             non_local_variable_patterns,
             injection_content_capture_index,
             injection_language_capture_index,
-            combined_injection_content_capture_index,
             local_scope_capture_index,
             local_def_capture_index,
             local_def_value_capture_index,
@@ -358,7 +356,7 @@ impl SyntaxHighlighter {
             text: Rope::new(),
             parser,
             tree: None,
-            injection_layers: HashMap::new(),
+            injection_layers: Vec::new(),
         })
     }
 
@@ -453,21 +451,26 @@ impl SyntaxHighlighter {
         let new_tree = new_tree.unwrap();
         self.tree = Some(new_tree.clone());
         self.text = text.clone();
-        self.parse_combined_injections(&new_tree);
+        self.parse_injection_layers(&new_tree);
         true
     }
 
     /// Returns the data needed to compute injection layers on a background thread.
-    /// Returns `None` if this language has no combined injections.
+    /// Returns `None` if this language has no injections.
     pub(crate) fn injection_parse_data(&self) -> Option<InjectionParseData> {
-        let query = self.combined_injections_query.clone()?;
+        let query = self.injections_query.clone()?;
         Some(InjectionParseData {
             query,
-            content_capture_index: self.combined_injection_content_capture_index,
+            content_capture_index: self.injection_content_capture_index,
+            language_capture_index: self.injection_language_capture_index,
             old_layers: self
                 .injection_layers
                 .iter()
-                .map(|(k, v)| (k.clone(), v.tree.clone()))
+                .map(|layer| ReusableInjectionLayer {
+                    language_name: layer.language_name.clone(),
+                    ranges: layer.ranges.clone(),
+                    tree: layer.tree.clone(),
+                })
                 .collect(),
         })
     }
@@ -479,73 +482,134 @@ impl SyntaxHighlighter {
         data: InjectionParseData,
         tree: &Tree,
         text: &Rope,
-    ) -> HashMap<SharedString, InjectionLayer> {
+    ) -> Vec<InjectionLayer> {
         let root_node = tree.root_node();
         let mut cursor = QueryCursor::new();
         let mut matches = cursor.matches(&data.query, root_node, TextProvider(text));
 
         let mut combined_ranges: HashMap<SharedString, Vec<tree_sitter::Range>> = HashMap::new();
+        let old_layer_trees: HashMap<_, _> = data
+            .old_layers
+            .iter()
+            .map(|layer| {
+                (
+                    (layer.language_name.clone(), range_key(&layer.ranges)),
+                    &layer.tree,
+                )
+            })
+            .collect();
+        let mut new_layers = Vec::new();
         while let Some(query_match) = matches.next() {
             let mut language_name: Option<SharedString> = None;
-            if let Some(prop) = data
-                .query
-                .property_settings(query_match.pattern_index)
-                .iter()
-                .find(|prop| prop.key.as_ref() == "injection.language")
-            {
-                language_name = prop
-                    .value
-                    .as_ref()
-                    .map(|v| SharedString::from(v.to_string()));
+            let mut combined = false;
+            for prop in data.query.property_settings(query_match.pattern_index) {
+                match prop.key.as_ref() {
+                    "injection.language" => {
+                        language_name = prop
+                            .value
+                            .as_ref()
+                            .map(|v| SharedString::from(v.to_string()));
+                    }
+                    "injection.combined" => combined = true,
+                    _ => {}
+                }
             }
+
+            // Captured language names are left for a follow-up so this slice can
+            // focus on fixed-language injections.
+            if language_name.is_none()
+                && query_match
+                    .captures
+                    .iter()
+                    .any(|cap| Some(cap.index) == data.language_capture_index)
+            {
+                continue;
+            }
+
             let Some(language_name) = language_name else {
                 continue;
             };
-            for capture in query_match
+
+            let mut ranges = query_match
                 .captures
                 .iter()
                 .filter(|cap| Some(cap.index) == data.content_capture_index)
-            {
-                combined_ranges
-                    .entry(language_name.clone())
-                    .or_default()
-                    .push(capture.node.range());
-            }
-        }
+                .map(|capture| capture.node.range())
+                .collect::<Vec<_>>();
 
-        let mut new_layers = HashMap::new();
-        for (language_name, ranges) in combined_ranges {
             if ranges.is_empty() {
                 continue;
             }
-            let Some(config) = LanguageRegistry::singleton().language(&language_name) else {
-                continue;
-            };
-            let mut parser = Parser::new();
-            if parser.set_language(&config.language).is_err() {
-                continue;
+            sort_ranges(&mut ranges);
+
+            if combined {
+                combined_ranges
+                    .entry(language_name.clone())
+                    .or_default()
+                    .extend(ranges);
+            } else {
+                let old_tree = old_layer_trees
+                    .get(&(language_name.clone(), range_key(&ranges)))
+                    .copied();
+                if let Some(layer) =
+                    Self::parse_injection_layer(&language_name, ranges, old_tree, text)
+                {
+                    new_layers.push(layer);
+                }
             }
-            if parser.set_included_ranges(&ranges).is_err() {
-                continue;
-            }
-            let old_tree = data.old_layers.get(&language_name);
-            let Some(new_tree) = parser.parse_with_options(
-                &mut |offset, _| {
-                    if offset >= text.len() {
-                        ""
-                    } else {
-                        let (chunk, chunk_byte_ix) = text.chunk(offset);
-                        &chunk[offset - chunk_byte_ix..]
-                    }
-                },
-                old_tree,
-                None,
-            ) else {
-                continue;
-            };
-            new_layers.insert(language_name, InjectionLayer { tree: new_tree });
         }
+
+        for (language_name, mut ranges) in combined_ranges {
+            if ranges.is_empty() {
+                continue;
+            }
+            sort_ranges(&mut ranges);
+            let old_tree = old_layer_trees
+                .get(&(language_name.clone(), range_key(&ranges)))
+                .copied();
+            if let Some(layer) = Self::parse_injection_layer(&language_name, ranges, old_tree, text)
+            {
+                new_layers.push(layer);
+            }
+        }
+        new_layers.sort_by_key(|layer| layer.byte_range.start);
         new_layers
+    }
+
+    /// Parse one injection layer for a fixed language over the given included ranges.
+    /// Reuses the previous tree when the ranges still match, which lets tree-sitter
+    /// incrementally update injected syntax after edits.
+    fn parse_injection_layer(
+        language_name: &SharedString,
+        ranges: Vec<tree_sitter::Range>,
+        old_tree: Option<&Tree>,
+        text: &Rope,
+    ) -> Option<InjectionLayer> {
+        let config = LanguageRegistry::singleton().language(language_name)?;
+        let mut parser = Parser::new();
+        parser.set_language(&config.language).ok()?;
+        parser.set_included_ranges(&ranges).ok()?;
+
+        let new_tree = parser.parse_with_options(
+            &mut |offset, _| {
+                if offset >= text.len() {
+                    ""
+                } else {
+                    let (chunk, chunk_byte_ix) = text.chunk(offset);
+                    &chunk[offset - chunk_byte_ix..]
+                }
+            },
+            old_tree,
+            None,
+        )?;
+
+        let byte_range = ranges_byte_range(&ranges)?;
+        Some(InjectionLayer {
+            language_name: language_name.clone(),
+            ranges,
+            byte_range,
+            tree: new_tree,
+        })
     }
 
     /// Apply a tree that was parsed on a background thread.
@@ -556,7 +620,7 @@ impl SyntaxHighlighter {
         &mut self,
         tree: Tree,
         text: &Rope,
-        injection_layers: HashMap<SharedString, InjectionLayer>,
+        injection_layers: Vec<InjectionLayer>,
     ) {
         // Only apply if the text still matches what was parsed.
         if !self.text.eq(text) {
@@ -567,12 +631,11 @@ impl SyntaxHighlighter {
         self.injection_layers = injection_layers;
     }
 
-    /// Parse all combined injections after main tree is updated.
+    /// Parse injection layers after the main tree is updated.
     /// pattern: parse once in update, query many times in render.
-    /// Parse all combined injections after main tree is updated.
-    /// pattern: parse once in update, query many times in render.
-    fn parse_combined_injections(&mut self, tree: &Tree) {
+    fn parse_injection_layers(&mut self, tree: &Tree) {
         let Some(data) = self.injection_parse_data() else {
+            self.injection_layers.clear();
             return;
         };
         self.injection_layers = Self::compute_injection_layers(data, tree, &self.text.clone());
@@ -593,8 +656,15 @@ impl SyntaxHighlighter {
         let source = &self.text;
 
         // Query pre-parsed injection layers.
-        for (language_name, layer) in &self.injection_layers {
-            let Some(query) = self.injection_queries.get(language_name) else {
+        for layer in &self.injection_layers {
+            if layer.byte_range.end <= range.start {
+                continue;
+            }
+            if layer.byte_range.start >= range.end {
+                break;
+            }
+
+            let Some(query) = self.injection_queries.get(&layer.language_name) else {
                 continue;
             };
 
@@ -604,17 +674,11 @@ impl SyntaxHighlighter {
             let mut matches =
                 query_cursor.matches(query, layer.tree.root_node(), TextProvider(&self.text));
 
-            let mut last_end = 0usize;
             while let Some(m) = matches.next() {
                 for cap in m.captures {
                     let node_range = cap.node.start_byte()..cap.node.end_byte();
 
-                    if node_range.start < last_end {
-                        continue;
-                    }
-
                     if let Some(highlight_name) = query.capture_names().get(cap.index as usize) {
-                        last_end = node_range.end;
                         highlights.push(HighlightItem::new(
                             node_range,
                             SharedString::from(highlight_name.to_string()),
@@ -881,6 +945,27 @@ fn collect_query_nodes_inner<'a>(
     out.push(node);
 }
 
+fn sort_ranges(ranges: &mut [tree_sitter::Range]) {
+    ranges.sort_unstable_by(|a, b| {
+        a.start_byte
+            .cmp(&b.start_byte)
+            .then_with(|| a.end_byte.cmp(&b.end_byte))
+    });
+}
+
+fn range_key(ranges: &[tree_sitter::Range]) -> Vec<(usize, usize)> {
+    ranges
+        .iter()
+        .map(|range| (range.start_byte, range.end_byte))
+        .collect()
+}
+
+fn ranges_byte_range(ranges: &[tree_sitter::Range]) -> Option<Range<usize>> {
+    let start = ranges.iter().map(|range| range.start_byte).min()?;
+    let end = ranges.iter().map(|range| range.end_byte).max()?;
+    Some(start..end)
+}
+
 /// Merge other style (Other on top)
 fn merge_highlight_style(style: &mut HighlightStyle, other: &HighlightStyle) {
     if let Some(color) = other.color {
@@ -917,6 +1002,22 @@ mod tests {
         let mut style = HighlightStyle::default();
         style.color = Some(color);
         style
+    }
+
+    #[cfg(feature = "tree-sitter-languages")]
+    fn has_highlight_covering(
+        highlights: &[HighlightItem],
+        source: &str,
+        text: &str,
+        highlight_name: &str,
+    ) -> bool {
+        let start = source.find(text).expect("text should exist in source");
+        let end = start + text.len();
+        highlights.iter().any(|item| {
+            item.name.as_ref() == highlight_name
+                && item.range.start <= start
+                && item.range.end >= end
+        })
     }
 
     #[track_caller]
@@ -966,6 +1067,57 @@ mod tests {
 
     #[test]
     #[cfg(feature = "tree-sitter-languages")]
+    fn test_html_script_and_style_injections() {
+        let html = r#"<style>
+.card { color: #336699; }
+</style>
+<script>
+const answer = 42;
+console.log(answer);
+</script>
+"#;
+
+        let rope = Rope::from_str(html);
+        let mut highlighter = SyntaxHighlighter::new("html");
+        highlighter.update(None, &rope, None);
+
+        assert!(
+            highlighter
+                .injection_layers
+                .iter()
+                .any(|layer| layer.language_name.as_ref() == "css"),
+            "style elements should create a CSS injection layer"
+        );
+        assert!(
+            highlighter
+                .injection_layers
+                .iter()
+                .any(|layer| layer.language_name.as_ref() == "javascript"),
+            "script elements should create a JavaScript injection layer"
+        );
+
+        let highlights = highlighter.match_styles(0..html.len());
+
+        assert!(
+            has_highlight_covering(&highlights, html, "color", "property"),
+            "CSS property names inside style elements should be highlighted"
+        );
+        assert!(
+            has_highlight_covering(&highlights, html, "#336699", "string.special"),
+            "CSS color values inside style elements should be highlighted"
+        );
+        assert!(
+            has_highlight_covering(&highlights, html, "const", "keyword"),
+            "JavaScript keywords inside script elements should be highlighted"
+        );
+        assert!(
+            has_highlight_covering(&highlights, html, "answer", "variable"),
+            "JavaScript identifiers inside script elements should be highlighted"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
     fn test_php_combined_injection_closing_tags() {
         let php_code = r#"<?php
 $x = 1;
@@ -985,11 +1137,6 @@ $x = 1;
         let rope = Rope::from_str(php_code);
         let mut highlighter = SyntaxHighlighter::new("php");
         highlighter.update(None, &rope, None);
-
-        assert!(
-            highlighter.combined_injections_query.is_some(),
-            "PHP should have combined injections query"
-        );
 
         let full_range = 0..php_code.len();
         let highlights = highlighter.match_styles(full_range);

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -1005,6 +1005,14 @@ mod tests {
     }
 
     #[cfg(feature = "tree-sitter-languages")]
+    fn markdown_highlights(markdown: &str) -> Vec<HighlightItem> {
+        let rope = Rope::from_str(markdown);
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &rope, None);
+        highlighter.match_styles(0..markdown.len())
+    }
+
+    #[cfg(feature = "tree-sitter-languages")]
     fn has_highlight_covering(
         highlights: &[HighlightItem],
         source: &str,
@@ -1018,6 +1026,28 @@ mod tests {
                 && item.range.start <= start
                 && item.range.end >= end
         })
+    }
+
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_highlight_theme() -> HighlightTheme {
+        serde_json::from_value(serde_json::json!({
+            "name": "test",
+            "appearance": "dark",
+            "style": {
+                "syntax": {
+                    "emphasis": {
+                        "font_style": "italic"
+                    },
+                    "strikethrough": {
+                        "font_style": "strikethrough"
+                    },
+                    "text.literal": {
+                        "color": "#6F42C1"
+                    }
+                }
+            }
+        }))
+        .expect("test theme should parse")
     }
 
     #[track_caller]
@@ -1158,6 +1188,162 @@ $x = 1;
                 tag, pos
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_strong_emphasis() {
+        let markdown = "This has **bold** text.";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "bold", "emphasis.strong"),
+            "bold text should be highlighted as strong emphasis"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_emphasis() {
+        let markdown = "This has _italic_ text.";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "italic", "emphasis"),
+            "italic text should be highlighted as emphasis"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_strikethrough() {
+        let markdown = "This has ~~deleted~~ text.";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "deleted", "strikethrough"),
+            "strikethrough text should be highlighted"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_emphasis_style_depends_on_theme() {
+        let markdown = "This has _italic_ text.";
+        let rope = Rope::from_str(markdown);
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &rope, None);
+        let theme = test_highlight_theme();
+
+        let styles = highlighter.styles(&(0..markdown.len()), &theme);
+        let start = markdown.find("italic").unwrap();
+        let end = start + "italic".len();
+
+        assert!(
+            styles.iter().any(|(range, style)| {
+                range.start <= start
+                    && range.end >= end
+                    && style.font_style == Some(gpui::FontStyle::Italic)
+            }),
+            "italic Markdown should use the theme's emphasis font style"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_strikethrough_style_depends_on_theme() {
+        let markdown = "This has ~~deleted~~ text.";
+        let rope = Rope::from_str(markdown);
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &rope, None);
+        let theme = test_highlight_theme();
+
+        let styles = highlighter.styles(&(0..markdown.len()), &theme);
+        let start = markdown.find("deleted").unwrap();
+        let end = start + "deleted".len();
+
+        assert!(
+            styles.iter().any(|(range, style)| {
+                range.start <= start && range.end >= end && style.strikethrough.is_some()
+            }),
+            "strikethrough Markdown should use the theme's strikethrough style"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_nested_emphasis_uses_default_bold_italic_style() {
+        let markdown = "This has _**bold**_ text.";
+        let rope = Rope::from_str(markdown);
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &rope, None);
+        let theme = HighlightTheme::default_dark();
+
+        let styles = highlighter.styles(&(0..markdown.len()), &theme);
+        let start = markdown.find("bold").unwrap();
+        let end = start + "bold".len();
+
+        assert!(
+            styles.iter().any(|(range, style)| {
+                range.start <= start
+                    && range.end >= end
+                    && style.font_weight == Some(gpui::FontWeight::BOLD)
+                    && style.font_style == Some(gpui::FontStyle::Italic)
+            }),
+            "strong emphasis nested in emphasis should be bold and italic by default"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_link_text() {
+        let markdown = "This has a [link](https://example.com).";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "link", "link_text"),
+            "link text should be highlighted"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_code_span() {
+        let markdown = "This has `code` text.";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "`code`", "text.literal"),
+            "inline code spans should be highlighted as literal text"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_latex_span() {
+        let markdown = "This has $x^2 + y^2 = z^2$ text.";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            has_highlight_covering(&highlights, markdown, "$x^2 + y^2 = z^2$", "text.literal"),
+            "inline LaTeX spans should be highlighted as literal text"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_regions_do_not_combine_across_paragraphs() {
+        let markdown = "first **open\n\nclose** second";
+        let highlights = markdown_highlights(markdown);
+
+        assert!(
+            !has_highlight_covering(&highlights, markdown, "open", "emphasis.strong"),
+            "unclosed strong emphasis should not highlight text before the paragraph break"
+        );
+        assert!(
+            !has_highlight_covering(&highlights, markdown, "close", "emphasis.strong"),
+            "unclosed strong emphasis should not highlight text after the paragraph break"
+        );
     }
 
     #[test]

--- a/crates/ui/src/highlighter/languages/markdown_inline/highlights.scm
+++ b/crates/ui/src/highlighter/languages/markdown_inline/highlights.scm
@@ -1,11 +1,19 @@
 [
+  (code_span)
+  (latex_block)
+] @text.literal
+
+[
   (emphasis_delimiter)
   (code_span_delimiter)
+  (latex_span_delimiter)
 ] @punctuation.delimiter
 
 (emphasis) @emphasis
 
 (strong_emphasis) @emphasis.strong
+
+(strikethrough) @strikethrough
 
 [
   (link_destination)

--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -1,4 +1,6 @@
-use gpui::{App, FontWeight, HighlightStyle, Hsla, SharedString};
+use gpui::{
+    App, FontWeight, HighlightStyle, Hsla, SharedString, StrikethroughStyle, UnderlineStyle, px,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -13,7 +15,7 @@ use crate::{
     highlighter::{Language, languages},
 };
 
-pub(super) const HIGHLIGHT_NAMES: [&str; 40] = [
+pub(super) const HIGHLIGHT_NAMES: [&str; 41] = [
     "attribute",
     "boolean",
     "comment",
@@ -46,6 +48,7 @@ pub(super) const HIGHLIGHT_NAMES: [&str; 40] = [
     "string.regex",
     "string.special",
     "string.special.symbol",
+    "strikethrough",
     "tag",
     "tag.doctype",
     "text.literal",
@@ -135,6 +138,7 @@ pub struct SyntaxColors {
     pub string_special: Option<ThemeStyle>,
     #[serde(rename = "string.special.symbol")]
     pub string_special_symbol: Option<ThemeStyle>,
+    pub strikethrough: Option<ThemeStyle>,
     pub tag: Option<ThemeStyle>,
     #[serde(rename = "tag.doctype")]
     pub tag_doctype: Option<ThemeStyle>,
@@ -155,6 +159,7 @@ pub enum FontStyle {
     Normal,
     Italic,
     Underline,
+    Strikethrough,
 }
 
 impl From<FontStyle> for gpui::FontStyle {
@@ -163,6 +168,7 @@ impl From<FontStyle> for gpui::FontStyle {
             FontStyle::Normal => gpui::FontStyle::Normal,
             FontStyle::Italic => gpui::FontStyle::Italic,
             FontStyle::Underline => gpui::FontStyle::Normal,
+            FontStyle::Strikethrough => gpui::FontStyle::Normal,
         }
     }
 }
@@ -206,12 +212,30 @@ pub struct ThemeStyle {
 
 impl From<ThemeStyle> for HighlightStyle {
     fn from(style: ThemeStyle) -> Self {
-        HighlightStyle {
+        let mut highlight = HighlightStyle {
             color: style.color,
             font_weight: style.font_weight.map(Into::into),
             font_style: style.font_style.map(Into::into),
             ..Default::default()
+        };
+
+        match style.font_style {
+            Some(FontStyle::Underline) => {
+                highlight.underline = Some(UnderlineStyle {
+                    thickness: px(1.),
+                    ..Default::default()
+                });
+            }
+            Some(FontStyle::Strikethrough) => {
+                highlight.strikethrough = Some(StrikethroughStyle {
+                    thickness: px(1.),
+                    ..Default::default()
+                });
+            }
+            _ => {}
         }
+
+        highlight
     }
 }
 
@@ -254,6 +278,7 @@ impl SyntaxColors {
             "string.regex" => self.string_regex,
             "string.special" => self.string_special,
             "string.special.symbol" => self.string_special_symbol,
+            "strikethrough" => self.strikethrough,
             "tag" => self.tag,
             "tag.doctype" => self.tag_doctype,
             "text.literal" => self.text_literal,

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -3,7 +3,7 @@
 //!
 //! Note: diagnostics.rs is available in WASM, only syntax highlighting requires stubs.
 
-use gpui::{HighlightStyle, SharedString};
+use gpui::{HighlightStyle, SharedString, StrikethroughStyle, UnderlineStyle, px};
 use std::ops::Range;
 use std::time::Duration;
 
@@ -99,6 +99,7 @@ pub enum FontStyle {
     Normal,
     Italic,
     Underline,
+    Strikethrough,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, JsonSchema, Serialize, Deserialize)]
@@ -124,7 +125,7 @@ pub struct ThemeStyle {
 
 impl From<ThemeStyle> for HighlightStyle {
     fn from(style: ThemeStyle) -> Self {
-        HighlightStyle {
+        let mut highlight = HighlightStyle {
             color: style.color,
             font_weight: style.font_weight.map(|w| match w {
                 FontWeightContent::Thin => gpui::FontWeight::THIN,
@@ -141,9 +142,28 @@ impl From<ThemeStyle> for HighlightStyle {
                 FontStyle::Normal => gpui::FontStyle::Normal,
                 FontStyle::Italic => gpui::FontStyle::Italic,
                 FontStyle::Underline => gpui::FontStyle::Normal,
+                FontStyle::Strikethrough => gpui::FontStyle::Normal,
             }),
             ..Default::default()
+        };
+
+        match style.font_style {
+            Some(FontStyle::Underline) => {
+                highlight.underline = Some(UnderlineStyle {
+                    thickness: px(1.),
+                    ..Default::default()
+                });
+            }
+            Some(FontStyle::Strikethrough) => {
+                highlight.strikethrough = Some(StrikethroughStyle {
+                    thickness: px(1.),
+                    ..Default::default()
+                });
+            }
+            _ => {}
         }
+
+        highlight
     }
 }
 

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -224,6 +224,7 @@ impl InputMode {
     pub(super) fn update_highlighter(
         &mut self,
         selected_range: &Range<usize>,
+        old_text: &Rope,
         text: &Rope,
         new_text: &str,
         force: bool,
@@ -250,29 +251,7 @@ impl InputMode {
                     return None;
                 };
 
-                // When full text changed, the selected_range may be out of bound (The before version).
-                let mut selected_range = selected_range.clone();
-                selected_range.end = selected_range.end.min(text.len());
-
-                // If insert a chart, this is 1.
-                // If backspace or delete, this is -1.
-                // If selected to delete, this is the length of the selected text.
-                // let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let new_end = (selected_range.end as isize + changed_len) as usize;
-
-                let start_pos = text.offset_to_point(selected_range.start);
-                let old_end_pos = text.offset_to_point(selected_range.end);
-                let new_end_pos = text.offset_to_point(new_end);
-
-                let edit = InputEdit {
-                    start_byte: selected_range.start,
-                    old_end_byte: selected_range.end,
-                    new_end_byte: new_end,
-                    start_position: start_pos,
-                    old_end_position: old_end_pos,
-                    new_end_position: new_end_pos,
-                };
+                let edit = replacement_input_edit(old_text, text, selected_range, new_text);
 
                 const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
                 let completed = h.update(Some(edit), text, Some(SYNC_PARSE_TIMEOUT));
@@ -320,14 +299,53 @@ impl InputMode {
     }
 }
 
+/// Builds the tree-sitter edit for a text replacement.
+///
+/// Byte offsets and old positions are measured in `old_text`, while the new
+/// end position is measured in `text`.
+fn replacement_input_edit(
+    old_text: &Rope,
+    text: &Rope,
+    selected_range: &Range<usize>,
+    new_text: &str,
+) -> InputEdit {
+    let start_byte = selected_range.start.min(old_text.len());
+    let old_end_byte = selected_range.end.min(old_text.len()).max(start_byte);
+    let new_end_byte = (start_byte + new_text.len()).min(text.len());
+
+    InputEdit {
+        start_byte,
+        old_end_byte,
+        new_end_byte,
+        start_position: old_text.offset_to_point(start_byte),
+        old_end_position: old_text.offset_to_point(old_end_byte),
+        new_end_position: text.offset_to_point(new_end_byte),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ropey::Rope;
 
+    use super::replacement_input_edit;
     use crate::{
         highlighter::DiagnosticSet,
-        input::{TabSize, mode::InputMode},
+        input::{Point, TabSize, mode::InputMode},
     };
+
+    #[test]
+    fn test_replacement_input_edit_backspace_at_end_uses_old_range() {
+        let old_text = Rope::from_str("-=");
+        let text = Rope::from_str("-");
+        let edit = replacement_input_edit(&old_text, &text, &(1..2), "");
+
+        assert_eq!(edit.start_byte, 1);
+        assert_eq!(edit.old_end_byte, 2);
+        assert_eq!(edit.new_end_byte, 1);
+        assert_eq!(edit.start_position, Point::new(0, 1));
+        assert_eq!(edit.old_end_position, Point::new(0, 2));
+        assert_eq!(edit.new_end_position, Point::new(0, 1));
+    }
 
     #[test]
     fn test_code_editor() {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2364,7 +2364,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2431,7 +2431,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2548,7 +2548,7 @@ impl Render for InputState {
         if self._pending_update {
             let bg = self
                 .mode
-                .update_highlighter(&(0..0), &self.text, "", false, cx);
+                .update_highlighter(&(0..0), &self.text, &self.text, "", false, cx);
             if let Some(bg) = bg {
                 Self::dispatch_background_parse(bg, window, cx);
             }

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -144,6 +144,12 @@
           "embedded": {
             "color": "#333333"
           },
+          "emphasis": {
+            "font_style": "italic"
+          },
+          "emphasis.strong": {
+            "font_weight": 700
+          },
           "function": {
             "color": "#0000A2"
           },
@@ -175,6 +181,9 @@
           },
           "string.special.symbol": {
             "color": "#d21f07"
+          },
+          "strikethrough": {
+            "font_style": "strikethrough"
           },
           "tag": {
             "color": "#0433ff"
@@ -345,6 +354,12 @@
           "embedded": {
             "color": "#CACCCA"
           },
+          "emphasis": {
+            "font_style": "italic"
+          },
+          "emphasis.strong": {
+            "font_weight": 700
+          },
           "function": {
             "color": "#fdd888"
           },
@@ -376,6 +391,9 @@
           },
           "string.special.symbol": {
             "color": "#E1D797"
+          },
+          "strikethrough": {
+            "font_style": "strikethrough"
           },
           "tag": {
             "color": "#b5af9a"


### PR DESCRIPTION
#2333 + #2337, without the markdown specific optimization in `highlighter.rs`

---

This PR adds highlighting for common inline Markdown content:

- Bold text
- Italic text
- Strikethrough text
- Inline code
- Link text and link URLs
- Inline LaTeX math spans

Existing styling for links and inline code was left unchanged. Inline LaTeX math currently uses the same visual style as inline code.

| Before | After |
| ------ | ----- |
| <img width="333" height="279" alt="Before screenshot" src="https://github.com/user-attachments/assets/9c9035c9-ffb9-4948-84dc-a98ec8dc1421" /> | <img width="333" height="264" alt="After screenshot" src="https://github.com/user-attachments/assets/06b83849-b346-429b-800c-7fa011840ce9" /> |

It also updates the syntax style system so underline and strikethrough styles from themes are shown correctly.

~To avoid extra work for plain text, Markdown inline parsing is skipped when the text does not contain inline Markdown markers. This is especially useful for long plain text and CJK text.~

This PR only changes inline Markdown highlighting. Code blocks and block quotes are not changed.

## Tests

Added tests for:

- Bold, italic, and nested formatting
- Strikethrough styling
- Inline code
- Link text
- Inline LaTeX math spans
- Paragraph boundaries for inline parsing

Also tested the Markdown story on Linux.

## Breaking Changes

- Added a new `Strikethrough` variant to the public `FontStyle` enum used by theme syntax styles. Code that matches this enum exhaustively must add a new arm.
- Added a new optional `strikethrough`  field on the public `SyntaxColors` struct. Rust code that constructs this struct with all fields listed must add the new field or use `Default`.

## Notes

While testing mixed CJK text in the Markdown story, a rendering delay was found when the default Linux monospace font required CJK font fallback. Using a font with CJK coverage, such as Sarasa Mono SC, removed the delay. This appears to be related to upstream font fallback behavior. A separate optimization for longest line calculation will be handled in another PR.

---

> Implemented by: Codex GPT-5.5
> Ideas/suggestions/reviews by: Claude Opus 4.7 and Human

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested Linux performance