### PR TITLE
highlighter: Bound Markdown inline injection parsing

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -157,6 +157,14 @@ fn should_include_injection_range(
     markdown_inline_range_has_trigger(text, range.start_byte..range.end_byte)
 }
 
+/// Returns whether an inline range contains any byte that could start a
+/// Markdown inline construct, so plain prose ranges skip the injected parse.
+///
+/// The byte set must stay a superset of the trigger characters for every node
+/// captured by `languages/markdown_inline/highlights.scm` (emphasis, code
+/// spans, links, images, autolinks). If that query gains a construct with a new
+/// trigger character (e.g. GFM bare autolinks), add it here or the construct
+/// will silently lose highlighting.
 fn markdown_inline_range_has_trigger(text: &Rope, range: Range<usize>) -> bool {
     text.slice(range).bytes().any(|byte| {
         matches!(
@@ -527,17 +535,10 @@ impl SyntaxHighlighter {
         }
 
         impl CombinedRanges {
-            fn push_limited(
-                &mut self,
-                language_name: &SharedString,
-                ranges: Vec<tree_sitter::Range>,
-                text: &Rope,
-            ) {
+            /// Ranges are already filtered by `should_include_injection_range`
+            /// before being pushed here; this only enforces the count/byte caps.
+            fn push_limited(&mut self, ranges: Vec<tree_sitter::Range>) {
                 for range in ranges {
-                    if !should_include_injection_range(language_name, &range, text) {
-                        continue;
-                    }
-
                     if self.ranges.len() >= MAX_INJECTION_RANGES {
                         break;
                     }
@@ -635,7 +636,7 @@ impl SyntaxHighlighter {
                         ranges: Vec::new(),
                         byte_count: 0,
                     })
-                    .push_limited(&language_name, ranges, text);
+                    .push_limited(ranges);
             } else {
                 if new_layers.len() >= MAX_INJECTION_LAYERS
                     || !injection_ranges_within_limits(&ranges)

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -18,6 +18,10 @@ use tree_sitter::{
 /// When a node spans more than this many bytes beyond the requested query
 /// range, we recurse into its children instead of querying it directly.
 const LARGE_NODE_THRESHOLD: usize = 8 * 1024;
+const MAX_INJECTION_LAYERS: usize = 256;
+const MAX_INJECTION_RANGES: usize = 4096;
+const MAX_INJECTION_BYTES: usize = 512 * 1024;
+const INJECTION_PARSE_TIMEOUT: Duration = Duration::from_millis(20);
 
 /// A syntax highlighter that supports incremental parsing, multiline text,
 /// and caching of highlight results.
@@ -126,6 +130,40 @@ impl<'a> Iterator for ByteChunks<'a> {
 
         Some(&chunk[start_in_chunk..end_in_chunk])
     }
+}
+
+fn injection_range_len(range: &tree_sitter::Range) -> usize {
+    range.end_byte.saturating_sub(range.start_byte)
+}
+
+fn injection_ranges_byte_count(ranges: &[tree_sitter::Range]) -> usize {
+    ranges.iter().map(injection_range_len).sum()
+}
+
+fn injection_ranges_within_limits(ranges: &[tree_sitter::Range]) -> bool {
+    ranges.len() <= MAX_INJECTION_RANGES
+        && injection_ranges_byte_count(ranges) <= MAX_INJECTION_BYTES
+}
+
+fn should_include_injection_range(
+    language_name: &SharedString,
+    range: &tree_sitter::Range,
+    text: &Rope,
+) -> bool {
+    if language_name.as_ref() != "markdown_inline" {
+        return true;
+    }
+
+    markdown_inline_range_has_trigger(text, range.start_byte..range.end_byte)
+}
+
+fn markdown_inline_range_has_trigger(text: &Rope, range: Range<usize>) -> bool {
+    text.slice(range).bytes().any(|byte| {
+        matches!(
+            byte,
+            b'*' | b'_' | b'`' | b'[' | b']' | b'(' | b')' | b'<' | b'>' | b'!' | b'~' | b'$'
+        )
+    })
 }
 
 #[derive(Debug, Default, Clone)]
@@ -483,6 +521,38 @@ impl SyntaxHighlighter {
         tree: &Tree,
         text: &Rope,
     ) -> Vec<InjectionLayer> {
+        struct CombinedRanges {
+            ranges: Vec<tree_sitter::Range>,
+            byte_count: usize,
+        }
+
+        impl CombinedRanges {
+            fn push_limited(
+                &mut self,
+                language_name: &SharedString,
+                ranges: Vec<tree_sitter::Range>,
+                text: &Rope,
+            ) {
+                for range in ranges {
+                    if !should_include_injection_range(language_name, &range, text) {
+                        continue;
+                    }
+
+                    if self.ranges.len() >= MAX_INJECTION_RANGES {
+                        break;
+                    }
+
+                    let range_len = injection_range_len(&range);
+                    if self.byte_count.saturating_add(range_len) > MAX_INJECTION_BYTES {
+                        break;
+                    }
+
+                    self.byte_count += range_len;
+                    self.ranges.push(range);
+                }
+            }
+        }
+
         fn sort_ranges(ranges: &mut [tree_sitter::Range]) {
             ranges.sort_unstable_by(|a, b| {
                 a.start_byte
@@ -492,17 +562,14 @@ impl SyntaxHighlighter {
         }
 
         fn ranges_cache_key(ranges: &[tree_sitter::Range]) -> Vec<(usize, usize)> {
-            ranges
-                .iter()
-                .map(|r| (r.start_byte, r.end_byte))
-                .collect()
+            ranges.iter().map(|r| (r.start_byte, r.end_byte)).collect()
         }
 
         let root_node = tree.root_node();
         let mut cursor = QueryCursor::new();
         let mut matches = cursor.matches(&data.query, root_node, TextProvider(text));
 
-        let mut combined_ranges: HashMap<SharedString, Vec<tree_sitter::Range>> = HashMap::new();
+        let mut combined_ranges: HashMap<SharedString, CombinedRanges> = HashMap::new();
         let old_layer_trees: HashMap<_, _> = data
             .old_layers
             .iter()
@@ -555,14 +622,27 @@ impl SyntaxHighlighter {
             if ranges.is_empty() {
                 continue;
             }
+            ranges.retain(|range| should_include_injection_range(&language_name, range, text));
+            if ranges.is_empty() {
+                continue;
+            }
             sort_ranges(&mut ranges);
 
             if combined {
                 combined_ranges
                     .entry(language_name.clone())
-                    .or_default()
-                    .extend(ranges);
+                    .or_insert_with(|| CombinedRanges {
+                        ranges: Vec::new(),
+                        byte_count: 0,
+                    })
+                    .push_limited(&language_name, ranges, text);
             } else {
+                if new_layers.len() >= MAX_INJECTION_LAYERS
+                    || !injection_ranges_within_limits(&ranges)
+                {
+                    continue;
+                }
+
                 let old_tree = old_layer_trees
                     .get(&(language_name.clone(), ranges_cache_key(&ranges)))
                     .copied();
@@ -574,7 +654,12 @@ impl SyntaxHighlighter {
             }
         }
 
-        for (language_name, mut ranges) in combined_ranges {
+        for (language_name, combined) in combined_ranges {
+            if new_layers.len() >= MAX_INJECTION_LAYERS {
+                break;
+            }
+
+            let mut ranges = combined.ranges;
             if ranges.is_empty() {
                 continue;
             }
@@ -608,6 +693,17 @@ impl SyntaxHighlighter {
         let mut parser = Parser::new();
         parser.set_language(&config.language).ok()?;
         parser.set_included_ranges(&ranges).ok()?;
+        let parse_start = Instant::now();
+        let mut timed_out = false;
+        let mut progress = |_: &tree_sitter::ParseState| -> ControlFlow<()> {
+            if parse_start.elapsed() > INJECTION_PARSE_TIMEOUT {
+                timed_out = true;
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        };
+        let options = ParseOptions::new().progress_callback(&mut progress);
 
         let new_tree = parser.parse_with_options(
             &mut |offset, _| {
@@ -619,8 +715,11 @@ impl SyntaxHighlighter {
                 }
             },
             old_tree,
-            None,
+            Some(options),
         )?;
+        if timed_out {
+            return None;
+        }
 
         let byte_range = bounding_byte_range(&ranges)?;
         Some(InjectionLayer {
@@ -987,7 +1086,6 @@ fn collect_query_nodes_inner<'a>(
     out.push(node);
 }
 
-
 /// Merge other style (Other on top)
 fn merge_highlight_style(style: &mut HighlightStyle, other: &HighlightStyle) {
     if let Some(color) = other.color {
@@ -1178,6 +1276,46 @@ $x = 1;
                 tag, pos
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_injection_layers_are_bounded() {
+        let markdown = (0..(MAX_INJECTION_RANGES + 1024))
+            .map(|i| format!("paragraph {i} *x*\n\n"))
+            .collect::<String>();
+        let rope = Rope::from_str(markdown.as_str());
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+
+        assert!(highlighter.update(None, &rope, None));
+        assert!(
+            highlighter.injection_layers.len() <= 1,
+            "markdown_inline should be combined instead of one layer per inline node"
+        );
+
+        if let Some(layer) = highlighter
+            .injection_layers
+            .iter()
+            .find(|layer| layer.language_name.as_ref() == "markdown_inline")
+        {
+            assert!(layer.ranges.len() <= MAX_INJECTION_RANGES);
+            assert!(injection_ranges_byte_count(&layer.ranges) <= MAX_INJECTION_BYTES);
+        }
+
+        let plain_markdown = (0..1024)
+            .map(|i| format!("paragraph {i} plain\n\n"))
+            .collect::<String>();
+        let plain_rope = Rope::from_str(plain_markdown.as_str());
+        let mut plain_highlighter = SyntaxHighlighter::new("markdown");
+
+        assert!(plain_highlighter.update(None, &plain_rope, None));
+        assert!(
+            plain_highlighter
+                .injection_layers
+                .iter()
+                .all(|layer| layer.language_name.as_ref() != "markdown_inline"),
+            "plain inline ranges should not create markdown_inline injection layers"
+        );
     }
 
     #[test]

--- a/crates/ui/src/highlighter/languages/markdown/injections.scm
+++ b/crates/ui/src/highlighter/languages/markdown/injections.scm
@@ -11,4 +11,6 @@
 
 ((plus_metadata) @injection.content (#set! injection.language "toml"))
 
-((inline) @injection.content (#set! injection.language "markdown_inline"))
+((inline) @injection.content
+  (#set! injection.language "markdown_inline")
+  (#set! injection.combined))


### PR DESCRIPTION
Closes #2429

## Description

This PR bounds Markdown inline injection parsing in the syntax highlighter.

The Markdown injection query currently captures every `(inline)` node as a
`markdown_inline` injection. After the main Markdown parse succeeds, injection
layers are parsed separately. For non-combined injection matches this could
create and retain one parsed tree per inline range, and the injected parse was
not covered by the main parser timeout.

This change:

- marks Markdown inline injection as `injection.combined`
- caps injected parsing by layer count, range count, and total injected bytes
- adds a timeout for injected parsing
- keeps the existing Markdown inline trigger-byte filter so plain inline text
  does not create unnecessary injected parse trees

This lets highlighting degrade by skipping expensive injected highlighting
instead of consuming unbounded CPU and memory.

I reviewed the changes and ran the tests listed below.

## PoC Validation

I validated the behavior with a standalone PoC before and after the patch. The
PoC mirrors the highlighter injection path and measures how many
`markdown_inline` injection trees are parsed and retained.

| Input | Before | After |
| --- | ---: | ---: |
| `220 '*'` | `parsed_layers=220` | `parsed_layers=1` |
| `100000 '*'` | `parsed_layers=100000`, `VmRSS=379644 kB` | `parsed_layers=0`, `combined_ranges=4096`, `VmRSS=214188 kB` |
| `1000000 '*'` | `parsed_layers=1000000`, `VmRSS=3759408 kB` | `parsed_layers=0`, `combined_ranges=4096`, `VmRSS=2082444 kB` |
| `100000 plain` | `parsed_layers=0`, `VmRSS=189992 kB` | `parsed_layers=0`, `VmRSS=190056 kB` |

The remaining RSS on very large marker-containing inputs is primarily from the
main Markdown parse and document size. The injected `markdown_inline` parse
trees no longer grow without bound.

## Screenshot

Not applicable; this is a syntax highlighter availability fix.

## Break Changes

None.

## How to Test

Repository regression test:

```bash
cargo test -p gpui-component --features tree-sitter-languages highlighter::highlighter::tests --offline
```

Result:

```text
running 6 tests
test highlighter::highlighter::tests::test_unique_styles ... ok
test highlighter::highlighter::tests::test_html_style_injects_css_highlights ... ok
test highlighter::highlighter::tests::test_html_script_injects_javascript_highlights ... ok
test highlighter::highlighter::tests::test_highlight_allow_overlap_property_combines_nested_captures ... ok
test highlighter::highlighter::tests::test_php_combined_injection_closing_tags ... ok
test highlighter::highlighter::tests::test_markdown_inline_injection_layers_are_bounded ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 197 filtered out; finished in 0.08s
```

Standalone PoC validation:

The standalone PoC from #2429 was run against the vulnerable behavior and then
against this patched branch. The PoC mirrors the Markdown injection-layer path
and reads the tested checkout's
`crates/ui/src/highlighter/languages/markdown/injections.scm`.

Representative commands:

```bash
cargo build --release --offline
./target/release/gpui_markdown_injection_dos_poc 220 '*' 5
./target/release/gpui_markdown_injection_dos_poc 100000 '*' 0
./target/release/gpui_markdown_injection_dos_poc 100000 plain 0
timeout 180s ./target/release/gpui_markdown_injection_dos_poc 1000000 '*' 0
```

The before/after PoC results are summarized in the `PoC Validation` section
above. The important regression is that marker-containing Markdown no longer
creates one retained `markdown_inline` parse tree per paragraph.

I did not run `cargo run` for the full story gallery because this change is in
the syntax highlighter parser path rather than a visual component story.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
