### PR TITLE
input: Fix folding perf regression

### DIFF
--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -16,6 +16,7 @@ pub(super) struct PendingBackgroundParse {
     pub parse_task: Rc<RefCell<Option<Task<()>>>>,
     pub language: SharedString,
     pub text: Rope,
+    pub is_folding: bool,
 }
 
 #[derive(Clone)]
@@ -234,6 +235,7 @@ impl InputMode {
                 language,
                 highlighter,
                 parse_task,
+                folding,
                 ..
             } => {
                 if !force && highlighter.borrow().is_some() {
@@ -287,6 +289,7 @@ impl InputMode {
                         text: text.clone(),
                         highlighter: highlighter.clone(),
                         parse_task: parse_task.clone(),
+                        is_folding: *folding,
                     };
                     drop(highlighter_ref);
                     Some(pending)

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2182,6 +2182,7 @@ impl InputState {
         let parse_task_rc = pending.parse_task;
         let language = pending.language;
         let text = pending.text;
+        let is_folding = pending.is_folding;
 
         let old_tree = highlighter_rc
             .borrow()
@@ -2232,19 +2233,28 @@ impl InputState {
                         Default::default()
                     };
 
-                    Some((new_tree, injection_layers))
+                    // Walk the syntax tree to extract fold ranges off the main thread.
+                    let fold_ranges = if is_folding {
+                        crate::input::display_map::extract_fold_ranges(&new_tree)
+                    } else {
+                        Vec::new()
+                    };
+
+                    Some((new_tree, injection_layers, fold_ranges))
                 })
                 .await;
 
-            if let Some((new_tree, injection_layers)) = result {
+            if let Some((new_tree, injection_layers, fold_ranges)) = result {
                 if let Some(h) = highlighter_rc.borrow_mut().as_mut() {
                     h.apply_background_tree(new_tree, &text_for_apply, injection_layers);
                 }
 
-                // Trigger re-render so the new highlights are displayed.
-                // Also update fold candidates now that the tree is ready.
+                // Trigger re-render so the new highlights are displayed and
+                // apply the fold candidates extracted in the background.
                 _ = entity.update(cx, |state, cx| {
-                    state.update_fold_candidates();
+                    if is_folding {
+                        state.display_map.set_fold_candidates(fold_ranges);
+                    }
                     cx.notify();
                 });
             }


### PR DESCRIPTION
## Description

#2260 fixed a bug (thanks!) but regressed in performance for large files.
This moves the folding to the background since the tree is available there. Note that this makes highlighting big files a bit slower since we wait for folding, but it doesn't disrupt the main thread at least. Perhaps there are performance gains in the collect foldable nodes functions?

## Screenshot

### Before (~15s on main thread)
<img width="1004" height="674" alt="Screenshot From 2026-05-05 13-03-13" src="https://github.com/user-attachments/assets/6a7c8ebd-2ec0-4fb3-a936-745e621d8287" />

### After (on worker thread)
<img width="1004" height="674" alt="Screenshot From 2026-05-05 13-05-25" src="https://github.com/user-attachments/assets/3fdf4ca8-ea42-433f-8629-3cecd44bb7fe" />

## How to Test

1. Generate test file `(echo '['; for i in $(seq 1 9999); do echo "{\"id\": $i, \"name\": \"user_$i\"},"; done; echo '{"id": 10000, "name": "user_10000"}'; echo ']') > test.json`
2. Disable/comment `lint_document` and `document_color_provider` in `editor.rs`
3. Run editor `cargo run --release --example editor`
4. Test folding

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)