### PR TITLE
Notify when a notification dismisses

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -259,6 +259,7 @@ impl Notification {
             _ = view.update_in(cx, |view, _, cx| {
                 view.closing = false;
                 cx.emit(DismissEvent);
+                cx.notify();
             });
             if let Some(on_close) = on_close {
                 _ = cx.update(|window, cx| on_close(window, cx));


### PR DESCRIPTION
When a notification dismissed itself after the default delay in my app, it was not totally disappearing. It would turn semi-transparent, but not totally disappear until something else happened that triggered the view to redraw. I added the `notify` call in the dismiss handler and it worked fine again.

## How to Test

Push a notification, have nothing else happen so the root view doesn't get redrawn by some other trigger.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
