### PR TITLE
dropdown_button: Fix style for selected outline button

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -893,6 +893,15 @@ impl ButtonVariant {
     }
 
     fn selected(&self, outline: bool, cx: &mut App) -> ButtonVariantStyle {
+        if outline {
+            let active_style = self.active(outline, cx);
+
+            return ButtonVariantStyle {
+                fg: self.text_color(outline, cx),
+                ..active_style
+            };
+        }
+
         let bg = match self {
             Self::Default => cx.theme().input.mix_oklab(cx.theme().transparent, 0.7),
             Self::Primary => cx.theme().button_primary_active,
@@ -1026,5 +1035,21 @@ mod tests {
         assert!(ButtonVariant::Link.no_padding());
         assert!(ButtonVariant::Text.no_padding());
         assert!(!ButtonVariant::Ghost.no_padding());
+    }
+
+    #[gpui::test]
+    fn test_outline_selected_uses_outline_active_style(cx: &mut gpui::TestAppContext) {
+        cx.update(crate::init);
+        let window = cx.add_empty_window();
+        window.update(|_, cx| {
+            let variant = ButtonVariant::Danger;
+            let active_style = variant.active(true, cx);
+            let selected_style = variant.selected(true, cx);
+
+            assert_eq!(selected_style.bg, active_style.bg);
+            assert_eq!(selected_style.border, active_style.border);
+            assert_eq!(selected_style.fg, cx.theme().danger);
+            assert_ne!(selected_style.bg, cx.theme().danger_active);
+        });
     }
 }


### PR DESCRIPTION
## Description

If the outline button is selected, use `active(outline, cx)`, plus the `text_color(outline, cx)`.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1582" height="1062" alt="Screenshot 2026-06-07 at 10 42 48 PM" src="https://github.com/user-attachments/assets/03368076-4ec5-487e-9f8c-25d390f38b5a" /> | <img width="1582" height="1062" alt="Screenshot 2026-06-07 at 10 37 21 PM" src="https://github.com/user-attachments/assets/141e6f68-1915-4617-85c2-2a07d476b63f" /> |

## How to Test

```
cargo test -p gpui-component test_outline_selected_uses_outline_active_palette --lib
```

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
