### PR TITLE
input: Expose API to`set_scroll_offset` method.

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -31,7 +31,6 @@ use super::{
 };
 use crate::Size;
 use crate::actions::{SelectDown, SelectLeft, SelectRight, SelectUp};
-use crate::scroll::AutoScroll;
 use crate::highlighter::DiagnosticSet;
 #[cfg(not(target_family = "wasm"))]
 use crate::highlighter::LanguageRegistry;
@@ -45,6 +44,7 @@ use crate::input::{
     search::{self, SearchPanel},
 };
 use crate::menu::PopupMenu;
+use crate::scroll::AutoScroll;
 use crate::{Root, history::History};
 
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
@@ -1797,6 +1797,12 @@ impl InputState {
     /// Current scroll offset of the editor viewport.
     pub fn scroll_offset(&self) -> gpui::Point<gpui::Pixels> {
         self.scroll_handle.offset()
+    }
+
+    /// Schedules an editor viewport scroll offset to apply on the next layout pass.
+    pub fn defer_scroll_offset(&mut self, offset: gpui::Point<gpui::Pixels>, cx: &mut Context<Self>) {
+        self.deferred_scroll_offset = Some(offset);
+        cx.notify();
     }
 
     /// Laid-out line height; `None` before first layout.

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1877,8 +1877,10 @@ impl InputState {
         self.scroll_handle.offset()
     }
 
-    /// Schedules an editor viewport scroll offset to apply on the next layout pass.
-    pub fn defer_scroll_offset(&mut self, offset: gpui::Point<gpui::Pixels>, cx: &mut Context<Self>) {
+    /// Set scroll offset of the editor viewport.
+    ///
+    /// The offset will be clamped to the valid range, and applied after the next layout.
+    pub fn set_scroll_offset(&mut self, offset: gpui::Point<gpui::Pixels>, cx: &mut Context<Self>) {
         self.deferred_scroll_offset = Some(offset);
         cx.notify();
     }


### PR DESCRIPTION
## Description

Expose the API to schedules the editor's viewport scroll offset on the next layout pass. So user can call `defer_scroll_offset` to scroll to an offset when restoring an editor's scroll offset.

## Changes

Add new API `defer_scroll_offset(offset, cx)` to `InputState`.

## How to Test

Replace line https://github.com/longbridge/gpui-component/blob/dadfca97fec7221acf3ce7047bccdc1eac0506b9/crates/story/examples/editor.rs#L802 with 
```rust
let line_height = state.line_height().unwrap_or(window.line_height());
let scroll_offset = state.scroll_offset();
state.defer_scroll_offset(
    point(
        scroll_offset.x,
        -(line_height * position.line as f32),
    ),
    cx,
);
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
