### PR TITLE
combobox: Fix SearchableList selection identity after filtering

### DIFF
--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -147,10 +147,9 @@ where
                             return;
                         };
 
-                        // Guard: verify the item exists before proceeding.
-                        if list_state.delegate().delegate.item(index).is_none() {
+                        let Some(item) = list_state.delegate().delegate.item(index).cloned() else {
                             return;
-                        }
+                        };
 
                         let ix = index;
 
@@ -163,23 +162,7 @@ where
                             (s.multiple, s.state.selection.clone())
                         };
 
-                        let is_selected = selection.iter().any(|(cur_ix, _)| cur_ix == &ix);
-                        let changes: Vec<SearchableListChange> = if multiple {
-                            if is_selected {
-                                vec![SearchableListChange::Deselect { index: ix }]
-                            } else {
-                                vec![SearchableListChange::Select { index: ix }]
-                            }
-                        } else {
-                            let mut changes: Vec<SearchableListChange> = selection
-                                .iter()
-                                .map(|(cur_ix, _)| SearchableListChange::Deselect {
-                                    index: *cur_ix,
-                                })
-                                .collect();
-                            changes.push(SearchableListChange::Select { index: ix });
-                            changes
-                        };
+                        let changes = Self::selection_changes(multiple, &selection, ix, &item);
 
                         let before_indices: Vec<IndexPath> =
                             selection.iter().map(|(ix, _)| *ix).collect();
@@ -361,6 +344,32 @@ where
         self.state.focus_handle.focus(window, cx);
     }
 
+    fn selection_changes(
+        multiple: bool,
+        selection: &[(IndexPath, D::Item)],
+        ix: IndexPath,
+        item: &D::Item,
+    ) -> Vec<SearchableListChange> {
+        let is_selected = selection
+            .iter()
+            .any(|(_, selected_item)| selected_item.value() == item.value());
+
+        if multiple {
+            if is_selected {
+                vec![SearchableListChange::Deselect { index: ix }]
+            } else {
+                vec![SearchableListChange::Select { index: ix }]
+            }
+        } else {
+            let mut changes: Vec<SearchableListChange> = selection
+                .iter()
+                .map(|(cur_ix, _)| SearchableListChange::Deselect { index: *cur_ix })
+                .collect();
+            changes.push(SearchableListChange::Select { index: ix });
+            changes
+        }
+    }
+
     /// Process an item click: single-select replaces the selection and closes; multi-select toggles.
     ///
     /// Calls `delegate.on_will_change` before committing and `delegate.on_confirm` when closing.
@@ -371,24 +380,19 @@ where
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let is_selected = self.state.selection.iter().any(|(cur_ix, _)| cur_ix == &ix);
-
-        let changes: Vec<SearchableListChange> = if self.multiple {
-            if is_selected {
-                vec![SearchableListChange::Deselect { index: ix }]
-            } else {
-                vec![SearchableListChange::Select { index: ix }]
-            }
-        } else {
-            let mut changes: Vec<SearchableListChange> = self
-                .state
-                .selection
-                .iter()
-                .map(|(cur_ix, _)| SearchableListChange::Deselect { index: *cur_ix })
-                .collect();
-            changes.push(SearchableListChange::Select { index: ix });
-            changes
+        let Some(item) = self
+            .state
+            .list
+            .read(cx)
+            .delegate()
+            .delegate
+            .item(ix)
+            .cloned()
+        else {
+            return;
         };
+
+        let changes = Self::selection_changes(self.multiple, &self.state.selection, ix, &item);
 
         let mut selection = self.state.selection.clone();
         let before_indices: Vec<IndexPath> = selection.iter().map(|(ix, _)| *ix).collect();
@@ -790,7 +794,9 @@ where
         mut self,
         builder: impl Fn(&mut Window, &App) -> E + 'static,
     ) -> Self {
-        self.empty = Some(Box::new(move |window, cx| builder(window, cx).into_any_element()));
+        self.empty = Some(Box::new(move |window, cx| {
+            builder(window, cx).into_any_element()
+        }));
         self
     }
 
@@ -925,13 +931,7 @@ fn render_trigger_container(
                 .rounded(cx.theme().radius)
                 .when(cx.theme().shadow, |this| this.shadow_xs())
         })
