### PR TITLE
theme: Fix dark theme `overlay` color

### DIFF
--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -292,7 +292,7 @@
         "title_bar.border": "#262626",
         "warning.background": "yellow-400",
         "warning.foreground": "yellow-600",
-        "overlay": "#ffffff08",
+        "overlay": "#00000033",
         "window.border": "#262626",
         "base.red": "red-400",
         "base.red.light": "red-300",


### PR DESCRIPTION
Closes #2367.

Refer to shadcn.

| Before | After |
| - | - |
| <img width="1159" height="957" alt="Before" src="https://github.com/user-attachments/assets/be7a28dc-4d1f-4448-9568-3870cee8378d" /> | <img width="1159" height="957" alt="After" src="https://github.com/user-attachments/assets/1031b693-8e2c-43e3-8767-d391bc0343d0" /> |