### PR TITLE
highlighter: prevent empty range style leaks

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -921,6 +921,9 @@ impl SyntaxHighlighter {
             if node_range.start > node_range.end {
                 node_range.end = node_range.start;
             }
+            if node_range.is_empty() {
+                continue;
+            }
 
             styles.push((node_range, theme.style(name.as_ref()).unwrap_or_default()));
         }
@@ -960,6 +963,11 @@ pub(crate) fn unique_styles(
     total_range: &Range<usize>,
     styles: Vec<(Range<usize>, HighlightStyle)>,
 ) -> Vec<(Range<usize>, HighlightStyle)> {
+    let styles: Vec<_> = styles
+        .into_iter()
+        .filter(|(range, _)| !range.is_empty())
+        .collect();
+
     if styles.is_empty() {
         return styles;
     }
@@ -1391,6 +1399,12 @@ $x = 1;
                 (45..60, blue),
                 (60..65, clean),
             ],
+        );
+
+        assert_unique_styles(
+            0..10,
+            vec![(2..2, red), (4..6, green)],
+            vec![(0..4, clean), (4..6, green), (6..10, clean)],
         );
     }
 }


### PR DESCRIPTION
## Summary

- Ignore empty syntax highlight ranges before style merging
- Filter empty ranges in `unique_styles` so zero-length captures cannot remain active after their position
- Add a focused regression case covering empty ranges leaking styles into later spans

## Screenshots

### Before

<img width="1918" height="1078" alt="before" src="https://github.com/user-attachments/assets/284d4a15-e044-4bd3-98c6-2fdf4ea47da3" />

### After

<img width="1918" height="1078" alt="after" src="https://github.com/user-attachments/assets/b07d2021-da2e-4efb-b3ce-90b697203894" />

