### PR TITLE
text: fix stuck selection after clicking a link

### DIFF
--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -13,8 +13,8 @@ use gpui::{
 };
 
 use crate::{
-    ActiveTheme, Root, global_state::GlobalState, input::Selection, text::TextViewMultiClickKind,
-    text::node::LinkMark, text::selection::word_range_at,
+    ActiveTheme, WindowExt as _, global_state::GlobalState, input::Selection,
+    text::TextViewMultiClickKind, text::node::LinkMark, text::selection::word_range_at,
 };
 
 /// A inline element used to render a inline text and support selectable.
@@ -455,7 +455,7 @@ impl Element for Inline {
                     if let Some(link) =
                         Self::link_for_position(&text_layout, &links, event.position)
                     {
-                        Root::update(window, cx, |root, _, cx| root.end_text_selection(cx));
+                        window.end_text_selection(cx);
                         cx.stop_propagation();
                         cx.open_url(&link.url);
                     }

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -13,7 +13,7 @@ use gpui::{
 };
 
 use crate::{
-    ActiveTheme, global_state::GlobalState, input::Selection, text::TextViewMultiClickKind,
+    ActiveTheme, Root, global_state::GlobalState, input::Selection, text::TextViewMultiClickKind,
     text::node::LinkMark, text::selection::word_range_at,
 };
 
@@ -455,6 +455,7 @@ impl Element for Inline {
                     if let Some(link) =
                         Self::link_for_position(&text_layout, &links, event.position)
                     {
+                        Root::update(window, cx, |root, _, cx| root.end_text_selection(cx));
                         cx.stop_propagation();
                         cx.open_url(&link.url);
                     }

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -15,7 +15,7 @@ use markdown::mdast;
 use ropey::Rope;
 
 use crate::{
-    ActiveTheme as _, Icon, IconName, Root, StyledExt, h_flex,
+    ActiveTheme as _, Icon, IconName, StyledExt, WindowExt as _, h_flex,
     highlighter::{HighlightTheme, LanguageRegistry, SyntaxHighlighter},
     input::{InputEdit, Point, RopeExt as _},
     text::{
@@ -817,9 +817,7 @@ impl Paragraph {
                                     Tooltip::new(title.clone()).build(window, cx)
                                 })
                                 .on_click(move |_, window, cx| {
-                                    Root::update(window, cx, |root, _, cx| {
-                                        root.end_text_selection(cx)
-                                    });
+                                    window.end_text_selection(cx);
                                     cx.stop_propagation();
                                     cx.open_url(&link.url);
                                 })

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -15,7 +15,7 @@ use markdown::mdast;
 use ropey::Rope;
 
 use crate::{
-    ActiveTheme as _, Icon, IconName, StyledExt, h_flex,
+    ActiveTheme as _, Icon, IconName, Root, StyledExt, h_flex,
     highlighter::{HighlightTheme, LanguageRegistry, SyntaxHighlighter},
     input::{InputEdit, Point, RopeExt as _},
     text::{
@@ -816,7 +816,10 @@ impl Paragraph {
                                 .tooltip(move |window, cx| {
                                     Tooltip::new(title.clone()).build(window, cx)
                                 })
-                                .on_click(move |_, _, cx| {
+                                .on_click(move |_, window, cx| {
+                                    Root::update(window, cx, |root, _, cx| {
+                                        root.end_text_selection(cx)
+                                    });
                                     cx.stop_propagation();
                                     cx.open_url(&link.url);
                                 })

--- a/crates/ui/src/window_ext.rs
+++ b/crates/ui/src/window_ext.rs
@@ -95,6 +95,9 @@ pub trait WindowExt: Sized {
 
     /// Clears the window-level text selection and all view-local selections.
     fn clear_text_selection(&mut self, cx: &mut App);
+
+    /// Ends the in-progress window-level text selection drag (if any).
+    fn end_text_selection(&mut self, cx: &mut App);
 }
 
 impl WindowExt for Window {
@@ -238,5 +241,13 @@ impl WindowExt for Window {
             return;
         };
         root.update(cx, |root, cx| root.clear_text_selection(cx));
+    }
+
+    #[inline]
+    fn end_text_selection(&mut self, cx: &mut App) {
+        let Some(root) = self.root::<Root>().flatten() else {
+            return;
+        };
+        root.update(cx, |root, cx| root.end_text_selection(cx));
     }
 }


### PR DESCRIPTION
## Description

Fixes an issue where dragging the mouse after clicking a link in a `TextView` causes an unintended text selection.

When a link is clicked, the `MouseUp` handler calls `cx.stop_propagation()` before opening the URL. This prevents the window-level `TextSelectionController` from receiving the event, leaving `is_selecting` stuck at `true`. Any subsequent mouse movement is then treated as a drag, highlighting text the user never intended to select.

This PR calls `Root::end_text_selection(cx)` before `stop_propagation()` in both link paths:
- Plain inline links — `crates/ui/src/text/inline.rs`
- Image links — `crates/ui/src/text/node.rs`

## Screenshot

### Before
https://github.com/user-attachments/assets/0c2049e4-725e-48c5-b641-40ac03ee42b7

### After
https://github.com/user-attachments/assets/956eede5-35b3-4b7b-9788-8a6c9ae43272

## How to Test

Open any story that renders a `TextView` containing a link (e.g. the Markdown story).

Click a link and let the browser open the URL.

Return to the app window and move the mouse **without pressing any button**.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
