### PR TITLE
editor: Fix search scroll direction on wrap

### DIFF
--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -219,6 +219,28 @@ impl InputState {
 }
 
 impl SearchPanel {
+    fn next_scroll_direction(
+        previous_match_ix: usize,
+        current_match_ix: usize,
+    ) -> Option<MoveDirection> {
+        if current_match_ix < previous_match_ix {
+            None
+        } else {
+            Some(MoveDirection::Down)
+        }
+    }
+
+    fn prev_scroll_direction(
+        previous_match_ix: usize,
+        current_match_ix: usize,
+    ) -> Option<MoveDirection> {
+        if current_match_ix > previous_match_ix {
+            None
+        } else {
+            Some(MoveDirection::Up)
+        }
+    }
+
     pub fn new(editor: Entity<InputState>, window: &mut Window, cx: &mut App) -> Entity<Self> {
         let search_input = cx.new(|cx| InputState::new(window, cx));
         let replace_input = cx.new(|cx| InputState::new(window, cx));
@@ -315,17 +337,23 @@ impl SearchPanel {
     }
 
     fn prev(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        let previous_match_ix = self.matcher.current_match_ix;
         if let Some(range) = self.matcher.next_back() {
+            let direction =
+                Self::prev_scroll_direction(previous_match_ix, self.matcher.current_match_ix);
             self.editor.update(cx, |state, cx| {
-                state.scroll_to(range.start, Some(MoveDirection::Up), cx);
+                state.scroll_to(range.start, direction, cx);
             });
         }
     }
 
     fn next(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        let previous_match_ix = self.matcher.current_match_ix;
         if let Some(range) = self.matcher.next() {
+            let direction =
+                Self::next_scroll_direction(previous_match_ix, self.matcher.current_match_ix);
             self.editor.update(cx, |state, cx| {
-                state.scroll_to(range.end, Some(MoveDirection::Down), cx);
+                state.scroll_to(range.end, direction, cx);
             });
         }
     }
@@ -637,5 +665,31 @@ mod tests {
 
         matcher.update_cursor_by_offset(31);
         assert_eq!(matcher.current_match_ix, 2);
+    }
+
+    #[test]
+    fn test_next_scroll_direction_returns_down_without_wrap() {
+        assert!(matches!(
+            SearchPanel::next_scroll_direction(0, 1),
+            Some(MoveDirection::Down)
+        ));
+    }
+
+    #[test]
+    fn test_next_scroll_direction_returns_none_on_wrap() {
+        assert!(SearchPanel::next_scroll_direction(2, 0).is_none());
+    }
+
+    #[test]
+    fn test_prev_scroll_direction_returns_up_without_wrap() {
+        assert!(matches!(
+            SearchPanel::prev_scroll_direction(2, 1),
+            Some(MoveDirection::Up)
+        ));
+    }
+
+    #[test]
+    fn test_prev_scroll_direction_returns_none_on_wrap() {
+        assert!(SearchPanel::prev_scroll_direction(0, 2).is_none());
     }
 }

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -81,8 +81,12 @@ impl SearchMatcher {
         self.matched_ranges = Rc::new(new_ranges);
         if !self.replacing {
             self.current_match_ix = 0;
-            self.replacing = false;
+        } else if self.matched_ranges.is_empty() {
+            self.current_match_ix = 0;
+        } else {
+            self.current_match_ix = self.current_match_ix.min(self.matched_ranges.len() - 1);
         }
+        self.replacing = false;
     }
 
     /// Update the search query and reset the current match index.
@@ -105,10 +109,6 @@ impl SearchMatcher {
     #[inline]
     fn len(&self) -> usize {
         self.matched_ranges.len()
-    }
-
-    fn peek(&self) -> Option<Range<usize>> {
-        self.matched_ranges.get(self.current_match_ix + 1).cloned()
     }
 
     fn label(&self) -> String {
@@ -223,7 +223,7 @@ impl SearchPanel {
         previous_match_ix: usize,
         current_match_ix: usize,
     ) -> Option<MoveDirection> {
-        if current_match_ix < previous_match_ix {
+        if current_match_ix <= previous_match_ix {
             None
         } else {
             Some(MoveDirection::Down)
@@ -234,7 +234,7 @@ impl SearchPanel {
         previous_match_ix: usize,
         current_match_ix: usize,
     ) -> Option<MoveDirection> {
-        if current_match_ix > previous_match_ix {
+        if current_match_ix >= previous_match_ix {
             None
         } else {
             Some(MoveDirection::Up)
@@ -369,6 +369,7 @@ impl SearchPanel {
     fn replace_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let new_text = self.replace_input.read(cx).value();
         self.matcher.replacing = true;
+        let previous_match_ix = self.matcher.current_match_ix;
         if let Some(range) = self
             .matcher
             .matched_ranges
@@ -376,13 +377,25 @@ impl SearchPanel {
             .cloned()
         {
             let text_state = self.editor.clone();
-
-            let next_range = self.matcher.peek().unwrap_or(range.clone());
+            let next_match_ix =
+                if previous_match_ix < self.matcher.matched_ranges.len().saturating_sub(1) {
+                    previous_match_ix + 1
+                } else {
+                    0
+                };
+            let next_range = self
+                .matcher
+                .matched_ranges
+                .get(next_match_ix)
+                .cloned()
+                .unwrap_or(range.clone());
+            self.matcher.current_match_ix = next_match_ix;
+            let direction = Self::next_scroll_direction(previous_match_ix, next_match_ix);
             cx.spawn_in(window, async move |_, cx| {
                 cx.update(|window, cx| {
                     text_state.update(cx, |state, cx| {
                         let range_utf16 = state.range_to_utf16(&range);
-                        state.scroll_to(next_range.end, Some(MoveDirection::Down), cx);
+                        state.scroll_to(next_range.end, direction, cx);
                         state.replace_text_in_range_silent(
                             Some(range_utf16),
                             new_text.as_str(),
@@ -681,6 +694,11 @@ mod tests {
     }
 
     #[test]
+    fn test_next_scroll_direction_returns_none_for_single_match() {
+        assert!(SearchPanel::next_scroll_direction(0, 0).is_none());
+    }
+
+    #[test]
     fn test_prev_scroll_direction_returns_up_without_wrap() {
         assert!(matches!(
             SearchPanel::prev_scroll_direction(2, 1),
@@ -691,5 +709,26 @@ mod tests {
     #[test]
     fn test_prev_scroll_direction_returns_none_on_wrap() {
         assert!(SearchPanel::prev_scroll_direction(0, 2).is_none());
+    }
+
+    #[test]
+    fn test_prev_scroll_direction_returns_none_for_single_match() {
+        assert!(SearchPanel::prev_scroll_direction(0, 0).is_none());
+    }
+
+    #[test]
+    fn test_update_matches_clamps_current_match_index_while_replacing() {
+        let mut matcher = SearchMatcher::new();
+        matcher.update(&Rope::from("foo foo foo"));
+        matcher.update_query("foo", true);
+        matcher.current_match_ix = 2;
+        matcher.replacing = true;
+
+        matcher.update(&Rope::from("foo xoo foo"));
+
+        assert_eq!(matcher.len(), 2);
+        assert_eq!(matcher.current_match_ix, 1);
+        assert_eq!(matcher.label(), "2/2");
+        assert!(!matcher.replacing);
     }
 }

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -121,12 +121,15 @@ impl SearchMatcher {
     fn next_ix(&self) -> Option<usize> {
         if self.matched_ranges.is_empty() {
             None
-        } else if self.current_match_ix < self.matched_ranges.len().saturating_sub(1) {
-            // if current match isn't the last one
+        } else if self.has_next_match_without_wrap() {
             Some(self.current_match_ix + 1)
         } else {
             Some(0)
         }
+    }
+
+    fn has_next_match_without_wrap(&self) -> bool {
+        self.current_match_ix < self.matched_ranges.len().saturating_sub(1)
     }
 
     fn label(&self) -> String {

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -41,8 +41,7 @@ pub struct SearchMatcher {
 
     pub(super) matched_ranges: Rc<Vec<Range<usize>>>,
     pub(super) current_match_ix: usize,
-    // TODO: update the comment
-    /// Is in replacing mode, if true, the next update will not reset the current match index.
+    /// Is in replacing mode, if true, the next update will update the current match index based on matched ranges.
     replacing: bool,
 }
 
@@ -80,7 +79,6 @@ impl SearchMatcher {
             }
         }
         self.matched_ranges = Rc::new(new_ranges);
-        // Is in replacing mode, if true, the next update will update the current match index based on matched ranges.
         if !self.replacing {
             self.current_match_ix = 0;
         } else if self.matched_ranges.is_empty() {

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -41,6 +41,7 @@ pub struct SearchMatcher {
 
     pub(super) matched_ranges: Rc<Vec<Range<usize>>>,
     pub(super) current_match_ix: usize,
+    // TODO: update the comment
     /// Is in replacing mode, if true, the next update will not reset the current match index.
     replacing: bool,
 }
@@ -79,6 +80,7 @@ impl SearchMatcher {
             }
         }
         self.matched_ranges = Rc::new(new_ranges);
+        // Is in replacing mode, if true, the next update will update the current match index based on matched ranges.
         if !self.replacing {
             self.current_match_ix = 0;
         } else if self.matched_ranges.is_empty() {
@@ -111,6 +113,22 @@ impl SearchMatcher {
         self.matched_ranges.len()
     }
 
+    fn peek(&self) -> Option<Range<usize>> {
+        let next_match_ix = self.next_ix()?;
+        self.matched_ranges.get(next_match_ix).cloned()
+    }
+
+    fn next_ix(&self) -> Option<usize> {
+        if self.matched_ranges.is_empty() {
+            None
+        } else if self.current_match_ix < self.matched_ranges.len().saturating_sub(1) {
+            // if current match isn't the last one
+            Some(self.current_match_ix + 1)
+        } else {
+            Some(0)
+        }
+    }
+
     fn label(&self) -> String {
         if self.len() == 0 {
             return "0/0".to_string();
@@ -133,17 +151,9 @@ impl Iterator for SearchMatcher {
     type Item = Range<usize>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.matched_ranges.is_empty() {
-            return None;
-        }
-
-        if self.current_match_ix < self.matched_ranges.len().saturating_sub(1) {
-            self.current_match_ix += 1;
-        } else {
-            self.current_match_ix = 0;
-        }
-
-        self.matched_ranges.get(self.current_match_ix).cloned()
+        let next_match_ix = self.next_ix()?;
+        self.current_match_ix = next_match_ix;
+        self.matched_ranges.get(next_match_ix).cloned()
     }
 }
 
@@ -377,18 +387,8 @@ impl SearchPanel {
             .cloned()
         {
             let text_state = self.editor.clone();
-            let next_match_ix =
-                if previous_match_ix < self.matcher.matched_ranges.len().saturating_sub(1) {
-                    previous_match_ix + 1
-                } else {
-                    0
-                };
-            let next_range = self
-                .matcher
-                .matched_ranges
-                .get(next_match_ix)
-                .cloned()
-                .unwrap_or(range.clone());
+            let next_match_ix = self.matcher.next_ix().unwrap_or(previous_match_ix);
+            let next_range = self.matcher.peek().unwrap_or(range.clone());
             self.matcher.current_match_ix = next_match_ix;
             let direction = Self::next_scroll_direction(previous_match_ix, next_match_ix);
             cx.spawn_in(window, async move |_, cx| {
@@ -696,6 +696,15 @@ mod tests {
     #[test]
     fn test_next_scroll_direction_returns_none_for_single_match() {
         assert!(SearchPanel::next_scroll_direction(0, 0).is_none());
+    }
+
+    #[test]
+    fn test_next_ix_wraps_to_start() {
+        let mut matcher = SearchMatcher::new();
+        matcher.matched_ranges = Rc::new(vec![5..10, 15..20, 25..30]);
+        matcher.current_match_ix = 2;
+
+        assert_eq!(matcher.next_ix(), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Description

In the search or replace mode in editor, when it reaches to the last matching text, it doesn't wrap the search.

## Video clips

Before (no search wrap)

https://github.com/user-attachments/assets/ba6590b1-3d78-4e15-b186-b22fc26068d6

After (wrapped search)

https://github.com/user-attachments/assets/7f7c42fa-4556-4d4a-acca-95c626823858

## Changes

- [Search] When the matching text is the last one, it wraps the search by determining the direction by calling `Self::prev_scroll_direction`
- [Replace] When the matching text is the last one, it wraps the search by determining the direction by calling `Self::prev_scroll_direction`
- Add a new helper `next_ix` to determine the next matching index
- [Search/Replace] Reset `current_match_ix` in `update_matches` when source or search keyword changes

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

1. Run `cargo r --example editor`
2. Search for text "HelloWorld struct provides greeting functionality with configuration options" (There should be 11 occurrences)
3. Keep clicking next button, it should wrap the search when hitting the last matching text

Same for prev and replace.

## AI Usage

Used AI to pinpoint the issue and understand some of the logic.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
