### PR TITLE
root: Add bordered option for layer-shell fullscreen windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6935,6 +6935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "root_borderless"
+version = "0.5.1"
+dependencies = [
+ "gpui",
+ "gpui-component",
+ "gpui_platform",
+]
+
+[[package]]
 name = "ropey"
 version = "2.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "examples/tooltip_top_edge",
     "examples/sidebar",
     "examples/text_selection",
+    "examples/root_borderless",
 ]
 resolver = "2"
 

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -46,6 +46,8 @@ pub struct Root {
     pub(crate) native_menu_overlay: Entity<FallbackMenuOverlay>,
     sheet_size: Option<DefiniteLength>,
     window_shadow_size: Pixels,
+    /// Skip Linux CSD `window_border` wrapper (layer-shell fullscreen, etc.).
+    borderless: bool,
     /// The focus handle that will be restored after a dialog is closed with animation.
     /// Used to handle rapid dialog opening/closing to maintain correct focus chain.
     pending_focus_restore: Option<WeakFocusHandle>,
@@ -100,10 +102,17 @@ impl Root {
             native_menu_overlay: cx.new(|_| FallbackMenuOverlay::new()),
             sheet_size: None,
             window_shadow_size: window_border::SHADOW_SIZE,
+            borderless: false,
             pending_focus_restore: None,
             text_selection: WindowTextSelection::default(),
             selectable_text_views: HashMap::new(),
         }
+    }
+
+    /// Skip Linux CSD `window_border` wrapper (layer-shell fullscreen, etc.).
+    pub fn borderless(mut self, borderless: bool) -> Self {
+        self.borderless = borderless;
+        self
     }
 
     /// Set the window border shadow size for Linux client-side decorations.
@@ -525,23 +534,30 @@ impl Render for Root {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         window.set_rem_size(cx.theme().font_size);
 
-        window_border().shadow_size(self.window_shadow_size).child(
-            div()
-                .id("root")
-                .key_context(CONTEXT)
-                .on_action(cx.listener(Self::on_action_tab))
-                .on_action(cx.listener(Self::on_action_tab_prev))
-                .on_action(cx.listener(Self::on_action_copy))
-                .relative()
-                .size_full()
-                .font_family(cx.theme().font_family.clone())
-                .bg(cx.theme().background)
-                .text_color(cx.theme().foreground)
-                .refine_style(&self.style)
-                .child(TextSelectionController)
-                .child(self.view.clone())
-                .child(self.tooltip_overlay.clone())
-                .child(self.native_menu_overlay.clone()),
-        )
+        let inner = div()
+            .id("root")
+            .key_context(CONTEXT)
+            .on_action(cx.listener(Self::on_action_tab))
+            .on_action(cx.listener(Self::on_action_tab_prev))
+            .on_action(cx.listener(Self::on_action_copy))
+            .relative()
+            .size_full()
+            .font_family(cx.theme().font_family.clone())
+            .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
+            .refine_style(&self.style)
+            .child(TextSelectionController)
+            .child(self.view.clone())
+            .child(self.tooltip_overlay.clone())
+            .child(self.native_menu_overlay.clone());
+
+        if self.borderless {
+            inner.into_any_element()
+        } else {
+            window_border()
+                .shadow_size(self.window_shadow_size)
+                .child(inner)
+                .into_any_element()
+        }
     }
 }

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -12,9 +12,9 @@ use crate::{
 };
 use gpui::{
     Anchor, AnyView, App, AppContext, ClipboardItem, Context, DefiniteLength, ElementId, Entity,
-    EntityId, FocusHandle, Hitbox, InteractiveElement, IntoElement, KeyBinding,
-    ParentElement as _, Pixels, Render, StyleRefinement, Styled, WeakEntity, WeakFocusHandle,
-    Window, actions, div, prelude::FluentBuilder as _,
+    EntityId, FocusHandle, Hitbox, InteractiveElement, IntoElement, KeyBinding, ParentElement as _,
+    Pixels, Render, StyleRefinement, Styled, WeakEntity, WeakFocusHandle, Window, actions, div,
+    prelude::FluentBuilder as _,
 };
 use std::{any::TypeId, collections::HashMap, rc::Rc};
 
