### PR TITLE
dialog: Focus first control on open

### DIFF
--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -212,6 +212,7 @@ pub struct Dialog {
 
     /// This will be change when open the dialog, the focus handle is create when open the dialog.
     pub(crate) focus_handle: FocusHandle,
+    pub(crate) focus_first_descendant: bool,
     pub(crate) layer_ix: usize,
 }
 
@@ -236,6 +237,7 @@ impl Dialog {
             content_builder: None,
             props: DialogProps::default(),
             children: Vec::new(),
+            focus_first_descendant: false,
             layer_ix: 0,
             button_props: DialogButtonProps::default(),
         }
@@ -445,6 +447,12 @@ impl RenderOnce for Dialog {
         let on_close = self.button_props.on_close.clone();
         let on_ok = self.button_props.on_ok.clone();
         let on_cancel = self.button_props.on_cancel.clone();
+        if self.focus_first_descendant {
+            let focus_handle = self.focus_handle.clone();
+            window.defer(cx, move |window, cx| {
+                Root::focus_first_descendant(&focus_handle, window, cx);
+            });
+        }
 
         let window_paddings = crate::window_border::window_paddings(window);
         let view_size = window.viewport_size()

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -13,7 +13,7 @@ use gpui::{
     InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Pixels, Render,
     StyleRefinement, Styled, WeakFocusHandle, Window, actions, div, prelude::FluentBuilder as _,
 };
-use std::{any::TypeId, rc::Rc};
+use std::{any::TypeId, cell::Cell, rc::Rc};
 
 actions!(root, [Tab, TabPrev]);
 
@@ -58,6 +58,7 @@ pub(crate) struct ActiveDialog {
     /// The previous focused handle before opening the Dialog.
     previous_focused_handle: Option<WeakFocusHandle>,
     builder: Rc<dyn Fn(Dialog, &mut Window, &mut App) -> Dialog + 'static>,
+    focus_first_descendant: Rc<Cell<bool>>,
 }
 
 impl ActiveDialog {
@@ -70,7 +71,12 @@ impl ActiveDialog {
             focus_handle,
             previous_focused_handle,
             builder: Rc::new(builder),
+            focus_first_descendant: Rc::new(Cell::new(true)),
         }
+    }
+
+    fn take_focus_first_descendant(&self) -> bool {
+        self.focus_first_descendant.replace(false)
     }
 }
 
@@ -222,6 +228,7 @@ impl Root {
                 //
                 // So we keep the focus handle in the `active_dialog`, this is owned by the `Root`.
                 dialog.focus_handle = active_dialog.focus_handle.clone();
+                dialog.focus_first_descendant = active_dialog.take_focus_first_descendant();
 
                 dialog.layer_ix = i;
                 // Find the dialog which one needs to show overlay.
@@ -263,6 +270,31 @@ impl Root {
             build,
         ));
         cx.notify();
+    }
+
+    pub(crate) fn focus_first_descendant(
+        container_focus_handle: &FocusHandle,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if !container_focus_handle.is_focused(window) {
+            return;
+        }
+
+        let previous_focus = window.focused(cx);
+        // The dialog container is in the focus tree but is not a tab stop, so advancing once
+        // lands on the first keyboard-focusable descendant when one exists.
+        window.focus_next(cx);
+
+        if container_focus_handle.contains_focused(window, cx)
+            && !container_focus_handle.is_focused(window)
+        {
+            return;
+        }
+
+        if let Some(previous_focus) = previous_focus {
+            window.focus(&previous_focus, cx);
+        }
     }
 
     fn close_dialog_internal(&mut self) -> Option<FocusHandle> {
@@ -507,5 +539,90 @@ impl Render for Root {
                 .child(self.view.clone())
                 .child(self.tooltip_overlay.clone()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{WindowExt as _, input::Input, theme::Theme};
+    use gpui::{Focusable as _, TestAppContext, VisualTestContext};
+
+    struct DialogFocusTest {
+        focus_handle: FocusHandle,
+    }
+
+    impl Render for DialogFocusTest {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .track_focus(&self.focus_handle)
+                .size_full()
+                .children(Root::render_dialog_layer(window, cx))
+        }
+    }
+
+    fn window_with_root(cx: &mut TestAppContext) -> &mut VisualTestContext {
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            cx.set_global(Theme::default());
+            crate::init(cx);
+
+            let view = cx.new(|cx| DialogFocusTest {
+                focus_handle: cx.focus_handle(),
+            });
+
+            Root::new(view, window, cx)
+        });
+
+        cx
+    }
+
+    #[gpui::test]
+    fn open_dialog_focuses_first_input(cx: &mut TestAppContext) {
+        let cx = window_with_root(cx);
+        let input = cx.update(|window, cx| cx.new(|cx| InputState::new(window, cx)));
+
+        cx.update(|window, cx| {
+            let input = input.clone();
+            window.open_dialog(cx, move |dialog, _, _| {
+                dialog.title("Initial focus").child(Input::new(&input))
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|window, cx| {
+            assert!(input.read(cx).focus_handle(cx).is_focused(window));
+        });
+
+        cx.simulate_input("abc");
+
+        cx.update(|_, cx| {
+            assert_eq!(input.read(cx).value().as_ref(), "abc");
+        });
+    }
+
+    #[gpui::test]
+    fn open_dialog_does_not_override_explicit_focus(cx: &mut TestAppContext) {
+        let cx = window_with_root(cx);
+        let first_input = cx.update(|window, cx| cx.new(|cx| InputState::new(window, cx)));
+        let explicit_input = cx.update(|window, cx| cx.new(|cx| InputState::new(window, cx)));
+
+        cx.update(|window, cx| {
+            let first_input = first_input.clone();
+            let explicit_input = explicit_input.clone();
+            window.open_dialog(cx, move |dialog, window, cx| {
+                explicit_input.update(cx, |input, cx| input.focus(window, cx));
+
+                dialog
+                    .title("Initial focus")
+                    .child(Input::new(&first_input))
+                    .child(Input::new(&explicit_input))
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|window, cx| {
+            assert!(!first_input.read(cx).focus_handle(cx).is_focused(window));
+            assert!(explicit_input.read(cx).focus_handle(cx).is_focused(window));
+        });
     }
 }


### PR DESCRIPTION
Closes #2068

## Description

This PR fixes the initial focus behavior for `Dialog`.

Previously, opening a dialog focused the dialog container itself. As a result, when the first interactive control inside the dialog was an input, users could not type immediately after the dialog opened unless they clicked the input or pressed Tab first.

The dialog now performs a one-time initial focus pass after it is rendered. If the dialog container still owns focus, it advances focus to the first keyboard-focusable descendant. If there is no focusable descendant, focus is restored to the dialog container. Explicit focus set by a dialog builder is preserved and will not be overridden.

## Screenshot

| Before                                            | After                                                    |
| ------------------------------------------------- | -------------------------------------------------------- |
|focus stayed on the dialog container itself | <img width="1066" height="624" alt="20260516_054649" src="https://github.com/user-attachments/assets/ba1ef3c6-b839-4454-a272-479efc6b43a8" /> |

## How to Test

Run the focused dialog regression tests:

```bash
cargo test -p gpui-component open_dialog_
```

Run the full `gpui-component` test suite:

```bash
cargo test -p gpui-component
```

Verify the web/wasm build path:

```bash
cd crates/story-web
cargo build --target wasm32-unknown-unknown
```

Manually verify the story gallery:

```bash
cargo run
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific). N/A: this change is not platform-specific.


