### PR TITLE
tooltip: Fix to hide Tooltip immediately on mouse down.

### DIFF
--- a/crates/story/src/stories/tooltip_story.rs
+++ b/crates/story/src/stories/tooltip_story.rs
@@ -1,6 +1,7 @@
 use gpui::{
     App, AppContext, Context, Entity, Focusable, InteractiveElement, KeyBinding, ParentElement,
     Render, StatefulInteractiveElement as _, Styled, Window, actions, div,
+    prelude::FluentBuilder as _,
 };
 
 use gpui_component::{
@@ -26,6 +27,7 @@ pub fn init(cx: &mut App) {
 
 pub struct TooltipStory {
     focus_handle: gpui::FocusHandle,
+    removable_button_visible: bool,
 }
 
 impl TooltipStory {
@@ -36,6 +38,7 @@ impl TooltipStory {
     fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
+            removable_button_visible: true,
         }
     }
 }
@@ -68,7 +71,7 @@ impl Render for TooltipStory {
     fn render(
         &mut self,
         _: &mut gpui::Window,
-        _cx: &mut gpui::Context<Self>,
+        cx: &mut gpui::Context<Self>,
     ) -> impl gpui::IntoElement {
         v_flex()
             .w_full()
@@ -142,6 +145,34 @@ impl Render for TooltipStory {
                             .build(window, cx)
                     },
                 )),
+            )
+            .child(
+                section("Tooltip trigger removed on click").child(
+                    h_flex()
+                        .gap_2()
+                        .when(self.removable_button_visible, |this| {
+                            this.child(
+                                Button::new("remove-tooltip-trigger")
+                                    .danger()
+                                    .label("Remove me")
+                                    .tooltip("Clicking this button removes the trigger.")
+                                    .on_click(cx.listener(|story, _, _, cx| {
+                                        story.removable_button_visible = false;
+                                        cx.notify();
+                                    })),
+                            )
+                        })
+                        .when(!self.removable_button_visible, |this| {
+                            this.child(
+                                Button::new("restore-tooltip-trigger")
+                                    .label("Restore button")
+                                    .on_click(cx.listener(|story, _, _, cx| {
+                                        story.removable_button_visible = true;
+                                        cx.notify();
+                                    })),
+                            )
+                        }),
+                ),
             )
     }
 }

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -2,9 +2,9 @@ use std::{cell::Cell, rc::Rc, time::Duration};
 
 use gpui::{
     Action, AnyElement, AnyView, App, AppContext, Bounds, Context, Display, Element, ElementId,
-    GlobalElementId, Half, InspectorElementId, IntoElement, LayoutId, ParentElement, Pixels, Point,
-    Position, Render, SharedString, Size, StatefulInteractiveElement, Style, StyleRefinement,
-    Styled, Task, Window, deferred, div, point, prelude::FluentBuilder, px,
+    GlobalElementId, Half, InspectorElementId, IntoElement, LayoutId, MouseButton, ParentElement,
+    Pixels, Point, Position, Render, SharedString, Size, StatefulInteractiveElement, Style,
+    StyleRefinement, Styled, Task, Window, deferred, div, point, prelude::FluentBuilder, px,
 };
 
 use crate::{
@@ -460,6 +460,30 @@ impl TooltipOverlay {
             });
         }));
     }
+
+    pub(crate) fn hide_now(&mut self, cx: &mut Context<Self>) {
+        if self.clear_state() {
+            cx.notify();
+        }
+    }
+
+    fn clear_state(&mut self) -> bool {
+        let changed = self.content.is_some()
+            || self.prev_trigger_bounds.is_some()
+            || self.had_recent_tooltip
+            || self.is_switching
+            || self._show_task.is_some()
+            || self._hide_task.is_some();
+
+        self.content = None;
+        self.prev_trigger_bounds = None;
+        self.had_recent_tooltip = false;
+        self.is_switching = false;
+        self._show_task = None;
+        self._hide_task = None;
+
+        changed
+    }
 }
 
 impl Render for TooltipOverlay {
@@ -597,6 +621,13 @@ pub(crate) trait ManagedTooltipExt:
                 }
             }
         })
+        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+            if let Some(overlay) = Root::tooltip_overlay(window, cx) {
+                overlay.update(cx, |overlay, cx| {
+                    overlay.hide_now(cx);
+                });
+            }
+        })
     }
 }
 
