### PR TITLE
input: Add `submit_on_enter` for chat-style textarea

### DIFF
--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -181,7 +181,9 @@ impl InputStory {
                     println!("Change: {}", text)
                 }
             }
-            InputEvent::PressEnter { secondary } => println!("PressEnter secondary: {}", secondary),
+            InputEvent::PressEnter { secondary, shift } => {
+                println!("PressEnter secondary: {}, shift: {}", secondary, shift)
+            }
             InputEvent::Focus => println!("Focus"),
             InputEvent::Blur => println!("Blur"),
         };

--- a/crates/story/src/stories/number_input_story.rs
+++ b/crates/story/src/stories/number_input_story.rs
@@ -141,8 +141,8 @@ impl NumberInputStory {
                 }
                 println!("Change: {}", text);
             }
-            InputEvent::PressEnter { secondary } => {
-                println!("PressEnter secondary: {}", secondary)
+            InputEvent::PressEnter { secondary, shift } => {
+                println!("PressEnter secondary: {}, shift: {}", secondary, shift)
             }
             InputEvent::Focus => println!("Focus"),
             InputEvent::Blur => println!("Blur"),

--- a/crates/story/src/stories/textarea_story.rs
+++ b/crates/story/src/stories/textarea_story.rs
@@ -1,14 +1,14 @@
 use gpui::{
-    App, AppContext as _, ClickEvent, Context, Entity, Focusable, IntoElement, ParentElement as _,
-    Render, Styled, Window, px,
+    App, AppContext as _, ClickEvent, Context, Entity, Focusable, InteractiveElement, IntoElement,
+    ParentElement as _, Render, Styled, Subscription, Window, div, px,
 };
 
 use crate::section;
 use gpui_component::{
-    Sizable,
+    ActiveTheme as _, Sizable,
     button::Button,
     h_flex,
-    input::{Input, InputState},
+    input::{Input, InputEvent, InputState},
     v_flex,
 };
 
@@ -19,6 +19,9 @@ pub struct TextareaStory {
     textarea_auto_grow: Entity<InputState>,
     textarea_no_wrap: Entity<InputState>,
     textarea_auto_grow_no_wrap: Entity<InputState>,
+    chat_input: Entity<InputState>,
+    chat_messages: Vec<String>,
+    _subscriptions: Vec<Subscription>,
 }
 
 impl super::Story for TextareaStory {
@@ -108,11 +111,39 @@ impl TextareaStory {
                 .default_value("Hello 世界，this is GPUI component.")
         });
 
+        let chat_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .auto_grow(1, 5)
+                .submit_on_enter(true)
+                .placeholder("Type a message, Enter to send, Shift+Enter for newline")
+        });
+
+        let _subscriptions = vec![cx.subscribe_in(
+            &chat_input,
+            window,
+            |this: &mut Self, input, event, window, cx| match event {
+                InputEvent::PressEnter { shift, .. } if !shift => {
+                    let text = input.read(cx).value().trim().to_string();
+                    if !text.is_empty() {
+                        this.chat_messages.push(text);
+                        input.update(cx, |state, cx| {
+                            state.set_value("", window, cx);
+                        });
+                        cx.notify();
+                    }
+                }
+                _ => {}
+            },
+        )];
+
         Self {
             textarea,
             textarea_auto_grow,
             textarea_no_wrap,
             textarea_auto_grow_no_wrap,
+            chat_input,
+            chat_messages: Vec::new(),
+            _subscriptions,
         }
     }
 
@@ -201,6 +232,25 @@ impl Render for TextareaStory {
                 section("Auto Grow with No Wrap")
                     .max_w_md()
                     .child(Input::new(&self.textarea_auto_grow_no_wrap)),
+            )
+            .child(
+                section("Submit on Enter (Chat)").max_w_md().child(
+                    v_flex()
+                        .gap_2()
+                        .w_full()
+                        .child(v_flex().gap_1().children(
+                            self.chat_messages.iter().enumerate().map(|(i, msg)| {
+                                div()
+                                    .id(("chat-msg", i))
+                                    .px_2()
+                                    .py_1()
+                                    .rounded(px(4.))
+                                    .bg(cx.theme().muted)
+                                    .child(msg.clone())
+                            }),
+                        ))
+                        .child(Input::new(&self.chat_input)),
+                ),
             )
     }
 }

--- a/crates/ui/src/input/popovers/code_action_menu.rs
+++ b/crates/ui/src/input/popovers/code_action_menu.rs
@@ -219,7 +219,7 @@ impl CodeActionMenu {
         }
 
         cx.propagate();
