### PR TITLE
text_view: Fix to require text hit for TextView selection

### DIFF
--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -11,10 +11,10 @@ use crate::{
     window_border,
 };
 use gpui::{
-    Anchor, AnyView, App, AppContext, ClipboardItem, Context, DefiniteLength, ElementId, Entity,
-    EntityId, FocusHandle, Hitbox, InteractiveElement, IntoElement, KeyBinding, ParentElement as _,
-    Pixels, Render, StyleRefinement, Styled, WeakEntity, WeakFocusHandle, Window, actions, div,
-    prelude::FluentBuilder as _,
+    Anchor, AnyView, App, AppContext, Bounds, ClipboardItem, Context, DefiniteLength, ElementId,
+    Entity, EntityId, FocusHandle, Hitbox, InteractiveElement, IntoElement, KeyBinding,
+    ParentElement as _, Pixels, Render, StyleRefinement, Styled, WeakEntity, WeakFocusHandle,
+    Window, actions, div, prelude::FluentBuilder as _,
 };
 use std::{any::TypeId, collections::HashMap, rc::Rc};
 
@@ -55,6 +55,8 @@ pub struct Root {
     pub(crate) text_selection: WindowTextSelection,
     /// Selectable TextViews registered this frame, keyed by entity id.
     pub(crate) selectable_text_views: HashMap<EntityId, (WeakEntity<TextViewState>, Hitbox)>,
+    /// Inline text bounds for selectable TextViews, keyed by parent TextView id.
+    pub(crate) selectable_text_inlines: HashMap<EntityId, Vec<Bounds<Pixels>>>,
 }
 
 #[derive(Clone)]
@@ -106,6 +108,7 @@ impl Root {
             pending_focus_restore: None,
             text_selection: WindowTextSelection::default(),
             selectable_text_views: HashMap::new(),
+            selectable_text_inlines: HashMap::new(),
         }
     }
 

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -152,8 +152,9 @@ impl Inline {
                 continue;
             };
 
+            let next_offset = offset + c.len_utf8();
             let mut char_width = line_height.half();
-            if let Some(next_pos) = text_layout.position_for_index(offset + 1) {
+            if let Some(next_pos) = text_layout.position_for_index(next_offset) {
                 if next_pos.y == pos.y {
                     char_width = next_pos.x - pos.x;
                 }
@@ -173,16 +174,66 @@ impl Inline {
                     selection = Some((offset..offset).into());
                 }
 
-                let next_offset = offset + c.len_utf8();
                 if let Some(selection) = selection.as_mut() {
                     selection.end = next_offset;
                 }
             }
 
-            offset += c.len_utf8();
+            offset = next_offset;
         }
 
         (true, true, selection)
+    }
+
+    fn text_line_bounds(
+        &self,
+        text_layout: &TextLayout,
+        line_height: Pixels,
+        mask_bounds: Bounds<Pixels>,
+    ) -> Vec<Bounds<Pixels>> {
+        let mut line_bounds = Vec::new();
+        let mut current_line_y = None;
+        let mut current_bounds: Option<Bounds<Pixels>> = None;
+        let mut offset = 0;
+
+        for c in self.text.chars() {
+            let next_offset = offset + c.len_utf8();
+            let Some(pos) = text_layout.position_for_index(offset) else {
+                offset = next_offset;
+                continue;
+            };
+
+            let mut char_width = line_height.half();
+            if let Some(next_pos) = text_layout.position_for_index(next_offset) {
+                if next_pos.y == pos.y {
+                    char_width = next_pos.x - pos.x;
+                }
+            }
+
+            let bounds = Bounds::from_corners(pos, point(pos.x + char_width, pos.y + line_height))
+                .intersect(&mask_bounds);
+            if bounds.size.width > px(0.) && bounds.size.height > px(0.) {
+                if current_line_y == Some(pos.y) {
+                    if let Some(current) = current_bounds.as_mut() {
+                        *current = current.union(&bounds);
+                    }
+                } else {
+                    if let Some(current) = current_bounds.take() {
+                        line_bounds.push(current);
+                    }
+                    current_line_y = Some(pos.y);
+                    current_bounds = Some(bounds);
+                }
+            }
+
+            offset = next_offset;
+        }
+
+        if let Some(current) = current_bounds {
+            line_bounds.push(current);
+        }
+
+        line_bounds
     }
 
     /// Paint the selection background.
