### PR TITLE
text_view: Restrict markdown table wheel scrolling

### DIFF
--- a/crates/ui/src/scroll/mod.rs
+++ b/crates/ui/src/scroll/mod.rs
@@ -5,5 +5,6 @@ mod scrollbar;
 
 pub use auto_scroll::AutoScroll;
 pub use scrollable::*;
+pub(crate) use scrollable_mask::horizontal_scroll_area;
 pub use scrollable_mask::*;
 pub use scrollbar::*;

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -1,11 +1,36 @@
 use gpui::{
     App, Axis, BorderStyle, Bounds, ContentMask, Edges, Element, ElementId, GlobalElementId,
-    Hitbox, Hsla, IntoElement, IsZero as _, LayoutId, PaintQuad, Point, Position, ScrollHandle,
-    ScrollWheelEvent, Style, Window, px, relative,
+    Hitbox, Hsla, InteractiveElement as _, IntoElement, IsZero as _, LayoutId, PaintQuad,
+    ParentElement as _, Point, Position, ScrollHandle, ScrollWheelEvent,
+    StatefulInteractiveElement as _, Style, StyleRefinement, Styled as _, Window, div, px,
+    relative,
 };
 use gpui::{Corners, Pixels};
 
-use crate::AxisExt;
+use crate::{AxisExt, StyledExt as _};
+
+/// A horizontal scroll viewport that only consumes horizontal wheel deltas.
+///
+/// GPUI's native `overflow_x_scroll` maps vertical wheel input onto horizontal
+/// scrolling when there is no vertical overflow. This wrapper keeps the visual
+/// clipping and scroll offset, while delegating wheel input to [`ScrollableMask`]
+/// so vertical wheel events can continue bubbling to the parent scroller.
+pub(crate) fn horizontal_scroll_area(
+    id: impl Into<ElementId>,
+    scroll_handle: &ScrollHandle,
+    style: &StyleRefinement,
+    child: impl IntoElement,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .w_full()
+        .relative()
+        .refine_style(style)
+        .overflow_hidden()
+        .track_scroll(scroll_handle)
+        .child(child)
+        .child(ScrollableMask::new(Axis::Horizontal, scroll_handle))
+}
 
 /// Make a scrollable mask element to cover the parent view with the mouse wheel event listening.
 ///