-        if action.partial_eq(&input::Enter { secondary: false }) {
+        if input::Enter::is_primary(&*action) {
             self.on_action_enter(window, cx);
         } else if action.partial_eq(&input::Escape) {
             self.on_action_escape(window, cx);

--- a/crates/ui/src/input/popovers/completion_menu.rs
+++ b/crates/ui/src/input/popovers/completion_menu.rs
@@ -282,7 +282,7 @@ impl CompletionMenu {
         }
 
         cx.propagate();
-        if action.partial_eq(&input::Enter { secondary: false }) {
+        if input::Enter::is_primary(&*action) {
             self.on_action_enter(window, cx);
         } else if action.partial_eq(&input::Escape) {
             self.on_action_escape(window, cx);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -51,6 +51,22 @@ use crate::{Root, history::History};
 pub struct Enter {
     /// Is confirm with secondary.
     pub secondary: bool,
+    /// Whether the Shift modifier was held when Enter was pressed.
+    pub shift: bool,
+}
+
+impl Enter {
+    /// Returns true if `action` is a primary `Enter` action (`secondary: false`),
+    /// regardless of whether Shift was held.
+    pub fn is_primary(action: &dyn Action) -> bool {
+        action.partial_eq(&Enter {
+            secondary: false,
+            shift: false,
+        }) || action.partial_eq(&Enter {
+            secondary: false,
+            shift: true,
+        })
+    }
 }
 
 actions!(
@@ -103,7 +119,7 @@ actions!(
 #[derive(Clone)]
 pub enum InputEvent {
     Change,
-    PressEnter { secondary: bool },
+    PressEnter { secondary: bool, shift: bool },
     Focus,
     Blur,
 }
@@ -130,9 +146,30 @@ pub(crate) fn init(cx: &mut App) {
         KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(CONTEXT)),
         #[cfg(not(target_os = "macos"))]
         KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(CONTEXT)),
-        KeyBinding::new("enter", Enter { secondary: false }, Some(CONTEXT)),
-        KeyBinding::new("shift-enter", Enter { secondary: false }, Some(CONTEXT)),
-        KeyBinding::new("secondary-enter", Enter { secondary: true }, Some(CONTEXT)),
+        KeyBinding::new(
+            "enter",
+            Enter {
+                secondary: false,
+                shift: false,
+            },
+            Some(CONTEXT),
+        ),
+        KeyBinding::new(
+            "shift-enter",
+            Enter {
+                secondary: false,
+                shift: true,
+            },
+            Some(CONTEXT),
+        ),
+        KeyBinding::new(
+            "secondary-enter",
+            Enter {
+                secondary: true,
+                shift: false,
+            },
+            Some(CONTEXT),
+        ),
         KeyBinding::new("escape", Escape, Some(CONTEXT)),
         KeyBinding::new("up", MoveUp, Some(CONTEXT)),
         KeyBinding::new("down", MoveDown, Some(CONTEXT)),
@@ -330,6 +367,7 @@ pub struct InputState {
     pub(super) disabled: bool,
     pub(super) masked: bool,
     pub(super) clean_on_escape: bool,
+    pub(super) submit_on_enter: bool,
     pub(super) soft_wrap: bool,
     pub(super) show_whitespaces: bool,
     /// This flag tells the renderer to prefer the end of the current visual line.
@@ -443,6 +481,7 @@ impl InputState {
             disabled: false,
             masked: false,
             clean_on_escape: false,
+            submit_on_enter: false,
             soft_wrap: true,
             show_whitespaces: false,
             loading: false,
@@ -819,6 +858,15 @@ impl InputState {
     /// Set true to clear the input by pressing Escape key.
     pub fn clean_on_escape(mut self) -> Self {
         self.clean_on_escape = true;
+        self
+    }
+
+    /// Set true to treat `Enter` as a submit action in multi-line mode,
+    /// while `Shift+Enter` inserts a newline.
+    ///
+    /// Default is `false` (both `Enter` and `Shift+Enter` insert a newline).
+    pub fn submit_on_enter(mut self, submit: bool) -> Self {
+        self.submit_on_enter = submit;
         self
     }
 
@@ -1323,7 +1371,13 @@ impl InputState {
             self.clear_inline_completion(cx);
         }
 
-        if self.mode.is_multi_line() {
+        // In multi-line mode with `submit_on_enter` enabled, a plain `Enter`
+        // (without Shift) is treated as submit: propagate the action and emit
+        // PressEnter without inserting a newline. `Shift+Enter` still inserts
+        // a newline.
+        let insert_newline = self.mode.is_multi_line() && (!self.submit_on_enter || action.shift);
+
+        if insert_newline {
             // Get current line indent
             let indent = if self.mode.is_code_editor() {
                 self.indent_of_next_line()
@@ -1336,12 +1390,14 @@ impl InputState {
             self.replace_text_in_range_silent(None, &new_line_text, window, cx);
             self.pause_blink_cursor(cx);
         } else {
-            // Single line input, just emit the event (e.g.: In a dialog to confirm).
+            // Single line input or submit-on-enter: just emit the event
+            // (e.g.: in a dialog to confirm, or a chat textarea to send).
             cx.propagate();
         }
 
         cx.emit(InputEvent::PressEnter {
             secondary: action.secondary,
+            shift: action.shift,
         });
     }
 


### PR DESCRIPTION
Add `InputState::submit_on_enter(bool)` builder. When enabled in multi-line mode, `Enter` propagates and emits `PressEnter` without inserting a newline,
while `Shift+Enter` still inserts a newline. Default is `false`, so existing behavior is unchanged.

## Breaking Change

```diff
- Enter { secondary: false }
+ Enter { secondary: false, shift: false }

- InputEvent::PressEnter { secondary } => ...
+ InputEvent::PressEnter { secondary, .. } => ...
```