### PR TITLE
input: Fix disabled input opacity rendering

### DIFF
--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -77,6 +77,7 @@ pub struct Example {
     soft_wrap: bool,
     show_whitespaces: bool,
     folding: bool,
+    disabled: bool,
     scroll_beyond_last_line: Option<usize>,
     cursor_surrounding_lines: Option<usize>,
     lsp_store: ExampleLspStore,
@@ -743,6 +744,7 @@ impl Example {
             soft_wrap: false,
             show_whitespaces: false,
             folding: true,
+            disabled: false,
             scroll_beyond_last_line: None,
             cursor_surrounding_lines: None,
             lsp_store,
@@ -969,11 +971,7 @@ impl Example {
         .h_full()
     }
 
-    fn render_line_number_button(
-        &self,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Button {
+    fn render_line_number_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
         Button::new("line-number")
             .when(self.line_number, |this| this.icon(IconName::Check))
             .label("Line Number")
@@ -1003,11 +1001,7 @@ impl Example {
             }))
     }
 
-    fn render_show_whitespaces_button(
-        &self,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Button {
+    fn render_show_whitespaces_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
         Button::new("show-whitespace")
             .ghost()
             .xsmall()
@@ -1022,11 +1016,7 @@ impl Example {
             }))
     }
 
-    fn render_indent_guides_button(
-        &self,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Button {
+    fn render_indent_guides_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
         Button::new("indent-guides")
             .ghost()
             .xsmall()
@@ -1052,6 +1042,18 @@ impl Example {
                 this.editor.update(cx, |state, cx| {
                     state.set_folding(this.folding, window, cx);
                 });
+                cx.notify();
+            }))
+    }
+
+    fn render_disabled_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
+        Button::new("disabled")
+            .ghost()
+            .xsmall()
+            .when(self.disabled, |this| this.icon(IconName::Check))
+            .label("Disabled")
+            .on_click(cx.listener(|this, _, _window, cx| {
+                this.disabled = !this.disabled;
                 cx.notify();
             }))
     }
@@ -1165,6 +1167,7 @@ impl Render for Example {
                             )
                             .child(
                                 Input::new(&self.editor)
+                                    .disabled(self.disabled)
                                     .bordered(false)
                                     .p_0()
                                     .h_full()
@@ -1181,6 +1184,7 @@ impl Render for Example {
                             .left(self.render_show_whitespaces_button(window, cx))
                             .left(self.render_indent_guides_button(window, cx))
                             .left(self.render_folding_button(window, cx))
+                            .left(self.render_disabled_button(window, cx))
                             .left(self.render_scroll_beyond_last_line_button(window, cx))
                             .left(self.render_cursor_surrounding_lines_button(window, cx))
                             .right(self.render_go_to_line_button(window, cx)),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -21,6 +21,8 @@ pub struct InputStory {
     prefix_input1: Entity<InputState>,
     suffix_input1: Entity<InputState>,
     both_input1: Entity<InputState>,
+    complete_input: Entity<InputState>,
+    complete_disabled_input: Entity<InputState>,
     large_input: Entity<InputState>,
     small_input: Entity<InputState>,
     phone_input: Entity<InputState>,
@@ -82,6 +84,16 @@ impl InputStory {
         });
         let both_input1 = cx.new(|cx| {
             InputState::new(window, cx).placeholder("This input have prefix and suffix.")
+        });
+        let complete_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder("Search account...")
+                .default_value("jane.doe@example.com")
+        });
+        let complete_disabled_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder("Search account...")
+                .default_value("disabled.account@example.com")
         });
 
         let phone_input = cx.new(|cx| InputState::new(window, cx).mask_pattern("(999)-999-9999"));
