### PR TITLE
search: Fix editor backward search

### DIFF
--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -328,8 +328,6 @@ impl SearchPanel {
     }
 
     fn on_action_enter(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
-        // The focused search box is an Input, so Shift+Enter is resolved there as
-        // Enter { shift: true } before the action bubbles to the SearchPanel.
         if action.shift {
             self.prev(window, cx);
         } else {

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -4,14 +4,13 @@ use std::{ops::Range, rc::Rc};
 
 use gpui::{
     App, AppContext as _, Context, Empty, Entity, FocusHandle, Focusable, Half,
-    InteractiveElement as _, IntoElement, KeyBinding, ParentElement as _, Pixels, Render, Styled,
+    InteractiveElement as _, IntoElement, ParentElement as _, Pixels, Render, Styled,
     Subscription, Window, actions, div, prelude::FluentBuilder as _,
 };
 use ropey::Rope;
 
 use crate::{
     ActiveTheme, Disableable, ElementExt, IconName, Selectable, Sizable,
-    actions::SelectUp,
     button::{Button, ButtonVariants},
     h_flex,
     input::{
@@ -25,14 +24,6 @@ use crate::{
 const CONTEXT: &'static str = "SearchPanel";
 
 actions!(input, [Tab]);
-
-pub(super) fn init(cx: &mut App) {
-    cx.bind_keys(vec![KeyBinding::new(
-        "shift-enter",
-        SelectUp,
-        Some(CONTEXT),
-    )]);
-}
 
 #[derive(Debug, Clone)]
 pub struct SearchMatcher {
@@ -336,12 +327,14 @@ impl SearchPanel {
         cx.notify();
     }
 
-    fn on_action_prev(&mut self, _: &SelectUp, window: &mut Window, cx: &mut Context<Self>) {
-        self.prev(window, cx);
-    }
-
-    fn on_action_next(&mut self, _: &Enter, window: &mut Window, cx: &mut Context<Self>) {
-        self.next(window, cx);
+    fn on_action_next(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
+        // The focused search box is an Input, so Shift+Enter is resolved there as
+        // Enter { shift: true } before the action bubbles to the SearchPanel.
+        if action.shift {
+            self.prev(window, cx);
+        } else {
+            self.next(window, cx);
+        }
     }
 
     fn on_action_escape(&mut self, _: &Escape, window: &mut Window, cx: &mut Context<Self>) {
@@ -481,7 +474,6 @@ impl Render for SearchPanel {
             .occlude()
             .track_focus(&self.focus_handle(cx))
             .key_context(CONTEXT)
-            .on_action(cx.listener(Self::on_action_prev))
             .on_action(cx.listener(Self::on_action_next))
             .on_action(cx.listener(Self::on_action_escape))
             .on_action(cx.listener(Self::on_action_tab))
@@ -747,6 +739,18 @@ mod tests {
     #[test]
     fn test_prev_scroll_direction_returns_none_for_single_match() {
         assert!(SearchPanel::prev_scroll_direction(0, 0).is_none());
+    }
+
+    #[test]
+    fn test_shift_enter_finds_previous_match() {
+        let mut matcher = SearchMatcher::new();
+        matcher.matched_ranges = Rc::new(vec![5..10, 15..20, 25..30]);
+        matcher.current_match_ix = 1;
+
+        let previous = matcher.next_back();
+
+        assert_eq!(previous, Some(5..10));
+        assert_eq!(matcher.current_match_ix, 0);
     }
 
     #[test]

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -742,18 +742,6 @@ mod tests {
     }
 
     #[test]
-    fn test_shift_enter_finds_previous_match() {
-        let mut matcher = SearchMatcher::new();
-        matcher.matched_ranges = Rc::new(vec![5..10, 15..20, 25..30]);
-        matcher.current_match_ix = 1;
-
-        let previous = matcher.next_back();
-
-        assert_eq!(previous, Some(5..10));
-        assert_eq!(matcher.current_match_ix, 0);
-    }
-
-    #[test]
     fn test_update_matches_clamps_current_match_index_while_replacing() {
         let mut matcher = SearchMatcher::new();
         matcher.update(&Rope::from("foo foo foo"));

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -327,7 +327,7 @@ impl SearchPanel {
         cx.notify();
     }
 
-    fn on_action_next(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
+    fn on_action_enter(&mut self, action: &Enter, window: &mut Window, cx: &mut Context<Self>) {
         // The focused search box is an Input, so Shift+Enter is resolved there as
         // Enter { shift: true } before the action bubbles to the SearchPanel.
         if action.shift {
@@ -474,7 +474,7 @@ impl Render for SearchPanel {
             .occlude()
             .track_focus(&self.focus_handle(cx))
             .key_context(CONTEXT)
-            .on_action(cx.listener(Self::on_action_next))
+            .on_action(cx.listener(Self::on_action_enter))
             .on_action(cx.listener(Self::on_action_escape))
             .on_action(cx.listener(Self::on_action_tab))
             .font_family(cx.theme().font_family.clone())

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -41,7 +41,7 @@ use crate::input::{
     display_map::LineLayout,
     element::RIGHT_MARGIN,
     popovers::{ContextMenu, DiagnosticPopover, HoverPopover, InputContextMenu},
-    search::{self, SearchPanel},
+    search::SearchPanel,
 };
 use crate::menu::PopupMenu;
 use crate::scroll::AutoScroll;
@@ -272,7 +272,6 @@ pub(crate) fn init(cx: &mut App) {
         KeyBinding::new("ctrl-f", Search, Some(CONTEXT)),
     ]);
 
-    search::init(cx);
     number_input::init(cx);
 }
 


### PR DESCRIPTION
## Description

Currently, `Shift+Enter` doesn't trigger backward search in editor. This change fixes it. 

Cause:
The focused widget in the SearchPanel is a Input, which has `Input`
key context. So, shift+enter resolved to action `Enter {shift: true}`,
when it's bubbled to SearchPanel, it's not a `SelectUp`. Hence the
`on_action_prev` isn't triggered.

## Video clips

**Before**

https://github.com/user-attachments/assets/bac4b2c5-3795-4b40-b11f-71e10df84046

**After**

https://github.com/user-attachments/assets/03d3ba7c-beba-4418-94a2-b33a34e79fee

## Break Changes
NA

## How to Test

1. Run `cargo run --example editor`
2. Search keyword and hit `Enter` or `Shift+Enter`
3. Run `cargo run` to test the multi line input for sanity check

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