-        .map(|this| {
-            if disabled {
-                this.shadow_none()
-            } else {
-                this
-            }
-        })
+        .map(|this| if disabled { this.shadow_none() } else { this })
         .overflow_hidden()
         .input_size(size)
         .input_text_size(size)
@@ -1133,8 +1133,7 @@ mod tests {
         let cx = cx.add_empty_window();
         cx.update(|window, cx| {
             let items = SearchableVec::new(vec!["React", "Vue", "Angular"]);
-            let state = cx
-                .new(|cx| ComboboxState::new(items, vec![], window, cx).multiple(true));
+            let state = cx.new(|cx| ComboboxState::new(items, vec![], window, cx).multiple(true));
 
             state.update(cx, |s, cx| s.add_selected_index(IndexPath::new(0), cx));
             assert_eq!(state.read(cx).selected_values(), &["React"]);
@@ -1144,6 +1143,100 @@ mod tests {
 
             state.update(cx, |s, cx| s.remove_selected_index(IndexPath::new(0), cx));
             assert_eq!(state.read(cx).selected_values(), &["Vue"]);
+        });
+    }
+
+    #[gpui::test]
+    fn test_multi_combo_box_search_selection_uses_value_identity(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["React", "Vue", "Angular"]);
+            let state = cx.new(|cx| ComboboxState::new(items, vec![], window, cx).multiple(true));
+
+            state.update(cx, |s, cx| s.add_selected_index(IndexPath::new(0), cx));
+            assert_eq!(state.read(cx).selected_values(), &["React"]);
+
+            state.update(cx, |s, cx| {
+                s.state.list.update(cx, |list, cx| {
+                    let _ = list
+                        .delegate_mut()
+                        .delegate
+                        .perform_search("Vue", window, cx);
+                });
+            });
+
+            state.read_with(cx, |s, cx| {
+                let selection = s.state.selection.clone();
+                let list = s.state.list.read(cx);
+                let delegate = &list.delegate().delegate;
+                let ix = IndexPath::new(0);
+                let item = delegate.item(ix).expect("filtered item exists");
+
+                assert_eq!(item.value(), &"Vue");
+                assert!(
+                    !delegate.is_item_checked(ix, item, &selection, cx),
+                    "filtered row 0 should not inherit React's checked state",
+                );
+            });
+
+            state.update(cx, |s, cx| {
+                s.handle_item_select(IndexPath::new(0), window, cx);
+            });
+            assert_eq!(state.read(cx).selected_values(), &["React", "Vue"]);
+        });
+    }
+
+    #[gpui::test]
+    fn test_multi_combo_box_search_deselects_by_value(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["React", "Vue", "Angular"]);
+            let state = cx.new(|cx| ComboboxState::new(items, vec![], window, cx).multiple(true));
+
+            state.update(cx, |s, cx| s.add_selected_index(IndexPath::new(0), cx));
+
+            state.update(cx, |s, cx| {
+                s.state.list.update(cx, |list, cx| {
+                    let _ = list
+                        .delegate_mut()
+                        .delegate
+                        .perform_search("React", window, cx);
+                });
+            });
+
+            state.update(cx, |s, cx| {
+                s.handle_item_select(IndexPath::new(0), window, cx);
+            });
+            assert!(state.read(cx).selected_values().is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn test_searchable_list_default_change_uses_value_identity(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let mut delegate = SearchableVec::new(vec!["React", "Vue", "Angular"]);
+            let mut selection = vec![(IndexPath::new(1), "Vue")];
+
+            let _ = delegate.perform_search("Vue", window, cx);
+            delegate.on_will_change(
+                &mut selection,
+                &[SearchableListChange::Deselect {
+                    index: IndexPath::new(0),
+                }],
+            );
+            assert!(selection.is_empty());
+
+            delegate.on_will_change(
+                &mut selection,
+                &[SearchableListChange::Select {
+                    index: IndexPath::new(0),
+                }],
+            );
+            assert_eq!(selection, vec![(IndexPath::new(0), "Vue")]);
         });
     }
 