@@ -607,12 +638,38 @@ mod tests {
     use super::*;
     use gpui::size;
 
+    fn test_content(bounds: Bounds<Pixels>) -> TooltipContent {
+        TooltipContent {
+            build: Rc::new(|window, cx| Tooltip::new("Test tooltip").build(window, cx)),
+            trigger_bounds: bounds,
+        }
+    }
+
     fn test_bounds(x: f32, y: f32, width: f32, height: f32) -> Bounds<Pixels> {
         Bounds::new(point(px(x), px(y)), size(px(width), px(height)))
     }
 
     fn test_size(width: f32, height: f32) -> Size<Pixels> {
         size(px(width), px(height))
+    }
+
+    #[test]
+    fn tooltip_overlay_clear_state_resets_active_tooltip() {
+        let mut overlay = TooltipOverlay::new();
+
+        overlay.content = Some(test_content(test_bounds(10., 10., 40., 20.)));
+        overlay.prev_trigger_bounds = Some(test_bounds(0., 0., 40., 20.));
+        overlay.had_recent_tooltip = true;
+        overlay.is_switching = true;
+        overlay._show_task = Some(Task::ready(()));
+
+        assert!(overlay.clear_state());
+        assert!(overlay.content.is_none());
+        assert!(overlay.prev_trigger_bounds.is_none());
+        assert!(!overlay.had_recent_tooltip);
+        assert!(!overlay.is_switching);
+        assert!(overlay._show_task.is_none());
+        assert!(overlay._hide_task.is_none());
     }
 
     #[test]

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -461,7 +461,7 @@ impl TooltipOverlay {
         }));
     }
 
-    pub(crate) fn hide_now(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn hide(&mut self, cx: &mut Context<Self>) {
         if self.clear_state() {
             cx.notify();
         }
@@ -624,7 +624,7 @@ pub(crate) trait ManagedTooltipExt:
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
             if let Some(overlay) = Root::tooltip_overlay(window, cx) {
                 overlay.update(cx, |overlay, cx| {
-                    overlay.hide_now(cx);
+                    overlay.hide(cx);
                 });
             }
         })


### PR DESCRIPTION
Closes #2381

## Description

Fix stale managed tooltips when a tooltip trigger removes itself on click. Managed tooltips are rendered by the Root overlay, so if the trigger is removed before the normal hover-leave path runs, the old tooltip can remain visible and cannot be dismissed by moving away from the removed trigger.

This change clears the active tooltip immediately on trigger mouse down, before the click handler mutates the UI tree. The normal hover-enter delay and hover-leave grace period are otherwise preserved.

This follows the shadcn/base-ui tooltip behavior. shadcn/ui delegates tooltip behavior to Base UI in its base implementation, and Base UI defaults tooltip triggers to `closeOnClick = true`. Base UI cancels delayed hover opens on trigger `onPointerDown` / `onClick`, and uses `useDismiss` with `referencePress` to dismiss an already-open tooltip when the trigger is pressed:

```tsx
const {
  closeOnClick = true,
} = componentProps;

onPointerDown(event) {
  store.set("closeOnClick", closeOnClick);
  if (closeOnClick && !store.select("open")) {
    store.cancelPendingOpen(event.nativeEvent);
  }
}

onClick(event) {
  if (closeOnClick && !store.select("open")) {
    store.cancelPendingOpen(event.nativeEvent);
  }
}

useDismiss(floatingRootContext, {
  referencePress: () => store.select("closeOnClick"),
});
```

## Screenshot

Before

https://github.com/user-attachments/assets/9a88bde2-402c-4b3a-a269-61e4491b5533

After

https://github.com/user-attachments/assets/7f63c5f3-36a5-407d-8dcb-c42e3402b97c

## How to Test

- `cargo test -p gpui-component tooltip`
- `cargo check -p gpui-component-story`
- `rustfmt --check crates/ui/src/tooltip.rs crates/story/src/stories/tooltip_story.rs`
- `git diff --check`

Manual verification steps:

1. Run `cargo run`.
2. Open the Tooltip story.
3. Hover `Remove me` until the tooltip appears.
4. Click `Remove me`.
5. Expected: the button disappears and the tooltip disappears with it.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
