### PR TITLE
text: Enable mixed bold/italic markdown rendering

### DIFF
--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use gpui::SharedString;
 use markdown::{
     ParseOptions,
@@ -53,6 +55,75 @@ fn parse_table_cell(row: &mut node::TableRow, node: &mdast::TableCell, cx: &mut 
     row.children.push(table_cell);
 }
 
+fn push_merged(
+    paragraph: &mut Paragraph,
+    text: String,
+    marks: Vec<(Range<usize>, TextMark)>,
+    new_mark: TextMark,
+) {
+    if text.is_empty() {
+        return;
+    }
+
+    let mut node = InlineNode::new(text).marks(marks);
+    let len = node.text.len();
+    if let Some(last) = node.marks.last_mut()
+        && last.0.start == 0
+        && last.0.end == len
+    {
+        last.1.merge(new_mark);
+    } else {
+        node.marks.push((0..len, new_mark));
+    }
+    paragraph.push(node);
+}
+
+fn merge_children_with_mark(
+    paragraph: &mut Paragraph,
+    children: &[mdast::Node],
+    mark: TextMark,
+    cx: &mut NodeContext,
+) -> String {
+    let mut text = String::new();
+    let mut merged_text = String::new();
+    let mut merged_marks = Vec::new();
+
+    for child in children {
+        let mut child_paragraph = Paragraph::default();
+        let child_text = parse_paragraph(&mut child_paragraph, child, cx);
+        text.push_str(&child_text);
+
+        for node in child_paragraph.children {
+            let merged_offset = merged_text.len();
+            merged_text.push_str(&node.text);
+
+            for (range, child_mark) in node.marks {
+                merged_marks.push((
+                    range.start + merged_offset..range.end + merged_offset,
+                    child_mark,
+                ));
+            }
+
+            if let Some(mut image) = node.image {
+                if let Some(link_mark) = mark.link.clone() {
+                    image.link = Some(link_mark);
+                }
+
+                push_merged(
+                    paragraph,
+                    std::mem::take(&mut merged_text),
+                    std::mem::take(&mut merged_marks),
+                    mark.clone(),
+                );
+                paragraph.push(InlineNode::image(image));
+            }
+        }
+    }
+
+    push_merged(paragraph, merged_text, merged_marks, mark);
+    text
+}
+
 fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeContext) -> String {
     let span = node.position().map(|pos| Span {
         start: cx.offset + pos.start.offset,
@@ -75,31 +146,27 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
             paragraph.push_str(&val.value)
         }
         Node::Emphasis(val) => {
-            let mut child_paragraph = Paragraph::default();
-            for child in val.children.iter() {
-                text.push_str(&parse_paragraph(&mut child_paragraph, &child, cx));
-            }
-            paragraph.push(
-                InlineNode::new(&text).marks(vec![(0..text.len(), TextMark::default().italic())]),
+            text = merge_children_with_mark(
+                paragraph,
+                &val.children,
+                TextMark::default().italic(),
+                cx,
             );
         }
         Node::Strong(val) => {
-            let mut child_paragraph = Paragraph::default();
-            for child in val.children.iter() {
-                text.push_str(&parse_paragraph(&mut child_paragraph, &child, cx));
-            }
-            paragraph.push(
-                InlineNode::new(&text).marks(vec![(0..text.len(), TextMark::default().bold())]),
+            text = merge_children_with_mark(
+                paragraph,
+                &val.children,
+                TextMark::default().bold(),
+                cx,
             );
         }
         Node::Delete(val) => {
-            let mut child_paragraph = Paragraph::default();
-            for child in val.children.iter() {
-                text.push_str(&parse_paragraph(&mut child_paragraph, &child, cx));
-            }
-            paragraph.push(
-                InlineNode::new(&text)
-                    .marks(vec![(0..text.len(), TextMark::default().strikethrough())]),
+            text = merge_children_with_mark(
+                paragraph,
+                &val.children,
+                TextMark::default().strikethrough(),
+                cx,
             );
         }
         Node::InlineCode(val) => {
@@ -115,28 +182,15 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
                 ..Default::default()
             });
 
-            let mut child_paragraph = Paragraph::default();
-            for child in val.children.iter() {
-                text.push_str(&parse_paragraph(&mut child_paragraph, &child, cx));
-            }
-
-            // FIXME: GPUI InteractiveText does not support inline images yet.
-            // So here we push images to the paragraph directly.
-            for child in child_paragraph.children.iter_mut() {
-                if let Some(image) = child.image.as_mut() {
-                    image.link = link_mark.clone();
-                }
-
-                child.marks.push((
-                    0..child.text.len(),
-                    TextMark {
-                        link: link_mark.clone(),
-                        ..Default::default()
-                    },
-                ));
-            }
-
-            paragraph.merge(child_paragraph);
+            text = merge_children_with_mark(
+                paragraph,
+                &val.children,
+                TextMark {
+                    link: link_mark,
+                    ..Default::default()
+                },
+                cx,
+            );
         }
         Node::Image(raw) => {
             paragraph.push_image(ImageNode {
@@ -439,5 +493,39 @@ fn ast_to_node(
             }
             BlockNode::Unknown
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nested_emphasis_merges_text_marks() {
+        let mut cx = NodeContext::default();
+        let document = parse(
+            "This has **_bold and italic_** text.",
+            &mut cx,
+            &HighlightTheme::default_light(),
+        )
+        .unwrap();
+
+        let BlockNode::Paragraph(paragraph) = &document.blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        let bold_italic = paragraph
+            .children
+            .iter()
+            .find(|child| child.text.as_ref() == "bold and italic")
+            .expect("expected emphasized text");
+
+        assert!(
+            bold_italic
+                .marks
+                .iter()
+                .any(|(_, mark)| mark.bold && mark.italic),
+            "nested emphasis should produce a bold and italic mark"
+        );
     }
 }

--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -261,25 +261,21 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
             )]));
         }
         Node::LinkReference(link) => {
-            let mut child_paragraph = Paragraph::default();
-            let mut child_text = String::new();
-            for child in link.children.iter() {
-                child_text.push_str(&parse_paragraph(&mut child_paragraph, child, cx));
-            }
-
             let link_mark = LinkMark {
                 url: "".into(),
                 title: link.label.clone().map(Into::into),
                 identifier: Some(link.identifier.clone().into()),
             };
 
-            paragraph.push(InlineNode::new(&child_text).marks(vec![(
-                0..child_text.len(),
+            text = merge_children_with_mark(
+                paragraph,
+                &link.children,
                 TextMark {
                     link: Some(link_mark),
                     ..Default::default()
                 },
-            )]));
+                cx,
+            );
         }
         _ => {
             if cfg!(debug_assertions) {

--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -55,6 +55,11 @@ fn parse_table_cell(row: &mut node::TableRow, node: &mdast::TableCell, cx: &mut 
     row.children.push(table_cell);
 }
 
+/// Push a text run with its existing `marks` plus `new_mark` across the full
+/// run.
+///
+/// If the last mark already covers the full run, merge into it. Otherwise add a
+/// new full-run mark. Empty runs are skipped so callers can flush freely.
 fn push_merged(
     paragraph: &mut Paragraph,
     text: String,
@@ -78,6 +83,13 @@ fn push_merged(
     paragraph.push(node);
 }
 
+/// Parse `children` and apply `mark` across each emitted text run.
+///
+/// Nested child marks are kept and shifted to match the combined text for the
+/// current run, which lets nested emphasis like `**_x_**` render as both bold
+/// and italic. Inline images split the run and are emitted as sibling image
+/// nodes. The return value is the plain text from all children, for callers that
+/// need to pass text back to their parent node.
 fn merge_children_with_mark(
     paragraph: &mut Paragraph,
     children: &[mdast::Node],
@@ -109,6 +121,9 @@ fn merge_children_with_mark(
                     image.link = Some(link_mark);
                 }
 
+                // GPUI InteractiveText does not support inline images, so
+                // flush the accumulated text run and emit the image as its
+                // own sibling InlineNode.
                 push_merged(
                     paragraph,
                     std::mem::take(&mut merged_text),


### PR DESCRIPTION
The markdown preview did not show text correctly when bold and italic were used together. For example, text marked as both bold and italic could lose one of those styles.

The solution keeps the existing text styles when nested markdown is parsed, then adds the outer style to the same text. This lets combined styles, such as bold plus italic, render correctly in the preview.  (Closes #2120)

**Tested in `gpui-component-story --example markdown`**
```
_italic_ *italic*
**bold** __bold__
***bold and italic*** ___bold and italic___
_**bold and italic**_ *__bold and italic__*
*italic with **bold*** _italic with __bold___
_italic **with** bold_ *italic __with__ bold*
**bold with *italic*** __bold with _italic___
__bold *with* italic__ **bold _with_ italic**
```
<img width="239" height="211" alt="Screenshot_20260508_122144" src="https://github.com/user-attachments/assets/5b6903e1-5b08-4e1e-872d-f3f347fb27a1" />

---

Implemented-by: Codex GPT-5.5
Reviewed-by: Claude Opus 4.7 and Human