@@ -367,6 +418,20 @@ impl Element for Inline {
         }
 
         if is_selectable {
+            if let Some(text_view_state) = GlobalState::global(cx).text_view_state().cloned() {
+                let text_bounds = self.text_line_bounds(
+                    &text_layout,
+                    text_layout.line_height(),
+                    window.content_mask().bounds,
+                );
+                crate::Root::register_selectable_text_inline(
+                    &text_view_state,
+                    text_bounds,
+                    window,
+                    cx,
+                );
+            }
+
             window.on_mouse_event({
                 let hitbox = hitbox.clone();
                 let text_layout = text_layout.clone();

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -259,18 +259,17 @@ impl Element for TextView {
         cx: &mut App,
     ) {
         let state = &request_layout.state;
+        if self.selectable {
+            // Register before painting children so this frame's Inline paint can
+            // repopulate the text bounds after stale ones are cleared.
+            crate::Root::register_selectable_text_view(state, hitbox, window, cx);
+        }
+
         GlobalState::global_mut(cx)
             .text_view_state_stack
             .push(state.clone());
         request_layout.element.paint(window, cx);
         GlobalState::global_mut(cx).text_view_state_stack.pop();
-
-        if self.selectable {
-            // Window-level selection: register this view (with its clipped
-            // hitbox) so the Root selection controller can hit-test and collect
-            // selected text. All mouse handling lives in TextSelectionController.
-            crate::Root::register_selectable_text_view(state, hitbox, window, cx);
-        }
     }
 }
 

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -16,6 +16,7 @@ pub struct WindowTextSelection {
     pub(crate) anchor: Option<SelectionEndpoint>,
     pub(crate) cursor: Option<SelectionEndpoint>,
     pub(crate) is_selecting: bool,
+    pub(crate) did_hit_text: bool,
 }
 
 /// A selection endpoint, content-anchored to a TextView.
@@ -39,6 +40,9 @@ pub(crate) struct SelectionEndpoint {
     /// endpoint is proxy-anchored to the nearest view from blank space (so
     /// the selection follows content when an outer container scrolls).
     pub(crate) inside: bool,
+    /// True when the endpoint hit an Inline text run, not just blank space in
+    /// the parent TextView bounds.
+    pub(crate) inside_text: bool,
 }
 
 impl SelectionEndpoint {
@@ -68,6 +72,9 @@ impl WindowTextSelection {
     /// The (anchor, cursor) points in window coordinates, `None` if the
     /// selection is empty.
     pub(crate) fn resolved_points(&self, cx: &App) -> Option<(Point<Pixels>, Point<Pixels>)> {
+        if !self.did_hit_text {
+            return None;
+        }
         let start = self.anchor.as_ref()?.resolve(cx)?;
         let end = self.cursor.as_ref()?.resolve(cx)?;
         if start == end {
@@ -121,6 +128,30 @@ impl Root {
             root.selectable_text_views
                 .retain(|_, (view, _)| view.upgrade().is_some());
             root.selectable_text_views.insert(id, (weak, hitbox));
+            root.selectable_text_inlines.remove(&id);
+        });
+    }
+
+    /// Register Inline text bounds for a selectable TextView.
+    /// Called from Inline's paint on every frame.
+    pub(crate) fn register_selectable_text_inline(
+        state: &Entity<TextViewState>,
+        text_bounds: Vec<Bounds<Pixels>>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if text_bounds.is_empty() {
+            return;
+        }
+        let Some(root) = window.root::<Root>().flatten() else {
+            return;
+        };
+        let id = state.entity_id();
+        root.update(cx, |root, _| {
+            root.selectable_text_inlines
+                .entry(id)
+                .or_default()
+                .extend(text_bounds);
         });
     }
 
@@ -188,6 +219,7 @@ impl Root {
         self.text_selection.anchor = None;
         self.text_selection.cursor = None;
         self.text_selection.is_selecting = false;
+        self.text_selection.did_hit_text = false;
         self.selectable_text_views.retain(|_, (view, _)| {
             let Some(view) = view.upgrade() else {
                 return false;
@@ -210,6 +242,8 @@ impl Root {
             }
             true
         });
+        self.selectable_text_inlines
+            .retain(|id, _| self.selectable_text_views.contains_key(id));
     }
 
     /// Clear the window selection when a view it is anchored to has been
@@ -258,6 +292,11 @@ impl Root {
         }
         self.text_selection.anchor = Some(endpoint.clone());
         self.text_selection.cursor = Some(endpoint);
+        self.text_selection.did_hit_text = self
+            .text_selection
+            .anchor
+            .as_ref()
+            .is_some_and(|endpoint| endpoint.inside_text);
         self.text_selection.is_selecting = true;
     }
 
@@ -281,7 +320,9 @@ impl Root {
         // matters: read the old points first, then update the cursor, then read
         // the new points.
         let old_points = self.text_selection.resolved_points(cx);
-        self.text_selection.cursor = Some(self.text_selection_endpoint(position, window, cx));
+        let endpoint = self.text_selection_endpoint(position, window, cx);
+        self.text_selection.did_hit_text |= endpoint.inside_text;
+        self.text_selection.cursor = Some(endpoint);
         let new_points = self.text_selection.resolved_points(cx);
 
         // Auto-scroll the anchor view when dragging near its viewport edges,
@@ -312,6 +353,11 @@ impl Root {
             return;
         }
         self.text_selection.is_selecting = false;
+        if !self.text_selection.did_hit_text {
+            self.text_selection.anchor = None;
+            self.text_selection.cursor = None;
+            return;
+        }
         // Only a true hit anchor (inside == true) had `is_selecting` and
         // auto-scroll set in `start_text_selection`; a proxy-anchored view
         // has nothing to tear down.
@@ -369,10 +415,15 @@ impl Root {
             best.and_then(|(view, _)| view.upgrade().map(|entity| (view, entity)))
         {
             let state = entity.read(cx);
+            let inside_text = self
+                .selectable_text_inlines
+                .get(&state.entity_id)
+                .is_some_and(|bounds| bounds.iter().any(|bounds| bounds.contains(&position)));
             return SelectionEndpoint {
                 point: position - state.bounds().origin - state.scroll_offset(),
                 view: Some(view),
                 inside: true,
+                inside_text,
             };
         }
 
@@ -413,12 +464,14 @@ impl Root {
                             point: position - state.bounds().origin - state.scroll_offset(),
                             view: Some(view),
                             inside: false,
+                            inside_text: false,
                         }
                     }
                     None => SelectionEndpoint {
                         view: None,
                         point: position,
                         inside: false,
+                        inside_text: false,
                     },
                 }
             }
@@ -426,6 +479,7 @@ impl Root {
                 view: None,
                 point: position,
                 inside: false,
+                inside_text: false,
             },
         }
     }
@@ -737,14 +791,26 @@ mod tests {
         from: gpui::Point<gpui::Pixels>,
         to: gpui::Point<gpui::Pixels>,
     ) {
+        drag_through(cx, &[from, to]);
+    }
+
+    fn drag_through(cx: &mut VisualTestContext, points: &[gpui::Point<gpui::Pixels>]) {
+        assert!(points.len() >= 2);
+        let from = points[0];
+        let to = *points.last().unwrap();
+
         cx.simulate_mouse_down(from, MouseButton::Left, Modifiers::default());
         cx.update(|window, cx| {
             let _ = window.draw(cx);
         });
-        cx.simulate_mouse_move(to, Some(MouseButton::Left), Modifiers::default());
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
+
+        for point in &points[1..] {
+            cx.simulate_mouse_move(*point, Some(MouseButton::Left), Modifiers::default());
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+        }
+
         cx.simulate_mouse_up(to, MouseButton::Left, Modifiers::default());
         cx.update(|window, cx| {
             let _ = window.draw(cx);
@@ -776,12 +842,52 @@ mod tests {
     fn drag_from_blank_space_selects_views_below(cx: &mut TestAppContext) {
         let (_, cx) = setup(true, cx);
 
-        // Start in the blank padding above the first view.
-        drag(cx, point(px(5.), px(2.)), point(px(300.), px(70.)));
+        // Start in the blank padding above the first view, enter the second
+        // view's rendered text, then drag past its end.
+        drag_through(
+            cx,
+            &[
+                point(px(5.), px(2.)),
+                point(px(20.), px(70.)),
+                point(px(300.), px(70.)),
+            ],
+        );
 
         let text = window_selected_text(cx);
         assert!(text.contains("Hello world"), "got: {text:?}");
         assert!(text.contains("Second message"), "got: {text:?}");
+    }
+
+    #[gpui::test]
+    fn drag_entirely_in_blank_gap_selects_nothing(cx: &mut TestAppContext) {
+        let (chat, cx) = setup(true, cx);
+
+        // Layout: first [10,50], gap [50,110], second [110,150].
+        chat.update(cx, |chat, cx| {
+            chat.mid_gap = px(60.);
+            cx.notify();
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        // Drag only inside the gap. The selection never enters either TextView.
+        drag(cx, point(px(5.), px(70.)), point(px(300.), px(90.)));
+
+        let text = window_selected_text(cx);
+        assert_eq!(text, "", "blank-only drag selected text: {text:?}");
+    }
+
+    #[gpui::test]
+    fn drag_entirely_in_right_gutter_selects_nothing(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        // x=300 is far to the right of the rendered text. Dragging vertically
+        // through only that blank gutter must not select nearby TextViews.
+        drag(cx, point(px(300.), px(2.)), point(px(300.), px(70.)));
+
+        let text = window_selected_text(cx);
+        assert_eq!(text, "", "right-gutter drag selected text: {text:?}");
     }
 
     #[gpui::test]
@@ -803,7 +909,14 @@ mod tests {
         // view, ending past the end of its text so the whole line is selected.
         // The anchor sits below "Hello world", so only the second view is
         // selected.
-        drag(cx, point(px(0.), px(80.)), point(px(300.), px(120.)));
+        drag_through(
+            cx,
+            &[
+                point(px(0.), px(80.)),
+                point(px(20.), px(120.)),
+                point(px(300.), px(120.)),
+            ],
+        );
         let before = window_selected_text(cx);
         assert!(
             before.contains("Second message") && !before.contains("Hello world"),
@@ -845,7 +958,14 @@ mod tests {
     fn non_selectable_view_is_excluded(cx: &mut TestAppContext) {
         let (_, cx) = setup(false, cx);
 
-        drag(cx, point(px(5.), px(2.)), point(px(300.), px(70.)));
+        drag_through(
+            cx,
+            &[
+                point(px(5.), px(2.)),
+                point(px(20.), px(15.)),
+                point(px(300.), px(15.)),
+            ],
+        );
 
         let text = window_selected_text(cx);
         assert!(text.contains("Hello world"), "got: {text:?}");


### PR DESCRIPTION
## Summary
- Track rendered Inline text bounds separately from full TextView hitboxes.
- Activate window-level TextView selection only after a drag actually touches rendered text.
- Add regression coverage for blank-gap and right-gutter drags that should not select text.

## Test Plan
- env CARGO_BUILD_RUSTC_WRAPPER= cargo test -p gpui-component