### PR TITLE
assets: Fix dependency of the `ui` crate on `assets` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "enum-iterator",
  "futures",
  "gpui",
+ "gpui-component-assets",
  "gpui-component-macros",
  "gpui_macros",
  "html5ever 0.27.0",

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -11,6 +11,18 @@ edition.workspace = true
 publish = true
 version = "0.5.1"
 
+# `links` is the documented cargo mechanism for sharing build-time metadata
+# across the dep graph: every dependent (regular OR build-dep) receives the
+# `cargo:KEY=VALUE` lines from our build.rs as `DEP_<links>_<KEY>` env vars
+# in its own build script. We use this to publish the absolute path of our
+# `assets/icons` directory so `gpui-component` can generate its `IconName`
+# enum at proc-macro expansion time without a sibling-crate reference
+# (which would break under `cargo vendor` / `cargo publish`). The value is
+# conventionally a native-library name; we use a unique identifier scoped
+# to this crate's purpose. Cargo enforces uniqueness across the build
+# graph, which also prevents accidental double-linkage in dependents.
+links = "gpui-component-default-icons"
+
 [lib]
 doctest = false
 

--- a/crates/assets/build.rs
+++ b/crates/assets/build.rs
@@ -1,0 +1,39 @@
+use std::{env, path::Path};
+
+fn main() {
+    // Publish the absolute path of `assets/icons` so dependents that need
+    // the icons at *build time* (notably `gpui-component`, whose `IconName`
+    // enum is generated at proc-macro expansion time) can find them without
+    // a sibling-crate reference. Cargo turns the `cargo:icons-dir=...` line
+    // below into the `DEP_GPUI_COMPONENT_DEFAULT_ICONS_ICONS_DIR` env var in
+    // every dependent's build script — see the `links` field in our
+    // `Cargo.toml` for the full mechanism.
+    //
+    // Within this crate, `assets/icons` is also consumed at *runtime* by
+    // `RustEmbed` (see `src/native_assets.rs`), which finds the files
+    // relative to our own `CARGO_MANIFEST_DIR`. So this build script does
+    // not need to copy or move anything — it only advertises the location.
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set by cargo");
+    let icons_dir = Path::new(&manifest_dir).join("assets/icons");
+
+    // Sanity-check that the directory we're advertising actually exists.
+    // Bail loudly if it's missing — silently publishing a bad path would
+    // give dependents a confusing "failed to read directory" later.
+    if !icons_dir.is_dir() {
+        panic!(
+            "expected default icons at {}, but the directory is missing",
+            icons_dir.display(),
+        );
+    }
+
+    println!("cargo:icons-dir={}", icons_dir.display());
+
+    // Rerun if the icon set changes (rename/add/remove). Per-SVG watching
+    // isn't needed because the dependent reads from this advertised path
+    // at *its own* expansion time, not via cached build-script output.
+    println!("cargo:rerun-if-changed=assets/icons");
+
+    // Also rerun if anyone fiddles with this script itself.
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -101,13 +101,13 @@ fn pascal_case(filename: &str) -> String {
 ///
 /// ```ignore
 /// // Literal path (relative to the calling crate's CARGO_MANIFEST_DIR)
-/// icon_named!(MyIcons, "icons");
+/// icon_named!(IconName, "icons");
 ///
 /// // Env-var reference (resolved at macro expansion time)
 /// icon_named!(IconName, "$GPUI_COMPONENT_DEFAULT_ICONS_DIR");
 ///
 /// // With custom derives
-/// icon_named!(MyIcons, "icons", [Debug, Copy, PartialEq, Eq]);
+/// icon_named!(IconName, "icons", [Debug, Copy, PartialEq, Eq]);
 /// ```
 #[proc_macro]
 pub fn icon_named(input: TokenStream) -> TokenStream {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -82,18 +82,32 @@ fn pascal_case(filename: &str) -> String {
 
 /// Generate a custom icon enum and its `IconNamed` impl by scanning a directory of SVG files.
 ///
-/// Accepts an enum name, a path relative to the calling crate's `CARGO_MANIFEST_DIR`,
-/// and optionally a list of additional derive traits.
+/// Accepts an enum name, a path, and optionally a list of additional derive traits.
 /// Each `.svg` file becomes an enum variant using PascalCase conversion.
+///
+/// The path may be either:
+///
+/// - **A literal path** (the common case), resolved relative to the calling crate's
+///   `CARGO_MANIFEST_DIR`. Use this when the icons live inside your own package.
+/// - **An env-var reference** of the form `"$NAME"`, where `NAME` names a build-time
+///   environment variable whose value is the absolute path to the icons directory.
+///   Use this when the icons live in *another* crate and the path is plumbed
+///   through cargo's `links` / `DEP_<X>_<KEY>` propagation mechanism. The default
+///   `IconName` enum in `gpui-component` uses this pattern to consume icons from
+///   `gpui-component-assets` without a sibling-crate reference, which would
+///   otherwise break `cargo vendor` and `cargo publish`.
 ///
 /// # Example
 ///
 /// ```ignore
-/// // Basic usage (derives IntoElement, Clone by default)
-/// icon_named!(IconName, "../assets/assets/icons");
+/// // Literal path (relative to the calling crate's CARGO_MANIFEST_DIR)
+/// icon_named!(MyIcons, "icons");
+///
+/// // Env-var reference (resolved at macro expansion time)
+/// icon_named!(IconName, "$GPUI_COMPONENT_DEFAULT_ICONS_DIR");
 ///
 /// // With custom derives
-/// icon_named!(IconName, "../assets/assets/icons", [Debug, Copy, PartialEq, Eq]);
+/// icon_named!(MyIcons, "icons", [Debug, Copy, PartialEq, Eq]);
 /// ```
 #[proc_macro]
 pub fn icon_named(input: TokenStream) -> TokenStream {
@@ -104,10 +118,27 @@ pub fn icon_named(input: TokenStream) -> TokenStream {
         ..
     } = syn::parse_macro_input!(input as IconNameInput);
 
-    let relative_path = path.value();
+    let raw_path = path.value();
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let icons_dir = std::path::Path::new(&manifest_dir).join(&relative_path);
+    // Resolve the path. A leading `$` switches us into env-var mode: the
+    // remainder of the string is an env var name whose value (set by the
+    // caller's `build.rs` via `cargo:rustc-env=`) is the absolute path of
+    // the icons directory. Otherwise treat the string as a path relative
+    // to the calling crate's `CARGO_MANIFEST_DIR`, the original behavior.
+    let icons_dir = if let Some(env_name) = raw_path.strip_prefix('$') {
+        let env_value = std::env::var(env_name).unwrap_or_else(|_| {
+            panic!(
+                "icon_named!: env var `{env_name}` is not set at expansion time. \
+                 Ensure the calling crate's build.rs propagates it via \
+                 `cargo:rustc-env={env_name}=<absolute path>`."
+            )
+        });
+        std::path::PathBuf::from(env_value)
+    } else {
+        let manifest_dir =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+        std::path::Path::new(&manifest_dir).join(&raw_path)
+    };
 
     let mut entries: Vec<(String, String)> = Vec::new();
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -98,6 +98,16 @@ anyhow.workspace = true
 gpui = { workspace = true }
 gpui_macros.workspace = true
 gpui-component-macros = { workspace = true }
+# `gpui-component-assets` ships the canonical icon set whose variants we
+# enumerate to generate `IconName` at build time. Cargo's
+# `DEP_<links>_<key>` propagation (the bridge that hands the icons-dir
+# path from the assets crate's build.rs into our own) only works through
+# *regular* dependencies, not build-deps, so this has to live here even
+# though our use is entirely build-time. The runtime cost is negligible:
+# downstream consumers were already pulling in gpui-component-assets
+# alongside gpui-component to load the SVGs that `IconName` paths point
+# at; this just formalizes a coupling that already existed semantically.
+gpui-component-assets = { workspace = true }
 notify.workspace = true
 ropey.workspace = true
 rust-i18n.workspace = true

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -98,15 +98,6 @@ anyhow.workspace = true
 gpui = { workspace = true }
 gpui_macros.workspace = true
 gpui-component-macros = { workspace = true }
-# `gpui-component-assets` ships the canonical icon set whose variants we
-# enumerate to generate `IconName` at build time. Cargo's
-# `DEP_<links>_<key>` propagation (the bridge that hands the icons-dir
-# path from the assets crate's build.rs into our own) only works through
-# *regular* dependencies, not build-deps, so this has to live here even
-# though our use is entirely build-time. The runtime cost is negligible:
-# downstream consumers were already pulling in gpui-component-assets
-# alongside gpui-component to load the SVGs that `IconName` paths point
-# at; this just formalizes a coupling that already existed semantically.
 gpui-component-assets = { workspace = true }
 notify.workspace = true
 ropey.workspace = true
@@ -201,3 +192,12 @@ indoc = "2"
 
 [lints]
 workspace = true
+
+# `gpui-component-assets` ships the canonical icon set whose variants we
+# enumerate to generate `IconName` at build time. Cargo's
+# `DEP_<links>_<key>` propagation (the bridge that hands the icons-dir
+# path from the assets crate's build.rs into our own) only works through
+# *regular* dependencies, not build-deps, so this has to live here even
+# though our use is entirely build-time.
+[package.metadata.cargo-machete]
+ignored = ["gpui-component-assets"]

--- a/crates/ui/build.rs
+++ b/crates/ui/build.rs
@@ -1,19 +1,33 @@
-use std::{fs, path::Path};
+use std::env;
 
 fn main() {
-    // Tell Cargo to rerun this build script if any SVG file in assets/icons changes.
-    let icons_dir = Path::new("../assets/assets/icons");
+    // `gpui-component-assets` exposes the absolute path of its default
+    // icons directory via cargo's `links` mechanism (see its `Cargo.toml`
+    // and `build.rs`). We receive that path as
+    // `DEP_GPUI_COMPONENT_DEFAULT_ICONS_ICONS_DIR` here, then re-publish
+    // it as a `rustc-env` so it's visible to the
+    // `icon_named!("$GPUI_COMPONENT_DEFAULT_ICONS_DIR")` proc-macro call
+    // in `src/icon.rs` at expansion time. This is what lets the default
+    // `IconName` enum be generated from the assets crate's icon set
+    // without a sibling-crate reference, which would otherwise break
+    // `cargo vendor` and `cargo publish`.
+    //
+    // Cargo only propagates `DEP_<name>_<key>` through *regular*
+    // dependencies, not through build-deps — see the `dependencies`
+    // (not `build-dependencies`) entry for `gpui-component-assets` in
+    // `Cargo.toml`.
+    let icons_dir = env::var("DEP_GPUI_COMPONENT_DEFAULT_ICONS_ICONS_DIR").expect(
+        "DEP_GPUI_COMPONENT_DEFAULT_ICONS_ICONS_DIR is set by gpui-component-assets's \
+         build.rs via its `links` field; make sure the regular dependency on \
+         gpui-component-assets is intact in Cargo.toml",
+    );
 
-    // Watch the icons directory itself.
-    println!("cargo:rerun-if-changed=../assets/assets/icons");
+    println!("cargo:rustc-env=GPUI_COMPONENT_DEFAULT_ICONS_DIR={icons_dir}");
 
-    // Watch each SVG file in the directory.
-    if let Ok(entries) = fs::read_dir(icons_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) == Some("svg") {
-                println!("cargo:rerun-if-changed={}", path.display());
-            }
-        }
-    }
+    // Rerun if the icons directory we point at changes. The assets crate's
+    // build.rs already declares the same `rerun-if-changed`, but cargo
+    // invalidates each build script independently, so this keeps us in
+    // lockstep.
+    println!("cargo:rerun-if-changed={icons_dir}");
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/crates/ui/src/icon.rs
+++ b/crates/ui/src/icon.rs
@@ -21,7 +21,12 @@ impl<T: IconNamed> From<T> for Icon {
     }
 }
 
-icon_named!(IconName, "../assets/assets/icons");
+// Generate `IconName` from the icons that `gpui-component-assets` ships.
+// The `$VAR` form resolves to the absolute path published by the assets
+// crate's `build.rs` (via cargo's `links` mechanism) and re-exported by
+// our own `build.rs`. See `gpui_component_macros::icon_named!`'s doc
+// comment for the full mechanism.
+icon_named!(IconName, "$GPUI_COMPONENT_DEFAULT_ICONS_DIR");
 
 impl IconName {
     /// Return the icon as a Entity<Icon>


### PR DESCRIPTION
## Description

Previously, generation of default icons escaped the ui crate's directory, assuming the presence of `../assets/assets/icons`. This broke any project using cargo vendor, nix, sandboxed builds, etc.

It might be better to create a separate `icons` crate that holds the SVGs and generates the default icons, but that's a more opinionated change.

This simply updates the macro to support an environment variable based path, and uses cargo links to publish the *real* path to the asset crate's icons.

This is the correct pattern in cargo, but isn't crazy common, hence verbose comments explaining the indirection. [The use of `package.links`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field) is most typically used for [native libraries](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) but also works perfectly for this case.

## Screenshot

This does not make any visual changes.

## Break Changes

This does not introduce breaking changes.

## How to Test

All existing tests should work without modification. Projects using gpui-component should now build with vendored/sandboxed/nix pipelines.

## AI Assistance

Claude Code wrote all substantial portions of this fix, and I did not see anything that needed revision. Fixed behavior was manually validated in the consuming app.