### PR TITLE
highlighter: Support fixed-language injection layers

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -483,6 +483,21 @@ impl SyntaxHighlighter {
         tree: &Tree,
         text: &Rope,
     ) -> Vec<InjectionLayer> {
+        fn sort_ranges(ranges: &mut [tree_sitter::Range]) {
+            ranges.sort_unstable_by(|a, b| {
+                a.start_byte
+                    .cmp(&b.start_byte)
+                    .then_with(|| a.end_byte.cmp(&b.end_byte))
+            });
+        }
+
+        fn ranges_cache_key(ranges: &[tree_sitter::Range]) -> Vec<(usize, usize)> {
+            ranges
+                .iter()
+                .map(|r| (r.start_byte, r.end_byte))
+                .collect()
+        }
+
         let root_node = tree.root_node();
         let mut cursor = QueryCursor::new();
         let mut matches = cursor.matches(&data.query, root_node, TextProvider(text));
@@ -493,7 +508,7 @@ impl SyntaxHighlighter {
             .iter()
             .map(|layer| {
                 (
-                    (layer.language_name.clone(), range_key(&layer.ranges)),
+                    (layer.language_name.clone(), ranges_cache_key(&layer.ranges)),
                     &layer.tree,
                 )
             })
@@ -549,7 +564,7 @@ impl SyntaxHighlighter {
                     .extend(ranges);
             } else {
                 let old_tree = old_layer_trees
-                    .get(&(language_name.clone(), range_key(&ranges)))
+                    .get(&(language_name.clone(), ranges_cache_key(&ranges)))
                     .copied();
                 if let Some(layer) =
                     Self::parse_injection_layer(&language_name, ranges, old_tree, text)
@@ -565,7 +580,7 @@ impl SyntaxHighlighter {
             }
             sort_ranges(&mut ranges);
             let old_tree = old_layer_trees
-                .get(&(language_name.clone(), range_key(&ranges)))
+                .get(&(language_name.clone(), ranges_cache_key(&ranges)))
                 .copied();
             if let Some(layer) = Self::parse_injection_layer(&language_name, ranges, old_tree, text)
             {
@@ -584,6 +599,11 @@ impl SyntaxHighlighter {
         old_tree: Option<&Tree>,
         text: &Rope,
     ) -> Option<InjectionLayer> {
+        fn bounding_byte_range(ranges: &[tree_sitter::Range]) -> Option<Range<usize>> {
+            let start = ranges.iter().map(|r| r.start_byte).min()?;
+            let end = ranges.iter().map(|r| r.end_byte).max()?;
+            Some(start..end)
+        }
         let config = LanguageRegistry::singleton().language(language_name)?;
         let mut parser = Parser::new();
         parser.set_language(&config.language).ok()?;
@@ -602,7 +622,7 @@ impl SyntaxHighlighter {
             None,
         )?;
 
-        let byte_range = ranges_byte_range(&ranges)?;
+        let byte_range = bounding_byte_range(&ranges)?;
         Some(InjectionLayer {
             language_name: language_name.clone(),
             ranges,
@@ -960,26 +980,6 @@ fn collect_query_nodes_inner<'a>(
     out.push(node);
 }
 
-fn sort_ranges(ranges: &mut [tree_sitter::Range]) {
-    ranges.sort_unstable_by(|a, b| {
-        a.start_byte
-            .cmp(&b.start_byte)
-            .then_with(|| a.end_byte.cmp(&b.end_byte))
-    });
-}
-
-fn range_key(ranges: &[tree_sitter::Range]) -> Vec<(usize, usize)> {
-    ranges
-        .iter()
-        .map(|range| (range.start_byte, range.end_byte))
-        .collect()
-}
-
-fn ranges_byte_range(ranges: &[tree_sitter::Range]) -> Option<Range<usize>> {
-    let start = ranges.iter().map(|range| range.start_byte).min()?;
-    let end = ranges.iter().map(|range| range.end_byte).max()?;
-    Some(start..end)
-}
 
 /// Merge other style (Other on top)
 fn merge_highlight_style(style: &mut HighlightStyle, other: &HighlightStyle) {

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -25,8 +25,8 @@ const LARGE_NODE_THRESHOLD: usize = 8 * 1024;
 pub struct SyntaxHighlighter {
     language: SharedString,
     query: Option<Query>,
-    /// A separate query for injection patterns that have `#set! injection.combined`.
-    combined_injections_query: Option<Arc<Query>>,
+    /// The full injections query. This is used to build injection layers during parsing.
+    injections_query: Option<Arc<Query>>,
     injection_queries: HashMap<SharedString, Query>,
 
     locals_pattern_index: usize,
@@ -35,7 +35,6 @@ pub struct SyntaxHighlighter {
     non_local_variable_patterns: Vec<bool>,
     injection_content_capture_index: Option<u32>,
     injection_language_capture_index: Option<u32>,
-    combined_injection_content_capture_index: Option<u32>,
     local_scope_capture_index: Option<u32>,
     local_def_capture_index: Option<u32>,
     local_def_value_capture_index: Option<u32>,
@@ -47,14 +46,17 @@ pub struct SyntaxHighlighter {
     /// The last parsed tree.
     tree: Option<Tree>,
 
-    /// Parsed injection trees (language → tree with ranges).
+    /// Parsed injection trees.
     /// These are built once in update() and queried multiple times in match_styles().
-    injection_layers: HashMap<SharedString, InjectionLayer>,
+    injection_layers: Vec<InjectionLayer>,
 }
 
 /// A parsed injection layer.
 /// Stores the parsed tree and the ranges it covers.
 pub(crate) struct InjectionLayer {
+    pub(crate) language_name: SharedString,
+    pub(crate) ranges: Vec<tree_sitter::Range>,
+    pub(crate) byte_range: Range<usize>,
     pub(crate) tree: Tree,
 }
 
@@ -62,8 +64,15 @@ pub(crate) struct InjectionLayer {
 pub(crate) struct InjectionParseData {
     pub(crate) query: Arc<Query>,
     pub(crate) content_capture_index: Option<u32>,
-    /// Old injection trees for incremental re-parsing.
-    pub(crate) old_layers: HashMap<SharedString, Tree>,
+    pub(crate) language_capture_index: Option<u32>,
+    /// Old injection trees that can be reused when the injected ranges are unchanged.
+    pub(crate) old_layers: Vec<ReusableInjectionLayer>,
+}
+
+pub(crate) struct ReusableInjectionLayer {
+    pub(crate) language_name: SharedString,
+    pub(crate) ranges: Vec<tree_sitter::Range>,
+    pub(crate) tree: Tree,
 }
 
 struct TextProvider<'a>(&'a Rope);
@@ -200,24 +209,24 @@ impl<'a> sum_tree::Dimension<'a, HighlightSummary> for Range<usize> {
 }
 
 impl SyntaxHighlighter {
-    /// Create a new SyntaxHighlighter for HTML.
+    /// Create a new SyntaxHighlighter for the given language.
     pub fn new(lang: &str) -> Self {
-        match Self::build_combined_injections_query(&lang) {
+        match Self::build_for_language(&lang) {
             Ok(result) => result,
             Err(err) => {
                 tracing::warn!(
                     "SyntaxHighlighter init failed, fallback to use `text`, {}",
                     err
                 );
-                Self::build_combined_injections_query("text").unwrap()
+                Self::build_for_language("text").unwrap()
             }
         }
     }
 
-    /// Build the combined injections query for the given language.
+    /// Build the highlighter for the given language.
     ///
     /// https://github.com/tree-sitter/tree-sitter/blob/v0.26.8/crates/highlight/src/highlight.rs#L339
-    fn build_combined_injections_query(lang: &str) -> Result<Self> {
+    fn build_for_language(lang: &str) -> Result<Self> {
         let Some(config) = LanguageRegistry::singleton().language(&lang) else {
             return Err(anyhow!(
                 "language {:?} is not registered in `LanguageRegistry`",
@@ -256,37 +265,19 @@ impl SyntaxHighlighter {
             }
         }
 
-        // Separate combined injection patterns into their own query.
-        // Combined injections (e.g., PHP's HTML text nodes) collect all matching
-        // ranges and parse them as a single document, so that opening/closing
-        // tags across injection boundaries are correctly matched.
-        let combined_injections_query = if !config.injections.is_empty() {
-            if let Ok(mut ciq) = Query::new(&config.language, &config.injections) {
-                let mut has_combined_query = false;
-                for pattern_index in 0..locals_pattern_index {
-                    let settings = query.property_settings(pattern_index);
-                    if settings.iter().any(|s| &*s.key == "injection.combined") {
-                        has_combined_query = true;
-                        query.disable_pattern(pattern_index);
-                    } else {
-                        ciq.disable_pattern(pattern_index);
-                    }
-                }
-                if has_combined_query { Some(Arc::new(ciq)) } else { None }
-            } else {
-                None
-            }
+        let injections_query = if !config.injections.is_empty() {
+            Query::new(&config.language, &config.injections)
+                .ok()
+                .map(Arc::new)
         } else {
             None
         };
 
-        let combined_injection_content_capture_index =
-            combined_injections_query.as_ref().and_then(|q| {
-                q.capture_names()
-                    .iter()
-                    .position(|name| *name == "injection.content")
-                    .map(|i| i as u32)
-            });
+        // Injection layers are computed separately during parsing, so do not
+        // emit injection captures from the main highlight query.
+        for pattern_index in 0..locals_pattern_index {
+            query.disable_pattern(pattern_index);
+        }
 
         // Find all of the highlighting patterns that are disabled for nodes that
         // have been identified as local variables.
@@ -300,8 +291,18 @@ impl SyntaxHighlighter {
             .collect();
 
         // Store the numeric ids for all of the special captures.
-        let mut injection_content_capture_index = None;
-        let mut injection_language_capture_index = None;
+        let injection_content_capture_index = injections_query.as_ref().and_then(|q| {
+            q.capture_names()
+                .iter()
+                .position(|name| *name == "injection.content")
+                .map(|i| i as u32)
+        });
+        let injection_language_capture_index = injections_query.as_ref().and_then(|q| {
+            q.capture_names()
+                .iter()
+                .position(|name| *name == "injection.language")
+                .map(|i| i as u32)
+        });
         let mut local_def_capture_index = None;
         let mut local_def_value_capture_index = None;
         let mut local_ref_capture_index = None;
@@ -309,8 +310,6 @@ impl SyntaxHighlighter {
         for (i, name) in query.capture_names().iter().enumerate() {
             let i = Some(i as u32);
             match *name {
-                "injection.content" => injection_content_capture_index = i,
-                "injection.language" => injection_language_capture_index = i,
                 "local.definition" => local_def_capture_index = i,
                 "local.definition-value" => local_def_value_capture_index = i,
                 "local.reference" => local_ref_capture_index = i,
@@ -342,7 +341,7 @@ impl SyntaxHighlighter {
         Ok(Self {
             language: config.name.clone(),
             query: Some(query),
-            combined_injections_query,
+            injections_query,
             injection_queries,
 
             locals_pattern_index,
@@ -350,7 +349,6 @@ impl SyntaxHighlighter {
             non_local_variable_patterns,
             injection_content_capture_index,
             injection_language_capture_index,
-            combined_injection_content_capture_index,
             local_scope_capture_index,
             local_def_capture_index,
             local_def_value_capture_index,
@@ -358,7 +356,7 @@ impl SyntaxHighlighter {
             text: Rope::new(),
             parser,
             tree: None,
-            injection_layers: HashMap::new(),
+            injection_layers: Vec::new(),
         })
     }
 
@@ -453,21 +451,26 @@ impl SyntaxHighlighter {
         let new_tree = new_tree.unwrap();
         self.tree = Some(new_tree.clone());
         self.text = text.clone();
-        self.parse_combined_injections(&new_tree);
+        self.parse_injection_layers(&new_tree);
         true
     }
 
     /// Returns the data needed to compute injection layers on a background thread.
-    /// Returns `None` if this language has no combined injections.
+    /// Returns `None` if this language has no injections.
     pub(crate) fn injection_parse_data(&self) -> Option<InjectionParseData> {
-        let query = self.combined_injections_query.clone()?;
+        let query = self.injections_query.clone()?;
         Some(InjectionParseData {
             query,
-            content_capture_index: self.combined_injection_content_capture_index,
+            content_capture_index: self.injection_content_capture_index,
+            language_capture_index: self.injection_language_capture_index,
             old_layers: self
                 .injection_layers
                 .iter()
-                .map(|(k, v)| (k.clone(), v.tree.clone()))
+                .map(|layer| ReusableInjectionLayer {
+                    language_name: layer.language_name.clone(),
+                    ranges: layer.ranges.clone(),
+                    tree: layer.tree.clone(),
+                })
                 .collect(),
         })
     }
@@ -479,73 +482,133 @@ impl SyntaxHighlighter {
         data: InjectionParseData,
         tree: &Tree,
         text: &Rope,
-    ) -> HashMap<SharedString, InjectionLayer> {
+    ) -> Vec<InjectionLayer> {
         let root_node = tree.root_node();
         let mut cursor = QueryCursor::new();
         let mut matches = cursor.matches(&data.query, root_node, TextProvider(text));
 
         let mut combined_ranges: HashMap<SharedString, Vec<tree_sitter::Range>> = HashMap::new();
+        let old_layer_trees: HashMap<_, _> = data
+            .old_layers
+            .iter()
+            .map(|layer| {
+                (
+                    (layer.language_name.clone(), range_key(&layer.ranges)),
+                    &layer.tree,
+                )
+            })
+            .collect();
+        let mut new_layers = Vec::new();
         while let Some(query_match) = matches.next() {
             let mut language_name: Option<SharedString> = None;
-            if let Some(prop) = data
-                .query
-                .property_settings(query_match.pattern_index)
-                .iter()
-                .find(|prop| prop.key.as_ref() == "injection.language")
-            {
-                language_name = prop
-                    .value
-                    .as_ref()
-                    .map(|v| SharedString::from(v.to_string()));
+            let mut combined = false;
+            for prop in data.query.property_settings(query_match.pattern_index) {
+                match prop.key.as_ref() {
+                    "injection.language" => {
+                        language_name = prop
+                            .value
+                            .as_ref()
+                            .map(|v| SharedString::from(v.to_string()));
+                    }
+                    "injection.combined" => combined = true,
+                    _ => {}
+                }
             }
+
+            // Captured language names are left for a follow-up so this change
+            // can focus on fixed-language injections.
+            if language_name.is_none()
+                && query_match
+                    .captures
+                    .iter()
+                    .any(|cap| Some(cap.index) == data.language_capture_index)
+            {
+                continue;
+            }
+
             let Some(language_name) = language_name else {
                 continue;
             };
-            for capture in query_match
+
+            let mut ranges = query_match
                 .captures
                 .iter()
                 .filter(|cap| Some(cap.index) == data.content_capture_index)
-            {
-                combined_ranges
-                    .entry(language_name.clone())
-                    .or_default()
-                    .push(capture.node.range());
-            }
-        }
+                .map(|capture| capture.node.range())
+                .collect::<Vec<_>>();
 
-        let mut new_layers = HashMap::new();
-        for (language_name, ranges) in combined_ranges {
             if ranges.is_empty() {
                 continue;
             }
-            let Some(config) = LanguageRegistry::singleton().language(&language_name) else {
-                continue;
-            };
-            let mut parser = Parser::new();
-            if parser.set_language(&config.language).is_err() {
-                continue;
+            sort_ranges(&mut ranges);
+
+            if combined {
+                combined_ranges
+                    .entry(language_name.clone())
+                    .or_default()
+                    .extend(ranges);
+            } else {
+                let old_tree = old_layer_trees
+                    .get(&(language_name.clone(), range_key(&ranges)))
+                    .copied();
+                if let Some(layer) =
+                    Self::parse_injection_layer(&language_name, ranges, old_tree, text)
+                {
+                    new_layers.push(layer);
+                }
             }
-            if parser.set_included_ranges(&ranges).is_err() {
-                continue;
-            }
-            let old_tree = data.old_layers.get(&language_name);
-            let Some(new_tree) = parser.parse_with_options(
-                &mut |offset, _| {
-                    if offset >= text.len() {
-                        ""
-                    } else {
-                        let (chunk, chunk_byte_ix) = text.chunk(offset);
-                        &chunk[offset - chunk_byte_ix..]
-                    }
-                },
-                old_tree,
-                None,
-            ) else {
-                continue;
-            };
-            new_layers.insert(language_name, InjectionLayer { tree: new_tree });
         }
+
+        for (language_name, mut ranges) in combined_ranges {
+            if ranges.is_empty() {
+                continue;
+            }
+            sort_ranges(&mut ranges);
+            let old_tree = old_layer_trees
+                .get(&(language_name.clone(), range_key(&ranges)))
+                .copied();
+            if let Some(layer) = Self::parse_injection_layer(&language_name, ranges, old_tree, text)
+            {
+                new_layers.push(layer);
+            }
+        }
+        new_layers.sort_by_key(|layer| layer.byte_range.start);
         new_layers
+    }
+
+    /// Parse one injection layer over the given included ranges.
+    /// Reuses the previous tree only when the language and byte ranges still match.
+    fn parse_injection_layer(
+        language_name: &SharedString,
+        ranges: Vec<tree_sitter::Range>,
+        old_tree: Option<&Tree>,
+        text: &Rope,
+    ) -> Option<InjectionLayer> {
+        let config = LanguageRegistry::singleton().language(language_name)?;
+        let mut parser = Parser::new();
+        parser.set_language(&config.language).ok()?;
+        parser.set_included_ranges(&ranges).ok()?;
+
+        let new_tree = parser.parse_with_options(
+            &mut |offset, _| {
+                if offset >= text.len() {
+                    ""
+                } else {
+                    let (chunk, chunk_byte_ix) = text.chunk(offset);
+                    &chunk[offset - chunk_byte_ix..]
+                }
+            },
+            old_tree,
+            None,
+        )?;
+
+        let byte_range = ranges_byte_range(&ranges)?;
+        Some(InjectionLayer {
+            language_name: language_name.clone(),
+            ranges,
+            byte_range,
+            tree: new_tree,
+        })
     }
 
     /// Apply a tree that was parsed on a background thread.
@@ -556,7 +619,7 @@ impl SyntaxHighlighter {
         &mut self,
         tree: Tree,
         text: &Rope,
-        injection_layers: HashMap<SharedString, InjectionLayer>,
+        injection_layers: Vec<InjectionLayer>,
     ) {
         // Only apply if the text still matches what was parsed.
         if !self.text.eq(text) {
@@ -567,12 +630,11 @@ impl SyntaxHighlighter {
         self.injection_layers = injection_layers;
     }
 
-    /// Parse all combined injections after main tree is updated.
+    /// Parse injection layers after the main tree is updated.
     /// pattern: parse once in update, query many times in render.
-    /// Parse all combined injections after main tree is updated.
-    /// pattern: parse once in update, query many times in render.
-    fn parse_combined_injections(&mut self, tree: &Tree) {
+    fn parse_injection_layers(&mut self, tree: &Tree) {
         let Some(data) = self.injection_parse_data() else {
+            self.injection_layers.clear();
             return;
         };
         self.injection_layers = Self::compute_injection_layers(data, tree, &self.text.clone());
@@ -593,8 +655,25 @@ impl SyntaxHighlighter {
         let source = &self.text;
 
         // Query pre-parsed injection layers.
-        for (language_name, layer) in &self.injection_layers {
-            let Some(query) = self.injection_queries.get(language_name) else {
+        let mut last_layer_start = 0;
+        for layer in &self.injection_layers {
+            debug_assert!(layer.byte_range.start >= last_layer_start);
+            last_layer_start = layer.byte_range.start;
+
+            if layer.byte_range.end <= range.start {
+                continue;
+            }
+
+            // Layers are sorted by start byte in compute_injection_layers.
+            if layer.byte_range.start >= range.end {
+                break;
+            }
+
+            let Some(query) = self.injection_queries.get(&layer.language_name) else {
+                tracing::debug!(
+                    "missing highlight query for injection language {:?}",
+                    layer.language_name
+                );
                 continue;
             };
 
@@ -881,6 +960,27 @@ fn collect_query_nodes_inner<'a>(
     out.push(node);
 }
 
+fn sort_ranges(ranges: &mut [tree_sitter::Range]) {
+    ranges.sort_unstable_by(|a, b| {
+        a.start_byte
+            .cmp(&b.start_byte)
+            .then_with(|| a.end_byte.cmp(&b.end_byte))
+    });
+}
+
+fn range_key(ranges: &[tree_sitter::Range]) -> Vec<(usize, usize)> {
+    ranges
+        .iter()
+        .map(|range| (range.start_byte, range.end_byte))
+        .collect()
+}
+
+fn ranges_byte_range(ranges: &[tree_sitter::Range]) -> Option<Range<usize>> {
+    let start = ranges.iter().map(|range| range.start_byte).min()?;
+    let end = ranges.iter().map(|range| range.end_byte).max()?;
+    Some(start..end)
+}
+
 /// Merge other style (Other on top)
 fn merge_highlight_style(style: &mut HighlightStyle, other: &HighlightStyle) {
     if let Some(color) = other.color {
@@ -1050,11 +1150,6 @@ $x = 1;
         let rope = Rope::from_str(php_code);
         let mut highlighter = SyntaxHighlighter::new("php");
         highlighter.update(None, &rope, None);
-
-        assert!(
-            highlighter.combined_injections_query.is_some(),
-            "PHP should have combined injections query"
-        );
 
         let full_range = 0..php_code.len();
         let highlights = highlighter.match_styles(full_range);

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -919,6 +919,22 @@ mod tests {
         style
     }
 
+    #[cfg(feature = "tree-sitter-languages")]
+    fn has_highlight_covering(
+        highlights: &[HighlightItem],
+        source: &str,
+        text: &str,
+        highlight_name: &str,
+    ) -> bool {
+        let start = source.find(text).expect("text should exist in source");
+        let end = start + text.len();
+        highlights.iter().any(|item| {
+            item.name.as_ref() == highlight_name
+                && item.range.start <= start
+                && item.range.end >= end
+        })
+    }
+
     #[track_caller]
     fn assert_unique_styles(
         range: Range<usize>,
@@ -962,6 +978,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_html_style_injects_css_highlights() {
+        let html = r#"<style>
+.card { color: #336699; }
+</style>
+"#;
+
+        let rope = Rope::from_str(html);
+        let mut highlighter = SyntaxHighlighter::new("html");
+        highlighter.update(None, &rope, None);
+
+        let highlights = highlighter.match_styles(0..html.len());
+
+        assert!(
+            has_highlight_covering(&highlights, html, "color", "property"),
+            "CSS property names inside style elements should be highlighted"
+        );
+        assert!(
+            has_highlight_covering(&highlights, html, "#336699", "string.special"),
+            "CSS color values inside style elements should be highlighted"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_html_script_injects_javascript_highlights() {
+        let html = r#"<script>
+const answer = 42;
+console.log(answer);
+</script>
+"#;
+
+        let rope = Rope::from_str(html);
+        let mut highlighter = SyntaxHighlighter::new("html");
+        highlighter.update(None, &rope, None);
+
+        let highlights = highlighter.match_styles(0..html.len());
+
+        assert!(
+            has_highlight_covering(&highlights, html, "const", "keyword"),
+            "JavaScript keywords inside script elements should be highlighted"
+        );
+        assert!(
+            has_highlight_covering(&highlights, html, "answer", "variable"),
+            "JavaScript identifiers inside script elements should be highlighted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This is the foundational work from the previous [inline markdown syntax highlighting PR](https://github.com/longbridge/gpui-component/pull/2339). It is now framed in terms of what it solves independently from inline markdown highlighting.

---

**Problem:**

HTML files can contain CSS and JavaScript inside style and script blocks. Before this change, those inner languages were not parsed and highlighted as their own languages. This meant CSS and JavaScript code inside HTML appeared with incomplete or plain highlighting.

This PR makes the highlighter recognize those fixed inner language regions, so CSS inside style blocks and JavaScript inside script blocks receive the correct syntax highlighting.

**Solution:**

- The highlighter now reads all injection rules for a language, not only the special combined case.

- It builds separate parsed layers for fixed inner languages, such as CSS inside style blocks and JavaScript inside script blocks.

- It keeps the existing behavior for cases that need multiple regions parsed together, such as HTML regions inside PHP.

- It reuses parsed inner layers when their language and text ranges have not changed.

- It adds tests that show CSS and JavaScript are highlighted correctly inside HTML.

**Tests:**

- The added failing tests now pass.
- I have manually tested `gpui-component-story --example editor` for intended behavior, edge cases and side effects.

---

> Implemented-by: Codex GPT-5.5
> Reviewed-by: Claude Opus 4.7 and Human