### PR TITLE
tabs: Fix segmented indicator flicker and add a new section to tab story

### DIFF
--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -4,7 +4,7 @@ use gpui::{
 };
 
 use gpui_component::{
-    ActiveTheme as _, IconName, Selectable as _, Sizable, Size,
+    ActiveTheme as _, Icon, IconName, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
     checkbox::Checkbox,
     h_flex,
@@ -17,6 +17,9 @@ use crate::section;
 pub struct TabsStory {
     focus_handle: FocusHandle,
     active_tab_ix: usize,
+    dynamic_active_tab_ix: usize,
+    dynamic_tabs: Vec<usize>,
+    dynamic_next_tab_id: usize,
     size: Size,
     menu: bool,
 }
@@ -44,6 +47,9 @@ impl TabsStory {
         Self {
             focus_handle: cx.focus_handle(),
             active_tab_ix: 0,
+            dynamic_active_tab_ix: 0,
+            dynamic_tabs: vec![0, 1, 2],
+            dynamic_next_tab_id: 3,
             size: Size::default(),
             menu: false,
         }
@@ -56,6 +62,31 @@ impl TabsStory {
 
     fn set_size(&mut self, size: Size, _: &mut Window, cx: &mut Context<Self>) {
         self.size = size;
+        cx.notify();
+    }
+
+    fn set_dynamic_active_tab(&mut self, ix: usize, _: &mut Window, cx: &mut Context<Self>) {
+        self.dynamic_active_tab_ix = ix;
+        cx.notify();
+    }
+
+    fn add_dynamic_tab(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        let id = self.dynamic_next_tab_id;
+        self.dynamic_next_tab_id += 1;
+        self.dynamic_tabs.push(id);
+        self.dynamic_active_tab_ix = self.dynamic_tabs.len() - 1;
+        cx.notify();
+    }
+
+    fn remove_last_dynamic_tab(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        if self.dynamic_tabs.len() <= 1 {
+            return;
+        }
+
+        self.dynamic_tabs.pop();
+        if self.dynamic_active_tab_ix >= self.dynamic_tabs.len() {
+            self.dynamic_active_tab_ix = self.dynamic_tabs.len() - 1;
+        }
         cx.notify();
     }
 }
@@ -247,6 +278,56 @@ impl Render for TabsStory {
                         .child(IconName::Map)
                         .children(vec!["Appearance", "Settings", "About", "License"]),
                 ),
+            )
+            .child(
+                section("Segmented Tabs (Dynamic with suffix and prefix)")
+                    .max_w_md()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("add-tab")
+                                    .outline()
+                                    .compact()
+                                    .label("Add Tab")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.add_dynamic_tab(window, cx);
+                                    })),
+                            )
+                            .child(
+                                Button::new("remove-tab")
+                                    .outline()
+                                    .compact()
+                                    .label("Remove Last")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.remove_last_dynamic_tab(window, cx);
+                                    })),
+                            ),
+                    )
+                    .child(
+                        TabBar::new("segmented-dynamic")
+                            .w_full()
+                            .segmented()
+                            .with_size(self.size)
+                            .selected_index(self.dynamic_active_tab_ix)
+                            .on_click(cx.listener(|this, ix: &usize, window, cx| {
+                                this.set_dynamic_active_tab(*ix, window, cx);
+                            }))
+                            .children(self.dynamic_tabs.iter().enumerate().map(|(ix, id)| {
+                                let label = format!("Tab {id}");
+                                Tab::new()
+                                    .px_2()
+                                    .prefix(Icon::new(IconName::BookOpen))
+                                    .label(label)
+                                    .suffix(
+                                        Button::new(format!("dynamic-tab-close-{id}"))
+                                            .ghost()
+                                            .xsmall()
+                                            .icon(IconName::Close),
+                                    )
+                                    .selected(self.dynamic_active_tab_ix == ix)
+                            })),
+                    ),
             )
             .child(
                 section("Segmented Tabs (With filling space)")

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -616,7 +616,7 @@ impl RenderOnce for Tab {
             self.variant == TabVariant::Segmented && self.indicator_active;
         let has_inline_inner_bg =
             self.selected && segmented_indicator_active && !self.indicator_ready;
-        let inline_inner_bg = cx.theme().background;
+        let inline_inner_bg = tab_style.inner_bg;
         let (inner_bg, hover_inner_bg) = if segmented_indicator_active && self.indicator_ready {
             (cx.theme().transparent, cx.theme().transparent)
         } else if has_inline_inner_bg {
@@ -624,8 +624,7 @@ impl RenderOnce for Tab {
         } else {
             (tab_style.inner_bg, hover_style.inner_bg)
         };
-        let inner_shadow =
-            tab_style.shadow && !(segmented_indicator_active && self.indicator_ready);
+        let inner_shadow = tab_style.shadow && !segmented_indicator_active;
 
         self.base
             .id(self.ix)

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -404,6 +404,7 @@ pub struct Tab {
     pub(super) disabled: bool,
     pub(super) selected: bool,
     pub(super) indicator_active: bool,
+    pub(super) indicator_ready: bool,
     on_click: Option<Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
 }
 
@@ -449,6 +450,7 @@ impl Default for Tab {
             disabled: false,
             selected: false,
             indicator_active: false,
+            indicator_ready: true,
             prefix: None,
             suffix: None,
             variant: TabVariant::default(),
@@ -610,8 +612,24 @@ impl RenderOnce for Tab {
         let inner_height = self.variant.inner_height(self.size);
         let height = self.variant.height(self.size);
 
+        let segmented_indicator_active =
+            self.variant == TabVariant::Segmented && self.indicator_active;
+        let has_inline_inner_bg =
+            self.selected && segmented_indicator_active && !self.indicator_ready;
+        let inline_inner_bg = cx.theme().background;
+        let (inner_bg, hover_inner_bg) = if segmented_indicator_active && self.indicator_ready {
+            (cx.theme().transparent, cx.theme().transparent)
+        } else if has_inline_inner_bg {
+            (inline_inner_bg, inline_inner_bg)
+        } else {
+            (tab_style.inner_bg, hover_style.inner_bg)
+        };
+        let inner_shadow =
+            tab_style.shadow && !(segmented_indicator_active && self.indicator_ready);
+
         self.base
             .id(self.ix)
+            .relative()
             .flex()
             .flex_wrap()
             .gap_1()
@@ -644,6 +662,26 @@ impl RenderOnce for Tab {
                         .rounded(radius)
                 })
             })
+            .when(has_inline_inner_bg, |this| {
+                this.child(
+                    div()
+                        .absolute()
+                        .left_0()
+                        .right_0()
+                        .top_0()
+                        .bottom_0()
+                        .flex()
+                        .items_center()
+                        .child(
+                            div()
+                                .w_full()
+                                .h(inner_height)
+                                .bg(inline_inner_bg)
+                                .rounded(inner_radius)
+                                .when(tab_style.shadow, |this| this.shadow_xs()),
+                        ),
+                )
+            })
             .when_some(self.prefix, |this, prefix| this.child(prefix))
             .child(
                 h_flex()
@@ -674,10 +712,10 @@ impl RenderOnce for Tab {
                             })
                             .children(self.children),
                     })
