### PR TITLE
input: Fix the InputEdit sent to tree-sitter when text is replaced

### DIFF
--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -224,6 +224,7 @@ impl InputMode {
     pub(super) fn update_highlighter(
         &mut self,
         selected_range: &Range<usize>,
+        old_text: &Rope,
         text: &Rope,
         new_text: &str,
         force: bool,
@@ -250,29 +251,7 @@ impl InputMode {
                     return None;
                 };
 
-                // When full text changed, the selected_range may be out of bound (The before version).
-                let mut selected_range = selected_range.clone();
-                selected_range.end = selected_range.end.min(text.len());
-
-                // If insert a chart, this is 1.
-                // If backspace or delete, this is -1.
-                // If selected to delete, this is the length of the selected text.
-                // let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let changed_len = new_text.len() as isize - selected_range.len() as isize;
-                let new_end = (selected_range.end as isize + changed_len) as usize;
-
-                let start_pos = text.offset_to_point(selected_range.start);
-                let old_end_pos = text.offset_to_point(selected_range.end);
-                let new_end_pos = text.offset_to_point(new_end);
-
-                let edit = InputEdit {
-                    start_byte: selected_range.start,
-                    old_end_byte: selected_range.end,
-                    new_end_byte: new_end,
-                    start_position: start_pos,
-                    old_end_position: old_end_pos,
-                    new_end_position: new_end_pos,
-                };
+                let edit = replacement_input_edit(old_text, text, selected_range, new_text);
 
                 const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
                 let completed = h.update(Some(edit), text, Some(SYNC_PARSE_TIMEOUT));
@@ -320,14 +299,88 @@ impl InputMode {
     }
 }
 
+/// Builds the tree-sitter edit for a text replacement.
+///
+/// Byte offsets and positions for `start`/`old_end` come from `old_text`;
+/// `new_end` byte/position come from the post-edit `text`.
+fn replacement_input_edit(
+    old_text: &Rope,
+    text: &Rope,
+    selected_range: &Range<usize>,
+    new_text: &str,
+) -> InputEdit {
+    let start_byte = selected_range.start.min(old_text.len());
+    let old_end_byte = selected_range.end.min(old_text.len()).max(start_byte);
+    let new_end_byte = (start_byte + new_text.len()).min(text.len());
+
+    InputEdit {
+        start_byte,
+        old_end_byte,
+        new_end_byte,
+        start_position: old_text.offset_to_point(start_byte),
+        old_end_position: old_text.offset_to_point(old_end_byte),
+        new_end_position: text.offset_to_point(new_end_byte),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ropey::Rope;
 
+    use super::replacement_input_edit;
     use crate::{
         highlighter::DiagnosticSet,
-        input::{TabSize, mode::InputMode},
+        input::{Point, TabSize, mode::InputMode},
     };
+
+    #[test]
+    fn test_replacement_input_edit_backspace_at_end_uses_old_range() {
+        let old_text = Rope::from_str("-=");
+        let text = Rope::from_str("-");
+        let edit = replacement_input_edit(&old_text, &text, &(1..2), "");
+
+        assert_eq!(edit.start_byte, 1);
+        assert_eq!(edit.old_end_byte, 2);
+        assert_eq!(edit.new_end_byte, 1);
+        assert_eq!(edit.start_position, Point::new(0, 1));
+        assert_eq!(edit.old_end_position, Point::new(0, 2));
+        assert_eq!(edit.new_end_position, Point::new(0, 1));
+    }
+
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn test_replacement_input_edit_shifts_tree_sitter_included_ranges() {
+        let old_source = "[1,2]";
+        let new_source = "[1,2";
+        let old_text = Rope::from_str(old_source);
+        let text = Rope::from_str(new_source);
+        let edit = replacement_input_edit(&old_text, &text, &(4..5), "");
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_json::LANGUAGE.into())
+            .expect("JSON parser should load");
+        parser
+            .set_included_ranges(&[tree_sitter::Range {
+                start_byte: 0,
+                end_byte: old_source.len(),
+                start_point: Point::new(0, 0),
+                end_point: Point::new(0, old_source.len()),
+            }])
+            .expect("included range should be valid");
+
+        let mut tree = parser
+            .parse(old_source, None)
+            .expect("old JSON should parse");
+        tree.edit(&edit);
+        let included_range = tree
+            .included_ranges()
+            .pop()
+            .expect("tree should keep the included range");
+
+        assert_eq!(included_range.end_byte, new_source.len());
+        assert_eq!(included_range.end_point, Point::new(0, new_source.len()));
+    }
 
     #[test]
     fn test_code_editor() {

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -225,8 +225,8 @@ impl InputMode {
         &mut self,
         selected_range: &Range<usize>,
         old_text: &Rope,
-        text: &Rope,
-        new_text: &str,
+        new_text: &Rope,
+        change_text: &str,
         force: bool,
         cx: &mut App,
     ) -> Option<PendingBackgroundParse> {
@@ -251,10 +251,10 @@ impl InputMode {
                     return None;
                 };
 
-                let edit = replacement_input_edit(old_text, text, selected_range, new_text);
+                let edit = replacement_input_edit(old_text, new_text, selected_range, change_text);
 
                 const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
-                let completed = h.update(Some(edit), text, Some(SYNC_PARSE_TIMEOUT));
+                let completed = h.update(Some(edit), new_text, Some(SYNC_PARSE_TIMEOUT));
                 if completed {
                     // Sync parse succeeded, cancel any pending background parse.
                     parse_task.borrow_mut().take();
@@ -263,7 +263,7 @@ impl InputMode {
                     // Timed out. Return the data needed for background parsing.
                     let pending = PendingBackgroundParse {
                         language: h.language().clone(),
-                        text: text.clone(),
+                        text: new_text.clone(),
                         highlighter: highlighter.clone(),
                         parse_task: parse_task.clone(),
                     };
@@ -305,13 +305,13 @@ impl InputMode {
 /// `new_end` byte/position come from the post-edit `text`.
 fn replacement_input_edit(
     old_text: &Rope,
-    text: &Rope,
+    new_text: &Rope,
     selected_range: &Range<usize>,
-    new_text: &str,
+    change_text: &str,
 ) -> InputEdit {
     let start_byte = selected_range.start.min(old_text.len());
     let old_end_byte = selected_range.end.min(old_text.len()).max(start_byte);
-    let new_end_byte = (start_byte + new_text.len()).min(text.len());
+    let new_end_byte = (start_byte + change_text.len()).min(new_text.len());
 
     InputEdit {
         start_byte,
@@ -319,7 +319,7 @@ fn replacement_input_edit(
         new_end_byte,
         start_position: old_text.offset_to_point(start_byte),
         old_end_position: old_text.offset_to_point(old_end_byte),
-        new_end_position: text.offset_to_point(new_end_byte),
+        new_end_position: new_text.offset_to_point(new_end_byte),
     }
 }
 

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2364,7 +2364,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2431,7 +2431,7 @@ impl EntityInputHandler for InputState {
 
         let bg = self
             .mode
-            .update_highlighter(&range, &self.text, &new_text, true, cx);
+            .update_highlighter(&range, &old_text, &self.text, &new_text, true, cx);
         if let Some(bg) = bg {
             Self::dispatch_background_parse(bg, window, cx);
         }
@@ -2548,7 +2548,7 @@ impl Render for InputState {
         if self._pending_update {
             let bg = self
                 .mode
-                .update_highlighter(&(0..0), &self.text, "", false, cx);
+                .update_highlighter(&(0..0), &self.text, &self.text, "", false, cx);
             if let Some(bg) = bg {
                 Self::dispatch_background_parse(bg, window, cx);
             }


### PR DESCRIPTION
Tree-sitter needs the old end position to come from the text before the edit. The previous code measured it from the text after the edit. For deletions at the end of the text, this could report the edit as if no old text was removed.

Example:

- Old text: `"[1,2]"`
- New text: `"[1,2"`
- Deleted range: `4..5`
- Correct `old_end_byte`: `5`
- Old code could send `old_end_byte`: `4`

That tells tree-sitter the edit is empty, so tree-sitter can keep old ranges past the end of the new text.

## Why

Tree-sitter documents that incremental parsing requires editing the old tree so it matches the source change:

- `ts_parser_parse`: the old tree must be edited in a way that exactly matches the source code changes: https://docs.rs/tree-sitter/latest/tree_sitter/ffi/fn.ts_parser_parse.html
- `ts_tree_edit`: the edit must describe byte offsets and row/column positions: https://docs.rs/tree-sitter/latest/tree_sitter/ffi/fn.ts_tree_edit.html
- Tree-sitter editing docs show `TSInputEdit` has both `old_end_byte` and `new_end_byte`: https://tree-sitter.github.io/tree-sitter/using-parsers/3-advanced-parsing.html#editing

## What Changed

- Pass the pre-edit text into `update_highlighter`.
- Build `InputEdit` with:
  - old offsets and old positions from the pre-edit text
  - new end offset and new end position from the post-edit text

Added tests for end-of-text deletion.

I checked the new tree-sitter included-range test against the old edit calculation. It failed as expected:

```text
left: 5
right: 4
```

This shows tree-sitter kept an old range ending at byte `5` after the new text ended at byte `4`.

---

> Implemented-by: Codex GPT-5.5
> Reviewed-by: Claude Opus 4.7 and Human