@@ -1241,9 +1334,8 @@ mod tests {
 
     // Suppress unused import warning for SearchableListState in test module.
     #[allow(unused)]
-    fn _uses_state<D: SearchableListDelegate + 'static>(
-        _: &SearchableListState<D>,
-    ) where
+    fn _uses_state<D: SearchableListDelegate + 'static>(_: &SearchableListState<D>)
+    where
         <D::Item as SearchableListItem>::Value: PartialEq + Clone,
     {
     }

--- a/crates/ui/src/searchable_list/delegate.rs
+++ b/crates/ui/src/searchable_list/delegate.rs
@@ -6,7 +6,7 @@ use super::change::SearchableListChange;
 
 /// An item that can appear in a searchable list (Select, ComboBox).
 pub trait SearchableListItem: Clone {
-    type Value: Clone;
+    type Value: Clone + PartialEq;
 
     /// Short display label shown in the dropdown row and in the trigger by default.
     fn title(&self) -> SharedString;
@@ -129,15 +129,17 @@ pub trait SearchableListDelegate: Sized + 'static {
     ///
     /// `current_selection` is the slice of currently selected `(IndexPath, Item)` pairs.
     ///
-    /// Default: checks whether `ix` is present in `current_selection`.
+    /// Default: checks whether the item's value is present in `current_selection`.
     fn is_item_checked(
         &self,
-        ix: IndexPath,
-        _item: &Self::Item,
+        _ix: IndexPath,
+        item: &Self::Item,
         current_selection: &[(IndexPath, Self::Item)],
         _cx: &App,
     ) -> bool {
-        current_selection.iter().any(|(sel_ix, _)| sel_ix == &ix)
+        current_selection
+            .iter()
+            .any(|(_, selected_item)| selected_item.value() == item.value())
     }
 
     // MARK: Lifecycle / selection hooks
@@ -162,14 +164,31 @@ pub trait SearchableListDelegate: Sized + 'static {
         for change in changes {
             match change {
                 SearchableListChange::Select { index } => {
-                    if !selection.iter().any(|(ix, _)| ix == index) {
-                        if let Some(item) = self.item(*index) {
-                            selection.push((*index, item.clone()));
-                        }
+                    let Some(item) = self.item(*index) else {
+                        continue;
+                    };
+
+                    if !selection
+                        .iter()
+                        .any(|(_, selected_item)| selected_item.value() == item.value())
+                    {
+                        selection.push((*index, item.clone()));
                     }
                 }
                 SearchableListChange::Deselect { index } => {
-                    selection.retain(|(ix, _)| ix != index);
+                    if let Some(item) = self.item(*index) {
+                        let has_value = selection
+                            .iter()
+                            .any(|(_, selected_item)| selected_item.value() == item.value());
+
+                        if has_value {
+                            selection
+                                .retain(|(_, selected_item)| selected_item.value() != item.value());
+                            continue;
+                        }
+                    }
+
+                    selection.retain(|(selected_ix, _)| selected_ix != index);
                 }
             }
         }


### PR DESCRIPTION
Closes #2384

## Description

Fixes searchable-list selection identity after filtering. Default searchable-list checked and change behavior now compares `SearchableListItem::value()` instead of treating `IndexPath` as a stable item identity. Combobox multi-select also resolves the clicked filtered item before computing toggle changes, preventing filtered row 0 from inheriting another item's checked state.

## Screenshot

Before:

[[Put Before Recording here]](https://github.com/user-attachments/assets/a9dd236b-bcc7-4499-bd4f-b040dca7405d)

After:

https://github.com/user-attachments/assets/869c8218-ab99-4e1b-953f-c1ef636422de


## Breaking Changes

- `SearchableListItem::Value` now requires `PartialEq` so default selection identity can compare item values.

```diff
- type Value: Clone;
+ type Value: Clone + PartialEq;
```

## How to Test

- `cargo test -p gpui-component combobox -- --nocapture`
- `cargo test -p gpui-component searchable_list -- --nocapture`
- `rustfmt --check crates/ui/src/combobox.rs crates/ui/src/searchable_list/delegate.rs`
- `git diff --check`

Note: full `cargo fmt --check` currently reports unrelated pre-existing formatting diffs outside this PR's touched files.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
