### PR TITLE
editor: Support disabling replace in search

### DIFF
--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -292,9 +292,9 @@ impl SearchPanel {
         cx.notify();
     }
 
-    fn allow_replace(&self, cx: &App) -> bool {
+    fn replaceable(&self, cx: &App) -> bool {
         let editor = self.editor.read(cx);
-        editor.allow_replace_in_search
+        editor.replaceable
     }
 
     pub(super) fn hide(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -344,7 +344,7 @@ impl SearchPanel {
     }
 
     fn replace_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.allow_replace(cx) {
+        if !self.replaceable(cx) {
             self.replace_mode = false;
             cx.notify();
             return;
@@ -380,7 +380,7 @@ impl SearchPanel {
     }
 
     fn replace_all(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.allow_replace(cx) {
+        if !self.replaceable(cx) {
             self.replace_mode = false;
             cx.notify();
             return;
@@ -429,7 +429,7 @@ impl Render for SearchPanel {
         }
 
         let has_matches = self.matcher.len() > 0;
-        let allow_replace = self.allow_replace(cx);
+        let allow_replace = self.replaceable(cx);
         if !allow_replace {
             self.replace_mode = false;
         }

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -292,6 +292,11 @@ impl SearchPanel {
         cx.notify();
     }
 
+    fn allow_replace(&self, cx: &App) -> bool {
+        let editor = self.editor.read(cx);
+        editor.allow_replace_in_search
+    }
+
     pub(super) fn hide(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.open = false;
         self.editor.read(cx).focus_handle.clone().focus(window, cx);
@@ -339,6 +344,12 @@ impl SearchPanel {
     }
 
     fn replace_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.allow_replace(cx) {
+            self.replace_mode = false;
+            cx.notify();
+            return;
+        }
+
         let new_text = self.replace_input.read(cx).value();
         self.matcher.replacing = true;
         if let Some(range) = self
@@ -369,6 +380,12 @@ impl SearchPanel {
     }
 
     fn replace_all(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.allow_replace(cx) {
+            self.replace_mode = false;
+            cx.notify();
+            return;
+        }
+
         let new_text = self.replace_input.read(cx).value();
         self.matcher.replacing = true;
         let ranges = self.matcher.matched_ranges.clone();
@@ -412,6 +429,10 @@ impl Render for SearchPanel {
         }
 
         let has_matches = self.matcher.len() > 0;
+        let allow_replace = self.allow_replace(cx);
+        if !allow_replace {
+            self.replace_mode = false;
+        }
 
         v_flex()
             .id("search-panel")
@@ -468,30 +489,32 @@ impl Render for SearchPanel {
                                 }
                             }),
                     )
-                    .child(
-                        Button::new("replace-mode")
-                            .xsmall()
-                            .ghost()
-                            .icon(IconName::Replace)
-                            .selected(self.replace_mode)
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.replace_mode = !this.replace_mode;
-                                if this.replace_mode {
-                                    this.replace_input
-                                        .read(cx)
-                                        .focus_handle
-                                        .clone()
-                                        .focus(window, cx);
-                                } else {
-                                    this.search_input
-                                        .read(cx)
-                                        .focus_handle
-                                        .clone()
-                                        .focus(window, cx);
-                                }
-                                cx.notify();
-                            })),
-                    )
+                    .when(allow_replace, |this| {
+                        this.child(
+                            Button::new("replace-mode")
+                                .xsmall()
+                                .ghost()
+                                .icon(IconName::Replace)
+                                .selected(self.replace_mode)
+                                .on_click(cx.listener(|this, _, window, cx| {
+                                    this.replace_mode = !this.replace_mode;
+                                    if this.replace_mode {
+                                        this.replace_input
+                                            .read(cx)
+                                            .focus_handle
+                                            .clone()
+                                            .focus(window, cx);
+                                    } else {
+                                        this.search_input
+                                            .read(cx)
+                                            .focus_handle
+                                            .clone()
+                                            .focus(window, cx);
+                                    }
+                                    cx.notify();
+                                })),
+                        )
+                    })
                     .child(
                         Button::new("prev")
                             .xsmall()
@@ -531,7 +554,7 @@ impl Render for SearchPanel {
                             })),
                     ),
             )
-            .when(self.replace_mode, |this| {
+            .when(self.replace_mode && allow_replace, |this| {
                 this.child(
                     h_flex()
                         .w_full()

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -351,6 +351,7 @@ pub struct InputState {
     pub(super) selected_range: Selection,
     pub(super) search_panel: Option<Entity<SearchPanel>>,
     pub(super) searchable: bool,
+    pub(super) allow_replace_in_search: bool,
     /// Range for save the selected word, use to keep word range when drag move.
     pub(super) selected_word_range: Option<Selection>,
     pub(super) selection_reversed: bool,
@@ -476,6 +477,7 @@ impl InputState {
             selected_range: Selection::default(),
             search_panel: None,
             searchable: false,
+            allow_replace_in_search: true,
             selected_word_range: None,
             selection_reversed: false,
             ime_marked_range: None,
@@ -585,6 +587,12 @@ impl InputState {
     pub fn searchable(mut self, searchable: bool) -> Self {
         debug_assert!(self.mode.is_multi_line());
         self.searchable = searchable;
+        self
+    }
+
+    /// Set whether search UI allows replacement, default is true.
+    pub fn allow_replace_in_search(mut self, allow: bool) -> Self {
+        self.allow_replace_in_search = allow;
         self
     }
 

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -351,7 +351,7 @@ pub struct InputState {
     pub(super) selected_range: Selection,
     pub(super) search_panel: Option<Entity<SearchPanel>>,
     pub(super) searchable: bool,
-    pub(super) allow_replace_in_search: bool,
+    pub(super) replaceable: bool,
     /// Range for save the selected word, use to keep word range when drag move.
     pub(super) selected_word_range: Option<Selection>,
     pub(super) selection_reversed: bool,
@@ -477,7 +477,7 @@ impl InputState {
             selected_range: Selection::default(),
             search_panel: None,
             searchable: false,
-            allow_replace_in_search: true,
+            replaceable: true,
             selected_word_range: None,
             selection_reversed: false,
             ime_marked_range: None,
@@ -591,8 +591,8 @@ impl InputState {
     }
 
     /// Set whether search UI allows replacement, default is true.
-    pub fn allow_replace_in_search(mut self, allow: bool) -> Self {
-        self.allow_replace_in_search = allow;
+    pub fn replaceable(mut self, allow: bool) -> Self {
+        self.replaceable = allow;
         self
     }
 


### PR DESCRIPTION
## Description

Allow to disable replace in Editor search feature.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img alt="with-replace" src="https://github.com/user-attachments/assets/e3167b52-4f88-40b3-8931-4f51be9ba864" /> | <img alt="no-replace" src="https://github.com/user-attachments/assets/f0b6dce0-7119-4e23-8294-56eca3b8d390" /> |

## Break Changes

Add new API `replaceable(&self, cx: &App)` to editor state.

## How to Test

In editor example code, add `.replaceable(false)` to https://github.com/longbridge/gpui-component/blob/2a2fa72d14fa9a4bae63b01ab58ed3fe7fb8ba0b/crates/story/examples/editor.rs#L696 to turn off the replace feature in search.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
