### PR TITLE
fix(linux): correct CSD window border resize cursor and hit-testing

### DIFF
--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -187,6 +187,7 @@ impl RenderOnce for WindowBorder {
                                     blur_radius: visual_shadow / 2.,
                                     spread_radius: px(0.),
                                     offset: point(px(0.0), px(0.0)),
+                                    inset: false,
                                 }])
                             }),
                     })

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -1,10 +1,9 @@
 // From:
 // https://github.com/zed-industries/zed/blob/56daba28d40301ee4c05546fadb691d070b7b2b6/crates/gpui/examples/window_shadow.rs
 use gpui::{
-    AnyElement, App, Bounds, CursorStyle, Decorations, Edges, Hitbox, HitboxBehavior, Hsla,
-    InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce,
-    ResizeEdge, Size, Styled as _, Tiling, Window, canvas, div, point, prelude::FluentBuilder as _,
-    px,
+    AnyElement, App, CursorStyle, Decorations, Edges, Hsla, InteractiveElement as _,
+    IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce, ResizeEdge, Size,
+    Styled as _, Tiling, Window, div, point, prelude::FluentBuilder as _, px,
 };
 
 use crate::ActiveTheme;
@@ -109,6 +108,7 @@ impl RenderOnce for WindowBorder {
         };
         let resize_hit_size = self.resize_hit_size;
         window.set_client_inset(shadow_size);
+        let window_size = window.window_bounds().get_bounds().size;
 
         div()
             .id("window-backdrop")
