### PR TITLE
chore: Bump gpui for BoxShadow inset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "indexmap",
  "rustc-hash 2.1.2",
@@ -1440,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.17.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8c4e3a1d02f5269ed15c2d70b4647167856f66f228dcdf99050ab77bbb5a56"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
 dependencies = [
  "bitflags 2.11.1",
  "fontdb",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "async-task",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "schemars",
  "serde",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "log",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "collections",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5469,7 +5469,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "collections",
  "serde",
@@ -6429,7 +6429,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "derive_refineable",
 ]
@@ -6481,7 +6481,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7520,7 +7520,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "heapless",
  "log",
@@ -8939,7 +8939,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "perf",
  "quote",
@@ -10879,7 +10879,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10896,7 +10896,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -10907,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#14befe215158182be6b505b26bccf25538831213"
+source = "git+https://github.com/zed-industries/zed#4bee412118dafea3bbd491cd044d354f16b3d665"
 
 [[package]]
 name = "zune-core"

--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -652,12 +652,14 @@ impl RenderOnce for Dialog {
                                         offset: point(px(0.), px(20.)),
                                         blur_radius: px(25.),
                                         spread_radius: px(-5.),
+                                        inset: false,
                                     },
                                     BoxShadow {
                                         color: hsla(0., 0., 0., 0.1 * delta),
                                         offset: point(px(0.), px(8.)),
                                         blur_radius: px(10.),
                                         spread_radius: px(-6.),
+                                        inset: false,
                                     },
                                 ];
                                 this.top(y * delta).shadow(shadow)

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -36,6 +36,7 @@ pub fn box_shadow(
         offset: point(x.into(), y.into()),
         blur_radius: blur.into(),
         spread_radius: spread.into(),
+        inset: false,
         color,
     }
 }

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -200,6 +200,7 @@ impl RenderOnce for WindowBorder {
                                     blur_radius: shadow_size / 2.,
                                     spread_radius: px(0.),
                                     offset: point(px(0.0), px(0.0)),
+                                    inset: false,
                                 }])
                             }),
                     })


### PR DESCRIPTION
## Summary

- Bump the GPUI/Zed dependency revision in `Cargo.lock`.
- Add the new `BoxShadow::inset` field to existing direct `BoxShadow` constructors.
- Keep current shadow behavior unchanged by defaulting existing usages to `inset: false`.

## Context

GPUI added an `inset` field to `BoxShadow` in zed-industries/zed@eb944cfd7a7395fa8691c3c196ae4c468041350c.

This PR updates gpui-component to compile against the newer GPUI API while preserving the existing non-inset drop-shadow behavior.

## Validation

- `cargo check -p gpui-component`