@@ -149,6 +161,8 @@ impl InputStory {
             prefix_input1,
             suffix_input1,
             both_input1,
+            complete_input,
+            complete_disabled_input,
             phone_input,
             mask_input2,
             currency_input,
@@ -243,6 +257,33 @@ impl Render for InputStory {
                         Input::new(&self.suffix_input1)
                             .cleanable(true)
                             .suffix(Button::new("info").ghost().icon(IconName::Info).xsmall()),
+                    ),
+            )
+            .child(
+                section("Complete Input")
+                    .max_w_md()
+                    .child(
+                        Input::new(&self.complete_input)
+                            .cleanable(true)
+                            .prefix(Icon::new(IconName::Search).small())
+                            .suffix(
+                                Button::new("complete-input-info")
+                                    .ghost()
+                                    .icon(IconName::Info)
+                                    .xsmall(),
+                            ),
+                    )
+                    .child(
+                        Input::new(&self.complete_disabled_input)
+                            .cleanable(true)
+                            .disabled(true)
+                            .prefix(Icon::new(IconName::Search).small())
+                            .suffix(
+                                Button::new("complete-disabled-input-info")
+                                    .ghost()
+                                    .icon(IconName::Info)
+                                    .xsmall(),
+                            ),
                     ),
             )
             .child(

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1934,11 +1934,17 @@ impl Element for TextElement {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let focus_handle = self.state.read(cx).focus_handle.clone();
-        let show_cursor = self.state.read(cx).show_cursor(window, cx);
+        let (focus_handle, show_cursor, disabled, selected_range) = {
+            let state = self.state.read(cx);
+            (
+                state.focus_handle.clone(),
+                state.show_cursor(window, cx),
+                state.disabled,
+                state.selected_range,
+            )
+        };
         let focused = focus_handle.is_focused(window);
         let bounds = prepaint.bounds;
-        let selected_range = self.state.read(cx).selected_range;
         let text_align = prepaint.last_layout.text_align;
 
         window.handle_input(
@@ -1976,7 +1982,17 @@ impl Element for TextElement {
         let origin = bounds.origin;
 
         let invisible_top_padding = prepaint.last_layout.visible_top;
-        let active_line_color = cx.theme().highlight_theme.style.editor_active_line;
+        let active_line_color = cx
+            .theme()
+            .highlight_theme
+            .style
+            .editor_active_line
+            .map(|color| if disabled { color.opacity(0.5) } else { color });
+        let editor_background = if disabled {
+            cx.theme().editor_background().opacity(0.5)
+        } else {
+            cx.theme().editor_background()
+        };
 
         // Paint active line
         let mut offset_y = px(0.);
@@ -2097,7 +2113,7 @@ impl Element for TextElement {
                             line_height,
                         ),
                     );
-                    window.paint_quad(fill(ghost_bounds, cx.theme().editor_background()));
+                    window.paint_quad(fill(ghost_bounds, editor_background));
 
                     // Paint ghost line text
                     _ = ghost_line.paint(
@@ -2219,7 +2235,7 @@ impl Element for TextElement {
 
                     // Paint background to cover any existing text
                     let bg_bounds = Bounds::new(p, size(first_line.width + px(4.), line_height));
-                    window.paint_quad(fill(bg_bounds, cx.theme().editor_background()));
+                    window.paint_quad(fill(bg_bounds, editor_background));
 
                     // Paint first line completion text
                     _ = first_line.paint(p, line_height, text_align, None, window, cx);

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1577,11 +1577,13 @@ impl Element for TextElement {
         let placeholder = self.placeholder.clone();
 
         let text_style = window.text_style();
-        let fg = text_style.color;
+        let disabled = state.disabled;
+        let dim = |color: Hsla| if disabled { color.opacity(0.5) } else { color };
+        let fg = dim(text_style.color);
         let (display_text, text_color) = if is_empty {
             (
                 &Rope::from(placeholder.as_str()),
-                cx.theme().muted_foreground,
+                dim(cx.theme().muted_foreground),
             )
         } else if state.masked {
             (
@@ -1675,6 +1677,10 @@ impl Element for TextElement {
                             run.strikethrough = marked_run.strikethrough;
                             run.underline = marked_run.underline;
                         }
+                    }
+
+                    if disabled {
+                        run.color = run.color.opacity(0.5)
                     }
 
                     run
@@ -2048,7 +2054,8 @@ impl Element for TextElement {
 
         // Paint document colors
         for (path, color) in prepaint.document_color_paths.iter() {
-            window.paint_path(path.clone(), *color);
+            let color = if disabled { color.opacity(0.5) } else { *color };
+            window.paint_path(path.clone(), color);
         }
 
         // Paint text with inline completion ghost line support

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -417,7 +417,7 @@ impl RenderOnce for Input {
                         .id("suffix")
                         .gap(gap_x)
                         .items_center()
-                        .when(!state.disabled, |this| this.opacity(0.5))
+                        .when(state.disabled, |this| this.opacity(0.5))
                         .when(state.loading, |this| {
                             this.child(Spinner::new().color(cx.theme().muted_foreground))
                         })

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -399,7 +399,11 @@ impl RenderOnce for Input {
             .items_center()
             .gap(gap_x)
             .refine_style(&self.style)
-            .children(prefix)
+            .children(prefix.map(|p| {
+                div()
+                    .when(state.disabled, |this| this.opacity(0.5))
+                    .child(p)
+            }))
             .when(state.mode.is_multi_line(), |mut this| {
                 let paddings = this.style().padding.clone();
                 this.child(Self::render_editor(paddings, &self.state, &state, window))
@@ -413,6 +417,7 @@ impl RenderOnce for Input {
                         .id("suffix")
                         .gap(gap_x)
                         .items_center()
+                        .when(!state.disabled, |this| this.opacity(0.5))
                         .when(state.loading, |this| {
                             this.child(Spinner::new().color(cx.theme().muted_foreground))
                         })

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -2,9 +2,9 @@ use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AnyElement, App, DefiniteLength, Edges, EdgesRefinement, Entity, Hsla,
-    InteractiveElement as _, IntoElement, MouseButton, ParentElement as _, Rems, RenderOnce,
-    StyleRefinement, Styled, TextAlign, Window, div, px, relative,
+    AnyElement, App, DefiniteLength, Edges, EdgesRefinement, Entity, Hsla, InteractiveElement as _,
+    IntoElement, MouseButton, ParentElement as _, Rems, RenderOnce, StyleRefinement, Styled,
+    TextAlign, Window, div, px, relative,
 };
 
 use crate::button::{Button, ButtonVariants as _};
@@ -271,6 +271,12 @@ impl RenderOnce for Input {
         } else {
             bg
         };
+        let bg = if state.disabled { bg.opacity(0.5) } else { bg };
+        let border_color = if state.disabled {
+            cx.theme().input.opacity(0.5)
+        } else {
+            cx.theme().input
+        };
 
         let prefix = self.prefix;
         let suffix = self.suffix;
@@ -380,10 +386,9 @@ impl RenderOnce for Input {
             })
             .when(self.appearance, |this| {
                 this.bg(bg)
-                    .when(self.disabled, |this| this.opacity(0.5))
                     .rounded(cx.theme().radius)
                     .when(self.bordered, |this| {
-                        this.border_color(cx.theme().input)
+                        this.border_color(border_color)
                             .border_1()
                             .when(cx.theme().shadow, |this| this.shadow_xs())
                             .when(focused && self.focus_bordered, |this| {


### PR DESCRIPTION
## Summary
- Render disabled inputs by fading background and border colors instead of applying inherited opacity to the whole element tree.
- Fade disabled editor line-height backgrounds used for active lines and inline completion overlays.
- Add a Disabled toggle to the editor example for testing.

Related context: https://github.com/zed-industries/zed/pull/59365

## Test Plan
- git diff --check
- rustfmt --edition 2024 --check crates/story/examples/editor.rs crates/ui/src/input/element.rs crates/ui/src/input/input.rs
- cargo check -p gpui-component-story --example editor

Note: full `cargo fmt --check` currently reports existing formatting diffs outside this change, so this PR validates the touched files directly.