### PR TITLE
text: Fix streaming markdown replay reset

### DIFF
--- a/crates/story/examples/stream_markdown.rs
+++ b/crates/story/examples/stream_markdown.rs
@@ -9,8 +9,9 @@ use gpui_component_assets::Assets;
 
 pub struct Example {
     markdown_state: Entity<TextViewState>,
-    tx: smol::channel::Sender<String>,
+    tx: smol::channel::Sender<(usize, String)>,
     scroll_handle: ScrollHandle,
+    replay_id: usize,
     _task: Task<()>,
     _update_task: Task<()>,
 }
@@ -23,17 +24,21 @@ impl Example {
             cx.new(|cx| TextViewState::markdown("# Streaming Markdown Parse\n\n", cx));
         let scroll_handle = ScrollHandle::new();
 
-        let (tx, rx) = smol::channel::unbounded::<String>();
+        let (tx, rx) = smol::channel::unbounded::<(usize, String)>();
         let _task = cx.spawn({
-            let scroll_handle = scroll_handle.clone();
-            let weak_state = markdown_state.downgrade();
-            async move |_, cx| {
-                while let Ok(chunk) = rx.recv().await {
-                    _ = weak_state.update(cx, |state, cx| {
+            async move |weak_self, cx| {
+                while let Ok((replay_id, chunk)) = rx.recv().await {
+                    _ = weak_self.update(cx, |this, cx| {
+                        if replay_id != this.replay_id {
+                            return;
+                        }
+
                         // Push the new chunk to the markdown state,
                         // it will reparse and re-render automatically.
-                        state.push_str(&chunk, cx);
-                        scroll_handle.scroll_to_bottom();
+                        this.markdown_state.update(cx, |state, cx| {
+                            state.push_str(&chunk, cx);
+                        });
+                        this.scroll_handle.scroll_to_bottom();
                     });
                 }
             }
@@ -43,6 +48,7 @@ impl Example {
             markdown_state,
             scroll_handle,
             tx,
+            replay_id: 0,
             _task,
             _update_task: Task::ready(()),
         }
@@ -56,6 +62,8 @@ impl Example {
     /// 50ms for a iteration, every time adding about 5 - 20 characters
     /// This is just for demonstration; in a real app, you'd stream from a source.
     fn replay(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        self.replay_id = self.replay_id.wrapping_add(1);
+        let replay_id = self.replay_id;
         let tx = self.tx.clone();
         let mut current = 0;
         self.markdown_state.update(cx, |state, cx| {
@@ -67,7 +75,7 @@ impl Example {
             while current < chars.len() {
                 let chunk_size = (5 + rand::random::<usize>() % 15).min(chars.len() - current);
                 let chunk: String = chars[current..current + chunk_size].iter().collect();
-                _ = tx.try_send(chunk);
+                _ = tx.try_send((replay_id, chunk));
                 current += chunk_size;
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -1,8 +1,5 @@
-use std::{
-    pin::Pin,
-    task::Poll,
-};
 use futures::Stream as _;
+use std::{pin::Pin, task::Poll};
 
 use gpui::{
     App, AppContext as _, Bounds, ClipboardItem, Context, FocusHandle, IntoElement, KeyBinding,
@@ -12,7 +9,7 @@ use gpui::{
 
 use crate::{
     ActiveTheme, ElementExt,
-    async_util::{Sender, Receiver, unbounded},
+    async_util::{Receiver, Sender, unbounded},
     highlighter::HighlightTheme,
     input::{self, Copy},
     text::{
@@ -61,7 +58,7 @@ pub struct TextViewState {
     selection_positions: (Option<Point<Pixels>>, Option<Point<Pixels>>),
 
     pub(super) parsed_content: ParsedContent,
-    text: SharedString,
+    text: String,
     parsed_error: Option<SharedString>,
     tx: Sender<UpdateOptions>,
     _parse_task: Task<()>,
@@ -119,7 +116,7 @@ impl TextViewState {
             is_selecting: false,
             parsed_content: Default::default(),
             parsed_error: None,
-            text: text.to_string().into(),
+            text: text.to_string(),
             tx,
             _parse_task,
             _receive_task,
@@ -163,7 +160,8 @@ impl TextViewState {
             return;
         }
 
-        self.text = text.to_string().into();
+        self.text.clear();
+        self.text.push_str(text);
         self.parsed_error = None;
         self.increment_update(text, false, cx);
     }
@@ -173,6 +171,7 @@ impl TextViewState {
         if new_text.is_empty() {
             return;
         }
+        self.text.push_str(new_text);
         self.increment_update(new_text, true, cx);
     }
 
@@ -184,7 +183,6 @@ impl TextViewState {
     fn increment_update(&mut self, text: &str, append: bool, cx: &mut Context<Self>) {
         let update_options = UpdateOptions {
             append,
-            content: self.parsed_content.clone(),
             pending_text: text.to_string(),
             highlight_theme: cx.theme().highlight_theme.clone(),
         };
@@ -316,6 +314,7 @@ pub(crate) struct ParsedContent {
 
 struct UpdateFuture {
     format: TextViewFormat,
+    content: ParsedContent,
     options: UpdateOptions,
     pending_text: String,
     rx: Pin<Box<Receiver<UpdateOptions>>>,
@@ -331,11 +330,11 @@ impl UpdateFuture {
     ) -> Self {
         Self {
             format,
+            content: Default::default(),
             pending_text: String::new(),
             options: UpdateOptions {
                 append: false,
                 pending_text: String::new(),
-                content: Default::default(),
                 highlight_theme: cx.theme().highlight_theme.clone(),
             },
             rx: Box::pin(rx),
@@ -360,13 +359,14 @@ impl Future for UpdateFuture {
 
                     // Process immediately without debounce
                     let pending_text = std::mem::take(&mut self.pending_text);
-                    let res = parse_content(
-                        self.format,
-                        &UpdateOptions {
-                            pending_text,
-                            ..self.options.clone()
-                        },
-                    );
+                    let options = UpdateOptions {
+                        pending_text,
+                        ..self.options.clone()
+                    };
+                    let res = parse_content(self.format, self.content.clone(), &options);
+                    if let Ok(content) = &res {
+                        self.content = content.clone();
+                    }
                     _ = self.tx_result.try_send(res);
                     continue;
                 }
@@ -379,18 +379,20 @@ impl Future for UpdateFuture {
 
 #[derive(Clone)]
 struct UpdateOptions {
-    content: ParsedContent,
     pending_text: String,
     append: bool,
     highlight_theme: std::sync::Arc<HighlightTheme>,
 }
 
-fn parse_content(format: TextViewFormat, options: &UpdateOptions) -> Result<ParsedContent, SharedString> {
+fn parse_content(
+    format: TextViewFormat,
+    mut content: ParsedContent,
+    options: &UpdateOptions,
+) -> Result<ParsedContent, SharedString> {
     let mut node_cx = NodeContext {
         ..NodeContext::default()
     };
 
-    let mut content = options.content.clone();
     let mut source = String::new();
     if options.append
         && let Some(last_block) = content.document.blocks.pop()
@@ -441,7 +443,36 @@ fn selection_points(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::point;
+    use gpui::{TestAppContext, point};
+
+    #[gpui::test]
+    fn set_text_then_push_str_appends_to_replaced_content(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let state = cx.update(|cx| cx.new(|cx| TextViewState::markdown("old", cx)));
+        cx.run_until_parked();
+
+        state.update(cx, |state, cx| {
+            state.set_text("", cx);
+            state.push_str("new", cx);
+            state.push_str(" text", cx);
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.text.as_str(), "new text");
+            assert_eq!(state.source().as_str(), "new text");
+        });
+
+        state.update(cx, |state, cx| {
+            state.set_text("", cx);
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.text.as_str(), "");
+            assert_eq!(state.source().as_str(), "");
+        });
+    }
 
     #[test]
     fn test_text_view_state_selection_points() {


### PR DESCRIPTION
Closes #1893

  ## Description

  Fix `TextViewState::set_text("")` not clearing streamed Markdown content before replaying.

  The issue was caused by `push_str` appending parsed content without keeping `TextViewState`'s source text in sync. After the first replay,
  the internal `text` field could still be empty, so a later `set_text("")` returned early and skipped the reset.

  This PR keeps the source text synchronized during streaming append and makes the background parser track its latest parsed content
  internally, so `set_text("")` followed by new streamed chunks starts from a clean document.

  ## Screenshot

  | Before | After |
  | ------ | ----- |
  | The second `Replay` could keep old streamed content. | The second `Replay` clears old content and streams from the beginning again. |

  ## How to Test

  Manual verification:

  ```bash
  cargo run -p gpui-component-story --example stream_markdown

  1. Click Replay.
  2. Wait for the streamed Markdown output to finish.
  3. Scroll down.
  4. Click Replay again.
  5. Confirm the old content is cleared before the Markdown streams from the beginning again.

  Automated checks:

  rustfmt --check crates/ui/src/text/state.rs
  cargo test -p gpui-component
  cargo clippy -p gpui-component --tests -- -D warnings
  cargo check -p gpui-component-story --example stream_markdown

  ## Checklist

  - [x] I have read the ../CONTRIBUTING.md document and followed the guidelines.
  - [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
  - [x] Passed cargo run for story tests related to the changes.
  - [x] Tested macOS, Windows and Linux platforms performance (N/A: this change is not platform-specific; manually verified on Linux).

https://github.com/user-attachments/assets/8217d3f5-6c7b-4db4-b9c0-0b6003fd8148