@@ -46,8 +46,8 @@ pub struct Root {
     pub(crate) native_menu_overlay: Entity<FallbackMenuOverlay>,
     sheet_size: Option<DefiniteLength>,
     window_shadow_size: Pixels,
-    /// Skip Linux CSD `window_border` wrapper (layer-shell fullscreen, etc.).
-    borderless: bool,
+    /// Render the Linux CSD `window_border` wrapper.
+    bordered: bool,
     /// The focus handle that will be restored after a dialog is closed with animation.
     /// Used to handle rapid dialog opening/closing to maintain correct focus chain.
     pending_focus_restore: Option<WeakFocusHandle>,
@@ -102,16 +102,19 @@ impl Root {
             native_menu_overlay: cx.new(|_| FallbackMenuOverlay::new()),
             sheet_size: None,
             window_shadow_size: window_border::SHADOW_SIZE,
-            borderless: false,
+            bordered: true,
             pending_focus_restore: None,
             text_selection: WindowTextSelection::default(),
             selectable_text_views: HashMap::new(),
         }
     }
 
-    /// Skip Linux CSD `window_border` wrapper (layer-shell fullscreen, etc.).
-    pub fn borderless(mut self, borderless: bool) -> Self {
-        self.borderless = borderless;
+    /// Enable or disable the Linux client-side window border wrapper.
+    ///
+    /// Defaults to `true`. Use `bordered(false)` for layer-shell fullscreen windows
+    /// or other surfaces that should not render GPUI Component's window border.
+    pub fn bordered(mut self, bordered: bool) -> Self {
+        self.bordered = bordered;
         self
     }
 
@@ -551,13 +554,50 @@ impl Render for Root {
             .child(self.tooltip_overlay.clone())
             .child(self.native_menu_overlay.clone());
 
-        if self.borderless {
-            inner.into_any_element()
-        } else {
+        if self.bordered {
             window_border()
                 .shadow_size(self.window_shadow_size)
                 .child(inner)
                 .into_any_element()
+        } else {
+            inner.into_any_element()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    struct TestView;
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+        }
+    }
+
+    #[gpui::test]
+    fn bordered_builder_toggles_window_border(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+
+        let (default_root, _) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|_| TestView);
+            Root::new(view, window, cx)
+        });
+        assert!(default_root.read_with(cx, |root, _| root.bordered));
+
+        let (root, _) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|_| TestView);
+            Root::new(view, window, cx).bordered(false)
+        });
+        assert!(!root.read_with(cx, |root, _| root.bordered));
+
+        let (root, _) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|_| TestView);
+            Root::new(view, window, cx).bordered(false).bordered(true)
+        });
+        assert!(root.read_with(cx, |root, _| root.bordered));
     }
 }

--- a/docs/docs/root.md
+++ b/docs/docs/root.md
@@ -27,6 +27,16 @@ fn main() {
 }
 ```
 
+## Window Border
+
+By default, [Root] renders GPUI Component's client-side window border wrapper. For
+layer-shell fullscreen windows or other surfaces that should not render this
+wrapper, disable it with `bordered(false)`:
+
+```rs
+cx.new(|cx| Root::new(view, window, cx).bordered(false))
+```
+
 ## Overlays
 
 We have dialogs, sheets, notifications, we need placement for them to show, so [Root] provides methods to render these overlays:

--- a/docs/zh-CN/docs/root.md
+++ b/docs/zh-CN/docs/root.md
@@ -27,6 +27,16 @@ fn main() {
 }
 ```
 
