### PR TITLE
text: Improve markdown code block rendering performance

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1260,7 +1260,8 @@ impl TextElement {
 
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
 
-        // Helper to flush a contiguous range of lines
+        // Helper to flush a contiguous range of lines. These ranges are disjoint,
+        // so appending avoids repeatedly cloning and recombining prior styles.
         let flush_range = |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
             let byte_start = text.line_start_offset(start_line);
             let byte_end = if is_multi_line {
@@ -1275,7 +1276,7 @@ impl TextElement {
                 highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme)
             };
 
-            *styles = gpui::combine_highlights(styles.clone(), range_styles).collect();
+            styles.extend(range_styles);
         };
 
         // Group contiguous visible lines into ranges and call styles() once per range

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::HashMap,
     ops::Range,
     sync::{Arc, Mutex},
@@ -15,7 +16,8 @@ use ropey::Rope;
 
 use crate::{
     ActiveTheme as _, Icon, IconName, StyledExt, h_flex,
-    highlighter::{HighlightTheme, SyntaxHighlighter},
+    highlighter::{HighlightTheme, LanguageRegistry, SyntaxHighlighter},
+    input::{InputEdit, Point, RopeExt as _},
     text::{
         CodeBlockActionsFn,
         document::NodeRenderOptions,
@@ -26,6 +28,11 @@ use crate::{
 };
 
 use super::{TextViewStyle, utils::list_item_prefix};
+
+thread_local! {
+    static CODE_BLOCK_HIGHLIGHTERS: RefCell<HashMap<SharedString, SyntaxHighlighter>> =
+        RefCell::new(HashMap::new());
+}
 
 /// The block-level nodes.
 #[derive(Debug, Clone, PartialEq)]
@@ -95,7 +102,7 @@ impl BlockNode {
     }
 
     /// Get the span of the node.
-    pub(super) fn span(&self) -> Option<Span> {
+    pub(crate) fn span(&self) -> Option<Span> {
         match self {
             BlockNode::Root { span, .. } => *span,
             BlockNode::Paragraph(paragraph) => paragraph.span,
@@ -499,14 +506,15 @@ impl Paragraph {
 #[derive(Debug, Clone)]
 pub struct CodeBlock {
     lang: Option<SharedString>,
-    styles: Vec<(Range<usize>, HighlightStyle)>,
+    styles: Arc<Mutex<Option<Vec<(Range<usize>, HighlightStyle)>>>>,
+    highlight_theme: Arc<HighlightTheme>,
     state: Arc<Mutex<InlineState>>,
     pub span: Option<Span>,
 }
 
 impl PartialEq for CodeBlock {
     fn eq(&self, other: &Self) -> bool {
-        self.lang == other.lang && self.styles == other.styles
+        self.lang == other.lang && self.code() == other.code() && self.span == other.span
     }
 }
 
@@ -527,22 +535,62 @@ impl CodeBlock {
         highlight_theme: &HighlightTheme,
         span: Option<impl Into<Span>>,
     ) -> Self {
-        let mut styles = vec![];
-        if let Some(lang) = &lang {
-            let mut highlighter = SyntaxHighlighter::new(&lang);
-            highlighter.update(None, &Rope::from_str(code.as_str()), None);
-            styles = highlighter.styles(&(0..code.len()), highlight_theme);
-        };
-
         let state = Arc::new(Mutex::new(InlineState::default()));
         state.lock().unwrap().set_text(code);
 
         Self {
             lang,
-            styles,
+            styles: Arc::new(Mutex::new(None)),
+            highlight_theme: Arc::new(highlight_theme.clone()),
             state,
             span: span.map(|s| s.into()),
         }
+    }
+
+    pub(crate) fn styles(&self) -> Vec<(Range<usize>, HighlightStyle)> {
+        let Some(lang) = &self.lang else {
+            return Vec::new();
+        };
+
+        let Ok(mut styles) = self.styles.lock() else {
+            return Vec::new();
+        };
+
+        if let Some(styles) = styles.as_ref() {
+            return styles.clone();
+        }
+
+        let code = self.code();
+        let computed_styles = CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            let highlighter = cache
+                .entry(lang.clone())
+                .or_insert_with(|| SyntaxHighlighter::new(lang));
+
+            if let Some(config) = LanguageRegistry::singleton().language(lang)
+                && highlighter.language() != &config.name
+            {
+                *highlighter = SyntaxHighlighter::new(lang);
+            }
+
+            let old_end_byte = highlighter.text().len();
+            let old_end_position = highlighter.text().offset_to_point(old_end_byte);
+            let code_rope = Rope::from_str(code.as_str());
+
+            let edit = InputEdit {
+                start_byte: 0,
+                old_end_byte,
+                new_end_byte: code.len(),
+                start_position: Point::new(0, 0),
+                old_end_position,
+                new_end_position: code_rope.offset_to_point(code.len()),
+            };
+
+            highlighter.update(Some(edit), &code_rope, None);
+            highlighter.styles(&(0..code.len()), &self.highlight_theme)
+        });
+        *styles = Some(computed_styles.clone());
+        computed_styles
     }
 
     pub(super) fn selected_text(&self) -> String {
@@ -580,7 +628,7 @@ impl CodeBlock {
                         "code",
                         self.state.clone(),
                         vec![],
-                        self.styles.clone(),
+                        self.styles(),
                     ))
                     .when_some(node_cx.code_block_actions.clone(), |this, actions| {
                         this.child(
@@ -1284,5 +1332,88 @@ impl BlockNode {
                 div().into_any_element()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_block_equality_includes_code_content() {
+        let theme = HighlightTheme::default_light();
+        let first = CodeBlock::new(
+            "let value = 1;".into(),
+            Some("rust".into()),
+            &theme,
+            None::<Span>,
+        );
+        let second = CodeBlock::new(
+            "let value = 2;".into(),
+            Some("rust".into()),
+            &theme,
+            None::<Span>,
+        );
+
+        assert_ne!(first, second);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn code_block_highlighter_cache_refreshes_after_language_registration() {
+        let lang = SharedString::from("json-cache-test");
+        let theme = HighlightTheme::default_light();
+
+        CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
+            cache.borrow_mut().remove(&lang);
+        });
+
+        let unknown_block = CodeBlock::new(
+            "{\"value\": 1}".into(),
+            Some(lang.clone()),
+            &theme,
+            None::<Span>,
+        );
+        _ = unknown_block.styles();
+
+        let cached_language = CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
+            cache
+                .borrow()
+                .get(&lang)
+                .map(|highlighter| highlighter.language().clone())
+        });
+        assert_eq!(cached_language.as_deref(), Some("text"));
+
+        LanguageRegistry::singleton().register(
+            lang.as_ref(),
+            &crate::highlighter::LanguageConfig::new(
+                lang.clone(),
+                tree_sitter_json::LANGUAGE.into(),
+                vec![],
+                r#"
+                    (string) @string
+                    (number) @number
+                    (pair key: (string) @property)
+                "#,
+                "",
+                "",
+            ),
+        );
+
+        let registered_block = CodeBlock::new(
+            "{\"value\": 2}".into(),
+            Some(lang.clone()),
+            &theme,
+            None::<Span>,
+        );
+        _ = registered_block.styles();
+
+        let cached_language = CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
+            cache
+                .borrow()
+                .get(&lang)
+                .map(|highlighter| highlighter.language().clone())
+        });
+        assert_eq!(cached_language.as_deref(), Some(lang.as_ref()));
     }
 }


### PR DESCRIPTION
## Description

This changes code block syntax highlighting to compute styles lazily and reuse `SyntaxHighlighter` instances through a thread-local language cache. This avoids repeated highlighter construction during markdown parsing/render setup for large files with many code blocks.

It also avoids repeatedly recombining visible input highlight ranges when the ranges are already disjoint.

I also tested #2371 against the same case, but it did not help with the slowdown I was seeing.

I first noticed the issue in my side project, then reproduced the same behavior in the example markdown editor. In local testing, Task Manager showed lower CPU usage while editing with this implementation, memory usage stayed about the same.

Adds regression coverage for code block equality and cached highlighter refresh behavior when a language is registered after an initial fallback.

AI assistance was used to help and prepare this PR. I manually reviewed the resulting code and tested the performance difference before opening the PR.

## Test File

I used this AI-generated markdown file to reproduce the issue and test the change:

[refactor-opportunities.md](https://github.com/user-attachments/files/28234513/refactor-opportunities.md)

## Videos

### Before

<video src="https://github.com/user-attachments/assets/dbcc45ab-f371-40c2-b6b5-1336fee995fe" controls></video>

### After

<video src="https://github.com/user-attachments/assets/4e3c0754-55b5-4d54-9eb6-a4261f940ad9" controls></video>

## Tests

- `cargo test -p gpui-component code_block_`
- `cargo test -p gpui-component input::`
- `cargo test -p gpui-component text::`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI-generated code, if any, is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows, and Linux platform performance, if the change is platform-specific.