### PR TITLE
text_view: Stabilize scrollbar by measuring all blocks

### DIFF
--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -127,7 +127,11 @@ impl TextViewState {
             select_all: false,
             selectable: false,
             scrollable: false,
-            list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
+            // Measure all blocks (not just visible ones) so the scrollbar
+            // thumb size stays stable. Without this, off-screen blocks count
+            // as zero height until scrolled into view, which makes the
+            // scrollbar jitter as more blocks get measured during scrolling.
+            list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)).measure_all(),
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
             is_selecting: false,


### PR DESCRIPTION
## Summary

The TextView scrollbar thumb jittered ("一会儿多一会儿少") while scrolling when `scrollable` is enabled.

The thumb size is derived from `ListState`'s content size, which sums every block's height. Off-screen blocks are `Unmeasured` with `size_hint: None`, so they count as **zero height** until scrolled into view. As scrolling measures more blocks, the total content height keeps growing, so the thumb gets recomputed and visibly jumps.

This enables GPUI's built-in `ListState::measure_all()`, which measures all blocks in the first layout phase. The total content height is then known up front and stays constant, so the scrollbar size is stable from the first frame. It also stays compatible with content updates: `render_root` calls `list_state.reset(...)`, and `reset()` keeps the `Measure` behavior (re-measuring all blocks) rather than reverting to visible-only.

## Note

This portion was AI-generated and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)