### PR TITLE
tree: emit TreeEvent on expand/collapse

### DIFF
--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -272,7 +272,7 @@ impl TreeState {
             if ix.is_some() {
                 self.selected_ix = ix;
             } else {
-                self.expand_ancestors(item.id.clone());
+                self.expand_ancestors(item.id.clone(), cx);
                 self.selected_ix = self
                     .entries
                     .iter()
@@ -299,7 +299,7 @@ impl TreeState {
         self.selected_ix.and_then(|ix| self.entries.get(ix))
     }
 
-    fn expand_ancestors(&mut self, target_id: SharedString) {
+    fn expand_ancestors(&mut self, target_id: SharedString, cx: &mut Context<Self>) {
         let mut ancestors = Vec::new();
 
         for entry in &self.entries {
@@ -313,8 +313,11 @@ impl TreeState {
             return;
         }
 
-        for ancestor in ancestors {
-            ancestor.state.borrow_mut().expanded = true;
+        for ancestor in ancestors.into_iter().rev() {
+            if !ancestor.is_expanded() {
+                ancestor.state.borrow_mut().expanded = true;
+                cx.emit(TreeEvent::Expanded(ancestor.id.clone()));
+            }
         }
 
         self.rebuild_entries();
@@ -807,5 +810,31 @@ mod tests {
 
         let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
         assert_eq!(events, vec![TreeEvent::Expanded("src/ui".into())]);
+    }
+
+    #[gpui::test]
+    fn test_set_selected_item_emits_expanded_events_for_hidden_ancestors(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let target = super::TreeItem::new("src/ui/button.rs", "button.rs");
+        let items = vec![
+            super::TreeItem::new("src", "src")
+                .child(super::TreeItem::new("src/ui", "ui").child(target.clone())),
+        ];
+        let state = cx.new(|cx| TreeState::new(cx).items(items));
+        let collector = cx.new(|cx| TestCollector::new(&state, cx));
+
+        state.update(cx, |state, cx| {
+            state.set_selected_item(Some(&target), cx);
+        });
+
+        let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
+        assert_eq!(
+            events,
+            vec![
+                TreeEvent::Expanded("src".into()),
+                TreeEvent::Expanded("src/ui".into())
+            ]
+        );
     }
 }

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -1,10 +1,10 @@
 use std::{cell::RefCell, ops::Range, rc::Rc};
 
 use gpui::{
-    App, Context, ElementId, Entity, FocusHandle, InteractiveElement as _, IntoElement, KeyBinding,
-    ListSizingBehavior, MouseButton, ParentElement, Render, RenderOnce, SharedString,
-    StyleRefinement, Styled, UniformListScrollHandle, Window, div, prelude::FluentBuilder as _,
-    uniform_list,
+    App, Context, ElementId, Entity, EventEmitter, FocusHandle, InteractiveElement as _,
+    IntoElement, KeyBinding, ListSizingBehavior, MouseButton, ParentElement, Render, RenderOnce,
+    SharedString, StyleRefinement, Styled, UniformListScrollHandle, Window, div,
+    prelude::FluentBuilder as _, uniform_list,
 };
 
 use crate::{
@@ -111,6 +111,15 @@ impl TreeEntry {
     }
 }
 
+/// Event emitted by [`TreeState`] when user-visible state changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TreeEvent {
+    /// A tree node was expanded.
+    Expanded(SharedString),
+    /// A tree node was collapsed.
+    Collapsed(SharedString),
+}
+
 impl TreeItem {
     /// Create a new tree item with the given label.
     ///
@@ -203,6 +212,8 @@ pub struct TreeState {
         Rc<dyn Fn(usize, &TreeEntry, PopupMenu, &mut Window, &mut Context<TreeState>) -> PopupMenu>,
     >,
 }
+
+impl EventEmitter<TreeEvent> for TreeState {}
 
 impl TreeState {
     /// Create a new empty tree state.
@@ -321,7 +332,7 @@ impl TreeState {
         }
     }
 
-    fn toggle_expand(&mut self, ix: usize) {
+    fn toggle_expand(&mut self, ix: usize, cx: &mut Context<Self>) {
         let Some(entry) = self.entries.get_mut(ix) else {
             return;
         };
@@ -329,7 +340,16 @@ impl TreeState {
             return;
         }
 
-        entry.item.state.borrow_mut().expanded = !entry.is_expanded();
+        let expanded = !entry.is_expanded();
+        let id = entry.item.id.clone();
+        entry.item.state.borrow_mut().expanded = expanded;
+
+        if expanded {
+            cx.emit(TreeEvent::Expanded(id));
+        } else {
+            cx.emit(TreeEvent::Collapsed(id));
+        }
+
         self.right_clicked_ix = None;
         self.rebuild_entries();
     }
@@ -355,7 +375,7 @@ impl TreeState {
         if let Some(selected_ix) = self.selected_ix {
             if let Some(entry) = self.entries.get(selected_ix) {
                 if entry.is_folder() {
-                    self.toggle_expand(selected_ix);
+                    self.toggle_expand(selected_ix, cx);
                     cx.notify();
                 }
             }
@@ -366,7 +386,7 @@ impl TreeState {
         if let Some(selected_ix) = self.selected_ix {
             if let Some(entry) = self.entries.get(selected_ix) {
                 if entry.is_folder() && entry.is_expanded() {
-                    self.toggle_expand(selected_ix);
+                    self.toggle_expand(selected_ix, cx);
                     cx.notify();
                 }
             }
@@ -377,7 +397,7 @@ impl TreeState {
         if let Some(selected_ix) = self.selected_ix {
             if let Some(entry) = self.entries.get(selected_ix) {
                 if entry.is_folder() && !entry.is_expanded() {
-                    self.toggle_expand(selected_ix);
+                    self.toggle_expand(selected_ix, cx);
                     cx.notify();
                 }
             }
@@ -415,7 +435,7 @@ impl TreeState {
 
     fn on_entry_click(&mut self, ix: usize, _: &mut Window, cx: &mut Context<Self>) {
         self.selected_ix = Some(ix);
-        self.toggle_expand(ix);
+        self.toggle_expand(ix, cx);
         cx.notify();
     }
 }
@@ -585,10 +605,44 @@ impl RenderOnce for Tree {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use indoc::indoc;
 
-    use super::TreeState;
-    use gpui::AppContext as _;
+    use super::{TreeEvent, TreeState};
+    use gpui::{AppContext as _, Render, Subscription};
+
+    struct TestCollector {
+        _state: gpui::Entity<TreeState>,
+        events: Rc<RefCell<Vec<TreeEvent>>>,
+        _subscription: Subscription,
+    }
+
+    impl TestCollector {
+        fn new(state: &gpui::Entity<TreeState>, cx: &mut gpui::Context<Self>) -> Self {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let events_clone = events.clone();
+            let _subscription = cx.subscribe(state, move |_, _, ev: &TreeEvent, _| {
+                events_clone.borrow_mut().push(ev.clone());
+            });
+            Self {
+                _state: state.clone(),
+                events,
+                _subscription,
+            }
+        }
+    }
+
+    impl Render for TestCollector {
+        fn render(
+            &mut self,
+            _: &mut gpui::Window,
+            _: &mut gpui::Context<Self>,
+        ) -> impl gpui::IntoElement {
+            gpui::div()
+        }
+    }
 
     fn assert_entries(entries: &Vec<super::TreeEntry>, expected: &str) {
         let actual: Vec<String> = entries
@@ -625,7 +679,7 @@ mod tests {
         ];
 
         let state = cx.new(|cx| TreeState::new(cx).items(items));
-        state.update(cx, |state, _| {
+        state.update(cx, |state, cx| {
             assert_entries(
                 &state.entries,
                 indoc! {
@@ -656,7 +710,7 @@ mod tests {
             assert_eq!(entry.is_expanded(), true);
             assert_eq!(entry.item().label.as_str(), "ui");
 
-            state.toggle_expand(1);
+            state.toggle_expand(1, cx);
             let entry = state.entries.get(1).unwrap();
             assert_eq!(entry.is_expanded(), false);
             assert_entries(
@@ -673,5 +727,85 @@ mod tests {
                 },
             );
         })
+    }
+
+    #[gpui::test]
+    fn test_emits_expanded_event(cx: &mut gpui::TestAppContext) {
+        let items = vec![
+            super::TreeItem::new("src", "src").child(super::TreeItem::new("src/lib.rs", "lib.rs")),
+        ];
+        let state = cx.new(|cx| TreeState::new(cx).items(items));
+        let collector = cx.new(|cx| TestCollector::new(&state, cx));
+
+        state.update(cx, |state, cx| {
+            state.toggle_expand(0, cx);
+        });
+
+        let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
+        assert_eq!(events, vec![TreeEvent::Expanded("src".into())]);
+    }
+
+    #[gpui::test]
+    fn test_emits_collapsed_event(cx: &mut gpui::TestAppContext) {
+        let items = vec![
+            super::TreeItem::new("src", "src")
+                .expanded(true)
+                .child(super::TreeItem::new("src/lib.rs", "lib.rs")),
+        ];
+        let state = cx.new(|cx| TreeState::new(cx).items(items));
+        let collector = cx.new(|cx| TestCollector::new(&state, cx));
+
+        state.update(cx, |state, cx| {
+            state.toggle_expand(0, cx);
+        });
+
+        let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
+        assert_eq!(events, vec![TreeEvent::Collapsed("src".into())]);
+    }
+
+    #[gpui::test]
+    fn test_set_items_does_not_emit_expansion_events(cx: &mut gpui::TestAppContext) {
+        let items = vec![
+            super::TreeItem::new("src", "src")
+                .expanded(true)
+                .child(super::TreeItem::new("src/lib.rs", "lib.rs")),
+        ];
+        let state = cx.new(|cx| TreeState::new(cx).items(items));
+        let collector = cx.new(|cx| TestCollector::new(&state, cx));
+
+        let new_items = vec![
+            super::TreeItem::new("docs", "docs")
+                .expanded(true)
+                .child(super::TreeItem::new("docs/readme.md", "readme.md")),
+        ];
+        state.update(cx, |state, cx| {
+            state.set_items(new_items, cx);
+        });
+
+        let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
+        assert!(
+            events.is_empty(),
+            "set_items should not emit Expanded/Collapsed events"
+        );
+    }
+
+    #[gpui::test]
+    fn test_event_carries_item_id(cx: &mut gpui::TestAppContext) {
+        let items = vec![
+            super::TreeItem::new("src", "src").expanded(true).child(
+                super::TreeItem::new("src/ui", "ui")
+                    .child(super::TreeItem::new("src/ui/button.rs", "button.rs")),
+            ),
+        ];
+        let state = cx.new(|cx| TreeState::new(cx).items(items));
+        let collector = cx.new(|cx| TestCollector::new(&state, cx));
+
+        // Toggle the child at index 1 ("src/ui"), event payload should be the id not the index.
+        state.update(cx, |state, cx| {
+            state.toggle_expand(1, cx);
+        });
+
+        let events = collector.read_with(cx, |c, _| c.events.borrow().clone());
+        assert_eq!(events, vec![TreeEvent::Expanded("src/ui".into())]);
     }
 }


### PR DESCRIPTION
(No associated issue - small additive enhancement)

## Description

Add explicit `TreeEvent` to `TreeState` so consumers can react to expand/collapse changes without maintaining a shadow copy of expansion state.

For lazy-loading trees (file browsers, database explorers, remote object browsers), consumers currently need to `cx.observe(&tree_state, ...)` and diff the entire expansion set after every notify.

With this change, consumers can subscribe directly:

```
cx.subscribe(&tree_state, |this, _, event: &TreeEvent, cx| {
    if let TreeEvent::Expanded(id) = event {
        this.load_children_for(id.as_ref(), cx);
    }
});
```

## Break Changes

Fully additive. Existing `cx.observe(&tree_state, ...)` consumers continue to work unchanged.


## How to Test

`cargo test -p gpui-component tree`

Four new tests were added:
- `test_emits_expanded_event` - toggling a collapsed folder emits `TreeEvent::Expanded(id)`
- `test_emits_collapsed_event` - toggling an expanded folder emits `TreeEvent::Collapsed(id)`
- `test_set_items_does_not_emit_expansion_events` - rebuilding the tree via `set_items()` is silent
- `test_event_carries_item_id` - event payload is `TreeItem.id`, not row index

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [N/A] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) (not platform specific)

AI Assistance Disclosure

🤖 Parts of this PR were generated with AI assistance and subsequently reviewed, tested, and refactored by a human to match the project's existing code style and patterns. Specifically:
  - The `TreeEvent` enum and `EventEmitter` implementation were drafted with AI, then aligned to match the existing `TableEvent` / `SliderEvent` patterns in the crate.
  - The test cases were AI-generated and then verified by running the full `gpui-component` test suite (219 tests pass, including the 4 new ones).