### PR TITLE
text_view: add window-level text selection across multiple TextViews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8123,6 +8123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_selection"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "gpui-component",
+ "gpui-component-assets",
+ "gpui_platform",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/focus_trap",
     "examples/tooltip_top_edge",
     "examples/sidebar",
+    "examples/text_selection",
 ]
 resolver = "2"
 

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -563,6 +563,9 @@ impl RenderOnce for Button {
 
                 // Avoid focus on mouse down.
                 window.prevent_default();
+
+                // Pressing a button must not start the window-level text selection.
+                crate::global_state::GlobalState::suppress_text_selection(cx);
             })
             .when_some(self.on_click, |this, on_click| {
                 this.on_click(move |event, window, cx| {

--- a/crates/ui/src/global_state.rs
+++ b/crates/ui/src/global_state.rs
@@ -17,6 +17,11 @@ pub struct GlobalState {
     open_deferred_popovers: HashSet<ElementId>,
     /// Application menus storage
     app_menus: Vec<OwnedMenu>,
+    /// When true, the window-level text selection must not start on the
+    /// current mouse down. Set by components that own their own mouse-down
+    /// interaction (e.g. `Input`, `Button`); reset by the selection
+    /// controller in the capture phase of every left mouse down.
+    pub(crate) suppress_text_selection: bool,
 }
 
 impl GlobalState {
@@ -25,7 +30,17 @@ impl GlobalState {
             text_view_state_stack: Vec::new(),
             open_deferred_popovers: HashSet::new(),
             app_menus: Vec::new(),
+            suppress_text_selection: false,
         }
+    }
+
+    /// Suppress the window-level text selection for the current mouse down.
+    ///
+    /// Call this from a mouse-down handler (bubble phase) of a component that
+    /// owns its own press/drag interaction, so that pressing it does not start
+    /// a window text selection. The flag is reset on the next mouse down.
+    pub fn suppress_text_selection(cx: &mut App) {
+        Self::global_mut(cx).suppress_text_selection = true;
     }
 
     pub fn global(cx: &App) -> &Self {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1510,9 +1510,9 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Input has its own text selection; mark the event as handled so the
-        // window-level text selection (Root) does not start a drag from here.
-        window.prevent_default();
+        // Input has its own text selection; suppress the window-level text
+        // selection (Root) so it does not start a drag from here.
+        crate::global_state::GlobalState::suppress_text_selection(cx);
 
         // Clear inline completion on any mouse interaction
         self.clear_inline_completion(cx);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1510,6 +1510,10 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Input has its own text selection; mark the event as handled so the
+        // window-level text selection (Root) does not start a drag from here.
+        window.prevent_default();
+
         // Clear inline completion on any mouse interaction
         self.clear_inline_completion(cx);
 

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -2,18 +2,20 @@ use crate::{
     ActiveTheme, ElementExt, Placement, StyledExt,
     dialog::{ANIMATION_DURATION, Dialog},
     focus_trap::FocusTrapManager,
-    input::InputState,
+    input::{Copy, InputState},
     notification::{Notification, NotificationList},
     sheet::Sheet,
+    text::{TextSelectionController, TextViewState, WindowTextSelection},
     tooltip::TooltipOverlay,
     window_border,
 };
 use gpui::{
-    Anchor, AnyView, App, AppContext, Context, DefiniteLength, ElementId, Entity, FocusHandle,
-    InteractiveElement, IntoElement, KeyBinding, ParentElement as _, Pixels, Render,
-    StyleRefinement, Styled, WeakFocusHandle, Window, actions, div, prelude::FluentBuilder as _,
+    Anchor, AnyView, App, AppContext, ClipboardItem, Context, DefiniteLength, ElementId, Entity,
+    EntityId, FocusHandle, Hitbox, InteractiveElement, IntoElement, KeyBinding,
+    ParentElement as _, Pixels, Render, StyleRefinement, Styled, WeakEntity, WeakFocusHandle,
+    Window, actions, div, prelude::FluentBuilder as _,
 };
-use std::{any::TypeId, rc::Rc};
+use std::{any::TypeId, collections::HashMap, rc::Rc};
 
 actions!(root, [Tab, TabPrev]);
 
@@ -22,6 +24,10 @@ pub(crate) fn init(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("tab", Tab, Some(CONTEXT)),
         KeyBinding::new("shift-tab", TabPrev, Some(CONTEXT)),
+        #[cfg(target_os = "macos")]
+        KeyBinding::new("cmd-c", Copy, Some(CONTEXT)),
+        #[cfg(not(target_os = "macos"))]
+        KeyBinding::new("ctrl-c", Copy, Some(CONTEXT)),
     ]);
 }
 
@@ -41,6 +47,10 @@ pub struct Root {
     /// The focus handle that will be restored after a dialog is closed with animation.
     /// Used to handle rapid dialog opening/closing to maintain correct focus chain.
     pending_focus_restore: Option<WeakFocusHandle>,
+    /// Window-level text selection state. See `text::window_selection`.
+    pub(crate) text_selection: WindowTextSelection,
+    /// Selectable TextViews registered this frame, keyed by entity id.
+    pub(crate) selectable_text_views: HashMap<EntityId, (WeakEntity<TextViewState>, Hitbox)>,
 }
 
 #[derive(Clone)]
@@ -88,6 +98,8 @@ impl Root {
             sheet_size: None,
             window_shadow_size: window_border::SHADOW_SIZE,
             pending_focus_restore: None,
+            text_selection: WindowTextSelection::default(),
+            selectable_text_views: HashMap::new(),
         }
     }
 
@@ -480,6 +492,15 @@ impl Root {
         // Normal tab navigation
         window.focus_prev(cx);
     }
+
+    fn on_action_copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
+        let text = self.window_selected_text(cx).trim().to_string();
+        if text.is_empty() {
+            cx.propagate();
+            return;
+        }
+        cx.write_to_clipboard(ClipboardItem::new_string(text));
+    }
 }
 
 impl Styled for Root {
@@ -498,12 +519,14 @@ impl Render for Root {
                 .key_context(CONTEXT)
                 .on_action(cx.listener(Self::on_action_tab))
                 .on_action(cx.listener(Self::on_action_tab_prev))
+                .on_action(cx.listener(Self::on_action_copy))
                 .relative()
                 .size_full()
                 .font_family(cx.theme().font_family.clone())
                 .bg(cx.theme().background)
                 .text_color(cx.theme().foreground)
                 .refine_style(&self.style)
+                .child(TextSelectionController)
                 .child(self.view.clone())
                 .child(self.tooltip_overlay.clone()),
         )

--- a/crates/ui/src/text/document.rs
+++ b/crates/ui/src/text/document.rs
@@ -46,6 +46,18 @@ impl ParsedDocument {
         text
     }
 
+    /// Synchronously clear the selection stored in every inline state.
+    ///
+    /// This mirrors the [`selected_text`](Self::selected_text) traversal so the
+    /// stored selection can be cleared without relying on a repaint. Offscreen
+    /// (virtualized) views do not repaint, so their `InlineState.selection`
+    /// would otherwise retain stale values from the last painted frame.
+    pub(super) fn clear_selection(&self) {
+        for block in self.blocks.iter() {
+            block.clear_selection();
+        }
+    }
+
     /// Converts the node to markdown format.
     ///
     /// This is used to generate markdown for test.

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -110,8 +110,8 @@ impl Inline {
 
         let text_view_state = text_view_state.read(cx);
         let is_selectable = text_view_state.is_selectable();
-        if !text_view_state.has_selection() {
-            return (is_selectable, false, None);
+        if !is_selectable {
+            return (false, false, None);
         }
 
         if text_view_state.is_all_selected() {
@@ -133,10 +133,12 @@ impl Inline {
             );
         }
 
-        let Some((selection_start, selection_end)) = text_view_state.selection_points() else {
+        let Some((selection_start, selection_end)) = text_view_state.selection_points(window, cx)
+        else {
             return (is_selectable, false, None);
         };
         let line_height = window.line_height();
+        let mask_bounds = window.content_mask().bounds;
 
         // Use for debug selection bounds
         // self.paint_selected_bounds(Bounds::from_corners(selection_start, selection_end), window, cx);
@@ -157,7 +159,15 @@ impl Inline {
                 }
             }
 
-            if point_in_text_selection(pos, char_width, selection_start, selection_end, line_height)
+            let char_center = point(pos.x + char_width.half(), pos.y + line_height.half());
+            if mask_bounds.contains(&char_center)
+                && point_in_text_selection(
+                    pos,
+                    char_width,
+                    selection_start,
+                    selection_end,
+                    line_height,
+                )
             {
                 if selection.is_none() {
                     selection = Some((offset..offset).into());
@@ -437,7 +447,7 @@ impl Element for Inline {
                     }
                     if text_view_state
                         .as_ref()
-                        .is_some_and(|state| state.read(cx).has_selection())
+                        .is_some_and(|state| state.read(cx).has_selection(window, cx))
                     {
                         return;
                     }

--- a/crates/ui/src/text/mod.rs
+++ b/crates/ui/src/text/mod.rs
@@ -7,11 +7,14 @@ mod state;
 mod style;
 mod text_view;
 mod utils;
+mod window_selection;
 
 use gpui::{App, ElementId, IntoElement, RenderOnce, SharedString, Window};
 pub use state::*;
 pub use style::*;
 pub use text_view::*;
+pub(crate) use window_selection::TextSelectionController;
+pub use window_selection::WindowTextSelection;
 
 pub(crate) fn init(cx: &mut App) {
     state::init(cx);

--- a/crates/ui/src/text/mod.rs
+++ b/crates/ui/src/text/mod.rs
@@ -14,7 +14,7 @@ pub use state::*;
 pub use style::*;
 pub use text_view::*;
 pub(crate) use window_selection::TextSelectionController;
-pub use window_selection::WindowTextSelection;
+pub(crate) use window_selection::WindowTextSelection;
 
 pub(crate) fn init(cx: &mut App) {
     state::init(cx);

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -222,6 +222,37 @@ impl BlockNode {
 
         text
     }
+
+    /// Synchronously clear the selection stored in every inline state.
+    ///
+    /// Mirrors the [`selected_text`](Self::selected_text) traversal so the
+    /// selection can be cleared without relying on a repaint.
+    pub(super) fn clear_selection(&self) {
+        match self {
+            BlockNode::Root { children, .. }
+            | BlockNode::Blockquote { children, .. }
+            | BlockNode::List { children, .. }
+            | BlockNode::ListItem { children, .. } => {
+                for child in children.iter() {
+                    child.clear_selection();
+                }
+            }
+            BlockNode::Paragraph(paragraph) => paragraph.clear_selection(),
+            BlockNode::Heading { children, .. } => children.clear_selection(),
+            BlockNode::Table(table) => {
+                for row in table.children.iter() {
+                    for cell in row.children.iter() {
+                        cell.children.clear_selection();
+                    }
+                }
+            }
+            BlockNode::CodeBlock(code_block) => code_block.clear_selection(),
+            BlockNode::Definition { .. }
+            | BlockNode::Break { .. }
+            | BlockNode::HorizontalRule { .. }
+            | BlockNode::Unknown { .. } => {}
+        }
+    }
 }
 
 #[allow(unused)]
@@ -430,6 +461,21 @@ impl Paragraph {
             text.push_str(&node.text);
         }
         text
+    }
+
+    /// Synchronously clear the selection stored in every inline state.
+    ///
+    /// Mirrors the [`selected_text`](Self::selected_text) traversal.
+    pub(super) fn clear_selection(&self) {
+        for c in self.children.iter() {
+            if let Ok(mut state) = c.state.lock() {
+                state.selection = None;
+            }
+        }
+
+        if let Ok(mut state) = self.state.lock() {
+            state.selection = None;
+        }
     }
 }
 
@@ -642,6 +688,15 @@ impl CodeBlock {
             .lock()
             .map(|state| state.text.to_string())
             .unwrap_or_default()
+    }
+
+    /// Synchronously clear the selection stored in the inline state.
+    ///
+    /// Mirrors the [`selected_text`](Self::selected_text) traversal.
+    pub(super) fn clear_selection(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.selection = None;
+        }
     }
 
     fn render(

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -249,6 +249,10 @@ impl TextViewState {
         self.select_all = false;
         self.is_selecting = false;
         self.auto_scroll.stop();
+        // Clear the inline selection state synchronously, so offscreen
+        // (virtualized) views that won't repaint don't leak stale selection
+        // text into a new cross-view copy.
+        self.parsed_content.document.clear_selection();
     }
 
     /// Clear the current text selection.

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -48,6 +48,7 @@ pub(super) enum TextViewFormat {
 /// The state of a TextView.
 pub struct TextViewState {
     pub(super) focus_handle: FocusHandle,
+    pub(super) entity_id: gpui::EntityId,
     pub(super) list_state: ListState,
 
     /// The bounds of the text view
@@ -88,6 +89,7 @@ impl TextViewState {
     /// Create a new TextViewState.
     fn new(format: TextViewFormat, text: &str, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
+        let entity_id = cx.entity_id();
 
         let (tx, rx) = unbounded::<UpdateOptions>();
         let (tx_result, rx_result) = unbounded::<Result<ParsedContent, SharedString>>();
@@ -120,6 +122,7 @@ impl TextViewState {
 
         let mut this = Self {
             focus_handle,
+            entity_id,
             bounds: Bounds::default(),
             selection_positions: (None, None),
             multi_click_selection: None,
@@ -227,6 +230,22 @@ impl TextViewState {
         self.bounds = bounds;
     }
 
+    pub(super) fn bounds(&self) -> Bounds<Pixels> {
+        self.bounds
+    }
+
+    /// Whether this view has a view-local selection (select-all, multi-click, or override),
+    /// independent of the window-level selection.
+    pub(super) fn has_view_selection(&self) -> bool {
+        self.select_all
+            || self.multi_click_selection.is_some()
+            || self.selected_text_override.is_some()
+    }
+
+    pub(super) fn stop_auto_scroll(&mut self) {
+        self.auto_scroll.stop();
+    }
+
     fn reset_selection(&mut self) {
         self.selection_positions = (None, None);
         self.multi_click_selection = None;
@@ -242,7 +261,7 @@ impl TextViewState {
         cx.notify();
     }
 
-    fn scroll_offset(&self) -> Point<Pixels> {
+    pub(super) fn scroll_offset(&self) -> Point<Pixels> {
         if self.scrollable {
             self.list_state.scroll_px_offset_for_scrollbar()
         } else {

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -2,8 +2,8 @@ use futures::Stream as _;
 use std::{pin::Pin, task::Poll};
 
 use gpui::{
-    App, AppContext as _, Bounds, ClipboardItem, Context, FocusHandle, IntoElement, KeyBinding,
-    ListState, ParentElement as _, Pixels, Point, Render, SharedString, Styled as _, Task, Window,
+    App, AppContext as _, Bounds, Context, FocusHandle, IntoElement, KeyBinding, ListState,
+    ParentElement as _, Pixels, Point, Render, SharedString, Styled as _, Task, Window,
     prelude::FluentBuilder as _, px,
 };
 
@@ -11,7 +11,7 @@ use crate::{
     ActiveTheme, ElementExt,
     async_util::{Receiver, Sender, unbounded},
     highlighter::HighlightTheme,
-    input::{self, Copy, SelectAll},
+    input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
         CodeBlockActionsFn, TextViewStyle,
@@ -60,8 +60,6 @@ pub struct TextViewState {
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
 
     pub(super) is_selecting: bool,
-    /// The local (in TextView) position of the selection.
-    selection_positions: (Option<Point<Pixels>>, Option<Point<Pixels>>),
     multi_click_selection: Option<TextViewMultiClickSelection>,
     selected_text_override: Option<String>,
     select_all: bool,
@@ -124,7 +122,6 @@ impl TextViewState {
             focus_handle,
             entity_id,
             bounds: Bounds::default(),
-            selection_positions: (None, None),
             multi_click_selection: None,
             selected_text_override: None,
             select_all: false,
@@ -247,7 +244,6 @@ impl TextViewState {
     }
 
     fn reset_selection(&mut self) {
-        self.selection_positions = (None, None);
         self.multi_click_selection = None;
         self.selected_text_override = None;
         self.select_all = false;
@@ -271,7 +267,6 @@ impl TextViewState {
 
     /// Select all rendered text in this view.
     pub fn select_all(&mut self, cx: &mut Context<Self>) {
-        self.selection_positions = (None, None);
         self.multi_click_selection = None;
         self.selected_text_override = None;
         self.select_all = true;
@@ -288,34 +283,9 @@ impl TextViewState {
     ) {
         let scroll_offset = self.scroll_offset();
         let pos = pos - self.bounds.origin - scroll_offset;
-        self.selection_positions = (None, None);
         self.multi_click_selection = Some(TextViewMultiClickSelection { pos, kind });
         self.selected_text_override = Some(selected_text);
         self.select_all = false;
-        self.is_selecting = false;
-        self.auto_scroll.stop();
-    }
-
-    pub(super) fn start_selection(&mut self, pos: Point<Pixels>) {
-        // Store content coordinates (not affected by scrolling)
-        let scroll_offset = self.scroll_offset();
-        let pos = pos - self.bounds.origin - scroll_offset;
-        self.selection_positions = (Some(pos), Some(pos));
-        self.multi_click_selection = None;
-        self.selected_text_override = None;
-        self.select_all = false;
-        self.is_selecting = true;
-    }
-
-    pub(super) fn update_selection(&mut self, pos: Point<Pixels>) {
-        let scroll_offset = self.scroll_offset();
-        let pos = pos - self.bounds.origin - scroll_offset;
-        if let (Some(start), Some(_)) = self.selection_positions {
-            self.selection_positions = (Some(start), Some(pos))
-        }
-    }
-
-    pub(super) fn end_selection(&mut self) {
         self.is_selecting = false;
         self.auto_scroll.stop();
     }
@@ -327,43 +297,32 @@ impl TextViewState {
         });
     }
 
-    pub(crate) fn has_selection(&self) -> bool {
-        if self.select_all {
-            return true;
+    /// Return the window selection (anchor, cursor) in window coordinates if
+    /// this view participates in it.
+    ///
+    /// Single-view fast path: when both endpoints are anchored inside one
+    /// TextView, only that view participates (identical to the previous
+    /// per-view behavior).
+    pub(crate) fn selection_points(
+        &self,
+        window: &Window,
+        cx: &App,
+    ) -> Option<(Point<Pixels>, Point<Pixels>)> {
+        if !self.selectable {
+            return None;
         }
-        if self.multi_click_selection.is_some() {
-            return true;
+        let root = window.root::<crate::Root>().flatten()?;
+        let selection = &root.read(cx).text_selection;
+        if let Some(view_id) = selection.single_view() {
+            if view_id != self.entity_id {
+                return None;
+            }
         }
-        if self.selected_text_override.is_some() {
-            return true;
-        }
-
-        if let (Some(start), Some(end)) = self.selection_positions {
-            start != end
-        } else {
-            false
-        }
+        selection.resolved_points(cx)
     }
 
-    /// Return the selection start/end in window coordinates.
-    pub(crate) fn selection_points(&self) -> Option<(Point<Pixels>, Point<Pixels>)> {
-        let scroll_offset = self.scroll_offset();
-
-        selection_points(
-            self.selection_positions.0,
-            self.selection_positions.1,
-            self.bounds,
-            scroll_offset,
-        )
-    }
-
-    pub(super) fn on_action_copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
-        let selected_text = self.selected_text().trim().to_string();
-        if selected_text.is_empty() {
-            return;
-        }
-
-        cx.write_to_clipboard(ClipboardItem::new_string(selected_text));
+    pub(crate) fn has_selection(&self, window: &Window, cx: &App) -> bool {
+        self.has_view_selection() || self.selection_points(window, cx).is_some()
     }
 
     pub(super) fn on_action_select_all(
@@ -438,10 +397,19 @@ impl Render for TextViewState {
                         .child(err.to_string()),
                 ),
             })
-            .on_prepaint(move |bounds, _, cx| {
+            .on_prepaint(move |bounds, window, cx| {
+                let size_changed = state.read(cx).bounds().size != bounds.size;
+                let id = state.entity_id();
                 state.update(cx, |state, _| {
                     state.update_bounds(bounds);
-                })
+                });
+                if size_changed {
+                    if let Some(root) = window.root::<crate::Root>().flatten() {
+                        root.update(cx, |root, cx| {
+                            root.clear_text_selection_for_resized_view(id, cx);
+                        });
+                    }
+                }
             })
     }
 }
@@ -564,26 +532,10 @@ fn parse_content(
     Ok(content)
 }
 
-fn selection_points(
-    start: Option<Point<Pixels>>,
-    end: Option<Point<Pixels>>,
-    bounds: Bounds<Pixels>,
-    scroll_offset: Point<Pixels>,
-) -> Option<(Point<Pixels>, Point<Pixels>)> {
-    if let (Some(start), Some(end)) = (start, end) {
-        // Convert content coordinates to window coordinates
-        let start = start + scroll_offset + bounds.origin;
-        let end = end + scroll_offset + bounds.origin;
-        return Some((start, end));
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, point};
+    use gpui::TestAppContext;
 
     #[gpui::test]
     fn set_text_then_push_str_appends_to_replaced_content(cx: &mut TestAppContext) {
@@ -625,7 +577,7 @@ mod tests {
         });
 
         state.read_with(cx, |state, _| {
-            assert!(state.has_selection());
+            assert!(state.has_view_selection());
             assert_eq!(state.selected_text().trim(), "quick value");
         });
 
@@ -634,94 +586,8 @@ mod tests {
         });
 
         state.read_with(cx, |state, _| {
-            assert!(!state.has_selection());
+            assert!(!state.has_view_selection());
             assert_eq!(state.selected_text(), "");
         });
-    }
-
-    #[test]
-    fn test_text_view_state_selection_points() {
-        assert_eq!(
-            selection_points(None, None, Default::default(), Point::default()),
-            None
-        );
-        assert_eq!(
-            selection_points(
-                None,
-                Some(point(px(10.), px(20.))),
-                Default::default(),
-                Point::default()
-            ),
-            None
-        );
-        assert_eq!(
-            selection_points(
-                Some(point(px(10.), px(20.))),
-                None,
-                Default::default(),
-                Point::default()
-            ),
-            None
-        );
-
-        // 10,10 start
-        //   |------|
-        //   |      |
-        //   |------|
-        //         50,50
-        assert_eq!(
-            selection_points(
-                Some(point(px(10.), px(10.))),
-                Some(point(px(50.), px(50.))),
-                Default::default(),
-                Point::default()
-            ),
-            Some((point(px(10.), px(10.)), point(px(50.), px(50.))))
-        );
-
-        // 10,10
-        //   |------|
-        //   |      |
-        //   |------|
-        //         50,50 start
-        assert_eq!(
-            selection_points(
-                Some(point(px(50.), px(50.))),
-                Some(point(px(10.), px(10.))),
-                Default::default(),
-                Point::default()
-            ),
-            Some((point(px(50.), px(50.)), point(px(10.), px(10.))))
-        );
-
-        //        50,10 start
-        //   |------|
-        //   |      |
-        //   |------|
-        // 10,50
-        assert_eq!(
-            selection_points(
-                Some(point(px(50.), px(10.))),
-                Some(point(px(10.), px(50.))),
-                Default::default(),
-                Point::default()
-            ),
-            Some((point(px(50.), px(10.)), point(px(10.), px(50.))))
-        );
-
-        //        50,10
-        //   |------|
-        //   |      |
-        //   |------|
-        // 10,50 start
-        assert_eq!(
-            selection_points(
-                Some(point(px(10.), px(50.))),
-                Some(point(px(50.), px(10.))),
-                Default::default(),
-                Point::default()
-            ),
-            Some((point(px(10.), px(50.)), point(px(50.), px(10.))))
-        );
     }
 }

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -219,7 +219,8 @@ impl Element for TextView {
             })
             .relative()
             .on_action(move |_: &crate::input::Copy, window, cx| {
-                let text = crate::Root::selected_text(window, cx).trim().to_string();
+                use crate::WindowExt as _;
+                let text = window.selected_text(cx).trim().to_string();
                 if text.is_empty() {
                     cx.propagate();
                     return;

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, Bounds, Element, ElementId, Entity, GlobalElementId, Hitbox, HitboxBehavior,
-    InspectorElementId, InteractiveElement, IntoElement, LayoutId, MouseButton, MouseDownEvent,
-    MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, SharedString, StyleRefinement, Styled,
-    Window, div,
+    InspectorElementId, InteractiveElement, IntoElement, LayoutId, ParentElement, Pixels,
+    SharedString, StyleRefinement, Styled, Window, div,
 };
 
 use crate::StyledExt;
-use crate::scroll::{AutoScroll, ScrollableElement};
+use crate::scroll::ScrollableElement;
 use crate::text::TextViewFormat;
 use crate::text::node::CodeBlock;
 use crate::text::state::TextViewState;
@@ -219,7 +218,14 @@ impl Element for TextView {
                 this.size_full().vertical_scrollbar(&list_state)
             })
             .relative()
-            .on_action(window.listener_for(&state, TextViewState::on_action_copy))
+            .on_action(move |_: &crate::input::Copy, window, cx| {
+                let text = crate::Root::selected_text(window, cx).trim().to_string();
+                if text.is_empty() {
+                    cx.propagate();
+                    return;
+                }
+                cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+            })
             .on_action(window.listener_for(&state, TextViewState::on_action_select_all))
             .child(state.clone())
             .refine_style(&self.style)
@@ -259,91 +265,10 @@ impl Element for TextView {
         GlobalState::global_mut(cx).text_view_state_stack.pop();
 
         if self.selectable {
-            let is_selecting = state.read(cx).is_selecting;
-            let has_selection = state.read(cx).has_selection();
-            let parent_view_id = window.current_view();
-
-            window.on_mouse_event({
-                let state = state.clone();
-                let hitbox = hitbox.clone();
-                move |event: &MouseDownEvent, phase, window, cx| {
-                    if !phase.bubble() || !hitbox.is_hovered(window) {
-                        return;
-                    }
-
-                    if event.button != MouseButton::Left {
-                        return;
-                    }
-
-                    state.update(cx, |state, cx| {
-                        state.focus_handle.focus(window, cx);
-
-                        if event.click_count == 1 {
-                            state.start_selection(event.position);
-                        }
-                    });
-                    cx.notify(parent_view_id);
-                }
-            });
-
-            if is_selecting {
-                let scrollable = self.scrollable;
-                let viewport_bounds = hitbox.bounds;
-
-                // move to update end position, auto-scroll when dragging near edges.
-                window.on_mouse_event({
-                    let state = state.clone();
-                    move |event: &MouseMoveEvent, phase, _, cx| {
-                        if !phase.bubble() {
-                            return;
-                        }
-
-                        state.update(cx, |state, cx| {
-                            state.update_selection(event.position);
-
-                            if scrollable {
-                                let delta =
-                                    AutoScroll::compute_delta(event.position.y, viewport_bounds);
-                                state.set_auto_scroll(delta, cx);
-                            }
-                        });
-                        cx.notify(parent_view_id);
-                    }
-                });
-
-                // up to end selection
-                window.on_mouse_event({
-                    let state = state.clone();
-                    move |_: &MouseUpEvent, phase, _, cx| {
-                        if !phase.bubble() {
-                            return;
-                        }
-
-                        state.update(cx, |state, _| {
-                            state.end_selection();
-                        });
-                        cx.notify(parent_view_id);
-                    }
-                });
-            }
-
-            if has_selection {
-                // down outside to clear selection
-                window.on_mouse_event({
-                    let state = state.clone();
-                    let hitbox = hitbox.clone();
-                    move |_: &MouseDownEvent, _, window, cx| {
-                        if hitbox.is_hovered(window) {
-                            return;
-                        }
-
-                        state.update(cx, |state, cx| {
-                            state.clear_selection(cx);
-                        });
-                        cx.notify(parent_view_id);
-                    }
-                });
-            }
+            // Window-level selection: register this view (with its clipped
+            // hitbox) so the Root selection controller can hit-test and collect
+            // selected text. All mouse handling lives in TextSelectionController.
+            crate::Root::register_selectable_text_view(state, hitbox, window, cx);
         }
     }
 }

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -4,7 +4,7 @@ use gpui::{
     MouseUpEvent, Pixels, Point, Style, WeakEntity, Window,
 };
 
-use crate::{Root, scroll::AutoScroll, text::TextViewState};
+use crate::{Root, global_state::GlobalState, scroll::AutoScroll, text::TextViewState};
 
 /// Window-level text selection state, owned by [`Root`].
 ///
@@ -197,14 +197,12 @@ impl Root {
         cx: &mut Context<Self>,
     ) {
         let endpoint = self.text_selection_endpoint(position, window, cx);
-        // GPUI's focus-on-mouse-down (`track_focus`) marks the event
-        // default-prevented when pressing any focusable element — including the
-        // TextView itself. A press that hits a selectable TextView must still
-        // start a selection; only blank-space presses respect default_prevented,
-        // which excludes presses consumed by Button, Input, etc.
-        if endpoint.view.is_none() && window.default_prevented() {
-            return;
-        }
+        // Components that own their own mouse-down interaction (Input, Button,
+        // etc.) set `GlobalState::suppress_text_selection` in their bubble-phase
+        // handler; the controller checks that flag before calling this, so a
+        // press starts a selection from any point that is not consumed by such a
+        // component — including blank space inside a focusable container, which
+        // GPUI's focus-on-mouse-down would otherwise mark default-prevented.
         if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
             view.update(cx, |state, cx| {
                 state.is_selecting = true;
@@ -223,6 +221,11 @@ impl Root {
         cx: &mut Context<Self>,
     ) {
         if !self.text_selection.is_selecting {
+            return;
+        }
+        // Do not update the selection while a GPUI drag-and-drop is active
+        // (e.g. dragging a dock tab or a resize handle across TextViews).
+        if cx.has_active_drag() {
             return;
         }
         self.text_selection.cursor = Some(self.text_selection_endpoint(position, window, cx));
@@ -328,11 +331,14 @@ impl Root {
 /// propagation or prevent default).
 ///
 /// Note: `window.on_mouse_event` handlers are window-global (not scoped to
-/// any hitbox); the phase check and the `default_prevented` guard inside
-/// `start_text_selection` are the only guards. `default_prevented` is checked
-/// there (not here) so that presses hitting a selectable TextView — which GPUI
-/// marks default-prevented via its focus-on-mouse-down auto-handler — still
-/// start a selection, while presses consumed by Button/Input etc. are excluded.
+/// any hitbox); the phase check and the `GlobalState::suppress_text_selection`
+/// flag are the only guards. The flag is reset in the capture phase of every
+/// left mouse down and set in the bubble phase by components that own their own
+/// press/drag interaction (Button, Input, etc.). Because bubble-phase listeners
+/// fire in reverse registration order and this controller registers earliest,
+/// it observes the flag after those components have set it, so presses consumed
+/// by them are excluded while presses on blank space (even inside a focusable
+/// container) still start a selection.
 pub(crate) struct TextSelectionController;
 
 impl IntoElement for TextSelectionController {
@@ -391,15 +397,19 @@ impl Element for TextSelectionController {
                 return;
             }
             if phase.capture() {
-                // Any left press clears the previous selection (browser
-                // behavior), even when an interactive component consumes the
-                // event in the bubble phase.
+                // Reset the suppression flag at the start of every press, then
+                // clear the previous selection (browser behavior), even when an
+                // interactive component consumes the event in the bubble phase.
+                GlobalState::global_mut(cx).suppress_text_selection = false;
                 Root::update(window, cx, |root, _, cx| root.clear_text_selection(cx));
             } else if event.click_count == 1 {
                 // Reaching bubble phase means no component stopped propagation.
-                // default_prevented is checked inside start_text_selection: presses
-                // that hit a selectable TextView must start a selection even though
-                // GPUI's focus-on-mouse-down marks them default-prevented.
+                // Components that own their own press (Button, Input, etc.) set
+                // `suppress_text_selection` in their bubble handler; if set, the
+                // press is theirs and must not start a window selection.
+                if GlobalState::global(cx).suppress_text_selection {
+                    return;
+                }
                 Root::update(window, cx, |root, window, cx| {
                     root.start_text_selection(event.position, window, cx);
                 });
@@ -426,17 +436,19 @@ impl Element for TextSelectionController {
 
 #[cfg(test)]
 mod tests {
+    use crate::global_state::GlobalState;
     use crate::{
         Root,
         text::{TextView, TextViewState},
     };
     use gpui::{
-        AppContext as _, Context, Entity, IntoElement, Modifiers, MouseButton, MouseDownEvent,
-        MouseUpEvent, ParentElement as _, Render, Styled as _, TestAppContext, VisualTestContext,
-        Window, div, point, px,
+        AppContext as _, Context, Entity, FocusHandle, InteractiveElement as _, IntoElement,
+        Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render,
+        Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
     };
 
     struct ChatTestView {
+        focus_handle: FocusHandle,
         first: Entity<TextViewState>,
         second: Entity<TextViewState>,
         second_selectable: bool,
@@ -445,6 +457,7 @@ mod tests {
     impl ChatTestView {
         fn new(second_selectable: bool, cx: &mut Context<Self>) -> Self {
             Self {
+                focus_handle: cx.focus_handle(),
                 first: cx.new(|cx| TextViewState::markdown("Hello world", cx)),
                 second: cx.new(|cx| TextViewState::markdown("Second message", cx)),
                 second_selectable,
@@ -454,7 +467,14 @@ mod tests {
 
     impl Render for ChatTestView {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            // `track_focus` makes the root a focusable container, so GPUI's
+            // focus-on-mouse-down marks every press inside it default-prevented.
+            // Selection must still start from blank space here (regression
+            // guard for `drag_from_blank_space_selects_views_below`), which the
+            // `suppress_text_selection` mechanism guarantees because blank-space
+            // presses never set that flag.
             div()
+                .track_focus(&self.focus_handle)
                 .size_full()
                 .pt(px(10.))
                 .child(
@@ -466,6 +486,16 @@ mod tests {
                     div()
                         .h(px(40.))
                         .child(TextView::new(&self.second).selectable(self.second_selectable)),
+                )
+                // A 20px region below the views that owns its press the way
+                // Input/Button do: its bubble-phase handler sets the suppress
+                // flag, so a press starting here must not start a selection.
+                .child(
+                    div()
+                        .h(px(20.))
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                            GlobalState::suppress_text_selection(cx);
+                        }),
                 )
         }
     }
@@ -538,6 +568,20 @@ mod tests {
         let text = window_selected_text(cx);
         assert!(text.contains("Hello world"), "got: {text:?}");
         assert!(text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn suppressed_mouse_down_does_not_start_selection(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // The suppress region sits below the two views (root pt=10, two 40px
+        // view rows -> y in [90, 110)). Pressing inside it makes its bubble
+        // handler set the suppress flag, so dragging up across both views must
+        // not produce any window selection.
+        drag(cx, point(px(20.), px(100.)), point(px(20.), px(15.)));
+
+        let text = window_selected_text(cx);
+        assert!(text.is_empty(), "expected no selection, got: {text:?}");
     }
 
     #[gpui::test]

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -161,6 +161,7 @@ impl Root {
 
     /// Clear the window selection and all view-local selections.
     pub fn clear_text_selection(&mut self, cx: &mut Context<Self>) {
+        let had_window_selection = self.text_selection.anchor.is_some();
         self.text_selection.anchor = None;
         self.text_selection.cursor = None;
         self.text_selection.is_selecting = false;
@@ -168,10 +169,22 @@ impl Root {
             let Some(view) = view.upgrade() else {
                 return false;
             };
-            view.update(cx, |state, cx| {
-                state.is_selecting = false;
-                state.clear_selection(cx);
-            });
+            // Skip views with nothing to clear: without a window selection nor
+            // a view-local selection, their inline selection state is already
+            // empty, and notifying would re-render every selectable view on
+            // every click.
+            //
+            // When `had_window_selection` is true this still clears every view,
+            // even though the selection may have covered only some of them: the
+            // set of views that painted a highlight is not cheaply tracked, so
+            // clearing all of them is the conservative, correctness-first
+            // choice.
+            if had_window_selection || view.read(cx).has_view_selection() {
+                view.update(cx, |state, cx| {
+                    state.is_selecting = false;
+                    state.clear_selection(cx);
+                });
+            }
             true
         });
     }
@@ -230,7 +243,14 @@ impl Root {
         if cx.has_active_drag() {
             return;
         }
+
+        // Compute the selection band before and after moving the cursor so the
+        // notify can be limited to the views that actually changed. Order
+        // matters: read the old points first, then update the cursor, then read
+        // the new points.
+        let old_points = self.text_selection.resolved_points(cx);
         self.text_selection.cursor = Some(self.text_selection_endpoint(position, window, cx));
+        let new_points = self.text_selection.resolved_points(cx);
 
         // Auto-scroll the anchor view when dragging near its viewport edges,
         // same semantics as the previous per-view implementation.
@@ -249,7 +269,7 @@ impl Root {
             });
         }
 
-        self.notify_selectable_text_views(cx);
+        self.notify_selection_band(old_points, new_points, cx);
     }
 
     pub(crate) fn end_text_selection(&mut self, cx: &mut Context<Self>) {
@@ -320,6 +340,56 @@ impl Root {
                 return false;
             };
             view.update(cx, |_, cx| cx.notify());
+            true
+        });
+    }
+
+    /// Notify the views affected by the current selection update. For a
+    /// single-view selection only the anchor view re-renders; for a
+    /// cross-view selection only views whose bounds intersect the vertical
+    /// band covered by the old and new selection participate, plus everything
+    /// that may need to clear a previously painted highlight.
+    fn notify_selection_band(
+        &mut self,
+        old_points: Option<(Point<Pixels>, Point<Pixels>)>,
+        new_points: Option<(Point<Pixels>, Point<Pixels>)>,
+        cx: &mut Context<Self>,
+    ) {
+        // Single-view fast path: only the anchored view can paint a highlight,
+        // so only it needs to re-render.
+        if let Some(id) = self.text_selection.single_view() {
+            if let Some((view, _)) = self.selectable_text_views.get(&id) {
+                if let Some(view) = view.upgrade() {
+                    view.update(cx, |_, cx| cx.notify());
+                }
+            }
+            return;
+        }
+
+        // Merge the old and new selection bands. The old band covers views that
+        // may need to clear a previously painted highlight; the new band covers
+        // views that may need to paint one. If both are empty there is nothing
+        // to update.
+        let band = |points: Option<(Point<Pixels>, Point<Pixels>)>| {
+            points.map(|(a, b)| {
+                let (lo, hi) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
+                (lo, hi)
+            })
+        };
+        let (band_min, band_max) = match (band(old_points), band(new_points)) {
+            (Some((lo_a, hi_a)), Some((lo_b, hi_b))) => (lo_a.min(lo_b), hi_a.max(hi_b)),
+            (Some(b), None) | (None, Some(b)) => b,
+            (None, None) => return,
+        };
+
+        self.selectable_text_views.retain(|_, (view, _)| {
+            let Some(view) = view.upgrade() else {
+                return false;
+            };
+            let bounds = view.read(cx).bounds();
+            if bounds.top() <= band_max && bounds.bottom() >= band_min {
+                view.update(cx, |_, cx| cx.notify());
+            }
             true
         });
     }

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -113,6 +113,11 @@ impl Root {
     /// Internal: collect selected text using `&self` directly, so it is safe
     /// to call while the Root entity is leased (e.g. inside Root's own action
     /// handler).
+    ///
+    /// Note: per-view selected text is collected from `InlineState`, which is
+    /// populated during paint. The result reflects the last painted frame; a
+    /// copy action racing ahead of a pending repaint may observe the previous
+    /// selection state.
     pub(crate) fn window_selected_text(&self, cx: &App) -> String {
         let resolved = self.text_selection.resolved_points(cx);
         let single_view = self.text_selection.single_view();
@@ -580,7 +585,7 @@ mod tests {
 
         // Double-click inside the first view: must trigger the per-view word
         // selection (Inline), not a window-level drag selection.
-        let position = point(px(5.), px(15.));
+        let position = point(px(10.), px(15.));
         cx.simulate_event(MouseDownEvent {
             position,
             modifiers: Modifiers::default(),

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -1,7 +1,7 @@
 use gpui::{
     App, Bounds, Context, Element, ElementId, Entity, EntityId, GlobalElementId, Hitbox,
     InspectorElementId, IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, Pixels, Point, Style, WeakEntity, Window,
+    MouseUpEvent, Pixels, Point, ScrollWheelEvent, Style, WeakEntity, Window,
 };
 
 use crate::{Root, global_state::GlobalState, scroll::AutoScroll, text::TextViewState};
@@ -18,17 +18,36 @@ pub struct WindowTextSelection {
     pub(crate) is_selecting: bool,
 }
 
-/// A selection endpoint, content-anchored if inside a TextView.
+/// A selection endpoint, content-anchored to a TextView.
+///
+/// `point` is always stored in the view's content coordinates (relative to its
+/// `bounds().origin` and `scroll_offset()`), even when the press landed in
+/// blank space: in that case the endpoint is proxy-anchored to the nearest view
+/// in document flow (see [`Root::text_selection_endpoint`]) and `inside` is
+/// false. This keeps the selection following the content when an outer
+/// container scrolls — a window-coordinate anchor would drift relative to the
+/// content. `view` is only `None` when no view is registered at all.
 #[derive(Clone)]
 pub(crate) struct SelectionEndpoint {
-    /// Some: the endpoint is inside this TextView; `point` is in that view's
-    /// content coordinates. None: blank space; `point` is window coordinates.
+    /// Some: the endpoint is anchored to this TextView; `point` is in that
+    /// view's content coordinates (may fall outside the view when proxy-
+    /// anchored from blank space). None: no view is registered; `point` is
+    /// window coordinates.
     pub(crate) view: Option<WeakEntity<TextViewState>>,
     pub(crate) point: Point<Pixels>,
+    /// True when the press actually hit the view's hitbox; false when the
+    /// endpoint is proxy-anchored to the nearest view from blank space (so
+    /// the selection follows content when an outer container scrolls).
+    pub(crate) inside: bool,
 }
 
 impl SelectionEndpoint {
     /// Resolve this endpoint to window coordinates.
+    ///
+    /// Whether the endpoint was a true hit or proxy-anchored from blank space,
+    /// `point` is in the view's content coordinates, so resolving uses the
+    /// view's current `bounds().origin + scroll_offset()` (refreshed every
+    /// frame in prepaint) and the endpoint follows the content as it moves.
     fn resolve(&self, cx: &App) -> Option<Point<Pixels>> {
         match &self.view {
             Some(view) => {
@@ -57,13 +76,17 @@ impl WindowTextSelection {
         Some((start, end))
     }
 
-    /// If both endpoints are anchored inside the same TextView, return its id.
+    /// If both endpoints are anchored to the same TextView, return its id.
     ///
-    /// This is the single-view fast path: when a drag starts and ends inside
-    /// one TextView, only that view participates, keeping the single-view
-    /// behavior identical to before. When either endpoint is in blank space,
-    /// all registered views participate and the per-character geometric test
-    /// (in `Inline`) decides what is actually selected.
+    /// This is the single-view fast path: when a drag starts and ends anchored
+    /// to one TextView, only that view participates, keeping the single-view
+    /// behavior identical to before. Proxy-anchored endpoints (from blank
+    /// space) count here too: a drag that begins in the blank space just above
+    /// view A proxy-anchors its anchor to A, so a drag from there into A stays
+    /// single-view — geometrically the selection starts at A's top, which is
+    /// correct. When the two endpoints anchor to different views, all
+    /// registered views participate and the per-character geometric test (in
+    /// `Inline`) decides what is actually selected.
     pub(crate) fn single_view(&self) -> Option<EntityId> {
         let anchor = self.anchor.as_ref()?.view_id()?;
         let cursor = self.cursor.as_ref()?.view_id()?;
@@ -192,6 +215,11 @@ impl Root {
     /// Clear the window selection when a view it is anchored to has been
     /// resized (its content coordinates are no longer valid). An active drag
     /// is not interrupted, so streaming (append-only) updates keep working.
+    ///
+    /// `involves` also matches a proxy-anchored endpoint (blank space anchored
+    /// to this view): once the view resizes, the content the blank endpoint was
+    /// pinned relative to has moved, so clearing the selection is the
+    /// conservative, correctness-first choice there too.
     pub(crate) fn clear_text_selection_for_resized_view(
         &mut self,
         view_id: EntityId,
@@ -218,11 +246,15 @@ impl Root {
         // press starts a selection from any point that is not consumed by such a
         // component — including blank space inside a focusable container, which
         // GPUI's focus-on-mouse-down would otherwise mark default-prevented.
-        if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
-            view.update(cx, |state, cx| {
-                state.is_selecting = true;
-                state.focus_handle.focus(window, cx);
-            });
+        // Only focus the view when the press actually hit it. A proxy-anchored
+        // endpoint (blank space) must not steal focus from wherever it was.
+        if endpoint.inside {
+            if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
+                view.update(cx, |state, cx| {
+                    state.is_selecting = true;
+                    state.focus_handle.focus(window, cx);
+                });
+            }
         }
         self.text_selection.anchor = Some(endpoint.clone());
         self.text_selection.cursor = Some(endpoint);
@@ -253,11 +285,14 @@ impl Root {
         let new_points = self.text_selection.resolved_points(cx);
 
         // Auto-scroll the anchor view when dragging near its viewport edges,
-        // same semantics as the previous per-view implementation.
+        // same semantics as the previous per-view implementation. Only a true
+        // hit anchor (inside == true) auto-scrolls; a proxy-anchored view was
+        // never pressed and must not scroll.
         if let Some(view) = self
             .text_selection
             .anchor
             .as_ref()
+            .filter(|e| e.inside)
             .and_then(|e| e.view.as_ref())
             .and_then(|v| v.upgrade())
         {
@@ -277,10 +312,14 @@ impl Root {
             return;
         }
         self.text_selection.is_selecting = false;
+        // Only a true hit anchor (inside == true) had `is_selecting` and
+        // auto-scroll set in `start_text_selection`; a proxy-anchored view
+        // has nothing to tear down.
         if let Some(view) = self
             .text_selection
             .anchor
             .as_ref()
+            .filter(|e| e.inside)
             .and_then(|e| e.view.as_ref())
             .and_then(|v| v.upgrade())
         {
@@ -295,6 +334,13 @@ impl Root {
 
     /// Resolve a window position to a selection endpoint. Uses hitbox hover
     /// testing so clipped or occluded TextViews are correctly excluded.
+    ///
+    /// When the position falls inside a view's hitbox, the endpoint is a true
+    /// hit (`inside == true`), anchored to that view's content coordinates.
+    /// When it lands in blank space, the endpoint is proxy-anchored to the
+    /// nearest view in document flow (`inside == false`), so the selection
+    /// still follows the content when an outer container scrolls. Only when no
+    /// view is registered does it fall back to a window-coordinate endpoint.
     fn text_selection_endpoint(
         &self,
         position: Point<Pixels>,
@@ -319,17 +365,67 @@ impl Root {
             }
         }
 
-        match best.and_then(|(view, _)| view.upgrade().map(|entity| (view, entity))) {
-            Some((view, entity)) => {
-                let state = entity.read(cx);
-                SelectionEndpoint {
-                    point: position - state.bounds().origin - state.scroll_offset(),
-                    view: Some(view),
+        if let Some((view, entity)) =
+            best.and_then(|(view, _)| view.upgrade().map(|entity| (view, entity)))
+        {
+            let state = entity.read(cx);
+            return SelectionEndpoint {
+                point: position - state.bounds().origin - state.scroll_offset(),
+                view: Some(view),
+                inside: true,
+            };
+        }
+
+        // Blank space: proxy-anchor to the nearest view in document flow so the
+        // endpoint moves with the content (a window-coordinate anchor would
+        // drift when an outer container scrolls). Prefer the view whose top is
+        // the largest value still at or above `position.y` (the nearest
+        // predecessor in the flow); if the position is above every view, fall
+        // back to the first view (smallest top). `point` is computed with the
+        // same formula as a true hit and may fall outside the view's bounds —
+        // it is a pure relative offset.
+        let mut predecessor: Option<(WeakEntity<TextViewState>, Pixels)> = None;
+        let mut first: Option<(WeakEntity<TextViewState>, Pixels)> = None;
+        for (view, _) in self.selectable_text_views.values() {
+            let Some(entity) = view.upgrade() else {
+                continue;
+            };
+            let top = entity.read(cx).bounds().top();
+            if top <= position.y {
+                if predecessor.as_ref().map_or(true, |(_, t)| top > *t) {
+                    predecessor = Some((view.clone(), top));
+                }
+            }
+            if first.as_ref().map_or(true, |(_, t)| top < *t) {
+                first = Some((view.clone(), top));
+            }
+        }
+
+        match predecessor.or(first) {
+            Some((view, _)) => {
+                let entity = view.upgrade();
+                // `view.upgrade()` succeeded above when the candidate was
+                // chosen; if it raced to None, fall back to a window endpoint.
+                match entity {
+                    Some(entity) => {
+                        let state = entity.read(cx);
+                        SelectionEndpoint {
+                            point: position - state.bounds().origin - state.scroll_offset(),
+                            view: Some(view),
+                            inside: false,
+                        }
+                    }
+                    None => SelectionEndpoint {
+                        view: None,
+                        point: position,
+                        inside: false,
+                    },
                 }
             }
             None => SelectionEndpoint {
                 view: None,
                 point: position,
+                inside: false,
             },
         }
     }
@@ -514,6 +610,25 @@ impl Element for TextSelectionController {
             }
             Root::update(window, cx, |root, _, cx| root.end_text_selection(cx));
         });
+
+        window.on_mouse_event(move |_: &ScrollWheelEvent, phase, window, cx| {
+            if !phase.bubble() {
+                return;
+            }
+            // While drag-selecting, a wheel scroll moves content under the
+            // stationary cursor; re-resolve the cursor endpoint at the current
+            // mouse position so the selection keeps extending to the pointer
+            // (browser behavior). `update_text_selection` is a no-op unless a
+            // selection drag is active, so the idle cost is negligible.
+            //
+            // Bounds are refreshed in the next frame's prepaint, so a single
+            // wheel event may resolve one frame stale; continuous scrolling
+            // converges, so this is left unhandled.
+            let position = window.mouse_position();
+            Root::update(window, cx, |root, window, cx| {
+                root.update_text_selection(position, window, cx);
+            });
+        });
     }
 }
 
@@ -537,6 +652,13 @@ mod tests {
         first: Entity<TextViewState>,
         second: Entity<TextViewState>,
         second_selectable: bool,
+        /// Top padding above the views. Bumping it shifts the whole content
+        /// down, which is the layout-level equivalent of an outer container
+        /// scrolling (see `selection_follows_content_when_layout_shifts`).
+        top_offset: gpui::Pixels,
+        /// Blank gap between the two views, used to anchor a selection in blank
+        /// space (the proxy-anchored endpoint path).
+        mid_gap: gpui::Pixels,
     }
 
     impl ChatTestView {
@@ -546,6 +668,8 @@ mod tests {
                 first: cx.new(|cx| TextViewState::markdown("Hello world", cx)),
                 second: cx.new(|cx| TextViewState::markdown("Second message", cx)),
                 second_selectable,
+                top_offset: px(10.),
+                mid_gap: px(0.),
             }
         }
     }
@@ -561,12 +685,16 @@ mod tests {
             div()
                 .track_focus(&self.focus_handle)
                 .size_full()
-                .pt(px(10.))
+                .pt(self.top_offset)
                 .child(
                     div()
                         .h(px(40.))
                         .child(TextView::new(&self.first).selectable(true)),
                 )
+                // A blank gap between the two views. It is not over any
+                // TextView hitbox, so a press here exercises the blank-space
+                // (proxy-anchored) endpoint path.
+                .child(div().h(self.mid_gap))
                 .child(
                     div()
                         .h(px(40.))
@@ -654,6 +782,49 @@ mod tests {
         let text = window_selected_text(cx);
         assert!(text.contains("Hello world"), "got: {text:?}");
         assert!(text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn selection_follows_content_when_layout_shifts(cx: &mut TestAppContext) {
+        let (chat, cx) = setup(true, cx);
+
+        // Open a blank gap between the two views so we can anchor a selection
+        // in blank space that sits *below* the first view's text and *above*
+        // the second. Layout: first [10,50], gap [50,110], second [110,150].
+        chat.update(cx, |chat, cx| {
+            chat.mid_gap = px(60.);
+            cx.notify();
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        // Anchor in the gap (blank space) and drag down-right into the second
+        // view, ending past the end of its text so the whole line is selected.
+        // The anchor sits below "Hello world", so only the second view is
+        // selected.
+        drag(cx, point(px(0.), px(80.)), point(px(300.), px(120.)));
+        let before = window_selected_text(cx);
+        assert!(
+            before.contains("Second message") && !before.contains("Hello world"),
+            "expected only the second view selected, got: {before:?}"
+        );
+
+        // Shift the whole content down by 80px — the equivalent of an outer
+        // container scrolling. A window-anchored blank endpoint stays at window
+        // y=80, which the first view now covers (first moves to ~[90,130]), so
+        // the selection drifts to also grab "Hello world". A proxy-anchored
+        // endpoint moves with the content and the selection stays stable.
+        chat.update(cx, |chat, cx| {
+            chat.top_offset = px(90.);
+            cx.notify();
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let after = window_selected_text(cx);
+        assert_eq!(before, after, "selection drifted after layout shift");
     }
 
     #[gpui::test]

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -1,0 +1,400 @@
+use gpui::{
+    App, Bounds, Context, Element, ElementId, Entity, EntityId, GlobalElementId, Hitbox,
+    InspectorElementId, IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, Pixels, Point, Style, WeakEntity, Window,
+};
+
+use crate::{Root, scroll::AutoScroll, text::TextViewState};
+
+/// Window-level text selection state, owned by [`Root`].
+///
+/// All text selection (including within a single TextView) is driven by this
+/// state. Selection endpoints are content-anchored when they fall inside a
+/// TextView, so the selection follows the content when it scrolls.
+#[derive(Default)]
+pub struct WindowTextSelection {
+    pub(crate) anchor: Option<SelectionEndpoint>,
+    pub(crate) cursor: Option<SelectionEndpoint>,
+    pub(crate) is_selecting: bool,
+}
+
+/// A selection endpoint, content-anchored if inside a TextView.
+#[derive(Clone)]
+pub(crate) struct SelectionEndpoint {
+    /// Some: the endpoint is inside this TextView; `point` is in that view's
+    /// content coordinates. None: blank space; `point` is window coordinates.
+    pub(crate) view: Option<WeakEntity<TextViewState>>,
+    pub(crate) point: Point<Pixels>,
+}
+
+impl SelectionEndpoint {
+    /// Resolve this endpoint to window coordinates.
+    fn resolve(&self, cx: &App) -> Option<Point<Pixels>> {
+        match &self.view {
+            Some(view) => {
+                let state = view.upgrade()?;
+                let state = state.read(cx);
+                Some(self.point + state.scroll_offset() + state.bounds().origin)
+            }
+            None => Some(self.point),
+        }
+    }
+
+    fn view_id(&self) -> Option<EntityId> {
+        self.view.as_ref().map(|view| view.entity_id())
+    }
+}
+
+impl WindowTextSelection {
+    /// The (anchor, cursor) points in window coordinates, `None` if the
+    /// selection is empty.
+    pub(crate) fn resolved_points(&self, cx: &App) -> Option<(Point<Pixels>, Point<Pixels>)> {
+        let start = self.anchor.as_ref()?.resolve(cx)?;
+        let end = self.cursor.as_ref()?.resolve(cx)?;
+        if start == end {
+            return None;
+        }
+        Some((start, end))
+    }
+
+    /// If both endpoints are anchored inside the same TextView, return its id.
+    ///
+    /// This is the single-view fast path: when a drag starts and ends inside
+    /// one TextView, only that view participates, keeping the single-view
+    /// behavior identical to before. When either endpoint is in blank space,
+    /// all registered views participate and the per-character geometric test
+    /// (in `Inline`) decides what is actually selected.
+    pub(crate) fn single_view(&self) -> Option<EntityId> {
+        let anchor = self.anchor.as_ref()?.view_id()?;
+        let cursor = self.cursor.as_ref()?.view_id()?;
+        (anchor == cursor).then_some(anchor)
+    }
+
+    fn involves(&self, view_id: EntityId) -> bool {
+        self.anchor.as_ref().and_then(|e| e.view_id()) == Some(view_id)
+            || self.cursor.as_ref().and_then(|e| e.view_id()) == Some(view_id)
+    }
+}
+
+impl Root {
+    /// Register a selectable TextView for window-level selection.
+    /// Called from TextView's paint on every frame.
+    pub(crate) fn register_selectable_text_view(
+        state: &Entity<TextViewState>,
+        hitbox: &Hitbox,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let Some(root) = window.root::<Root>().flatten() else {
+            return;
+        };
+        let id = state.entity_id();
+        let weak = state.downgrade();
+        let hitbox = hitbox.clone();
+        root.update(cx, |root, _| {
+            root.selectable_text_views
+                .retain(|_, (view, _)| view.upgrade().is_some());
+            root.selectable_text_views.insert(id, (weak, hitbox));
+        });
+    }
+
+    /// Return the merged selected text across all selectable TextViews in this
+    /// window, ordered by vertical position (top to bottom), joined with `\n`.
+    pub fn selected_text(window: &Window, cx: &App) -> String {
+        let Some(root) = window.root::<Root>().flatten() else {
+            return String::new();
+        };
+        root.read(cx).window_selected_text(cx)
+    }
+
+    /// Internal: collect selected text using `&self` directly, so it is safe
+    /// to call while the Root entity is leased (e.g. inside Root's own action
+    /// handler).
+    pub(crate) fn window_selected_text(&self, cx: &App) -> String {
+        let resolved = self.text_selection.resolved_points(cx);
+        let single_view = self.text_selection.single_view();
+
+        let mut items: Vec<(Point<Pixels>, String)> = Vec::new();
+        for (id, (view, _)) in self.selectable_text_views.iter() {
+            let Some(view) = view.upgrade() else { continue };
+            let state = view.read(cx);
+            let in_window_selection = resolved.is_some()
+                && state.is_selectable()
+                && single_view.map_or(true, |v| v == *id);
+            if !state.has_view_selection() && !in_window_selection {
+                continue;
+            }
+            let text = state.selected_text();
+            if text.trim().is_empty() {
+                continue;
+            }
+            items.push((state.bounds().origin, text));
+        }
+
+        items.sort_by(|a, b| {
+            a.0.y
+                .partial_cmp(&b.0.y)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(
+                    a.0.x
+                        .partial_cmp(&b.0.x)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                )
+        });
+
+        items
+            .into_iter()
+            .map(|(_, text)| text)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Clear the window selection and all view-local selections.
+    pub fn clear_text_selection(&mut self, cx: &mut Context<Self>) {
+        self.text_selection.anchor = None;
+        self.text_selection.cursor = None;
+        self.text_selection.is_selecting = false;
+        self.selectable_text_views.retain(|_, (view, _)| {
+            let Some(view) = view.upgrade() else {
+                return false;
+            };
+            view.update(cx, |state, cx| {
+                state.is_selecting = false;
+                state.clear_selection(cx);
+            });
+            true
+        });
+    }
+
+    /// Clear the window selection when a view it is anchored to has been
+    /// resized (its content coordinates are no longer valid). An active drag
+    /// is not interrupted, so streaming (append-only) updates keep working.
+    pub(crate) fn clear_text_selection_for_resized_view(
+        &mut self,
+        view_id: EntityId,
+        cx: &mut Context<Self>,
+    ) {
+        if self.text_selection.is_selecting {
+            return;
+        }
+        if self.text_selection.involves(view_id) {
+            self.clear_text_selection(cx);
+        }
+    }
+
+    pub(crate) fn start_text_selection(
+        &mut self,
+        position: Point<Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let endpoint = self.text_selection_endpoint(position, window, cx);
+        if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
+            view.update(cx, |state, cx| {
+                state.is_selecting = true;
+                state.focus_handle.focus(window, cx);
+            });
+        }
+        self.text_selection.anchor = Some(endpoint.clone());
+        self.text_selection.cursor = Some(endpoint);
+        self.text_selection.is_selecting = true;
+    }
+
+    pub(crate) fn update_text_selection(
+        &mut self,
+        position: Point<Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.text_selection.is_selecting {
+            return;
+        }
+        self.text_selection.cursor = Some(self.text_selection_endpoint(position, window, cx));
+
+        // Auto-scroll the anchor view when dragging near its viewport edges,
+        // same semantics as the previous per-view implementation.
+        if let Some(view) = self
+            .text_selection
+            .anchor
+            .as_ref()
+            .and_then(|e| e.view.as_ref())
+            .and_then(|v| v.upgrade())
+        {
+            view.update(cx, |state, cx| {
+                if state.scrollable {
+                    let delta = AutoScroll::compute_delta(position.y, state.bounds());
+                    state.set_auto_scroll(delta, cx);
+                }
+            });
+        }
+
+        self.notify_selectable_text_views(cx);
+    }
+
+    pub(crate) fn end_text_selection(&mut self, cx: &mut Context<Self>) {
+        if !self.text_selection.is_selecting {
+            return;
+        }
+        self.text_selection.is_selecting = false;
+        if let Some(view) = self
+            .text_selection
+            .anchor
+            .as_ref()
+            .and_then(|e| e.view.as_ref())
+            .and_then(|v| v.upgrade())
+        {
+            view.update(cx, |state, cx| {
+                state.is_selecting = false;
+                state.stop_auto_scroll();
+                cx.notify();
+            });
+        }
+        self.notify_selectable_text_views(cx);
+    }
+
+    /// Resolve a window position to a selection endpoint. Uses hitbox hover
+    /// testing so clipped or occluded TextViews are correctly excluded.
+    fn text_selection_endpoint(
+        &self,
+        position: Point<Pixels>,
+        window: &Window,
+        cx: &App,
+    ) -> SelectionEndpoint {
+        let mut best: Option<(WeakEntity<TextViewState>, f32)> = None;
+        for (view, hitbox) in self.selectable_text_views.values() {
+            if view.upgrade().is_none() {
+                continue;
+            }
+            if !hitbox.is_hovered(window) {
+                continue;
+            }
+            let area = f32::from(hitbox.bounds.size.width) * f32::from(hitbox.bounds.size.height);
+            if best.as_ref().map_or(true, |(_, a)| area < *a) {
+                best = Some((view.clone(), area));
+            }
+        }
+
+        match best.and_then(|(view, _)| view.upgrade().map(|entity| (view, entity))) {
+            Some((view, entity)) => {
+                let state = entity.read(cx);
+                SelectionEndpoint {
+                    point: position - state.bounds().origin - state.scroll_offset(),
+                    view: Some(view),
+                }
+            }
+            None => SelectionEndpoint {
+                view: None,
+                point: position,
+            },
+        }
+    }
+
+    fn notify_selectable_text_views(&mut self, cx: &mut Context<Self>) {
+        self.selectable_text_views.retain(|_, (view, _)| {
+            let Some(view) = view.upgrade() else {
+                return false;
+            };
+            view.update(cx, |_, cx| cx.notify());
+            true
+        });
+    }
+}
+
+/// A zero-size element that drives window-level text selection.
+///
+/// Must be the FIRST child of Root's container div: bubble-phase mouse
+/// listeners fire in reverse registration order, so registering earliest makes
+/// the controller run AFTER interactive components (which may stop
+/// propagation or prevent default).
+///
+/// Note: `window.on_mouse_event` handlers are window-global (not scoped to
+/// any hitbox); the phase and `default_prevented` checks are the only guards.
+pub(crate) struct TextSelectionController;
+
+impl IntoElement for TextSelectionController {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for TextSelectionController {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (window.request_layout(Style::default(), [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        _: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        _: &mut Window,
+        _: &mut App,
+    ) -> Self::PrepaintState {
+    }
+
+    fn paint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        _: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        _: &mut Self::PrepaintState,
+        window: &mut Window,
+        _: &mut App,
+    ) {
+        window.on_mouse_event(move |event: &MouseDownEvent, phase, window, cx| {
+            if event.button != MouseButton::Left {
+                return;
+            }
+            if phase.capture() {
+                // Any left press clears the previous selection (browser
+                // behavior), even when an interactive component consumes the
+                // event in the bubble phase.
+                Root::update(window, cx, |root, _, cx| root.clear_text_selection(cx));
+            } else if event.click_count == 1 && !window.default_prevented() {
+                // Reaching bubble phase means no component stopped
+                // propagation; default_prevented covers Button-like
+                // components.
+                Root::update(window, cx, |root, window, cx| {
+                    root.start_text_selection(event.position, window, cx);
+                });
+            }
+        });
+
+        window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
+            if !phase.bubble() {
+                return;
+            }
+            Root::update(window, cx, |root, window, cx| {
+                root.update_text_selection(event.position, window, cx);
+            });
+        });
+
+        window.on_mouse_event(move |_: &MouseUpEvent, phase, window, cx| {
+            if !phase.bubble() {
+                return;
+            }
+            Root::update(window, cx, |root, _, cx| root.end_text_selection(cx));
+        });
+    }
+}

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -355,15 +355,26 @@ impl Root {
         new_points: Option<(Point<Pixels>, Point<Pixels>)>,
         cx: &mut Context<Self>,
     ) {
-        // Single-view fast path: only the anchored view can paint a highlight,
-        // so only it needs to re-render.
-        if let Some(id) = self.text_selection.single_view() {
-            if let Some((view, _)) = self.selectable_text_views.get(&id) {
-                if let Some(view) = view.upgrade() {
-                    view.update(cx, |_, cx| cx.notify());
+        // Single-view fast path: when the selection lives entirely in the
+        // anchor view, only it can paint a highlight, so only it needs to
+        // re-render.
+        //
+        // This is only safe when there is no *previous* band that may have
+        // painted a highlight on some other view: a drag that crossed into a
+        // second view and then came back inside the anchor view leaves the new
+        // band single-view, but the old band still covers the view that must
+        // clear its now-stale highlight. In that case fall through to the
+        // general band path (band = old ∪ new), which always covers the anchor
+        // view too.
+        if old_points.is_none() {
+            if let Some(id) = self.text_selection.single_view() {
+                if let Some((view, _)) = self.selectable_text_views.get(&id) {
+                    if let Some(view) = view.upgrade() {
+                        view.update(cx, |_, cx| cx.notify());
+                    }
                 }
+                return;
             }
-            return;
         }
 
         // Merge the old and new selection bands. The old band covers views that
@@ -518,6 +529,8 @@ mod tests {
         Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render,
         Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
     };
+    use std::cell::Cell;
+    use std::rc::Rc;
 
     struct ChatTestView {
         focus_handle: FocusHandle,
@@ -723,5 +736,68 @@ mod tests {
         let text = window_selected_text(cx);
         assert_eq!(text.trim(), "Hello", "expected word selection: {text:?}");
         assert!(!text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn drag_back_into_anchor_view_clears_other_views(cx: &mut TestAppContext) {
+        let (chat, cx) = setup(true, cx);
+        let second = chat.read_with(cx, |chat, _| chat.second.clone());
+
+        // Drag from view A down into view B: this is a cross-view selection, so
+        // B paints a highlight and `selected_text` reports it.
+        cx.simulate_mouse_down(
+            point(px(0.), px(15.)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.simulate_mouse_move(
+            point(px(300.), px(70.)),
+            Some(MouseButton::Left),
+            Modifiers::default(),
+        );
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let text = second.read_with(cx, |state, _| state.selected_text());
+        assert!(
+            text.contains("Second message"),
+            "precondition: B should be selected, got {text:?}"
+        );
+
+        // Observe B's re-render requests. A view only drops a stale highlight
+        // when it is notified and repaints; this asserts the controller does
+        // notify B, independently of whether the test harness happens to
+        // repaint B for unrelated reasons.
+        let b_notified = Rc::new(Cell::new(false));
+        let _subscription = cx.update({
+            let b_notified = b_notified.clone();
+            let second = second.clone();
+            move |_, cx| cx.observe(&second, move |_, _| b_notified.set(true))
+        });
+        b_notified.set(false);
+
+        // Drag back up inside view A. The drag now lives entirely in A, so
+        // `single_view` is Some(A) and the fast path runs. It must still notify
+        // B (whose old band crossed B) so B can clear its now-stale highlight.
+        //
+        // We check this on the in-drag frame, not after mouse-up:
+        // `end_text_selection` notifies every selectable view, which would
+        // notify B for an unrelated reason and mask the bug.
+        cx.simulate_mouse_move(
+            point(px(60.), px(15.)),
+            Some(MouseButton::Left),
+            Modifiers::default(),
+        );
+        cx.run_until_parked();
+
+        assert!(
+            b_notified.get(),
+            "view B was not notified when the drag returned to the anchor view, \
+             so its stale highlight would never be repainted away",
+        );
     }
 }

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -192,6 +192,14 @@ impl Root {
         cx: &mut Context<Self>,
     ) {
         let endpoint = self.text_selection_endpoint(position, window, cx);
+        // GPUI's focus-on-mouse-down (`track_focus`) marks the event
+        // default-prevented when pressing any focusable element — including the
+        // TextView itself. A press that hits a selectable TextView must still
+        // start a selection; only blank-space presses respect default_prevented,
+        // which excludes presses consumed by Button, Input, etc.
+        if endpoint.view.is_none() && window.default_prevented() {
+            return;
+        }
         if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
             view.update(cx, |state, cx| {
                 state.is_selecting = true;
@@ -315,7 +323,11 @@ impl Root {
 /// propagation or prevent default).
 ///
 /// Note: `window.on_mouse_event` handlers are window-global (not scoped to
-/// any hitbox); the phase and `default_prevented` checks are the only guards.
+/// any hitbox); the phase check and the `default_prevented` guard inside
+/// `start_text_selection` are the only guards. `default_prevented` is checked
+/// there (not here) so that presses hitting a selectable TextView — which GPUI
+/// marks default-prevented via its focus-on-mouse-down auto-handler — still
+/// start a selection, while presses consumed by Button/Input etc. are excluded.
 pub(crate) struct TextSelectionController;
 
 impl IntoElement for TextSelectionController {
@@ -378,10 +390,11 @@ impl Element for TextSelectionController {
                 // behavior), even when an interactive component consumes the
                 // event in the bubble phase.
                 Root::update(window, cx, |root, _, cx| root.clear_text_selection(cx));
-            } else if event.click_count == 1 && !window.default_prevented() {
-                // Reaching bubble phase means no component stopped
-                // propagation; default_prevented covers Button-like
-                // components.
+            } else if event.click_count == 1 {
+                // Reaching bubble phase means no component stopped propagation.
+                // default_prevented is checked inside start_text_selection: presses
+                // that hit a selectable TextView must start a selection even though
+                // GPUI's focus-on-mouse-down marks them default-prevented.
                 Root::update(window, cx, |root, window, cx| {
                     root.start_text_selection(event.position, window, cx);
                 });

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -92,6 +92,9 @@ impl Root {
         let weak = state.downgrade();
         let hitbox = hitbox.clone();
         root.update(cx, |root, _| {
+            // Prune dead views on each registration. This is O(N) per call (O(N²)
+            // per frame across N selectable views), acceptable for typical view
+            // counts; revisit if a window ever hosts hundreds of selectable views.
             root.selectable_text_views
                 .retain(|_, (view, _)| view.upgrade().is_some());
             root.selectable_text_views.insert(id, (weak, hitbox));
@@ -261,6 +264,10 @@ impl Root {
         cx: &App,
     ) -> SelectionEndpoint {
         let mut best: Option<(WeakEntity<TextViewState>, f32)> = None;
+        // `is_hovered` reflects the hitbox state as of the last prepaint frame —
+        // a one-frame lag that is negligible for mouse-driven selection.
+        // Smallest-area wins as a proxy for the innermost (topmost) view when
+        // TextViews overlap.
         for (view, hitbox) in self.selectable_text_views.values() {
             if view.upgrade().is_none() {
                 continue;

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -418,3 +418,188 @@ impl Element for TextSelectionController {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Root,
+        text::{TextView, TextViewState},
+    };
+    use gpui::{
+        AppContext as _, Context, Entity, IntoElement, Modifiers, MouseButton, MouseDownEvent,
+        MouseUpEvent, ParentElement as _, Render, Styled as _, TestAppContext, VisualTestContext,
+        Window, div, point, px,
+    };
+
+    struct ChatTestView {
+        first: Entity<TextViewState>,
+        second: Entity<TextViewState>,
+        second_selectable: bool,
+    }
+
+    impl ChatTestView {
+        fn new(second_selectable: bool, cx: &mut Context<Self>) -> Self {
+            Self {
+                first: cx.new(|cx| TextViewState::markdown("Hello world", cx)),
+                second: cx.new(|cx| TextViewState::markdown("Second message", cx)),
+                second_selectable,
+            }
+        }
+    }
+
+    impl Render for ChatTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .pt(px(10.))
+                .child(
+                    div()
+                        .h(px(40.))
+                        .child(TextView::new(&self.first).selectable(true)),
+                )
+                .child(
+                    div()
+                        .h(px(40.))
+                        .child(TextView::new(&self.second).selectable(self.second_selectable)),
+                )
+        }
+    }
+
+    fn setup(
+        second_selectable: bool,
+        cx: &mut TestAppContext,
+    ) -> (Entity<ChatTestView>, &mut VisualTestContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let chat = cx.new(|cx| ChatTestView::new(second_selectable, cx));
+            Root::new(chat, window, cx)
+        });
+        let chat = root.read_with(cx, |root, _| {
+            root.view().clone().downcast::<ChatTestView>().unwrap()
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        (chat, cx)
+    }
+
+    fn drag(
+        cx: &mut VisualTestContext,
+        from: gpui::Point<gpui::Pixels>,
+        to: gpui::Point<gpui::Pixels>,
+    ) {
+        cx.simulate_mouse_down(from, MouseButton::Left, Modifiers::default());
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.simulate_mouse_move(to, Some(MouseButton::Left), Modifiers::default());
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.simulate_mouse_up(to, MouseButton::Left, Modifiers::default());
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    fn window_selected_text(cx: &mut VisualTestContext) -> String {
+        cx.update(|window, cx| Root::selected_text(window, cx))
+    }
+
+    #[gpui::test]
+    fn cross_view_drag_merges_text_top_to_bottom(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // From the very start of the first view down into the second view.
+        drag(cx, point(px(0.), px(15.)), point(px(300.), px(70.)));
+
+        let text = window_selected_text(cx);
+        let first = text.find("Hello world").expect("first view text missing");
+        let second = text
+            .find("Second message")
+            .expect("second view text missing");
+        assert!(first < second, "wrong order: {text:?}");
+        assert!(text.contains('\n'), "expected newline separator: {text:?}");
+    }
+
+    #[gpui::test]
+    fn drag_from_blank_space_selects_views_below(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // Start in the blank padding above the first view.
+        drag(cx, point(px(5.), px(2.)), point(px(300.), px(70.)));
+
+        let text = window_selected_text(cx);
+        assert!(text.contains("Hello world"), "got: {text:?}");
+        assert!(text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn non_selectable_view_is_excluded(cx: &mut TestAppContext) {
+        let (_, cx) = setup(false, cx);
+
+        drag(cx, point(px(5.), px(2.)), point(px(300.), px(70.)));
+
+        let text = window_selected_text(cx);
+        assert!(text.contains("Hello world"), "got: {text:?}");
+        assert!(!text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn drag_within_single_view_excludes_others(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // Entirely inside the first view.
+        drag(cx, point(px(5.), px(15.)), point(px(60.), px(15.)));
+
+        let text = window_selected_text(cx);
+        assert!(!text.contains("Second message"), "got: {text:?}");
+        assert!(!text.trim().is_empty(), "expected some selection");
+    }
+
+    #[gpui::test]
+    fn mouse_down_clears_previous_selection(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        drag(cx, point(px(5.), px(15.)), point(px(300.), px(70.)));
+        assert!(!window_selected_text(cx).is_empty());
+
+        // A plain click clears the selection.
+        cx.simulate_click(point(px(300.), px(100.)), Modifiers::default());
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert_eq!(window_selected_text(cx), "");
+    }
+
+    #[gpui::test]
+    fn double_click_selects_word_under_root(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // Double-click inside the first view: must trigger the per-view word
+        // selection (Inline), not a window-level drag selection.
+        let position = point(px(5.), px(15.));
+        cx.simulate_event(MouseDownEvent {
+            position,
+            modifiers: Modifiers::default(),
+            button: MouseButton::Left,
+            click_count: 2,
+            first_mouse: false,
+        });
+        cx.simulate_event(MouseUpEvent {
+            position,
+            modifiers: Modifiers::default(),
+            button: MouseButton::Left,
+            click_count: 2,
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let text = window_selected_text(cx);
+        assert_eq!(text.trim(), "Hello", "expected word selection: {text:?}");
+        assert!(!text.contains("Second message"), "got: {text:?}");
+    }
+}

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -101,13 +101,15 @@ impl Root {
         });
     }
 
-    /// Return the merged selected text across all selectable TextViews in this
-    /// window, ordered by vertical position (top to bottom), joined with `\n`.
-    pub fn selected_text(window: &Window, cx: &App) -> String {
-        let Some(root) = window.root::<Root>().flatten() else {
-            return String::new();
-        };
-        root.read(cx).window_selected_text(cx)
+    /// Whether there is an active text selection (window-level or view-local).
+    pub(crate) fn has_text_selection(&self, cx: &App) -> bool {
+        if self.text_selection.resolved_points(cx).is_some() {
+            return true;
+        }
+        self.selectable_text_views.values().any(|(view, _)| {
+            view.upgrade()
+                .is_some_and(|view| view.read(cx).has_view_selection())
+        })
     }
 
     /// Internal: collect selected text using `&self` directly, so it is safe
@@ -539,7 +541,8 @@ mod tests {
     }
 
     fn window_selected_text(cx: &mut VisualTestContext) -> String {
-        cx.update(|window, cx| Root::selected_text(window, cx))
+        use crate::WindowExt as _;
+        cx.update(|window, cx| window.selected_text(cx))
     }
 
     #[gpui::test]

--- a/crates/ui/src/window_ext.rs
+++ b/crates/ui/src/window_ext.rs
@@ -81,6 +81,20 @@ pub trait WindowExt: Sized {
     fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>>;
     /// Returns true if there is a focused Input entity.
     fn has_focused_input(&mut self, cx: &mut App) -> bool;
+
+    /// Returns the merged selected text across all selectable TextViews in
+    /// this window, ordered top to bottom and joined with `\n`.
+    ///
+    /// Returns an empty string if the window root is not a [`Root`].
+    fn selected_text(&mut self, cx: &mut App) -> String;
+
+    /// Returns true if there is an active text selection in this window
+    /// (either a window-level drag selection or a view-local selection such
+    /// as select-all or a double-click word selection).
+    fn has_text_selection(&mut self, cx: &mut App) -> bool;
+
+    /// Clears the window-level text selection and all view-local selections.
+    fn clear_text_selection(&mut self, cx: &mut App);
 }
 
 impl WindowExt for Window {
@@ -200,5 +214,29 @@ impl WindowExt for Window {
     #[inline]
     fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>> {
         Root::read(self, cx).focused_input.clone()
+    }
+
+    #[inline]
+    fn selected_text(&mut self, cx: &mut App) -> String {
+        let Some(root) = self.root::<Root>().flatten() else {
+            return String::new();
+        };
+        root.read(cx).window_selected_text(cx)
+    }
+
+    #[inline]
+    fn has_text_selection(&mut self, cx: &mut App) -> bool {
+        let Some(root) = self.root::<Root>().flatten() else {
+            return false;
+        };
+        root.read(cx).has_text_selection(cx)
+    }
+
+    #[inline]
+    fn clear_text_selection(&mut self, cx: &mut App) {
+        let Some(root) = self.root::<Root>().flatten() else {
+            return;
+        };
+        root.update(cx, |root, cx| root.clear_text_selection(cx));
     }
 }

--- a/examples/text_selection/Cargo.toml
+++ b/examples/text_selection/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "text_selection"
+description = "Window-level text selection across multiple TextView bubbles."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+gpui_platform.workspace = true
+gpui-component = { workspace = true }
+gpui-component-assets.workspace = true
+
+[lints]
+workspace = true

--- a/examples/text_selection/src/main.rs
+++ b/examples/text_selection/src/main.rs
@@ -1,0 +1,102 @@
+//! Window-level text selection demo: drag across multiple chat bubbles and
+//! press cmd-c / ctrl-c to copy the merged text.
+//!
+//! - Drag from anywhere inside the window (even the blank space between
+//!   bubbles) to start a selection that spans multiple `TextView`s.
+//! - The copied text keeps the top-to-bottom order, joined by newlines.
+//! - Clicking the `Button` does NOT start a selection.
+//! - Dragging inside the `Input` only drives the `Input`'s own selection.
+//!
+//! Run: `cargo run -p text_selection`
+
+use gpui::{prelude::FluentBuilder as _, *};
+use gpui_component::{
+    button::Button,
+    input::{Input, InputState},
+    text::TextView,
+    *,
+};
+use gpui_component_assets::Assets;
+
+struct ChatExample {
+    input: Entity<InputState>,
+}
+
+impl ChatExample {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self {
+            input: cx.new(|cx| {
+                InputState::new(window, cx)
+                    .placeholder("Type here (selection must NOT start from here)")
+            }),
+        }
+    }
+
+    fn bubble(&self, ix: usize, text: &str, mine: bool, cx: &App) -> impl IntoElement {
+        div().flex().when(mine, |this| this.justify_end()).child(
+            div()
+                .max_w(px(420.))
+                .p_3()
+                .rounded_lg()
+                .bg(if mine {
+                    cx.theme().primary.opacity(0.1)
+                } else {
+                    cx.theme().muted
+                })
+                // `selectable(true)` opts this TextView into window-level
+                // selection, so a drag started anywhere can extend into it.
+                .child(TextView::markdown(("msg", ix), text).selectable(true)),
+        )
+    }
+}
+
+impl Render for ChatExample {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .size_full()
+            .p_4()
+            .gap_3()
+            .child(self.bubble(0, "**Hello!** How can I help you today?", false, cx))
+            .child(self.bubble(
+                1,
+                "I want to select text *across* multiple bubbles.",
+                true,
+                cx,
+            ))
+            .child(self.bubble(
+                2,
+                "Sure — drag from anywhere, even from the blank space between \
+                 bubbles, then press `cmd-c` to copy everything.",
+                false,
+                cx,
+            ))
+            .child(self.bubble(3, "Nice, it also keeps the top-to-bottom order.", true, cx))
+            .child(div().flex_1())
+            .child(Button::new("noop").label("Clicking me must not start selection"))
+            .child(Input::new(&self.input))
+    }
+}
+
+fn main() {
+    let app = gpui_platform::application().with_assets(Assets);
+
+    app.run(move |cx| {
+        // This must be called before using any GPUI Component features.
+        gpui_component::init(cx);
+
+        let window_options = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(800.), px(600.)), cx)),
+            ..Default::default()
+        };
+
+        cx.spawn(async move |cx| {
+            cx.open_window(window_options, |window, cx| {
+                let view = cx.new(|cx| ChatExample::new(window, cx));
+                // The first level view on the window should be a Root.
+                cx.new(|cx| Root::new(view, window, cx))
+            })
+            .expect("Failed to open window");
+        })
+        .detach();
+    });
+}


### PR DESCRIPTION
## What's Changed

Text selection is now driven by a window-level mechanism in `Root`, instead of
each `TextView` handling its own mouse events.

- Drag from anywhere (even blank space) to select across multiple `TextView`s,
  like in a chat view with many bubbles.
- `cmd-c` / `ctrl-c` copies the merged text, ordered top to bottom, joined
  with newlines.
- New `WindowExt` APIs: `window.selected_text(cx)`,
  `window.has_text_selection(cx)`, `window.clear_text_selection(cx)`.
- Single-view selection, double/triple click, auto-scroll, and
  `selectable(false)` opt-out all work as before.
- `Button` and `Input` presses do not start a selection. Components that own
  their press can opt out via `GlobalState::suppress_text_selection(cx)`.
- Drag updates only re-render the views inside the selection band, not every
  selectable view.
- Added `examples/text_selection` chat demo and cross-view tests.

Note: text selection now requires the window root to be `Root` (this is
already required by the library).

> Implemented with Claude Code (AI-generated, human reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)