+## 窗口边框
+
+默认情况下，[Root] 会渲染 GPUI Component 的客户端窗口边框包装层。对于
+layer-shell 全屏窗口，或其他不应该渲染这层边框的场景，可以用 `bordered(false)`
+关闭：
+
+```rs
+cx.new(|cx| Root::new(view, window, cx).bordered(false))
+```
+
 ## 浮层
 
 对话框、抽屉、通知等 UI 都需要一个统一的展示层，[Root] 提供了这些浮层的渲染入口：

--- a/examples/root_borderless/Cargo.toml
+++ b/examples/root_borderless/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "root_borderless"
+description = "Example demonstrating disabling Root's window border wrapper."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+gpui.workspace = true
+gpui_platform.workspace = true
+gpui-component = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/root_borderless/src/main.rs
+++ b/examples/root_borderless/src/main.rs
@@ -1,0 +1,73 @@
+use gpui::*;
+use gpui_component::{ActiveTheme as _, Root, StyledExt as _, h_flex, v_flex};
+
+struct RootBorderlessExample;
+
+impl Render for RootBorderlessExample {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .size_full()
+            .gap_4()
+            .p_8()
+            .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
+            .child(
+                div()
+                    .text_2xl()
+                    .font_semibold()
+                    .child("Root::bordered(false)"),
+            )
+            .child(
+                div()
+                    .max_w(px(560.))
+                    .text_color(cx.theme().muted_foreground)
+                    .child(
+                        "This window requests client-side decorations, while Root disables GPUI Component's window border wrapper.",
+                    ),
+            )
+            .child(
+                h_flex()
+                    .gap_3()
+                    .child(
+                        div()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .px_3()
+                            .py_2()
+                            .child("Root.bordered = false"),
+                    )
+                    .child(
+                        div()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .px_3()
+                            .py_2()
+                            .child("window_decorations = Client"),
+                    ),
+            )
+    }
+}
+
+fn main() {
+    gpui_platform::application().run(move |cx| {
+        gpui_component::init(cx);
+
+        let window_options = WindowOptions {
+            titlebar: None,
+            window_bounds: Some(WindowBounds::centered(size(px(640.), px(320.)), cx)),
+            window_decorations: Some(WindowDecorations::Client),
+            ..Default::default()
+        };
+
+        cx.spawn(async move |cx| {
+            cx.open_window(window_options, |window, cx| {
+                let view = cx.new(|_| RootBorderlessExample);
+                cx.new(|cx| Root::new(view, window, cx).bordered(false))
+            })
+            .expect("Failed to open window");
+        })
+        .detach();
+    });
+}


### PR DESCRIPTION
Add `Root::borderless()` so that layer-shell fullscreen surfaces (greeter, lock screen, screensaver, panel taskbar, etc.) can skip the Linux CSD `window_border` wrapper, which otherwise paints an unwanted border and shadow around an edge-to-edge surface.

When `borderless` is set, `Root::render` returns the inner content directly instead of wrapping it in `window_border()`. The default is `false`, so existing behavior is unchanged.

## Description

On Linux, `Root::render` always wraps its content in `window_border()` to draw client-side decoration borders and shadows. For layer-shell fullscreen surfaces (greeters, lock screens, screensavers, panels, etc.) this wrapper is undesirable: such surfaces are edge-to-edge and should not have a border or drop shadow around them.

This PR adds an opt-in `Root::borderless(bool)` builder method backed by a `borderless: bool` field (default `false`). When `borderless` is `true`, `Root::render` returns the inner content element directly; otherwise it keeps wrapping the content in `window_border().shadow_size(...)` exactly as before. Both branches end with `.into_any_element()` so the return type is unified.

Because the default is `false`, all existing windows are unaffected.

## Break Changes

None.

## How to Test

- `cargo build -p gpui-component`
- On Linux with client-side decorations, set `Root::borderless(true)` on a layer-shell fullscreen surface and confirm the border and shadow are no longer drawn around it.
- Confirm that a default `Root` (without `borderless`, or `borderless(false)`) still renders the usual border and shadow.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)