### PR TITLE
input: add editor.gutter.background theme key

### DIFF
--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -427,6 +427,10 @@ pub struct HighlightThemeStyle {
     pub editor_active_line_number: Option<Hsla>,
     #[serde(rename = "editor.invisible")]
     pub editor_invisible: Option<Hsla>,
+    /// Optional background color for the gutter (line-number column).
+    /// Falls back to [`Self::editor_background`] when unset.
+    #[serde(rename = "editor.gutter.background")]
+    pub editor_gutter_background: Option<Hsla>,
     #[serde(flatten)]
     pub status: StatusColors,
     #[serde(rename = "syntax")]

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -2070,6 +2070,15 @@ impl Element for TextElement {
         if let Some(line_numbers) = prepaint.line_numbers.as_ref() {
             offset_y += invisible_top_padding;
 
+            // Gutter background: prefer the dedicated `editor.gutter.background`
+            // theme key, falling back to the editor background so existing
+            // themes render unchanged.
+            let gutter_bg = cx
+                .theme()
+                .highlight_theme
+                .style
+                .editor_gutter_background
+                .unwrap_or_else(|| cx.theme().editor_background());
             window.paint_quad(fill(
                 Bounds {
                     origin: input_bounds.origin,
@@ -2078,7 +2087,7 @@ impl Element for TextElement {
                         input_bounds.size.height + prepaint.ghost_lines_height,
                     ),
                 },
-                cx.theme().editor_background(),
+                gutter_bg,
             ));
 
             // Each item is the normal lines.


### PR DESCRIPTION
## Problem

The line-number gutter is painted with the same color as the editor text
background (`editor_background()`), and there's no way for a theme to give
the gutter its own background. Some themes (and some editor UIs) want the
gutter visually distinct from the text area — e.g. a slightly different
shade so the line-number column reads as separate chrome.

## Solution

Add an optional `editor.gutter.background` key to the highlight theme:

- `HighlightThemeStyle` gains `editor_gutter_background: Option<Hsla>`,
  parsed via the same `#[serde(rename = "...")]` pattern as the
  surrounding `editor.*` keys.
- The gutter paint in `input/element.rs` reads this field first and falls
  back to `editor_background()` when it's unset.

Because the field is optional and defaults to the existing editor
background, themes that don't define the key render exactly as before —
this is a strict addition with no behavior change.