@@ -117,25 +117,12 @@ impl RenderOnce for WindowBorder {
                 Decorations::Server => div,
                 Decorations::Client { tiling, .. } => div
                     .bg(gpui::transparent_black())
-                    .child(
-                        canvas(
-                            |_bounds, window, _| {
-                                window.insert_hitbox(
-                                    Bounds::new(
-                                        point(px(0.0), px(0.0)),
-                                        window.window_bounds().get_bounds().size,
-                                    ),
-                                    HitboxBehavior::Normal,
-                                )
-                            },
-                            move |_bounds, hitbox, window, _| {
-                                // set_cursor_style is paint-phase only; reset when leaving edges.
-                                update_resize_cursor(window, shadow_size, resize_hit_size, &hitbox);
-                            },
-                        )
-                        .size_full()
-                        .absolute(),
-                    )
+                    .children(resize_hit_zones(
+                        window_size,
+                        shadow_size,
+                        resize_hit_size,
+                        &tiling,
+                    ))
                     .when(!(tiling.top || tiling.right), |div| {
                         div.rounded_tr(BORDER_RADIUS)
                     })
@@ -146,10 +133,6 @@ impl RenderOnce for WindowBorder {
                     .when(!tiling.bottom, |div| div.pb(shadow_size))
                     .when(!tiling.left, |div| div.pl(shadow_size))
                     .when(!tiling.right, |div| div.pr(shadow_size))
-                    .on_mouse_move(move |_, window, _| {
-                        // Padding sits under the content layer; refresh to repaint cursors.
-                        window.refresh();
-                    })
                     .on_mouse_down(MouseButton::Left, move |_, window, _| {
                         let Decorations::Client { tiling } = window.window_decorations() else {
                             return;
@@ -218,27 +201,106 @@ fn cursor_style_for_resize_edge(edge: ResizeEdge) -> CursorStyle {
     }
 }
 
-/// Update the resize cursor from the current pointer position; reset to default off edges.
-fn update_resize_cursor(
-    window: &mut Window,
+/// Builds a separate hit layer for each resize edge/corner. `.cursor()` lets GPUI update the
+/// cursor immediately on hitbox changes, avoiding the one-frame lag from canvas +
+/// `window.refresh()` (PR #617).
+fn resize_hit_zones(
+    window_size: Size<Pixels>,
     shadow_size: Pixels,
-    resize_hit_size: Pixels,
-    hitbox: &Hitbox,
-) {
-    let Decorations::Client { tiling } = window.window_decorations() else {
-        return;
-    };
+    hit_size: Pixels,
+    tiling: &Tiling,
+) -> Vec<AnyElement> {
     if tiling.top && tiling.bottom && tiling.left && tiling.right {
-        return;
+        return Vec::new();
     }
 
-    let mouse = window.mouse_position();
-    let size = window.window_bounds().get_bounds().size;
-    let insets = client_frame_insets(shadow_size, &tiling);
-    let style = resize_edge(mouse, size, insets, &tiling, resize_hit_size)
-        .map(cursor_style_for_resize_edge)
-        .unwrap_or(CursorStyle::default());
-    window.set_cursor_style(style, hitbox);
+    let insets = client_frame_insets(shadow_size, tiling);
+    let inner_left = insets.left;
+    let inner_right = window_size.width - insets.right;
+    let inner_top = insets.top;
+    let inner_bottom = window_size.height - insets.bottom;
+    let band = hit_size + hit_size;
+    let span_x = inner_right - inner_left + band;
+    let span_y = inner_bottom - inner_top + band;
+
+    let mut zones: Vec<AnyElement> = Vec::new();
+
+    let mut push_zone = |edge: ResizeEdge, origin: Point<Pixels>, zone_size: Size<Pixels>| {
+        zones.push(
+            div()
+                .absolute()
+                .left(origin.x)
+                .top(origin.y)
+                .w(zone_size.width)
+                .h(zone_size.height)
+                .cursor(cursor_style_for_resize_edge(edge))
+                .on_mouse_down(MouseButton::Left, move |_, window, _| {
+                    window.start_window_resize(edge);
+                })
+                .into_any_element(),
+        );
+    };
+
+    if !tiling.top {
+        push_zone(
+            ResizeEdge::Top,
+            point(inner_left - hit_size, inner_top - hit_size),
+            Size::new(span_x, band),
+        );
+    }
+    if !tiling.bottom {
+        push_zone(
+            ResizeEdge::Bottom,
+            point(inner_left - hit_size, inner_bottom - hit_size),
+            Size::new(span_x, band),
+        );
+    }
+    if !tiling.left {
+        push_zone(
+            ResizeEdge::Left,
+            point(inner_left - hit_size, inner_top - hit_size),
+            Size::new(band, span_y),
+        );
+    }
+    if !tiling.right {
+        push_zone(
+            ResizeEdge::Right,
+            point(inner_right - hit_size, inner_top - hit_size),
+            Size::new(band, span_y),
+        );
+    }
+
+    // Corners are pushed after edge strips so hit-testing prefers them over adjacent edges.
+    if !tiling.top && !tiling.left {
+        push_zone(
+            ResizeEdge::TopLeft,
+            point(inner_left - hit_size, inner_top - hit_size),
+            Size::new(band, band),
+        );
+    }
+    if !tiling.top && !tiling.right {
+        push_zone(
+            ResizeEdge::TopRight,
+            point(inner_right - hit_size, inner_top - hit_size),
+            Size::new(band, band),
+        );
+    }
+    if !tiling.bottom && !tiling.left {
+        push_zone(
+            ResizeEdge::BottomLeft,
+            point(inner_left - hit_size, inner_bottom - hit_size),
+            Size::new(band, band),
+        );
+    }
+    if !tiling.bottom && !tiling.right {
+        push_zone(
+            ResizeEdge::BottomRight,
+            point(inner_right - hit_size, inner_bottom - hit_size),
+            Size::new(band, band),
+        );
+    }
+
+    zones
 }
 
 /// Hit-test resize edges on a narrow band around the visible inner frame, not the full shadow padding.

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -3,7 +3,8 @@
 use gpui::{
     AnyElement, App, Bounds, CursorStyle, Decorations, Edges, Hitbox, HitboxBehavior, Hsla,
     InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce,
-    ResizeEdge, Size, Styled as _, Window, canvas, div, point, prelude::FluentBuilder as _, px,
+    ResizeEdge, Size, Styled as _, Tiling, Window, canvas, div, point, prelude::FluentBuilder as _,
+    px,
 };
 
 use crate::ActiveTheme;
@@ -13,6 +14,8 @@ pub(crate) const SHADOW_SIZE: Pixels = px(0.0);
 #[cfg(target_os = "linux")]
 pub(crate) const SHADOW_SIZE: Pixels = px(12.0);
 const BORDER_SIZE: Pixels = px(1.0);
+/// Half-width of the resize hit band on each side of the visible frame (inner border).
+const RESIZE_HIT_SIZE: Pixels = px(4.0);
 pub(crate) const BORDER_RADIUS: Pixels = px(0.0);
 
 /// Create a new window border.
@@ -24,6 +27,7 @@ pub fn window_border() -> WindowBorder {
 #[derive(IntoElement)]
 pub struct WindowBorder {
     shadow_size: Pixels,
+    resize_hit_size: Pixels,
     children: Vec<AnyElement>,
 }
 
@@ -31,6 +35,7 @@ impl Default for WindowBorder {
     fn default() -> Self {
         Self {
             shadow_size: SHADOW_SIZE,
+            resize_hit_size: RESIZE_HIT_SIZE,
             children: Vec::new(),
         }
     }
@@ -48,6 +53,32 @@ impl WindowBorder {
         self.shadow_size = size.into();
         self
     }
+
+    /// Set the resize hit band half-width around the visible inner frame edge.
+    ///
+    /// Default: [`RESIZE_HIT_SIZE`]
+    pub fn resize_hit_size(mut self, size: impl Into<Pixels>) -> Self {
+        self.resize_hit_size = size.into();
+        self
+    }
+}
+
+/// Per-side inset of the visible frame from the outer window bounds.
+fn client_frame_insets(shadow_size: Pixels, tiling: &Tiling) -> Edges<Pixels> {
+    let mut insets = Edges::all(shadow_size);
+    if tiling.top {
+        insets.top = px(0.0);
+    }
+    if tiling.bottom {
+        insets.bottom = px(0.0);
+    }
+    if tiling.left {
+        insets.left = px(0.0);
+    }
+    if tiling.right {
+        insets.right = px(0.0);
+    }
+    insets
 }
 
 /// Get the window paddings.
@@ -55,22 +86,7 @@ pub fn window_paddings(window: &Window) -> Edges<Pixels> {
     let shadow_size = window.client_inset().unwrap_or(SHADOW_SIZE);
     match window.window_decorations() {
         Decorations::Server => Edges::all(px(0.0)),
-        Decorations::Client { tiling } => {
-            let mut paddings = Edges::all(shadow_size);
-            if tiling.top {
-                paddings.top = px(0.0);
-            }
-            if tiling.bottom {
-                paddings.bottom = px(0.0);
-            }
-            if tiling.left {
-                paddings.left = px(0.0);
-            }
-            if tiling.right {
-                paddings.right = px(0.0);
-            }
-            paddings
-        }
+        Decorations::Client { tiling } => client_frame_insets(shadow_size, &tiling),
     }
 }
 
@@ -91,6 +107,7 @@ impl RenderOnce for WindowBorder {
             }
             _ => self.shadow_size,
         };
+        let resize_hit_size = self.resize_hit_size;
         window.set_client_inset(shadow_size);
 
         div()
@@ -113,7 +130,7 @@ impl RenderOnce for WindowBorder {
                             },
                             move |_bounds, hitbox, window, _| {
                                 // set_cursor_style is paint-phase only; reset when leaving edges.
-                                update_resize_cursor(window, shadow_size, &hitbox);
+                                update_resize_cursor(window, shadow_size, resize_hit_size, &hitbox);
                             },
                         )
                         .size_full()
@@ -130,7 +147,7 @@ impl RenderOnce for WindowBorder {
                     .when(!tiling.left, |div| div.pl(shadow_size))
                     .when(!tiling.right, |div| div.pr(shadow_size))
                     .on_mouse_move(move |_, window, _| {
-                        // Padding hit zone sits under the content layer; refresh to repaint cursors.
+                        // Padding sits under the content layer; refresh to repaint cursors.
                         window.refresh();
                     })
                     .on_mouse_down(MouseButton::Left, move |_, window, _| {
@@ -142,8 +159,9 @@ impl RenderOnce for WindowBorder {
                         }
                         let size = window.window_bounds().get_bounds().size;
                         let pos = window.mouse_position();
+                        let insets = client_frame_insets(shadow_size, &tiling);
 
-                        match resize_edge(pos, shadow_size, size) {
+                        match resize_edge(pos, size, insets, &tiling, resize_hit_size) {
                             Some(edge) => window.start_window_resize(edge),
                             None => {}
                         };
@@ -201,7 +219,12 @@ fn cursor_style_for_resize_edge(edge: ResizeEdge) -> CursorStyle {
 }
 
 /// Update the resize cursor from the current pointer position; reset to default off edges.
-fn update_resize_cursor(window: &mut Window, shadow_size: Pixels, hitbox: &Hitbox) {
+fn update_resize_cursor(
+    window: &mut Window,
+    shadow_size: Pixels,
+    resize_hit_size: Pixels,
+    hitbox: &Hitbox,
+) {
     let Decorations::Client { tiling } = window.window_decorations() else {
         return;
     };
@@ -211,31 +234,67 @@ fn update_resize_cursor(window: &mut Window, shadow_size: Pixels, hitbox: &Hitbo
 
     let mouse = window.mouse_position();
     let size = window.window_bounds().get_bounds().size;
-    let style = resize_edge(mouse, shadow_size, size)
+    let insets = client_frame_insets(shadow_size, &tiling);
+    let style = resize_edge(mouse, size, insets, &tiling, resize_hit_size)
         .map(cursor_style_for_resize_edge)
         .unwrap_or(CursorStyle::default());
     window.set_cursor_style(style, hitbox);
 }
 
-fn resize_edge(pos: Point<Pixels>, shadow_size: Pixels, size: Size<Pixels>) -> Option<ResizeEdge> {
-    let edge = if pos.y < shadow_size && pos.x < shadow_size {
-        ResizeEdge::TopLeft
-    } else if pos.y < shadow_size && pos.x > size.width - shadow_size {
-        ResizeEdge::TopRight
-    } else if pos.y < shadow_size {
-        ResizeEdge::Top
-    } else if pos.y > size.height - shadow_size && pos.x < shadow_size {
-        ResizeEdge::BottomLeft
-    } else if pos.y > size.height - shadow_size && pos.x > size.width - shadow_size {
-        ResizeEdge::BottomRight
-    } else if pos.y > size.height - shadow_size {
-        ResizeEdge::Bottom
-    } else if pos.x < shadow_size {
-        ResizeEdge::Left
-    } else if pos.x > size.width - shadow_size {
-        ResizeEdge::Right
-    } else {
-        return None;
-    };
-    Some(edge)
+/// Hit-test resize edges on a narrow band around the visible inner frame, not the full shadow padding.
+fn resize_edge(
+    pos: Point<Pixels>,
+    size: Size<Pixels>,
+    insets: Edges<Pixels>,
+    tiling: &Tiling,
+    hit_size: Pixels,
+) -> Option<ResizeEdge> {
+    let inner_left = insets.left;
+    let inner_right = size.width - insets.right;
+    let inner_top = insets.top;
+    let inner_bottom = size.height - insets.bottom;
+
+    // 每条边只在内框对应线段附近生效，不向阴影 padding 的「延长线」上延伸。
+    let on_left = pos.x >= inner_left - hit_size
+        && pos.x <= inner_left + hit_size
+        && pos.y >= inner_top - hit_size
+        && pos.y <= inner_bottom + hit_size;
+    let on_right = pos.x >= inner_right - hit_size
+        && pos.x <= inner_right + hit_size
+        && pos.y >= inner_top - hit_size
+        && pos.y <= inner_bottom + hit_size;
+    let on_top = pos.y >= inner_top - hit_size
+        && pos.y <= inner_top + hit_size
+        && pos.x >= inner_left - hit_size
+        && pos.x <= inner_right + hit_size;
+    let on_bottom = pos.y >= inner_bottom - hit_size
+        && pos.y <= inner_bottom + hit_size
+        && pos.x >= inner_left - hit_size
+        && pos.x <= inner_right + hit_size;
+
+    if !tiling.top && !tiling.left && on_top && on_left {
+        return Some(ResizeEdge::TopLeft);
+    }
+    if !tiling.top && !tiling.right && on_top && on_right {
+        return Some(ResizeEdge::TopRight);
+    }
+    if !tiling.bottom && !tiling.left && on_bottom && on_left {
+        return Some(ResizeEdge::BottomLeft);
+    }
+    if !tiling.bottom && !tiling.right && on_bottom && on_right {
+        return Some(ResizeEdge::BottomRight);
+    }
+    if !tiling.top && on_top {
+        return Some(ResizeEdge::Top);
+    }
+    if !tiling.bottom && on_bottom {
+        return Some(ResizeEdge::Bottom);
+    }
+    if !tiling.left && on_left {
+        return Some(ResizeEdge::Left);
+    }
+    if !tiling.right && on_right {
+        return Some(ResizeEdge::Right);
+    }
+    None
 }

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -254,7 +254,7 @@ fn resize_edge(
     let inner_top = insets.top;
     let inner_bottom = size.height - insets.bottom;
 
-    // 每条边只在内框对应线段附近生效，不向阴影 padding 的「延长线」上延伸。
+    // Each edge only applies along its corresponding inner-frame segment; it does not extend along the "extension lines" of the shadow padding.
     let on_left = pos.x >= inner_left - hit_size
         && pos.x <= inner_left + hit_size
         && pos.y >= inner_top - hit_size

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -22,7 +22,7 @@ pub fn window_border() -> WindowBorder {
     WindowBorder::new()
 }
 
-/// Window border use to render a custom window border and shadow for Linux.
+/// Renders a custom window border and shadow on Linux.
 #[derive(IntoElement)]
 pub struct WindowBorder {
     shadow_size: Pixels,
@@ -98,7 +98,12 @@ impl ParentElement for WindowBorder {
 impl RenderOnce for WindowBorder {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let decorations = window.window_decorations();
-        let shadow_size = match decorations {
+        // Keep the platform client inset stable. When the window is tiled on all sides we stop drawing
+        // shadow padding, but `set_client_inset` must still use the full shadow size. Clearing it
+        // makes the first resize after restore double-count the shadow in `compute_outer_size`, and
+        // the window jumps larger.
+        let platform_inset = self.shadow_size;
+        let visual_shadow = match decorations {
             Decorations::Client { tiling }
                 if tiling.top && tiling.bottom && tiling.left && tiling.right =>
             {
@@ -107,7 +112,9 @@ impl RenderOnce for WindowBorder {
             _ => self.shadow_size,
         };
         let resize_hit_size = self.resize_hit_size;
-        window.set_client_inset(shadow_size);
+        if matches!(decorations, Decorations::Client { .. }) {
+            window.set_client_inset(platform_inset);
+        }
         let window_size = window.window_bounds().get_bounds().size;
 
         div()
@@ -126,10 +133,10 @@ impl RenderOnce for WindowBorder {
                     .when(!(tiling.top || tiling.left), |div| {
                         div.rounded_tl(BORDER_RADIUS)
                     })
-                    .when(!tiling.top, |div| div.pt(shadow_size))
-                    .when(!tiling.bottom, |div| div.pb(shadow_size))
-                    .when(!tiling.left, |div| div.pl(shadow_size))
-                    .when(!tiling.right, |div| div.pr(shadow_size))
+                    .when(!tiling.top, |div| div.pt(visual_shadow))
+                    .when(!tiling.bottom, |div| div.pb(visual_shadow))
+                    .when(!tiling.left, |div| div.pl(visual_shadow))
+                    .when(!tiling.right, |div| div.pr(visual_shadow))
                     .on_mouse_down(MouseButton::Left, move |_, window, _| {
                         let Decorations::Client { tiling } = window.window_decorations() else {
                             return;
@@ -139,7 +146,7 @@ impl RenderOnce for WindowBorder {
                         }
                         let size = window.window_bounds().get_bounds().size;
                         let pos = window.mouse_position();
-                        let insets = client_frame_insets(shadow_size, &tiling);
+                        let insets = client_frame_insets(platform_inset, &tiling);
 
                         match resize_edge(pos, size, insets, &tiling, resize_hit_size) {
                             Some(edge) => window.start_window_resize(edge),
@@ -177,10 +184,9 @@ impl RenderOnce for WindowBorder {
                                         l: 0.,
                                         a: 0.3,
                                     },
-                                    blur_radius: shadow_size / 2.,
+                                    blur_radius: visual_shadow / 2.,
                                     spread_radius: px(0.),
                                     offset: point(px(0.0), px(0.0)),
-                                    inset: false,
                                 }])
                             }),
                     })
@@ -202,7 +208,7 @@ impl RenderOnce for WindowBorder {
                             .size_full()
                             .children(resize_hit_zones(
                                 window_size,
-                                shadow_size,
+                                platform_inset,
                                 resize_hit_size,
                                 &tiling,
                             )),

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -180,6 +180,7 @@ impl RenderOnce for WindowBorder {
                                     blur_radius: shadow_size / 2.,
                                     spread_radius: px(0.),
                                     offset: point(px(0.0), px(0.0)),
+                                    inset: false,
                                 }])
                             }),
                     })

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -116,6 +116,9 @@ impl RenderOnce for WindowBorder {
             .map(|div| match decorations {
                 Decorations::Server => div,
                 Decorations::Client { tiling, .. } => div
+                    .flex()
+                    .flex_col()
+                    .overflow_hidden()
                     .bg(gpui::transparent_black())
                     .children(resize_hit_zones(
                         window_size,
@@ -155,8 +158,12 @@ impl RenderOnce for WindowBorder {
                 div()
                     .cursor(CursorStyle::default())
                     .map(|div| match decorations {
-                        Decorations::Server => div,
+                        Decorations::Server => div.size_full(),
                         Decorations::Client { tiling } => div
+                            .flex_1()
+                            .min_h_0()
+                            .min_w_0()
+                            .overflow_hidden()
                             .when(!(tiling.top || tiling.right), |div| {
                                 div.rounded_tr(BORDER_RADIUS)
                             })
@@ -186,7 +193,6 @@ impl RenderOnce for WindowBorder {
                         cx.stop_propagation();
                     })
                     .bg(gpui::transparent_black())
-                    .size_full()
                     .children(self.children),
             )
     }

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -1,7 +1,7 @@
 // From:
 // https://github.com/zed-industries/zed/blob/56daba28d40301ee4c05546fadb691d070b7b2b6/crates/gpui/examples/window_shadow.rs
 use gpui::{
-    AnyElement, App, Bounds, CursorStyle, Decorations, Edges, HitboxBehavior, Hsla,
+    AnyElement, App, Bounds, CursorStyle, Decorations, Edges, Hitbox, HitboxBehavior, Hsla,
     InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce,
     ResizeEdge, Size, Styled as _, Window, canvas, div, point, prelude::FluentBuilder as _, px,
 };
@@ -112,34 +112,8 @@ impl RenderOnce for WindowBorder {
                                 )
                             },
                             move |_bounds, hitbox, window, _| {
-                                let mouse = window.mouse_position();
-                                let size = window.window_bounds().get_bounds().size;
-                                let Decorations::Client { tiling } = window.window_decorations() else {
-                                    return;
-                                };
-                                if tiling.top && tiling.bottom && tiling.left && tiling.right {
-                                    return;
-                                }
-                                let Some(edge) = resize_edge(mouse, shadow_size, size) else {
-                                    return;
-                                };
-                                window.set_cursor_style(
-                                    match edge {
-                                        ResizeEdge::Top | ResizeEdge::Bottom => {
-                                            CursorStyle::ResizeUpDown
-                                        }
-                                        ResizeEdge::Left | ResizeEdge::Right => {
-                                            CursorStyle::ResizeLeftRight
-                                        }
-                                        ResizeEdge::TopLeft | ResizeEdge::BottomRight => {
-                                            CursorStyle::ResizeUpLeftDownRight
-                                        }
-                                        ResizeEdge::TopRight | ResizeEdge::BottomLeft => {
-                                            CursorStyle::ResizeUpRightDownLeft
-                                        }
-                                    },
-                                    &hitbox,
-                                );
+                                // set_cursor_style is paint-phase only; reset when leaving edges.
+                                update_resize_cursor(window, shadow_size, &hitbox);
                             },
                         )
                         .size_full()
@@ -155,6 +129,10 @@ impl RenderOnce for WindowBorder {
                     .when(!tiling.bottom, |div| div.pb(shadow_size))
                     .when(!tiling.left, |div| div.pl(shadow_size))
                     .when(!tiling.right, |div| div.pr(shadow_size))
+                    .on_mouse_move(move |_, window, _| {
+                        // Padding hit zone sits under the content layer; refresh to repaint cursors.
+                        window.refresh();
+                    })
                     .on_mouse_down(MouseButton::Left, move |_, window, _| {
                         let Decorations::Client { tiling } = window.window_decorations() else {
                             return;
@@ -211,6 +189,32 @@ impl RenderOnce for WindowBorder {
                     .children(self.children),
             )
     }
+}
+
+fn cursor_style_for_resize_edge(edge: ResizeEdge) -> CursorStyle {
+    match edge {
+        ResizeEdge::Top | ResizeEdge::Bottom => CursorStyle::ResizeUpDown,
+        ResizeEdge::Left | ResizeEdge::Right => CursorStyle::ResizeLeftRight,
+        ResizeEdge::TopLeft | ResizeEdge::BottomRight => CursorStyle::ResizeUpLeftDownRight,
+        ResizeEdge::TopRight | ResizeEdge::BottomLeft => CursorStyle::ResizeUpRightDownLeft,
+    }
+}
+
+/// Update the resize cursor from the current pointer position; reset to default off edges.
+fn update_resize_cursor(window: &mut Window, shadow_size: Pixels, hitbox: &Hitbox) {
+    let Decorations::Client { tiling } = window.window_decorations() else {
+        return;
+    };
+    if tiling.top && tiling.bottom && tiling.left && tiling.right {
+        return;
+    }
+
+    let mouse = window.mouse_position();
+    let size = window.window_bounds().get_bounds().size;
+    let style = resize_edge(mouse, shadow_size, size)
+        .map(cursor_style_for_resize_edge)
+        .unwrap_or(CursorStyle::default());
+    window.set_cursor_style(style, hitbox);
 }
 
 fn resize_edge(pos: Point<Pixels>, shadow_size: Pixels, size: Size<Pixels>) -> Option<ResizeEdge> {

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -120,12 +120,6 @@ impl RenderOnce for WindowBorder {
                     .flex_col()
                     .overflow_hidden()
                     .bg(gpui::transparent_black())
-                    .children(resize_hit_zones(
-                        window_size,
-                        shadow_size,
-                        resize_hit_size,
-                        &tiling,
-                    ))
                     .when(!(tiling.top || tiling.right), |div| {
                         div.rounded_tr(BORDER_RADIUS)
                     })
@@ -186,7 +180,6 @@ impl RenderOnce for WindowBorder {
                                     blur_radius: shadow_size / 2.,
                                     spread_radius: px(0.),
                                     offset: point(px(0.0), px(0.0)),
-                                    inset: false,
                                 }])
                             }),
                     })
@@ -195,6 +188,25 @@ impl RenderOnce for WindowBorder {
                     })
                     .bg(gpui::transparent_black())
                     .children(self.children),
+            )
+            .when(
+                matches!(decorations, Decorations::Client { .. }),
+                |this| {
+                    let Decorations::Client { tiling, .. } = decorations else {
+                        return this;
+                    };
+                    this.child(
+                        div()
+                            .absolute()
+                            .size_full()
+                            .children(resize_hit_zones(
+                                window_size,
+                                shadow_size,
+                                resize_hit_size,
+                                &tiling,
+                            )),
+                    )
+                },
             )
     }
 }
@@ -208,9 +220,9 @@ fn cursor_style_for_resize_edge(edge: ResizeEdge) -> CursorStyle {
     }
 }
 
-/// Builds a separate hit layer for each resize edge/corner. `.cursor()` lets GPUI update the
-/// cursor immediately on hitbox changes, avoiding the one-frame lag from canvas +
-/// `window.refresh()` (PR #617).
+/// Cursor-only overlay for each resize edge/corner. Resize starts from the backdrop
+/// `on_mouse_down` via [`resize_edge`]. `.cursor()` updates immediately on hitbox changes
+/// without `window.refresh()` (PR #617).
 fn resize_hit_zones(
     window_size: Size<Pixels>,
     shadow_size: Pixels,
@@ -226,6 +238,8 @@ fn resize_hit_zones(
     let inner_right = window_size.width - insets.right;
     let inner_top = insets.top;
     let inner_bottom = window_size.height - insets.bottom;
+    // Overlay is laid out in the padded content box; convert from window coords.
+    let frame_origin = point(insets.left, insets.top);
     let band = hit_size + hit_size;
     let span_x = inner_right - inner_left + band;
     let span_y = inner_bottom - inner_top + band;
@@ -233,6 +247,7 @@ fn resize_hit_zones(
     let mut zones: Vec<AnyElement> = Vec::new();
 
     let mut push_zone = |edge: ResizeEdge, origin: Point<Pixels>, zone_size: Size<Pixels>| {
+        let origin = origin - frame_origin;
         zones.push(
             div()
                 .absolute()
@@ -241,9 +256,6 @@ fn resize_hit_zones(
                 .w(zone_size.width)
                 .h(zone_size.height)
                 .cursor(cursor_style_for_resize_edge(edge))
-                .on_mouse_down(MouseButton::Left, move |_, window, _| {
-                    window.start_window_resize(edge);
-                })
                 .into_any_element(),
         );
     };


### PR DESCRIPTION
## Summary

Fixes stale resize cursors on Linux client-side decorations (CSD): the pointer can keep showing a horizontal resize shape after leaving a left/right edge, even when hovering over a top/bottom edge where drag behavior is already correct.

## Symptoms

On Linux with `WindowDecorations::Client` (via `Root` + `window_border`):

1. Hover over a left or right border → cursor shows **horizontal** resize.
2. Move away from that edge, then hover over the **bottom** border.
3. **Cursor still shows horizontal resize**, but clicking and dragging performs a **vertical** resize as expected.

Cursor feedback and actual resize direction can disagree, especially when moving between edges without leaving the window.

## Root cause

Resize cursor updates live in `window_border.rs`, inside the `canvas` **paint** callback. Two issues combine:

1. **No reset when leaving an edge**   When `resize_edge()` returned `None`, the paint callback returned early and never called `set_cursor_style(CursorStyle::default(), ...)`. The last resize cursor (e.g. horizontal) remained on screen.

2. **Cursor update path ≠ resize click path**  
   - **Cursor**: updated only in the canvas paint callback (full-window hitbox; GPUI requires `set_cursor_style` during paint).
   - **Resize on click**: handled on the outer padded `#window-backdrop` via `on_mouse_down` + `start_window_resize`, using the **current** mouse position.

   Click/drag can therefore be correct while the displayed cursor is stale from a previous edge.

   The padding strip (`shadow_size`) also sits structurally below the inner content layer; without a refresh trigger, paint may not re-run often enough to update the cursor in the border hit zone.

## Fix

- Extract `update_resize_cursor()` and `cursor_style_for_resize_edge()`.
- In canvas paint: when not on a resize edge, set `CursorStyle::default()` instead of returning early.
- On the padded backdrop: `on_mouse_move` → `window.refresh()` so paint-phase cursor updates run reliably in the border padding area.

## Test plan

- [ ] Linux + Wayland/X11, app using `Root` with CSD (`WindowDecorations::Client`).
- [ ] Hover left/right edge → horizontal cursor; move to interior → default arrow.
- [ ] From left edge, move to bottom edge → vertical cursor before click.
- [ ] Click-drag on each edge/corner: cursor shape matches resize direction.
- [ ] No panic on mouse move (`set_cursor_style` must stay in paint; do not call it from `on_mouse_event` handlers).


## Changes

```diff
+ Introduce `RESIZE_HIT_SIZE` (default 4px) and `WindowBorder::resize_hit_size()`.
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
