### PR TITLE
dock: Allow drag-to-expand on collapsed bottom dock

### DIFF
--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -306,9 +306,18 @@ impl Dock {
                 cx.new(|_| info.deref().clone())
             })
     }
-    fn resize(&mut self, mouse_position: Point<Pixels>, _: &mut Window, cx: &mut Context<Self>) {
+    fn resize(
+        &mut self,
+        mouse_position: Point<Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if !self.resizing {
             return;
+        }
+
+        if !self.open {
+            self.set_open(true, window, cx);
         }
 
         let dock_area = self


### PR DESCRIPTION
## Before
https://github.com/user-attachments/assets/6a90d63f-f324-4755-b528-c76ce9e5080f


## After
https://github.com/user-attachments/assets/3bc9cd96-407a-40d3-aacf-72ca03b67c41

