### PR TITLE
settings: Added a way to add additional search keywords

### DIFF
--- a/crates/story/src/stories/settings_story.rs
+++ b/crates/story/src/stories/settings_story.rs
@@ -325,7 +325,7 @@ impl SettingsStory {
                             .default_value(false),
                         )
                         .description("Find me by searching for my sibling")
-                        .search_aliases(["Bar"]),
+                        .keywords(["Bar"]),
                         SettingItem::render(|options, _, _| {
                             h_flex()
                                 .w_full()

--- a/crates/story/src/stories/settings_story.rs
+++ b/crates/story/src/stories/settings_story.rs
@@ -314,6 +314,18 @@ impl SettingsStory {
                             .default_value(false),
                         )
                         .description("Lock the other settings."),
+                        SettingItem::new(
+                            "Foo",
+                            SettingField::switch(
+                                |cx: &App| AppSettings::global(cx).disabled,
+                                |checked: bool, cx: &mut App| {
+                                    AppSettings::global_mut(cx).disabled = checked
+                                },
+                            )
+                            .default_value(false),
+                        )
+                        .description("Find me by searching for my sibling")
+                        .search_aliases(["Bar"]),
                         SettingItem::render(|options, _, _| {
                             h_flex()
                                 .w_full()

--- a/crates/ui/src/setting/item.rs
+++ b/crates/ui/src/setting/item.rs
@@ -22,6 +22,7 @@ pub enum SettingItem {
     Item {
         title: SharedString,
         description: Option<Text>,
+        search_aliases: Vec<SharedString>,
         layout: Axis,
         disabled: bool,
         field: Rc<dyn AnySettingField>,
@@ -29,6 +30,7 @@ pub enum SettingItem {
     /// A full custom element to render.
     Element {
         disabled: bool,
+        search_aliases: Vec<SharedString>,
         render: Rc<dyn Fn(&RenderOptions, &mut Window, &mut App) -> AnyElement + 'static>,
     },
 }
@@ -44,6 +46,7 @@ impl SettingItem {
             description: None,
             layout: Axis::Horizontal,
             disabled: false,
+            search_aliases: Vec::new(),
             field: Rc::new(field),
         }
     }
@@ -56,10 +59,34 @@ impl SettingItem {
     {
         SettingItem::Element {
             disabled: false,
+            search_aliases: Vec::new(),
             render: Rc::new(move |options, window, cx| {
                 render(options, window, cx).into_any_element()
             }),
         }
+    }
+
+    /// Additional strings that will act as search aliases.
+    ///
+    /// For example, an item titled "Enable Two-factor auth" may be
+    /// aliased with "MFA". Another use case for aliases is when working
+    /// with custom elements that don't have a title/desc while still
+    /// wanting them to show up in search results.
+    pub fn search_aliases<I, S>(mut self, aliases: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<SharedString>,
+    {
+        let aliases: Vec<SharedString> = aliases.into_iter().map(Into::into).collect();
+        match &mut self {
+            SettingItem::Item {
+                search_aliases: a, ..
+            } => *a = aliases,
+            SettingItem::Element {
+                search_aliases: a, ..
+            } => *a = aliases,
+        }
+        self
     }
 
     /// Set whether the setting item is disabled, default is false.
@@ -106,17 +133,23 @@ impl SettingItem {
     pub(crate) fn is_match(&self, query: &str, cx: &App) -> bool {
         match self {
             SettingItem::Item {
-                title, description, ..
+                title,
+                description,
+                search_aliases,
+                ..
             } => {
-                title.to_lowercase().contains(&query.to_lowercase())
-                    || description.as_ref().map_or(false, |d| {
-                        d.get_text(cx)
-                            .to_lowercase()
-                            .contains(&query.to_lowercase())
-                    })
+                let q = &query.to_lowercase();
+                title.to_lowercase().contains(q)
+                    || description
+                        .as_ref()
+                        .map_or(false, |d| d.get_text(cx).to_lowercase().contains(q))
+                    || search_aliases.iter().any(|s| s.to_lowercase().contains(q))
             }
             // We need to show all custom elements when not searching.
-            SettingItem::Element { .. } => query.is_empty(),
+            SettingItem::Element { search_aliases, .. } => {
+                let q = &query.to_lowercase();
+                query.is_empty() || search_aliases.iter().any(|s| s.to_lowercase().contains(q))
+            }
         }
     }
 
@@ -191,6 +224,7 @@ impl SettingItem {
                     layout,
                     disabled,
                     field,
+                    ..
                 } => div()
                     .w_full()
                     .overflow_hidden()
@@ -235,7 +269,9 @@ impl SettingItem {
                         cx,
                     )))
                     .into_any_element(),
-                SettingItem::Element { disabled, render } => div()
+                SettingItem::Element {
+                    disabled, render, ..
+                } => div()
                     .w_full()
                     .when(disabled, |this| this.opacity(0.5))
                     .child((render)(

--- a/crates/ui/src/setting/item.rs
+++ b/crates/ui/src/setting/item.rs
@@ -22,7 +22,7 @@ pub enum SettingItem {
     Item {
         title: SharedString,
         description: Option<Text>,
-        search_aliases: Vec<SharedString>,
+        keywords: Vec<SharedString>,
         layout: Axis,
         disabled: bool,
         field: Rc<dyn AnySettingField>,
@@ -30,7 +30,7 @@ pub enum SettingItem {
     /// A full custom element to render.
     Element {
         disabled: bool,
-        search_aliases: Vec<SharedString>,
+        keywords: Vec<SharedString>,
         render: Rc<dyn Fn(&RenderOptions, &mut Window, &mut App) -> AnyElement + 'static>,
     },
 }
@@ -46,7 +46,7 @@ impl SettingItem {
             description: None,
             layout: Axis::Horizontal,
             disabled: false,
-            search_aliases: Vec::new(),
+            keywords: Vec::new(),
             field: Rc::new(field),
         }
     }
@@ -59,32 +59,27 @@ impl SettingItem {
     {
         SettingItem::Element {
             disabled: false,
-            search_aliases: Vec::new(),
+            keywords: Vec::new(),
             render: Rc::new(move |options, window, cx| {
                 render(options, window, cx).into_any_element()
             }),
         }
     }
 
-    /// Additional strings that will act as search aliases.
+    /// Set additional keywords used only for search matching (not rendered).
     ///
-    /// For example, an item titled "Enable Two-factor auth" may be
-    /// aliased with "MFA". Another use case for aliases is when working
-    /// with custom elements that don't have a title/desc while still
-    /// wanting them to show up in search results.
-    pub fn search_aliases<I, S>(mut self, aliases: I) -> Self
+    /// For example, an item titled "Enable Two-factor auth" can be made
+    /// searchable via "MFA". This is also useful for custom elements that
+    /// have no title/description but should still show up in search results.
+    pub fn keywords<I, S>(mut self, keywords: I) -> Self
     where
         I: IntoIterator<Item = S>,
         S: Into<SharedString>,
     {
-        let aliases: Vec<SharedString> = aliases.into_iter().map(Into::into).collect();
+        let keywords: Vec<SharedString> = keywords.into_iter().map(Into::into).collect();
         match &mut self {
-            SettingItem::Item {
-                search_aliases: a, ..
-            } => *a = aliases,
-            SettingItem::Element {
-                search_aliases: a, ..
-            } => *a = aliases,
+            SettingItem::Item { keywords: k, .. } => *k = keywords,
+            SettingItem::Element { keywords: k, .. } => *k = keywords,
         }
         self
     }
@@ -135,7 +130,7 @@ impl SettingItem {
             SettingItem::Item {
                 title,
                 description,
-                search_aliases,
+                keywords,
                 ..
             } => {
                 let q = &query.to_lowercase();
@@ -143,12 +138,12 @@ impl SettingItem {
                     || description
                         .as_ref()
                         .map_or(false, |d| d.get_text(cx).to_lowercase().contains(q))
-                    || search_aliases.iter().any(|s| s.to_lowercase().contains(q))
+                    || keywords.iter().any(|s| s.to_lowercase().contains(q))
             }
             // We need to show all custom elements when not searching.
-            SettingItem::Element { search_aliases, .. } => {
+            SettingItem::Element { keywords, .. } => {
                 let q = &query.to_lowercase();
-                query.is_empty() || search_aliases.iter().any(|s| s.to_lowercase().contains(q))
+                query.is_empty() || keywords.iter().any(|s| s.to_lowercase().contains(q))
             }
         }
     }

--- a/docs/docs/components/settings.md
+++ b/docs/docs/components/settings.md
@@ -8,7 +8,7 @@ description: A settings UI with grouped setting items and pages.
 > Since: v0.5.0
 
 The Settings component provides a UI for managing application settings. It includes grouped setting items and pages.
-We can search by title and description to filter the settings to display only relevant settings (Like this macOS, iOS Settings).
+We can search by title, description, and custom keywords to filter the settings to display only relevant settings (Like this macOS, iOS Settings).
 
 ## Import
 
@@ -258,6 +258,30 @@ SettingItem::render(|options, _, _| {
         .into_any_element()
 })
 .disabled(true)
+```
+
+### Search Keywords
+
+Use `keywords` to attach additional search terms to an item. They are only used
+for search matching and are never rendered. For example, an item titled "Enable
+Two-factor auth" can be made searchable via "MFA":
+
+```rust
+SettingItem::new(
+    "Enable Two-factor auth",
+    SettingField::switch(...)
+)
+.keywords(["MFA", "2FA"])
+```
+
+This is also useful for [SettingItem::render] custom items that have no title or
+description but should still appear in search results:
+
+```rust
+SettingItem::render(|options, _, _| {
+    h_flex().child("Custom content").into_any_element()
+})
+.keywords(["Advanced", "Network"])
 ```
 
 ## Setting Fields

--- a/docs/zh-CN/docs/components/settings.md
+++ b/docs/zh-CN/docs/components/settings.md
@@ -7,7 +7,7 @@ description: 用于构建设置页、设置分组和设置项的界面组件。
 
 > Since: v0.5.0
 
-Settings 组件用于构建应用设置界面，支持页面分组、搜索过滤以及多种字段类型，适合实现类似 macOS 或 iOS 设置页的结构。
+Settings 组件用于构建应用设置界面，支持页面分组、按标题/描述/自定义关键词搜索过滤以及多种字段类型，适合实现类似 macOS 或 iOS 设置页的结构。
 
 ## 导入
 
@@ -251,6 +251,30 @@ SettingItem::render(|options, _, _| {
         .into_any_element()
 })
 .disabled(true)
+```
+
+### 搜索关键词
+
+通过 `keywords` 可以为设置项附加额外的搜索关键词。这些关键词仅用于搜索匹配，
+不会被渲染出来。例如，标题为 "Enable Two-factor auth" 的设置项可以通过 "MFA"
+搜索到：
+
+```rust
+SettingItem::new(
+    "Enable Two-factor auth",
+    SettingField::switch(...)
+)
+.keywords(["MFA", "2FA"])
+```
+
+这对于没有标题和描述、但仍希望能被搜索到的 [SettingItem::render] 自定义项同样
+有用：
+
+```rust
+SettingItem::render(|options, _, _| {
+    h_flex().child("Custom content").into_any_element()
+})
+.keywords(["Advanced", "Network"])
 ```
 
 ## Setting Fields


### PR DESCRIPTION
## Description
This adds a field for both SettingsItem::{Item, Element} to allow additional search aliases for that item. This can be used to either provide more search terms for a field, e.g. having a field titled "Enable Two-factor auth" aliased with "MFA". Another use case is to allow custom elements to provide their own search terms as they don't have/want a title/description.

## Screenshot
N/A

## How to Test

`cargo clippy` + verified behavior with example in the settings story 

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
