### PR TITLE
setting: Fix number input step button and reset not updating value

### DIFF
--- a/crates/ui/src/setting/fields/number.rs
+++ b/crates/ui/src/setting/fields/number.rs
@@ -63,78 +63,97 @@ impl SettingFieldRender for NumberField {
     ) -> AnyElement {
         let value = get_value::<f64>(&field, cx);
         let set_value = set_value::<f64>(&field, cx);
+        let step_set_value = set_value.clone();
         let num_options = self.options.clone();
 
-        let state = window
-            .use_keyed_state(
-                SharedString::from(format!(
-                    "number-state-{}-{}-{}",
-                    options.page_ix, options.group_ix, options.item_ix
-                )),
-                cx,
-                |window, cx| {
-                    let input =
-                        cx.new(|cx| InputState::new(window, cx).default_value(value.to_string()));
-                    let _subscriptions = vec![
-                        cx.subscribe_in(&input, window, {
-                            move |_, input, event: &NumberInputEvent, window, cx| match event {
-                                NumberInputEvent::Step(action) => input.update(cx, |input, cx| {
-                                    let value = input.value();
+        let state_entity = window.use_keyed_state(
+            SharedString::from(format!(
+                "number-state-{}-{}-{}",
+                options.page_ix, options.group_ix, options.item_ix
+            )),
+            cx,
+            |window, cx| {
+                let input =
+                    cx.new(|cx| InputState::new(window, cx).default_value(value.to_string()));
+                let _subscriptions = vec![
+                    cx.subscribe_in(&input, window, {
+                        move |state: &mut State, input, event: &NumberInputEvent, window, cx| {
+                            match event {
+                                NumberInputEvent::Step(action) => {
+                                    let value = input.read(cx).value();
                                     if let Ok(value) = value.parse::<f64>() {
                                         let new_value = if *action == StepAction::Increment {
                                             value + num_options.step
                                         } else {
                                             value - num_options.step
                                         };
-                                        input.set_value(
-                                            SharedString::from(new_value.to_string()),
-                                            window,
-                                            cx,
-                                        );
-                                    }
-                                }),
-                            }
-                        }),
-                        cx.subscribe_in(&input, window, {
-                            move |state: &mut State, input, event: &InputEvent, window, cx| {
-                                match event {
-                                    InputEvent::Change => {
+                                        let clamp_value =
+                                            new_value.clamp(num_options.min, num_options.max);
+
                                         input.update(cx, |input, cx| {
-                                            let value = input.value();
-                                            if value == state.initial_value.to_string() {
-                                                return;
-                                            }
-
-                                            if let Ok(value) = value.parse::<f64>() {
-                                                let clamp_value =
-                                                    value.clamp(num_options.min, num_options.max);
-
-                                                set_value(clamp_value, cx);
-                                                state.initial_value = clamp_value;
-                                                if clamp_value != value {
-                                                    input.set_value(
-                                                        SharedString::from(clamp_value.to_string()),
-                                                        window,
-                                                        cx,
-                                                    );
-                                                }
-                                            }
+                                            input.set_value(
+                                                SharedString::from(clamp_value.to_string()),
+                                                window,
+                                                cx,
+                                            );
                                         });
+                                        step_set_value(clamp_value, cx);
+                                        state.initial_value = clamp_value;
                                     }
-                                    _ => {}
                                 }
                             }
-                        }),
-                    ];
+                        }
+                    }),
+                    cx.subscribe_in(&input, window, {
+                        move |state: &mut State, input, event: &InputEvent, window, cx| match event
+                        {
+                            InputEvent::Change => {
+                                input.update(cx, |input, cx| {
+                                    let value = input.value();
+                                    if value == state.initial_value.to_string() {
+                                        return;
+                                    }
 
-                    State {
-                        input,
-                        initial_value: value,
-                        _subscriptions,
-                    }
-                },
-            )
-            .read(cx);
+                                    if let Ok(value) = value.parse::<f64>() {
+                                        let clamp_value =
+                                            value.clamp(num_options.min, num_options.max);
+
+                                        set_value(clamp_value, cx);
+                                        state.initial_value = clamp_value;
+                                        if clamp_value != value {
+                                            input.set_value(
+                                                SharedString::from(clamp_value.to_string()),
+                                                window,
+                                                cx,
+                                            );
+                                        }
+                                    }
+                                });
+                            }
+                            _ => {}
+                        }
+                    }),
+                ];
+
+                State {
+                    input,
+                    initial_value: value,
+                    _subscriptions,
+                }
+            },
+        );
+
+        // Sync the displayed value when the underlying setting changed externally
+        state_entity.update(cx, |state, cx| {
+            if state.initial_value != value {
+                state.initial_value = value;
+                state.input.update(cx, |input, cx| {
+                    input.set_value(SharedString::from(value.to_string()), window, cx);
+                });
+            }
+        });
+
+        let state = state_entity.read(cx);
 
         NumberInput::new(&state.input)
             .disabled(options.disabled)

--- a/crates/ui/src/setting/fields/string.rs
+++ b/crates/ui/src/setting/fields/string.rs
@@ -44,15 +44,17 @@ where
         cx: &mut App,
     ) -> AnyElement {
         let value = get_value::<T>(&field, cx);
+        let value: SharedString = value.into();
         let set_value = set_value::<T>(&field, cx);
 
-        let state = window
-            .use_keyed_state(
-                SharedString::from(format!(
-                    "string-state-{}-{}-{}",
-                    options.page_ix, options.group_ix, options.item_ix
-                )),
-                cx,
+        let state_entity = window.use_keyed_state(
+            SharedString::from(format!(
+                "string-state-{}-{}-{}",
+                options.page_ix, options.group_ix, options.item_ix
+            )),
+            cx,
+            {
+                let value = value.clone();
                 |window, cx| {
                     let input = cx.new(|cx| InputState::new(window, cx).default_value(value));
                     let _subscription = cx.subscribe(&input, {
@@ -69,9 +71,20 @@ where
                         input,
                         _subscription,
                     }
-                },
-            )
-            .read(cx);
+                }
+            },
+        );
+
+        // Sync the displayed value when the underlying setting changed externally
+        state_entity.update(cx, |state, cx| {
+            if state.input.read(cx).value() != value {
+                state.input.update(cx, |input, cx| {
+                    input.set_value(value.clone(), window, cx);
+                });
+            }
+        });
+
+        let state = state_entity.read(cx);
 
         Input::new(&state.input)
             .disabled(options.disabled)


### PR DESCRIPTION
The step (+/-) buttons of `SettingField::number_input` stopped persisting their value: since `InputState::set_value` no longer emits `InputEvent::Change` (#2267), the `Change` subscription that wrote the value back to the setting never ran. Persist the clamped value directly in the `NumberInputEvent::Step` handler instead of relying on `Change`.

Reset also failed to restore the displayed value: the number and string fields cache their `InputState` via `use_keyed_state`, so resetting the underlying setting left the input showing stale text. Reconcile the displayed value with the setting on render when they diverge.

Closes #2413