### PR TITLE
html: Add support for <u> underline tag in HTML format

### DIFF
--- a/crates/story/examples/fixtures/test.html
+++ b/crates/story/examples/fixtures/test.html
@@ -7,7 +7,7 @@
             <mention>@Mention Tag</mention>
             <a href="https://google.com"
                 >Link with: <b>Bold <i>italic</i></b></a
-            >, <strong>bold</strong>, <em>italic</em>, and
+            >, <strong>bold</strong>, <em>italic</em>, <u>underline</u>, and
             <code>code</code> text.
         </p>
         <script>

--- a/crates/ui/src/text/format/html.rs
+++ b/crates/ui/src/text/format/html.rs
@@ -299,6 +299,9 @@ fn parse_paragraph(
             local_name!("del") | local_name!("s") => {
                 merge_children_with_mark(node, paragraph, Some(TextMark::default().strikethrough()));
             }
+            local_name!("u") => {
+                merge_children_with_mark(node, paragraph, Some(TextMark::default().underline()));
+            }
             local_name!("code") => {
                 merge_children_with_mark(node, paragraph, Some(TextMark::default().code()));
             }

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -211,6 +211,7 @@ pub struct TextMark {
     pub bold: bool,
     pub italic: bool,
     pub strikethrough: bool,
+    pub underline: bool,
     pub code: bool,
     pub link: Option<LinkMark>,
 }
@@ -231,6 +232,11 @@ impl TextMark {
         self
     }
 
+    pub fn underline(mut self) -> Self {
+        self.underline = true;
+        self
+    }
+
     pub fn code(mut self) -> Self {
         self.code = true;
         self
@@ -245,6 +251,7 @@ impl TextMark {
         self.bold |= other.bold;
         self.italic |= other.italic;
         self.strikethrough |= other.strikethrough;
+        self.underline |= other.underline;
         self.code |= other.code;
         if let Some(link) = other.link {
             self.link = Some(link);
@@ -693,6 +700,12 @@ impl Paragraph {
                     }
                     if style.strikethrough {
                         highlight.strikethrough = Some(gpui::StrikethroughStyle {
+                            thickness: gpui::px(1.),
+                            ..Default::default()
+                        });
+                    }
+                    if style.underline {
+                        highlight.underline = Some(gpui::UnderlineStyle {
                             thickness: gpui::px(1.),
                             ..Default::default()
                         });


### PR DESCRIPTION
<img width="946" height="432" alt="image" src="https://github.com/user-attachments/assets/0ec98d38-25c4-4b55-8fc7-941602cd91d7" />