@@ -158,5 +183,77 @@ impl Element for ScrollableMask {
                 }
             });
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{
+        Context, IntoElement, Render, ScrollDelta, ScrollWheelEvent, TestAppContext,
+        VisualTestContext, Window, div, point, px,
+    };
+
+    struct HorizontalScrollAreaTest {
+        scroll_handle: ScrollHandle,
+    }
+
+    impl Render for HorizontalScrollAreaTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(100.)).h(px(40.)).child(horizontal_scroll_area(
+                "horizontal-scroll-area",
+                &self.scroll_handle,
+                &Default::default(),
+                div().w(px(300.)).h(px(40.)),
+            ))
+        }
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_ignores_vertical_wheel(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let (_, cx) = cx.add_window_view({
+            let scroll_handle = scroll_handle.clone();
+            move |_, _| HorizontalScrollAreaTest {
+                scroll_handle: scroll_handle.clone(),
+            }
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        assert_eq!(scroll_handle.offset().x, px(0.));
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_uses_horizontal_wheel(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let (_, cx) = cx.add_window_view({
+            let scroll_handle = scroll_handle.clone();
+            move |_, _| HorizontalScrollAreaTest {
+                scroll_handle: scroll_handle.clone(),
+            }
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-40.), px(0.))),
+            ..Default::default()
+        });
+
+        assert_eq!(scroll_handle.offset().x, px(-40.));
     }
 }

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -7,9 +7,9 @@ use std::{
 
 use gpui::{
     AnyElement, App, DefiniteLength, Div, ElementId, FontStyle, FontWeight, Half, HighlightStyle,
-    InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement, SharedString,
-    SharedUri, StatefulInteractiveElement, Styled, StyledImage as _, Window, div, img,
-    prelude::FluentBuilder as _, px, relative, rems,
+    InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement, ScrollHandle,
+    SharedString, SharedUri, StatefulInteractiveElement, Styled, StyledImage as _, Window, div,
+    img, prelude::FluentBuilder as _, px, relative, rems,
 };
 use markdown::mdast;
 use ropey::Rope;
@@ -18,6 +18,7 @@ use crate::{
     ActiveTheme as _, Icon, IconName, StyledExt, WindowExt as _, h_flex,
     highlighter::{HighlightTheme, LanguageRegistry, SyntaxHighlighter},
     input::{InputEdit, Point, RopeExt as _},
+    scroll::horizontal_scroll_area,
     text::{
         CodeBlockActionsFn,
         document::NodeRenderOptions,
@@ -1289,6 +1290,24 @@ impl BlockNode {
         let total_w: f32 = col_w.iter().sum();
 
         let style = &node_cx.style;
+        let table_scroll_key = if let Some(span) = table.span {
+            SharedString::from(format!(
+                "{}-table-scroll-{}:{}",
+                window.current_view(),
+                span.start,
+                span.end
+            ))
+        } else {
+            SharedString::from(format!(
+                "{}-table-scroll-{}",
+                window.current_view(),
+                options.ix
+            ))
+        };
+        let scroll_handle = window
+            .use_keyed_state(table_scroll_key, cx, |_, _| ScrollHandle::default())
+            .read(cx)
+            .clone();
         let row_count = table.children.len();
         let mut rows = Vec::with_capacity(row_count);
         for (row_ix, row) in table.children.iter().enumerate() {
@@ -1338,26 +1357,26 @@ impl BlockNode {
             .w_full()
             .child(
                 // Scroll viewport: clips and scrolls horizontally (overflow-x
-                // comes from `style.table` via `refine_style`). No border — the
-                // frame is on the inner track so it wraps the table tightly.
-                div()
-                    .id(("table", options.ix))
-                    .w_full()
-                    .refine_style(&style.table)
-                    .child(
-                        // Bordered track sized to `max(viewport, total table
-                        // width)`: `min_w_full` fills the frame when the table is
-                        // narrow (cells then grow to fill), the definite
-                        // `w(total_w)` lets it exceed the viewport and scroll when
-                        // the content is wider.
-                        div()
-                            .min_w_full()
-                            .w(px(total_w))
-                            .border_1()
-                            .border_color(cx.theme().border)
-                            .rounded(cx.theme().radius)
-                            .children(rows),
-                    ),
+                // is handled by `ScrollableMask`, so vertical wheel events keep
+                // bubbling to the parent TextView). No border — the frame is on
+                // the inner track so it wraps the table tightly.
+                horizontal_scroll_area(
+                    ("table", options.ix),
+                    &scroll_handle,
+                    &style.table,
+                    // Bordered track sized to `max(viewport, total table
+                    // width)`: `min_w_full` fills the frame when the table is
+                    // narrow (cells then grow to fill), the definite `w(total_w)`
+                    // lets it exceed the viewport and scroll when the content is
+                    // wider.
+                    div()
+                        .min_w_full()
+                        .w(px(total_w))
+                        .border_1()
+                        .border_color(cx.theme().border)
+                        .rounded(cx.theme().radius)
+                        .children(rows),
+                ),
             )
             .into_any_element()
     }


### PR DESCRIPTION
## Summary
- Add a horizontal scroll area helper that ignores vertical wheel input while preserving horizontal scrolling.
- Use it for markdown table scroll mode so TextView vertical scrolling does not move tables sideways.
- Add tests covering vertical wheel ignored and horizontal wheel accepted.

## Test Plan
- cargo test -p gpui-component --lib