-                    .bg(tab_style.inner_bg)
+                    .bg(inner_bg)
                     .rounded(inner_radius)
-                    .when(tab_style.shadow, |this| this.shadow_xs())
-                    .hover(|this| this.bg(hover_style.inner_bg).rounded(inner_radius)),
+                    .when(inner_shadow, |this| this.shadow_xs())
+                    .hover(|this| this.bg(hover_inner_bg).rounded(inner_radius)),
             )
             .when_some(self.suffix, |this, suffix| this.child(suffix))
             .on_mouse_down(MouseButton::Left, |_, _, cx| {

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -300,15 +300,19 @@ impl TabBar {
             return;
         }
 
-        // Same selection, no bounds yet: initialize position
-        if anim_params.read(cx).3 != px(0.) {
-            return;
-        }
-
         if let Some(to_b) = bounds.tabs.get(selected_ix) {
             let left = to_b.origin.x - container.origin.x;
             let width = to_b.size.width;
-            anim_params.update(cx, |v, _| *v = (left, width, left, width, v.4));
+            let (_, _, to_left, to_width, epoch) = *anim_params.read(cx);
+
+            if to_width == px(0.) {
+                anim_params.update(cx, |v, _| *v = (left, width, left, width, epoch));
+                return;
+            }
+
+            if left != to_left || width != to_width {
+                anim_params.update(cx, |v, _| *v = (left, width, left, width, epoch));
+            }
         }
     }
 }
@@ -395,6 +399,7 @@ impl RenderOnce for TabBar {
         };
 
         let indicator_element = self.render_indicator(&bounds_rc, window, cx);
+        let indicator_ready = indicator_element.is_some();
 
         let has_suffix_or_menu = self.suffix.is_some() || self.menu;
         let mut item_metas: Vec<(Option<SharedString>, Option<Icon>, bool)> = Vec::new();
@@ -456,6 +461,7 @@ impl RenderOnce for TabBar {
                                 .with_variant(self.variant)
                                 .with_size(self.size);
                             tab.indicator_active = has_indicator;
+                            tab.indicator_ready = indicator_ready;
                             let tab = tab
                                 .when_some(self.selected_index, |this, selected_ix| {
                                     this.selected(selected_ix == ix)


### PR DESCRIPTION
Closes #2395

## Description
Fixes segmented tab suffix flicker when tabs are added or switched by rendering a fallback inner background until the indicator is ready and deferring per‑tab inner styling to the indicator. Adds a simple story repro with dynamic segmented tabs and suffix buttons so the issue can be tested reliably.

## Screenshot

### Before
Here we can see Tab 3’s inner background grow on the next paint after it’s added. A similar effect happens when switching tabs with clicks.

https://github.com/user-attachments/assets/6d9822bf-76af-44b4-944a-94e971498956

### After
And now it's consistent and flicker is not happening. 

https://github.com/user-attachments/assets/82e60ab4-162f-4199-a718-ced3eef66a11

## How to Test
1. Run `cargo run`.
2. Open the **Tabs** story.
3. Use **Segmented Tabs (Dynamic)**.
4. Click **Add Tab** and **Remove Last** repeatedly.
5. Confirm the selected tab’s inner background stays correct and the suffix stays inside during/after the add animation.

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)