### PR TITLE
select: Fix initial `selected_index` not shown on trigger

### DIFF
--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -1108,6 +1108,26 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_combo_box_initial_selection_seeds_cursor(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["React", "Vue", "Angular"]);
+            let state = cx.new(|cx| {
+                ComboboxState::new(items, vec![IndexPath::new(1)], window, cx).multiple(true)
+            });
+
+            let state_ref = state.read(cx);
+            assert_eq!(
+                state_ref.state.list.read(cx).selected_index(),
+                Some(IndexPath::new(1)),
+                "initial selected_indices should seed ListState.selected_index, not just the snapshot",
+            );
+            assert_eq!(state_ref.selected_values(), vec!["Vue"]);
+        });
+    }
+
+    #[gpui::test]
     fn test_multi_combo_box_toggle(cx: &mut TestAppContext) {
         cx.update(crate::init);
         let cx = cx.add_empty_window();

--- a/crates/ui/src/searchable_list/adapter.rs
+++ b/crates/ui/src/searchable_list/adapter.rs
@@ -35,7 +35,6 @@ pub(crate) struct SearchableListAdapter<D: SearchableListDelegate + 'static> {
 impl<D: SearchableListDelegate + 'static> SearchableListAdapter<D> {
     pub(crate) fn new(
         delegate: D,
-        selected_index: Option<IndexPath>,
         on_confirm: impl Fn(Option<IndexPath>, bool, &mut Window, &mut Context<ListState<Self>>)
         + 'static,
         on_cancel: impl Fn(Option<IndexPath>, &mut Window, &mut Context<ListState<Self>>) + 'static,
@@ -43,7 +42,7 @@ impl<D: SearchableListDelegate + 'static> SearchableListAdapter<D> {
     ) -> Self {
         Self {
             delegate,
-            selected_index,
+            selected_index: None,
             selection_snapshot: Vec::new(),
             on_confirm: Box::new(on_confirm),
             on_cancel: Box::new(on_cancel),

--- a/crates/ui/src/searchable_list/state.rs
+++ b/crates/ui/src/searchable_list/state.rs
@@ -52,16 +52,16 @@ where
         delegate: D,
         selected_indices: Vec<IndexPath>,
         on_confirm: impl Fn(
-                Option<IndexPath>,
-                bool,
-                &mut Window,
-                &mut Context<ListState<SearchableListAdapter<D>>>,
-            ) + 'static,
+            Option<IndexPath>,
+            bool,
+            &mut Window,
+            &mut Context<ListState<SearchableListAdapter<D>>>,
+        ) + 'static,
         on_cancel: impl Fn(
-                Option<IndexPath>,
-                &mut Window,
-                &mut Context<ListState<SearchableListAdapter<D>>>,
-            ) + 'static,
+            Option<IndexPath>,
+            &mut Window,
+            &mut Context<ListState<SearchableListAdapter<D>>>,
+        ) + 'static,
         on_render_empty: impl Fn(&mut Window, &mut App) -> AnyElement + 'static,
         on_blur: fn(&mut P, &mut Window, &mut Context<P>),
         window: &mut Window,
@@ -69,14 +69,7 @@ where
     ) -> Self {
         let focus_handle = cx.focus_handle();
 
-        let initial_cursor = selected_indices.first().copied();
-        let adapter = SearchableListAdapter::new(
-            delegate,
-            initial_cursor,
-            on_confirm,
-            on_cancel,
-            on_render_empty,
-        );
+        let adapter = SearchableListAdapter::new(delegate, on_confirm, on_cancel, on_render_empty);
         let list = cx.new(|cx| ListState::new(adapter, window, cx).reset_on_cancel(false));
 
         let list_focus_handle = list.read(cx).focus_handle.clone();
@@ -91,6 +84,12 @@ where
                 .filter_map(|ix| delegate.item(ix).map(|i| (ix, i.clone())))
                 .collect::<Vec<_>>()
         };
+
+        if let Some(cursor) = selected_indices.first().copied() {
+            list.update(cx, |l, cx| {
+                l.set_selected_index(Some(cursor), window, cx);
+            });
+        }
 
         // Prime the adapter's snapshot so the very first render pass sees correct check state.
         let initial_snapshot = selection.clone();

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -764,3 +764,50 @@ where
             .child(self.state)
     }
 }
+
+// MARK: Tests
+
+#[cfg(test)]
+mod tests {
+    use gpui::{AppContext as _, TestAppContext};
+
+    use crate::{
+        IndexPath,
+        searchable_list::SearchableVec,
+        select::{SelectGroup, SelectState},
+    };
+
+    #[gpui::test]
+    fn test_select_initial_selection_seeds_cursor(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["Rust", "Go", "C++"]);
+            let state = cx.new(|cx| SelectState::new(items, Some(IndexPath::new(1)), window, cx));
+
+            assert_eq!(
+                state.read(cx).selected_index(cx),
+                Some(IndexPath::new(1)),
+                "initial cursor should be seeded on ListState so display_title can read it",
+            );
+            assert_eq!(state.read(cx).selected_value(), Some(&"Go"));
+        });
+    }
+
+    #[gpui::test]
+    fn test_select_initial_grouped_selection_seeds_cursor(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let mut groups: SearchableVec<SelectGroup<&'static str>> = SearchableVec::new(vec![]);
+            groups.push(SelectGroup::new("A").items(["Apple", "Avocado"]));
+            groups.push(SelectGroup::new("B").items(["Banana", "Blueberry", "Blackberry"]));
+
+            let initial = IndexPath::new(1).section(1);
+            let state = cx.new(|cx| SelectState::new(groups, Some(initial), window, cx));
+
+            assert_eq!(state.read(cx).selected_index(cx), Some(initial));
+            assert_eq!(state.read(cx).selected_value(), Some(&"Blueberry"));
+        });
+    }
+}


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1212" height="939" alt="Before" src="https://github.com/user-attachments/assets/e338f35e-97ea-4261-aab5-17ee43cd379c" /> | <img width="1213" height="941" alt="After" src="https://github.com/user-attachments/assets/4d30d82c-5b76-49fd-a3e3-25ba6234074f" /> |