### PR TITLE
highlighter: Enable markdown code spans

### DIFF
--- a/crates/ui/src/highlighter/languages/markdown_inline/highlights.scm
+++ b/crates/ui/src/highlighter/languages/markdown_inline/highlights.scm
@@ -1,4 +1,8 @@
 [
+  (code_span)
+] @text.code.span
+
+[
   (emphasis_delimiter)
   (code_span_delimiter)
 ] @punctuation.delimiter

--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -13,7 +13,7 @@ use crate::{
     highlighter::{Language, languages},
 };
 
-pub(super) const HIGHLIGHT_NAMES: [&str; 40] = [
+pub(super) const HIGHLIGHT_NAMES: [&str; 41] = [
     "attribute",
     "boolean",
     "comment",
@@ -48,6 +48,7 @@ pub(super) const HIGHLIGHT_NAMES: [&str; 40] = [
     "string.special.symbol",
     "tag",
     "tag.doctype",
+    "text.code.span",
     "text.literal",
     "title",
     "type",
@@ -138,6 +139,8 @@ pub struct SyntaxColors {
     pub tag: Option<ThemeStyle>,
     #[serde(rename = "tag.doctype")]
     pub tag_doctype: Option<ThemeStyle>,
+    #[serde(rename = "text.code.span")]
+    pub text_code_span: Option<ThemeStyle>,
     #[serde(rename = "text.literal")]
     pub text_literal: Option<ThemeStyle>,
     pub title: Option<ThemeStyle>,
@@ -256,6 +259,7 @@ impl SyntaxColors {
             "string.special.symbol" => self.string_special_symbol,
             "tag" => self.tag,
             "tag.doctype" => self.tag_doctype,
+            "text.code.span" => self.text_code_span,
             "text.literal" => self.text_literal,
             "title" => self.title,
             "type" => self.type_,

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -188,6 +188,9 @@
           "text.literal": {
             "color": "#6F42C1"
           },
+          "text.code.span": {
+            "color": "#6F42C1"
+          },
           "title": {
             "color": "#0433FF"
           },
@@ -393,6 +396,9 @@
             "color": "#b5af9a"
           },
           "text.literal": {
+            "color": "#E1D797"
+          },
+          "text.code.span": {
             "color": "#E1D797"
           },
           "title": {


### PR DESCRIPTION
Creates a new `text.code.span` for more flexible styling, but mirrors the default for `text.literal`.