### PR TITLE
text_view: Add Markdown plugin support

### DIFF
--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -276,17 +276,19 @@ This is final paragraph, it includes a code block and a list of items.
 
 ### Custom components
 
-A custom element (a hyphenated HTML tag) registered via `TextView::element`
-is rendered as an arbitrary, interactive component. Props are passed as
-attributes. Here a `<stock-quote>` renders a stateful stock card (click the
-star to toggle the watchlist):
+A custom Markdown parser converts project-specific syntax into typed nodes,
+then registered renderers turn those nodes into arbitrary interactive
+components.
 
-<stock-quote symbol="AAPL" />
+Ticker blocks render as compact one-line quote rows:
 
-<stock-quote symbol="TSLA" />
+$AAPL.US
 
-A `<contact-card>` renders a contact card with an avatar and a follow toggle:
+$TSLA.US
 
-<contact-card id="huacnlee" />
+A `<UserCard />` block renders a user card with a 24px avatar and a follow
+button:
 
-<contact-card id="madcodelife" />
+<UserCard id="huacnlee" />
+
+<UserCard id="madcodelife" />

--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -273,3 +273,20 @@ x^3 + y^3 &= z^3
 $$
 
 This is final paragraph, it includes a code block and a list of items.
+
+### Custom components
+
+A custom element (a hyphenated HTML tag) registered via `TextView::element`
+is rendered as an arbitrary, interactive component. Props are passed as
+attributes. Here a `<stock-quote>` renders a stateful stock card (click the
+star to toggle the watchlist):
+
+<stock-quote symbol="AAPL" />
+
+<stock-quote symbol="TSLA" />
+
+A `<contact-card>` renders a contact card with an avatar and a follow toggle:
+
+<contact-card id="huacnlee" />
+
+<contact-card id="madcodelife" />

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -14,7 +14,9 @@ use gpui_component::{
     },
     resizable::{h_resizable, resizable_panel},
     status_bar::StatusBar,
-    text::{TextViewStyle, markdown},
+    text::{
+        MarkdownNode, MarkdownParseContext, MarkdownPlugin, TextViewStyle, markdown, markdown_ast,
+    },
     v_flex,
 };
 use gpui_component_assets::Assets;
@@ -30,6 +32,344 @@ const MARKERS: &[(&str, &str)] = &[
     ("HACK", "function"),
     ("NOTE", "type"),
 ];
+
+#[derive(Clone)]
+struct TickerNode {
+    symbol: String,
+}
+
+#[derive(Clone)]
+struct UserCardNode {
+    id: String,
+}
+
+#[derive(Clone, Copy)]
+struct TickerQuote {
+    name: &'static str,
+    price: f64,
+    change: f64,
+}
+
+#[derive(Clone)]
+struct TickerPlugin {
+    apple_quote: TickerQuote,
+    tesla_quote: TickerQuote,
+}
+
+impl TickerPlugin {
+    fn new(apple_quote: TickerQuote, tesla_quote: TickerQuote) -> Self {
+        Self {
+            apple_quote,
+            tesla_quote,
+        }
+    }
+
+    fn quote(&self, symbol: &str) -> TickerQuote {
+        match symbol {
+            "AAPL.US" => self.apple_quote,
+            "TSLA.US" => self.tesla_quote,
+            _ => TickerQuote {
+                name: "Unknown",
+                price: 0.0,
+                change: 0.0,
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+struct UserCardPlugin;
+
+impl UserCardPlugin {
+    fn new() -> Self {
+        Self
+    }
+}
+
+fn mdx_attr(attrs: &[markdown_ast::AttributeContent], name: &str) -> Option<String> {
+    attrs.iter().find_map(|attr| match attr {
+        markdown_ast::AttributeContent::Property(prop) if prop.name == name => {
+            match prop.value.as_ref() {
+                Some(markdown_ast::AttributeValue::Literal(value)) => Some(value.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    })
+}
+
+fn html_tag_name(value: &str) -> Option<&str> {
+    value
+        .trim()
+        .strip_prefix('<')?
+        .split([' ', '/', '>'])
+        .next()
+}
+
+fn html_attr(value: &str, name: &str) -> Option<String> {
+    let pattern = format!("{name}=\"");
+    let start = value.find(&pattern)? + pattern.len();
+    let end = value[start..].find('"')?;
+    Some(value[start..start + end].to_string())
+}
+
+fn ticker_symbol(value: &str) -> Option<&str> {
+    let symbol = value.strip_prefix('$')?;
+    if symbol.is_empty()
+        || !symbol.contains('.')
+        || !symbol
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '.')
+    {
+        return None;
+    }
+    Some(symbol)
+}
+
+fn parse_ticker_block(
+    node: &markdown_ast::Node,
+    cx: &MarkdownParseContext<'_>,
+) -> Option<MarkdownNode> {
+    let markdown_ast::Node::Paragraph(paragraph) = node else {
+        return None;
+    };
+    let [markdown_ast::Node::Text(text)] = paragraph.children.as_slice() else {
+        return None;
+    };
+    let symbol = ticker_symbol(&text.value)?;
+    Some(
+        MarkdownNode::new("ticker")
+            .with_text(format!("${symbol}"))
+            .with_markdown(cx.node_source(node).unwrap_or(text.value.as_str()))
+            .with_data(TickerNode {
+                symbol: symbol.to_string(),
+            }),
+    )
+}
+
+fn parse_user_card_block(
+    node: &markdown_ast::Node,
+    cx: &MarkdownParseContext<'_>,
+) -> Option<MarkdownNode> {
+    match node {
+        markdown_ast::Node::MdxJsxFlowElement(element)
+            if element.name.as_deref() == Some("UserCard") =>
+        {
+            let id = mdx_attr(&element.attributes, "id")?;
+            Some(
+                MarkdownNode::new("user-card")
+                    .with_text(id.clone())
+                    .with_markdown(cx.node_source(node).unwrap_or_default())
+                    .with_data(UserCardNode { id }),
+            )
+        }
+        markdown_ast::Node::Html(raw) if html_tag_name(&raw.value) == Some("UserCard") => {
+            let id = html_attr(&raw.value, "id")?;
+            Some(
+                MarkdownNode::new("user-card")
+                    .with_text(id.clone())
+                    .with_markdown(cx.node_source(node).unwrap_or(raw.value.as_str()))
+                    .with_data(UserCardNode { id }),
+            )
+        }
+        _ => None,
+    }
+}
+
+fn render_ticker_quote(
+    node: &MarkdownNode,
+    plugin: &TickerPlugin,
+    cx: &mut App,
+) -> impl IntoElement {
+    let ticker = node
+        .data::<TickerNode>()
+        .expect("ticker markdown node data");
+    let symbol = ticker.symbol.as_str();
+    let quote = plugin.quote(symbol);
+    let up = quote.change >= 0.0;
+    let trend = if up { cx.theme().green } else { cx.theme().red };
+
+    v_flex()
+        .w(px(240.))
+        .gap_1()
+        .px_3()
+        .py_2()
+        .rounded(cx.theme().radius)
+        .border_1()
+        .border_color(cx.theme().border)
+        .bg(cx.theme().background)
+        .child(
+            h_flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    v_flex()
+                        .gap_0()
+                        .child(
+                            div()
+                                .text_sm()
+                                .line_height(relative(1.))
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .child(format!("${symbol}")),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .line_height(relative(1.))
+                                .text_color(cx.theme().muted_foreground)
+                                .child(quote.name),
+                        ),
+                )
+                .child(
+                    h_flex()
+                        .items_center()
+                        .gap_0p5()
+                        .px_1()
+                        .py_0p5()
+                        .rounded(cx.theme().radius)
+                        .bg(trend.opacity(0.12))
+                        .text_xs()
+                        .line_height(relative(1.))
+                        .text_color(trend)
+                        .child(
+                            Icon::new(if up {
+                                IconName::ArrowUp
+                            } else {
+                                IconName::ArrowDown
+                            })
+                            .xsmall(),
+                        )
+                        .child(
+                            div()
+                                .font_weight(FontWeight::MEDIUM)
+                                .child(format!("{:+.1}%", quote.change)),
+                        ),
+                ),
+        )
+        .child(
+            h_flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_lg()
+                        .line_height(relative(1.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .child(format!("{:.2}", quote.price)),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .line_height(relative(1.))
+                        .text_color(cx.theme().muted_foreground)
+                        .child("Last"),
+                ),
+        )
+}
+
+fn render_user_card(node: &MarkdownNode, window: &mut Window, cx: &mut App) -> impl IntoElement {
+    let user = node
+        .data::<UserCardNode>()
+        .expect("user-card markdown node data");
+    let id = user.id.as_str();
+    let (name, avatar) = match id {
+        "huacnlee" => (
+            "Jason Lee",
+            "https://avatars.githubusercontent.com/u/5518?v=4",
+        ),
+        "madcodelife" => (
+            "Floyd Wang",
+            "https://avatars.githubusercontent.com/u/28998859?v=4",
+        ),
+        _ => ("Unknown", ""),
+    };
+
+    let following = window.use_keyed_state(
+        SharedString::from(format!("user-card-follow-{id}")),
+        cx,
+        |_, _| false,
+    );
+    let is_following = *following.read(cx);
+
+    h_flex()
+        .w(px(300.))
+        .items_center()
+        .gap_3()
+        .px_3()
+        .py_2()
+        .rounded(cx.theme().radius)
+        .border_1()
+        .border_color(cx.theme().border)
+        .child(
+            Avatar::new()
+                .name(name)
+                .with_size(px(24.))
+                .when(!avatar.is_empty(), |this| this.src(avatar)),
+        )
+        .child(
+            div()
+                .flex_1()
+                .text_sm()
+                .font_weight(FontWeight::MEDIUM)
+                .child(name),
+        )
+        .child(
+            Button::new(SharedString::from(format!("follow-{id}")))
+                .outline()
+                .small()
+                .label(if is_following { "Following" } else { "Follow" })
+                .on_click(move |_, _, cx| {
+                    following.update(cx, |v, cx| {
+                        *v = !*v;
+                        cx.notify();
+                    });
+                }),
+        )
+}
+
+impl MarkdownPlugin for TickerPlugin {
+    fn is_block(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        "ticker"
+    }
+
+    fn parse(
+        &self,
+        node: &markdown_ast::Node,
+        cx: &MarkdownParseContext<'_>,
+    ) -> Option<MarkdownNode> {
+        parse_ticker_block(node, cx)
+    }
+
+    fn render(&self, node: &MarkdownNode, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        render_ticker_quote(node, self, cx)
+    }
+}
+
+impl MarkdownPlugin for UserCardPlugin {
+    fn is_block(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        "user-card"
+    }
+
+    fn parse(
+        &self,
+        node: &markdown_ast::Node,
+        cx: &MarkdownParseContext<'_>,
+    ) -> Option<MarkdownNode> {
+        parse_user_card_block(node, cx)
+    }
+
+    fn render(&self, node: &MarkdownNode, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        render_user_card(node, window, cx)
+    }
+}
 
 /// Example [`DocumentRangeSemanticTokensProvider`]: tags `TODO` / `FIXME` /
 /// `XXX` / `HACK` / `NOTE` markers anywhere in the document, each with its
@@ -265,194 +605,19 @@ impl Render for Example {
                                                         }
                                                     })
                                             })
-                                            // Register a custom, stateful component for the
-                                            // <stock-quote symbol="…"> element. The rendered
-                                            // result can be any element (here a stock quote
-                                            // card with a watchlist toggle persisted per
-                                            // symbol via `window.use_keyed_state`).
-                                            .element("stock-quote", |el, window, cx| {
-                                                // Demo data keyed by the `symbol` prop; a real
-                                                // app would fetch a live quote here.
-                                                let symbol = el.attr("symbol").unwrap_or_default();
-                                                let (name, price, change) = match symbol {
-                                                    "AAPL" => ("Apple Inc.", 229.87, 1.24),
-                                                    "TSLA" => ("Tesla, Inc.", 412.05, -2.13),
-                                                    _ => ("—", 0.0, 0.0),
-                                                };
-                                                let up = change >= 0.0;
-                                                let trend = if up {
-                                                    cx.theme().green
-                                                } else {
-                                                    cx.theme().red
-                                                };
-
-                                                let starred = window.use_keyed_state(
-                                                    SharedString::from(format!(
-                                                        "quote-star-{symbol}"
-                                                    )),
-                                                    cx,
-                                                    |_, _| false,
-                                                );
-                                                let is_starred = *starred.read(cx);
-
-                                                h_flex()
-                                                    .w(px(300.))
-                                                    .justify_between()
-                                                    .items_center()
-                                                    .gap_4()
-                                                    .px_4()
-                                                    .py_3()
-                                                    .rounded(cx.theme().radius_lg)
-                                                    .border_1()
-                                                    .border_color(cx.theme().border)
-                                                    .child(
-                                                        v_flex()
-                                                            .gap_1()
-                                                            .child(
-                                                                h_flex()
-                                                                    .items_center()
-                                                                    .gap_2()
-                                                                    .child(
-                                                                        div()
-                                                                            .font_weight(
-                                                                                FontWeight::SEMIBOLD,
-                                                                            )
-                                                                            .child(symbol.to_string()),
-                                                                    )
-                                                                    .child(
-                                                                        div()
-                                                                            .text_xs()
-                                                                            .text_color(
-                                                                                cx.theme()
-                                                                                    .muted_foreground,
-                                                                            )
-                                                                            .child(name),
-                                                                    ),
-                                                            )
-                                                            .child(
-                                                                div()
-                                                                    .text_xl()
-                                                                    .font_weight(
-                                                                        FontWeight::SEMIBOLD,
-                                                                    )
-                                                                    .child(format!("${price:.2}")),
-                                                            ),
-                                                    )
-                                                    .child(
-                                                        v_flex()
-                                                            .gap_2()
-                                                            .items_end()
-                                                            .child(
-                                                                Button::new(SharedString::from(
-                                                                    format!("star-{symbol}"),
-                                                                ))
-                                                                .ghost()
-                                                                .xsmall()
-                                                                .icon(if is_starred {
-                                                                    IconName::StarFill
-                                                                } else {
-                                                                    IconName::Star
-                                                                })
-                                                                .on_click(move |_, _, cx| {
-                                                                    starred.update(cx, |v, cx| {
-                                                                        *v = !*v;
-                                                                        cx.notify();
-                                                                    });
-                                                                }),
-                                                            )
-                                                            .child(
-                                                                h_flex()
-                                                                    .items_center()
-                                                                    .gap_1()
-                                                                    .text_color(trend)
-                                                                    .child(
-                                                                        Icon::new(if up {
-                                                                            IconName::ArrowUp
-                                                                        } else {
-                                                                            IconName::ArrowDown
-                                                                        })
-                                                                        .xsmall(),
-                                                                    )
-                                                                    .child(
-                                                                        div()
-                                                                            .text_sm()
-                                                                            .font_weight(
-                                                                                FontWeight::MEDIUM,
-                                                                            )
-                                                                            .child(format!(
-                                                                                "{change:+.2}%"
-                                                                            )),
-                                                                    ),
-                                                            ),
-                                                    )
-                                            })
-                                            // Another custom component: a <contact-card id="…">
-                                            // element renders a contact card with an `Avatar`
-                                            // and a follow toggle persisted per id.
-                                            .element("contact-card", |el, window, cx| {
-                                                let id = el.attr("id").unwrap_or_default();
-                                                let (name, avatar) = match id {
-                                                    "huacnlee" => (
-                                                        "Jason Lee",
-                                                        "https://avatars.githubusercontent.com/u/5518?v=4",
-                                                    ),
-                                                    "madcodelife" => (
-                                                        "Floyd Wang",
-                                                        "https://avatars.githubusercontent.com/u/28998859?v=4",
-                                                    ),
-                                                    _ => ("Unknown", ""),
-                                                };
-
-                                                let following = window.use_keyed_state(
-                                                    SharedString::from(format!(
-                                                        "contact-follow-{id}"
-                                                    )),
-                                                    cx,
-                                                    |_, _| false,
-                                                );
-                                                let is_following = *following.read(cx);
-
-                                                h_flex()
-                                                    .w(px(300.))
-                                                    .items_center()
-                                                    .gap_3()
-                                                    .px_4()
-                                                    .py_3()
-                                                    .rounded(cx.theme().radius_lg)
-                                                    .border_1()
-                                                    .border_color(cx.theme().border)
-                                                    .child(
-                                                        Avatar::new().name(name).large().when(
-                                                            !avatar.is_empty(),
-                                                            |this| this.src(avatar),
-                                                        ),
-                                                    )
-                                                    .child(
-                                                        div()
-                                                            .flex_1()
-                                                            .font_weight(FontWeight::SEMIBOLD)
-                                                            .child(name),
-                                                    )
-                                                    .child(
-                                                        Button::new(SharedString::from(format!(
-                                                            "follow-{id}"
-                                                        )))
-                                                        .xsmall()
-                                                        .map(|this| {
-                                                            if is_following {
-                                                                this.outline().label("Following")
-                                                            } else {
-                                                                this.primary().label("Follow")
-                                                            }
-                                                        })
-                                                        .on_click(move |_, _, cx| {
-                                                            following.update(cx, |v, cx| {
-                                                                *v = !*v;
-                                                                cx.notify();
-                                                            });
-                                                        }),
-                                                    )
-                                            })
+                                            .plugin(TickerPlugin::new(
+                                                TickerQuote {
+                                                    name: "Apple Inc.",
+                                                    price: 300.21,
+                                                    change: 5.2,
+                                                },
+                                                TickerQuote {
+                                                    name: "Tesla, Inc.",
+                                                    price: 412.05,
+                                                    change: -2.13,
+                                                },
+                                            ))
+                                            .plugin(UserCardPlugin::new())
                                             // Tables scroll horizontally by default; the
                                             // status bar toggle switches to wrapping.
                                             .style(self.text_view_style())

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -191,7 +191,7 @@ fn render_ticker_quote(
 
     v_flex()
         .w(px(240.))
-        .gap_1()
+        .gap_1p5()
         .px_3()
         .py_2()
         .rounded(cx.theme().radius)
@@ -204,7 +204,7 @@ fn render_ticker_quote(
                 .justify_between()
                 .child(
                     v_flex()
-                        .gap_0()
+                        .gap_1()
                         .child(
                             div()
                                 .text_sm()

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -126,207 +126,6 @@ fn ticker_symbol(value: &str) -> Option<&str> {
     Some(symbol)
 }
 
-fn parse_ticker_block(
-    node: &markdown_ast::Node,
-    cx: &MarkdownParseContext<'_>,
-) -> Option<MarkdownNode> {
-    let markdown_ast::Node::Paragraph(paragraph) = node else {
-        return None;
-    };
-    let [markdown_ast::Node::Text(text)] = paragraph.children.as_slice() else {
-        return None;
-    };
-    let symbol = ticker_symbol(&text.value)?;
-    Some(
-        MarkdownNode::new("ticker")
-            .with_text(format!("${symbol}"))
-            .with_markdown(cx.node_source(node).unwrap_or(text.value.as_str()))
-            .with_data(TickerNode {
-                symbol: symbol.to_string(),
-            }),
-    )
-}
-
-fn parse_user_card_block(
-    node: &markdown_ast::Node,
-    cx: &MarkdownParseContext<'_>,
-) -> Option<MarkdownNode> {
-    match node {
-        markdown_ast::Node::MdxJsxFlowElement(element)
-            if element.name.as_deref() == Some("UserCard") =>
-        {
-            let id = mdx_attr(&element.attributes, "id")?;
-            Some(
-                MarkdownNode::new("user-card")
-                    .with_text(id.clone())
-                    .with_markdown(cx.node_source(node).unwrap_or_default())
-                    .with_data(UserCardNode { id }),
-            )
-        }
-        markdown_ast::Node::Html(raw) if html_tag_name(&raw.value) == Some("UserCard") => {
-            let id = html_attr(&raw.value, "id")?;
-            Some(
-                MarkdownNode::new("user-card")
-                    .with_text(id.clone())
-                    .with_markdown(cx.node_source(node).unwrap_or(raw.value.as_str()))
-                    .with_data(UserCardNode { id }),
-            )
-        }
-        _ => None,
-    }
-}
-
-fn render_ticker_quote(
-    node: &MarkdownNode,
-    plugin: &TickerPlugin,
-    cx: &mut App,
-) -> impl IntoElement {
-    let ticker = node
-        .data::<TickerNode>()
-        .expect("ticker markdown node data");
-    let symbol = ticker.symbol.as_str();
-    let quote = plugin.quote(symbol);
-    let up = quote.change >= 0.0;
-    let trend = if up { cx.theme().green } else { cx.theme().red };
-
-    v_flex()
-        .w(px(240.))
-        .gap_1p5()
-        .px_3()
-        .py_2()
-        .rounded(cx.theme().radius)
-        .border_1()
-        .border_color(cx.theme().border)
-        .bg(cx.theme().background)
-        .child(
-            h_flex()
-                .items_center()
-                .justify_between()
-                .child(
-                    v_flex()
-                        .gap_1()
-                        .child(
-                            div()
-                                .text_sm()
-                                .line_height(relative(1.))
-                                .font_weight(FontWeight::SEMIBOLD)
-                                .child(format!("${symbol}")),
-                        )
-                        .child(
-                            div()
-                                .text_xs()
-                                .line_height(relative(1.))
-                                .text_color(cx.theme().muted_foreground)
-                                .child(quote.name),
-                        ),
-                )
-                .child(
-                    h_flex()
-                        .items_center()
-                        .gap_0p5()
-                        .px_1()
-                        .py_0p5()
-                        .rounded(cx.theme().radius)
-                        .bg(trend.opacity(0.12))
-                        .text_xs()
-                        .line_height(relative(1.))
-                        .text_color(trend)
-                        .child(
-                            Icon::new(if up {
-                                IconName::ArrowUp
-                            } else {
-                                IconName::ArrowDown
-                            })
-                            .xsmall(),
-                        )
-                        .child(
-                            div()
-                                .font_weight(FontWeight::MEDIUM)
-                                .child(format!("{:+.1}%", quote.change)),
-                        ),
-                ),
-        )
-        .child(
-            h_flex()
-                .items_center()
-                .justify_between()
-                .child(
-                    div()
-                        .text_lg()
-                        .line_height(relative(1.))
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child(format!("{:.2}", quote.price)),
-                )
-                .child(
-                    div()
-                        .text_xs()
-                        .line_height(relative(1.))
-                        .text_color(cx.theme().muted_foreground)
-                        .child("Last"),
-                ),
-        )
-}
-
-fn render_user_card(node: &MarkdownNode, window: &mut Window, cx: &mut App) -> impl IntoElement {
-    let user = node
-        .data::<UserCardNode>()
-        .expect("user-card markdown node data");
-    let id = user.id.as_str();
-    let (name, avatar) = match id {
-        "huacnlee" => (
-            "Jason Lee",
-            "https://avatars.githubusercontent.com/u/5518?v=4",
-        ),
-        "madcodelife" => (
-            "Floyd Wang",
-            "https://avatars.githubusercontent.com/u/28998859?v=4",
-        ),
-        _ => ("Unknown", ""),
-    };
-
-    let following = window.use_keyed_state(
-        SharedString::from(format!("user-card-follow-{id}")),
-        cx,
-        |_, _| false,
-    );
-    let is_following = *following.read(cx);
-
-    h_flex()
-        .w(px(300.))
-        .items_center()
-        .gap_3()
-        .px_3()
-        .py_2()
-        .rounded(cx.theme().radius)
-        .border_1()
-        .border_color(cx.theme().border)
-        .child(
-            Avatar::new()
-                .name(name)
-                .with_size(px(24.))
-                .when(!avatar.is_empty(), |this| this.src(avatar)),
-        )
-        .child(
-            div()
-                .flex_1()
-                .text_sm()
-                .font_weight(FontWeight::MEDIUM)
-                .child(name),
-        )
-        .child(
-            Button::new(SharedString::from(format!("follow-{id}")))
-                .outline()
-                .small()
-                .label(if is_following { "Following" } else { "Follow" })
-                .on_click(move |_, _, cx| {
-                    following.update(cx, |v, cx| {
-                        *v = !*v;
-                        cx.notify();
-                    });
-                }),
-        )
-}
-
 impl MarkdownPlugin for TickerPlugin {
     fn is_block(&self) -> bool {
         true
@@ -341,11 +140,108 @@ impl MarkdownPlugin for TickerPlugin {
         node: &markdown_ast::Node,
         cx: &MarkdownParseContext<'_>,
     ) -> Option<MarkdownNode> {
-        parse_ticker_block(node, cx)
+        let markdown_ast::Node::Paragraph(paragraph) = node else {
+            return None;
+        };
+        let [markdown_ast::Node::Text(text)] = paragraph.children.as_slice() else {
+            return None;
+        };
+        let symbol = ticker_symbol(&text.value)?;
+        Some(
+            MarkdownNode::new("ticker")
+                .with_text(format!("${symbol}"))
+                .with_markdown(cx.node_source(node).unwrap_or(text.value.as_str()))
+                .with_data(TickerNode {
+                    symbol: symbol.to_string(),
+                }),
+        )
     }
 
     fn render(&self, node: &MarkdownNode, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        render_ticker_quote(node, self, cx)
+        let ticker = node
+            .data::<TickerNode>()
+            .expect("ticker markdown node data");
+        let symbol = ticker.symbol.as_str();
+        let quote = self.quote(symbol);
+        let up = quote.change >= 0.0;
+        let trend = if up { cx.theme().green } else { cx.theme().red };
+
+        v_flex()
+            .w(px(240.))
+            .gap_1p5()
+            .px_3()
+            .py_2()
+            .rounded(cx.theme().radius)
+            .border_1()
+            .border_color(cx.theme().border)
+            .bg(cx.theme().background)
+            .child(
+                h_flex()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        v_flex()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .line_height(relative(1.))
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .child(format!("${symbol}")),
+                            )
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .line_height(relative(1.))
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(quote.name),
+                            ),
+                    )
+                    .child(
+                        h_flex()
+                            .items_center()
+                            .gap_0p5()
+                            .px_1()
+                            .py_0p5()
+                            .rounded(cx.theme().radius)
+                            .bg(trend.opacity(0.12))
+                            .text_xs()
+                            .line_height(relative(1.))
+                            .text_color(trend)
+                            .child(
+                                Icon::new(if up {
+                                    IconName::ArrowUp
+                                } else {
+                                    IconName::ArrowDown
+                                })
+                                .xsmall(),
+                            )
+                            .child(
+                                div()
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .child(format!("{:+.1}%", quote.change)),
+                            ),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_lg()
+                            .line_height(relative(1.))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(format!("{:.2}", quote.price)),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .line_height(relative(1.))
+                            .text_color(cx.theme().muted_foreground)
+                            .child("Last"),
+                    ),
+            )
     }
 }
 
@@ -363,11 +259,89 @@ impl MarkdownPlugin for UserCardPlugin {
         node: &markdown_ast::Node,
         cx: &MarkdownParseContext<'_>,
     ) -> Option<MarkdownNode> {
-        parse_user_card_block(node, cx)
+        match node {
+            markdown_ast::Node::MdxJsxFlowElement(element)
+                if element.name.as_deref() == Some("UserCard") =>
+            {
+                let id = mdx_attr(&element.attributes, "id")?;
+                Some(
+                    MarkdownNode::new("user-card")
+                        .with_text(id.clone())
+                        .with_markdown(cx.node_source(node).unwrap_or_default())
+                        .with_data(UserCardNode { id }),
+                )
+            }
+            markdown_ast::Node::Html(raw) if html_tag_name(&raw.value) == Some("UserCard") => {
+                let id = html_attr(&raw.value, "id")?;
+                Some(
+                    MarkdownNode::new("user-card")
+                        .with_text(id.clone())
+                        .with_markdown(cx.node_source(node).unwrap_or(raw.value.as_str()))
+                        .with_data(UserCardNode { id }),
+                )
+            }
+            _ => None,
+        }
     }
 
     fn render(&self, node: &MarkdownNode, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        render_user_card(node, window, cx)
+        let user = node
+            .data::<UserCardNode>()
+            .expect("user-card markdown node data");
+        let id = user.id.as_str();
+        let (name, avatar) = match id {
+            "huacnlee" => (
+                "Jason Lee",
+                "https://avatars.githubusercontent.com/u/5518?v=4",
+            ),
+            "madcodelife" => (
+                "Floyd Wang",
+                "https://avatars.githubusercontent.com/u/28998859?v=4",
+            ),
+            _ => ("Unknown", ""),
+        };
+
+        let following = window.use_keyed_state(
+            SharedString::from(format!("user-card-follow-{id}")),
+            cx,
+            |_, _| false,
+        );
+        let is_following = *following.read(cx);
+
+        h_flex()
+            .w(px(300.))
+            .items_center()
+            .gap_3()
+            .px_3()
+            .py_2()
+            .rounded(cx.theme().radius)
+            .border_1()
+            .border_color(cx.theme().border)
+            .child(
+                Avatar::new()
+                    .name(name)
+                    .with_size(px(24.))
+                    .when(!avatar.is_empty(), |this| this.src(avatar)),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .text_sm()
+                    .font_weight(FontWeight::MEDIUM)
+                    .child(name),
+            )
+            .child(
+                Button::new(SharedString::from(format!("follow-{id}")))
+                    .outline()
+                    .small()
+                    .label(if is_following { "Following" } else { "Follow" })
+                    .on_click(move |_, _, cx| {
+                        following.update(cx, |v, cx| {
+                            *v = !*v;
+                            cx.notify();
+                        });
+                    }),
+            )
     }
 }
 

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -148,12 +148,14 @@ impl MarkdownPlugin for TickerPlugin {
         };
         let symbol = ticker_symbol(&text.value)?;
         Some(
-            MarkdownNode::new("ticker")
-                .with_text(format!("${symbol}"))
-                .with_markdown(cx.node_source(node).unwrap_or(text.value.as_str()))
-                .with_data(TickerNode {
+            MarkdownNode::new(
+                "ticker",
+                TickerNode {
                     symbol: symbol.to_string(),
-                }),
+                },
+            )
+            .text(format!("${symbol}"))
+            .markdown(cx.node_source(node).unwrap_or(text.value.as_str())),
         )
     }
 
@@ -265,19 +267,17 @@ impl MarkdownPlugin for UserCardPlugin {
             {
                 let id = mdx_attr(&element.attributes, "id")?;
                 Some(
-                    MarkdownNode::new("user-card")
-                        .with_text(id.clone())
-                        .with_markdown(cx.node_source(node).unwrap_or_default())
-                        .with_data(UserCardNode { id }),
+                    MarkdownNode::new("user-card", UserCardNode { id: id.clone() })
+                        .text(id)
+                        .markdown(cx.node_source(node).unwrap_or_default()),
                 )
             }
             markdown_ast::Node::Html(raw) if html_tag_name(&raw.value) == Some("UserCard") => {
                 let id = html_attr(&raw.value, "id")?;
                 Some(
-                    MarkdownNode::new("user-card")
-                        .with_text(id.clone())
-                        .with_markdown(cx.node_source(node).unwrap_or(raw.value.as_str()))
-                        .with_data(UserCardNode { id }),
+                    MarkdownNode::new("user-card", UserCardNode { id: id.clone() })
+                        .text(id)
+                        .markdown(cx.node_source(node).unwrap_or(raw.value.as_str())),
                 )
             }
             _ => None,

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -3,7 +3,8 @@ use std::rc::Rc;
 
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme as _, IconName, Sizable as _,
+    ActiveTheme as _, Icon, IconName, Sizable as _,
+    avatar::Avatar,
     button::{Button, ButtonVariants as _},
     clipboard::Clipboard,
     h_flex,
@@ -263,6 +264,194 @@ impl Render for Example {
                                                             this
                                                         }
                                                     })
+                                            })
+                                            // Register a custom, stateful component for the
+                                            // <stock-quote symbol="…"> element. The rendered
+                                            // result can be any element (here a stock quote
+                                            // card with a watchlist toggle persisted per
+                                            // symbol via `window.use_keyed_state`).
+                                            .element("stock-quote", |el, window, cx| {
+                                                // Demo data keyed by the `symbol` prop; a real
+                                                // app would fetch a live quote here.
+                                                let symbol = el.attr("symbol").unwrap_or_default();
+                                                let (name, price, change) = match symbol {
+                                                    "AAPL" => ("Apple Inc.", 229.87, 1.24),
+                                                    "TSLA" => ("Tesla, Inc.", 412.05, -2.13),
+                                                    _ => ("—", 0.0, 0.0),
+                                                };
+                                                let up = change >= 0.0;
+                                                let trend = if up {
+                                                    cx.theme().green
+                                                } else {
+                                                    cx.theme().red
+                                                };
+
+                                                let starred = window.use_keyed_state(
+                                                    SharedString::from(format!(
+                                                        "quote-star-{symbol}"
+                                                    )),
+                                                    cx,
+                                                    |_, _| false,
+                                                );
+                                                let is_starred = *starred.read(cx);
+
+                                                h_flex()
+                                                    .w(px(300.))
+                                                    .justify_between()
+                                                    .items_center()
+                                                    .gap_4()
+                                                    .px_4()
+                                                    .py_3()
+                                                    .rounded(cx.theme().radius_lg)
+                                                    .border_1()
+                                                    .border_color(cx.theme().border)
+                                                    .child(
+                                                        v_flex()
+                                                            .gap_1()
+                                                            .child(
+                                                                h_flex()
+                                                                    .items_center()
+                                                                    .gap_2()
+                                                                    .child(
+                                                                        div()
+                                                                            .font_weight(
+                                                                                FontWeight::SEMIBOLD,
+                                                                            )
+                                                                            .child(symbol.to_string()),
+                                                                    )
+                                                                    .child(
+                                                                        div()
+                                                                            .text_xs()
+                                                                            .text_color(
+                                                                                cx.theme()
+                                                                                    .muted_foreground,
+                                                                            )
+                                                                            .child(name),
+                                                                    ),
+                                                            )
+                                                            .child(
+                                                                div()
+                                                                    .text_xl()
+                                                                    .font_weight(
+                                                                        FontWeight::SEMIBOLD,
+                                                                    )
+                                                                    .child(format!("${price:.2}")),
+                                                            ),
+                                                    )
+                                                    .child(
+                                                        v_flex()
+                                                            .gap_2()
+                                                            .items_end()
+                                                            .child(
+                                                                Button::new(SharedString::from(
+                                                                    format!("star-{symbol}"),
+                                                                ))
+                                                                .ghost()
+                                                                .xsmall()
+                                                                .icon(if is_starred {
+                                                                    IconName::StarFill
+                                                                } else {
+                                                                    IconName::Star
+                                                                })
+                                                                .on_click(move |_, _, cx| {
+                                                                    starred.update(cx, |v, cx| {
+                                                                        *v = !*v;
+                                                                        cx.notify();
+                                                                    });
+                                                                }),
+                                                            )
+                                                            .child(
+                                                                h_flex()
+                                                                    .items_center()
+                                                                    .gap_1()
+                                                                    .text_color(trend)
+                                                                    .child(
+                                                                        Icon::new(if up {
+                                                                            IconName::ArrowUp
+                                                                        } else {
+                                                                            IconName::ArrowDown
+                                                                        })
+                                                                        .xsmall(),
+                                                                    )
+                                                                    .child(
+                                                                        div()
+                                                                            .text_sm()
+                                                                            .font_weight(
+                                                                                FontWeight::MEDIUM,
+                                                                            )
+                                                                            .child(format!(
+                                                                                "{change:+.2}%"
+                                                                            )),
+                                                                    ),
+                                                            ),
+                                                    )
+                                            })
+                                            // Another custom component: a <contact-card id="…">
+                                            // element renders a contact card with an `Avatar`
+                                            // and a follow toggle persisted per id.
+                                            .element("contact-card", |el, window, cx| {
+                                                let id = el.attr("id").unwrap_or_default();
+                                                let (name, avatar) = match id {
+                                                    "huacnlee" => (
+                                                        "Jason Lee",
+                                                        "https://avatars.githubusercontent.com/u/5518?v=4",
+                                                    ),
+                                                    "madcodelife" => (
+                                                        "Floyd Wang",
+                                                        "https://avatars.githubusercontent.com/u/28998859?v=4",
+                                                    ),
+                                                    _ => ("Unknown", ""),
+                                                };
+
+                                                let following = window.use_keyed_state(
+                                                    SharedString::from(format!(
+                                                        "contact-follow-{id}"
+                                                    )),
+                                                    cx,
+                                                    |_, _| false,
+                                                );
+                                                let is_following = *following.read(cx);
+
+                                                h_flex()
+                                                    .w(px(300.))
+                                                    .items_center()
+                                                    .gap_3()
+                                                    .px_4()
+                                                    .py_3()
+                                                    .rounded(cx.theme().radius_lg)
+                                                    .border_1()
+                                                    .border_color(cx.theme().border)
+                                                    .child(
+                                                        Avatar::new().name(name).large().when(
+                                                            !avatar.is_empty(),
+                                                            |this| this.src(avatar),
+                                                        ),
+                                                    )
+                                                    .child(
+                                                        div()
+                                                            .flex_1()
+                                                            .font_weight(FontWeight::SEMIBOLD)
+                                                            .child(name),
+                                                    )
+                                                    .child(
+                                                        Button::new(SharedString::from(format!(
+                                                            "follow-{id}"
+                                                        )))
+                                                        .xsmall()
+                                                        .map(|this| {
+                                                            if is_following {
+                                                                this.outline().label("Following")
+                                                            } else {
+                                                                this.primary().label("Follow")
+                                                            }
+                                                        })
+                                                        .on_click(move |_, _, cx| {
+                                                            following.update(cx, |v, cx| {
+                                                                *v = !*v;
+                                                                cx.notify();
+                                                            });
+                                                        }),
+                                                    )
                                             })
                                             // Tables scroll horizontally by default; the
                                             // status bar toggle switches to wrapping.

--- a/crates/ui/src/text/format/html.rs
+++ b/crates/ui/src/text/format/html.rs
@@ -10,8 +10,8 @@ use markup5ever_rcdom::{Node, NodeData, RcDom};
 
 use crate::text::document::ParsedDocument;
 use crate::text::node::{
-    self, BlockNode, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph, Table, TableRow,
-    TextMark,
+    self, BlockNode, CustomElement, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph, Table,
+    TableRow, TextMark,
 };
 
 const BLOCK_ELEMENTS: [&str; 35] = [
@@ -99,6 +99,19 @@ fn attr_value(attrs: &RefCell<Vec<html5ever::Attribute>>, name: LocalName) -> Op
             None
         }
     })
+}
+
+/// Recursively collect the raw text content of an element's descendants.
+fn element_text(node: &Rc<Node>) -> String {
+    let mut text = String::new();
+    for child in node.children.borrow().iter() {
+        match &child.data {
+            NodeData::Text { contents } => text.push_str(&contents.borrow()),
+            NodeData::Element { .. } => text.push_str(&element_text(child)),
+            _ => {}
+        }
+    }
+    text
 }
 
 /// Get style properties to HashMap
@@ -233,18 +246,23 @@ fn trim_text(text: &str) -> String {
     out
 }
 
-fn parse_paragraph(
-    paragraph: &mut Paragraph,
-    node: &Rc<Node>,
-) {
-    fn push_merged(paragraph: &mut Paragraph, text: String, marks: Vec<(Range<usize>, TextMark)>, new_mark: Option<TextMark>) {
+fn parse_paragraph(paragraph: &mut Paragraph, node: &Rc<Node>) {
+    fn push_merged(
+        paragraph: &mut Paragraph,
+        text: String,
+        marks: Vec<(Range<usize>, TextMark)>,
+        new_mark: Option<TextMark>,
+    ) {
         if text.is_empty() {
             return;
         }
         let mut node = InlineNode::new(text).marks(marks);
         if let Some(new_mark) = new_mark {
             let len = node.text.len();
-            if let Some(last) = node.marks.last_mut() && last.0.start == 0 && last.0.end == len {
+            if let Some(last) = node.marks.last_mut()
+                && last.0.start == 0
+                && last.0.end == len
+            {
                 last.1.merge(new_mark);
             } else {
                 node.marks.push((0..node.text.len(), new_mark));
@@ -253,7 +271,11 @@ fn parse_paragraph(
         paragraph.push(node);
     }
 
-    fn merge_children_with_mark(node: &Node, paragraph: &mut Paragraph, new_mark: Option<TextMark>) {
+    fn merge_children_with_mark(
+        node: &Node,
+        paragraph: &mut Paragraph,
+        new_mark: Option<TextMark>,
+    ) {
         let mut merged_text = String::new();
         let mut merged_marks = Vec::new();
 
@@ -265,7 +287,7 @@ fn parse_paragraph(
                 let offset = merged_text.len();
                 merged_text.push_str(&node.text);
                 for (range, child_mark) in node.marks {
-                    merged_marks.push((range.start+offset .. range.end+offset, child_mark));
+                    merged_marks.push((range.start + offset..range.end + offset, child_mark));
                 }
 
                 if let Some(mut image) = node.image {
@@ -273,8 +295,12 @@ fn parse_paragraph(
                         image.link = Some(link_mark);
                     }
 
-                    push_merged(paragraph, std::mem::take(&mut merged_text),
-                        std::mem::take(&mut merged_marks), new_mark.clone());
+                    push_merged(
+                        paragraph,
+                        std::mem::take(&mut merged_text),
+                        std::mem::take(&mut merged_marks),
+                        new_mark.clone(),
+                    );
 
                     paragraph.push(InlineNode::image(image));
                 }
@@ -297,7 +323,11 @@ fn parse_paragraph(
                 merge_children_with_mark(node, paragraph, Some(TextMark::default().bold()));
             }
             local_name!("del") | local_name!("s") => {
-                merge_children_with_mark(node, paragraph, Some(TextMark::default().strikethrough()));
+                merge_children_with_mark(
+                    node,
+                    paragraph,
+                    Some(TextMark::default().strikethrough()),
+                );
             }
             local_name!("u") => {
                 merge_children_with_mark(node, paragraph, Some(TextMark::default().underline()));
@@ -314,7 +344,11 @@ fn parse_paragraph(
                     ..Default::default()
                 };
 
-                merge_children_with_mark(node, paragraph, Some(TextMark::default().link(link_mark)));
+                merge_children_with_mark(
+                    node,
+                    paragraph,
+                    Some(TextMark::default().link(link_mark)),
+                );
             }
             local_name!("img") => {
                 let Some(src) = attr_value(attrs, local_name!("src")) else {
@@ -524,6 +558,40 @@ fn parse_node(
                 })
             }
             local_name!("style") | local_name!("script") => None,
+            _ if name.local.contains('-') => {
+                // Custom element (W3C convention: tag name contains a hyphen).
+                // Capture tag name, attributes (props) and raw inner text; the
+                // renderer registered via `TextView::element` dispatches by name.
+                let mut children = vec![];
+                consume_paragraph(&mut children, paragraph);
+
+                let attributes = attrs
+                    .borrow()
+                    .iter()
+                    .map(|attr| {
+                        (
+                            SharedString::from(attr.name.local.to_string()),
+                            SharedString::from(attr.value.to_string()),
+                        )
+                    })
+                    .collect();
+                let custom = BlockNode::Custom(CustomElement::new(
+                    name.local.to_string(),
+                    attributes,
+                    element_text(node),
+                    None,
+                ));
+
+                if children.is_empty() {
+                    Some(custom)
+                } else {
+                    children.push(custom);
+                    Some(BlockNode::Root {
+                        children,
+                        span: None,
+                    })
+                }
+            }
             _ => {
                 if BLOCK_ELEMENTS.contains(&name.local.trim()) {
                     let mut children: Vec<BlockNode> = vec![];

--- a/crates/ui/src/text/format/html.rs
+++ b/crates/ui/src/text/format/html.rs
@@ -10,8 +10,8 @@ use markup5ever_rcdom::{Node, NodeData, RcDom};
 
 use crate::text::document::ParsedDocument;
 use crate::text::node::{
-    self, BlockNode, CustomElement, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph, Table,
-    TableRow, TextMark,
+    self, BlockNode, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph, Table, TableRow,
+    TextMark,
 };
 
 const BLOCK_ELEMENTS: [&str; 35] = [
@@ -99,19 +99,6 @@ fn attr_value(attrs: &RefCell<Vec<html5ever::Attribute>>, name: LocalName) -> Op
             None
         }
     })
-}
-
-/// Recursively collect the raw text content of an element's descendants.
-fn element_text(node: &Rc<Node>) -> String {
-    let mut text = String::new();
-    for child in node.children.borrow().iter() {
-        match &child.data {
-            NodeData::Text { contents } => text.push_str(&contents.borrow()),
-            NodeData::Element { .. } => text.push_str(&element_text(child)),
-            _ => {}
-        }
-    }
-    text
 }
 
 /// Get style properties to HashMap
@@ -558,40 +545,6 @@ fn parse_node(
                 })
             }
             local_name!("style") | local_name!("script") => None,
-            _ if name.local.contains('-') => {
-                // Custom element (W3C convention: tag name contains a hyphen).
-                // Capture tag name, attributes (props) and raw inner text; the
-                // renderer registered via `TextView::element` dispatches by name.
-                let mut children = vec![];
-                consume_paragraph(&mut children, paragraph);
-
-                let attributes = attrs
-                    .borrow()
-                    .iter()
-                    .map(|attr| {
-                        (
-                            SharedString::from(attr.name.local.to_string()),
-                            SharedString::from(attr.value.to_string()),
-                        )
-                    })
-                    .collect();
-                let custom = BlockNode::Custom(CustomElement::new(
-                    name.local.to_string(),
-                    attributes,
-                    element_text(node),
-                    None,
-                ));
-
-                if children.is_empty() {
-                    Some(custom)
-                } else {
-                    children.push(custom);
-                    Some(BlockNode::Root {
-                        children,
-                        span: None,
-                    })
-                }
-            }
             _ => {
                 if BLOCK_ELEMENTS.contains(&name.local.trim()) {
                     let mut children: Vec<BlockNode> = vec![];

--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -1,15 +1,13 @@
 use std::ops::Range;
 
 use gpui::SharedString;
-use markdown::{
-    ParseOptions,
-    mdast::{self, Node},
-};
+use markdown::mdast::{self, Node};
 
 use crate::{
     highlighter::HighlightTheme,
     text::{
         document::ParsedDocument,
+        markdown_ext::MarkdownParseContext,
         node::{
             self, BlockNode, CodeBlock, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph,
             Span, Table, TableRow, TextMark,
@@ -25,7 +23,8 @@ pub(crate) fn parse(
     cx: &mut NodeContext,
     highlight_theme: &HighlightTheme,
 ) -> Result<ParsedDocument, SharedString> {
-    markdown::to_mdast(&source, &ParseOptions::gfm())
+    let options = cx.markdown_extensions.parse_options();
+    markdown::to_mdast(&source, &options)
         .map(|n| ast_to_document(source, n, cx, highlight_theme))
         .map_err(|e| e.to_string().into())
 }
@@ -169,12 +168,8 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
             );
         }
         Node::Strong(val) => {
-            text = merge_children_with_mark(
-                paragraph,
-                &val.children,
-                TextMark::default().bold(),
-                cx,
-            );
+            text =
+                merge_children_with_mark(paragraph, &val.children, TextMark::default().bold(), cx);
         }
         Node::Delete(val) => {
             text = merge_children_with_mark(
@@ -301,7 +296,7 @@ fn ast_to_document(
     let blocks = root
         .children
         .into_iter()
-        .map(|c| ast_to_node(c, cx, highlight_theme))
+        .map(|c| ast_to_node(source, c, cx, highlight_theme))
         .collect();
     ParsedDocument {
         source: source.to_string().into(),
@@ -319,10 +314,18 @@ fn new_span(pos: Option<markdown::unist::Position>, cx: &NodeContext) -> Option<
 }
 
 fn ast_to_node(
+    source: &str,
     value: mdast::Node,
     cx: &mut NodeContext,
     highlight_theme: &HighlightTheme,
 ) -> BlockNode {
+    let span = new_span(value.position().cloned(), cx);
+    let parse_cx = MarkdownParseContext::new(source, cx.offset);
+    if let Some(mut node) = cx.markdown_extensions.parse_block(&value, &parse_cx) {
+        node.set_span(span);
+        return BlockNode::Custom(node);
+    }
+
     match value {
         Node::Root(_) => unreachable!("node::Root should be handled separately"),
         Node::Paragraph(val) => {
@@ -337,7 +340,7 @@ fn ast_to_node(
             let children = val
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx, highlight_theme))
                 .collect();
             BlockNode::Blockquote {
                 children,
@@ -348,7 +351,7 @@ fn ast_to_node(
             let children = list
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx, highlight_theme))
                 .collect();
             BlockNode::List {
                 ordered: list.ordered,
@@ -360,7 +363,7 @@ fn ast_to_node(
             let children = val
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx, highlight_theme))
                 .collect();
             BlockNode::ListItem {
                 children,
@@ -510,6 +513,9 @@ fn ast_to_node(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::ParentElement;
+
+    use crate::text::{MarkdownExtensions, MarkdownNode, MarkdownPlugin};
 
     #[test]
     fn test_nested_emphasis_merges_text_marks() {
@@ -537,6 +543,109 @@ mod tests {
                 .iter()
                 .any(|(_, mark)| mark.bold && mark.italic),
             "nested emphasis should produce a bold and italic mark"
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Ticker {
+        symbol: String,
+    }
+
+    fn parse_ticker_block(node: &Node, cx: &MarkdownParseContext<'_>) -> Option<MarkdownNode> {
+        let Node::Paragraph(paragraph) = node else {
+            return None;
+        };
+        let [Node::Text(text)] = paragraph.children.as_slice() else {
+            return None;
+        };
+        let symbol = text.value.strip_prefix('$')?.to_string();
+
+        Some(
+            MarkdownNode::new("ticker")
+                .with_text(format!("${symbol}"))
+                .with_markdown(cx.node_source(node).unwrap_or_default())
+                .with_data(Ticker { symbol }),
+        )
+    }
+
+    #[test]
+    fn custom_block_parser_converts_ticker_syntax_to_custom_node() {
+        let extensions = MarkdownExtensions::default().block_parser(parse_ticker_block);
+
+        let mut cx = NodeContext {
+            markdown_extensions: extensions.into(),
+            ..NodeContext::default()
+        };
+        let document = parse("$TSLA.US", &mut cx, &HighlightTheme::default_light()).unwrap();
+
+        let BlockNode::Custom(node) = &document.blocks[0] else {
+            panic!("expected custom markdown node");
+        };
+        assert_eq!(node.name(), "ticker");
+        assert_eq!(node.text(), "$TSLA.US");
+        assert_eq!(node.markdown(), "$TSLA.US");
+        assert_eq!(
+            node.data::<Ticker>(),
+            Some(&Ticker {
+                symbol: "TSLA.US".to_string()
+            })
+        );
+        assert_eq!(document.text(), "$TSLA.US\n");
+        assert_eq!(document.to_markdown(), "$TSLA.US");
+    }
+
+    struct TickerPlugin {
+        name: &'static str,
+    }
+
+    impl TickerPlugin {
+        fn new(name: &'static str) -> Self {
+            Self { name }
+        }
+    }
+
+    impl MarkdownPlugin for TickerPlugin {
+        fn is_block(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn parse(&self, node: &Node, cx: &MarkdownParseContext<'_>) -> Option<MarkdownNode> {
+            parse_ticker_block(node, cx)
+        }
+
+        fn render(
+            &self,
+            node: &MarkdownNode,
+            _window: &mut gpui::Window,
+            _cx: &mut gpui::App,
+        ) -> impl gpui::IntoElement {
+            gpui::div().child(node.text().to_string())
+        }
+    }
+
+    #[test]
+    fn custom_block_plugin_registers_parser_and_renderer() {
+        let extensions = MarkdownExtensions::default().plugin(TickerPlugin::new("ticker"));
+
+        let mut cx = NodeContext {
+            markdown_extensions: extensions.into(),
+            ..NodeContext::default()
+        };
+        let document = parse("$TSLA.US", &mut cx, &HighlightTheme::default_light()).unwrap();
+
+        let BlockNode::Custom(node) = &document.blocks[0] else {
+            panic!("expected custom markdown node");
+        };
+        assert_eq!(node.name(), "ticker");
+        assert_eq!(
+            node.data::<Ticker>(),
+            Some(&Ticker {
+                symbol: "TSLA.US".to_string()
+            })
         );
     }
 }

--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -559,12 +559,12 @@ mod tests {
             return None;
         };
         let symbol = text.value.strip_prefix('$')?.to_string();
+        let node_text = format!("${symbol}");
 
         Some(
-            MarkdownNode::new("ticker")
-                .with_text(format!("${symbol}"))
-                .with_markdown(cx.node_source(node).unwrap_or_default())
-                .with_data(Ticker { symbol }),
+            MarkdownNode::new("ticker", Ticker { symbol })
+                .text(node_text)
+                .markdown(cx.node_source(node).unwrap_or_default()),
         )
     }
 
@@ -582,8 +582,8 @@ mod tests {
             panic!("expected custom markdown node");
         };
         assert_eq!(node.name(), "ticker");
-        assert_eq!(node.text(), "$TSLA.US");
-        assert_eq!(node.markdown(), "$TSLA.US");
+        assert_eq!(node.as_text(), "$TSLA.US");
+        assert_eq!(node.as_markdown(), "$TSLA.US");
         assert_eq!(
             node.data::<Ticker>(),
             Some(&Ticker {
@@ -623,7 +623,7 @@ mod tests {
             _window: &mut gpui::Window,
             _cx: &mut gpui::App,
         ) -> impl gpui::IntoElement {
-            gpui::div().child(node.text().to_string())
+            gpui::div().child(node.as_text().to_string())
         }
     }
 

--- a/crates/ui/src/text/markdown_ext.rs
+++ b/crates/ui/src/text/markdown_ext.rs
@@ -90,13 +90,16 @@ pub struct MarkdownNode {
 }
 
 impl MarkdownNode {
-    /// Create a custom Markdown node with a stable name.
-    pub fn new(name: impl Into<SharedString>) -> Self {
+    /// Create a custom Markdown node with a stable name and typed data.
+    pub fn new<T>(name: impl Into<SharedString>, data: T) -> Self
+    where
+        T: Any + Send + Sync + 'static,
+    {
         Self {
             name: name.into(),
             text: SharedString::default(),
             markdown: SharedString::default(),
-            data: Arc::new(()),
+            data: Arc::new(data),
             span: None,
         }
     }
@@ -106,39 +109,29 @@ impl MarkdownNode {
         &self.name
     }
 
-    /// Text used for copy/select-all and fallback rendering.
-    pub fn text(&self) -> &str {
+    /// Text representation of this custom node.
+    pub fn as_text(&self) -> &str {
         &self.text
     }
 
-    /// Markdown used when converting the parsed document back to Markdown.
-    pub fn markdown(&self) -> &str {
+    /// Markdown representation of this custom node.
+    pub fn as_markdown(&self) -> &str {
         &self.markdown
     }
 
-    /// Attach text used for copy/select-all and fallback rendering.
-    pub fn with_text(mut self, text: impl Into<SharedString>) -> Self {
+    /// Set the text representation of this custom node.
+    pub fn text(mut self, text: impl Into<SharedString>) -> Self {
         self.text = text.into();
         self
     }
 
-    /// Attach Markdown used when converting the parsed document back to
-    /// Markdown.
-    pub fn with_markdown(mut self, markdown: impl Into<SharedString>) -> Self {
+    /// Set the Markdown representation of this custom node.
+    pub fn markdown(mut self, markdown: impl Into<SharedString>) -> Self {
         self.markdown = markdown.into();
         self
     }
 
-    /// Attach typed data produced by the parser and consumed by the renderer.
-    pub fn with_data<T>(mut self, data: T) -> Self
-    where
-        T: Any + Send + Sync + 'static,
-    {
-        self.data = Arc::new(data);
-        self
-    }
-
-    /// Read typed data attached by the parser.
+    /// Read typed data.
     pub fn data<T>(&self) -> Option<&T>
     where
         T: Any + Send + Sync + 'static,

--- a/crates/ui/src/text/markdown_ext.rs
+++ b/crates/ui/src/text/markdown_ext.rs
@@ -1,0 +1,312 @@
+use std::{
+    any::Any,
+    collections::HashMap,
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use gpui::{AnyElement, App, IntoElement, SharedString, Window};
+use markdown::{ParseOptions, mdast};
+
+use crate::text::node::Span;
+
+static MARKDOWN_EXTENSIONS_REVISION: AtomicU64 = AtomicU64::new(1);
+
+/// Re-export of the Markdown AST types used by custom parsers.
+pub use markdown::mdast as markdown_ast;
+
+/// Type for a custom Markdown block parser.
+///
+/// Parsers run during Markdown AST conversion, often on a background task. They
+/// must not depend on [`Window`] or [`App`]; return parsed, reusable data in a
+/// [`MarkdownNode`] and render it later with a block renderer.
+pub type MarkdownBlockParserFn =
+    dyn for<'a> Fn(&mdast::Node, &MarkdownParseContext<'a>) -> Option<MarkdownNode> + Send + Sync;
+
+/// Type for a custom Markdown block renderer.
+pub type MarkdownBlockRenderFn =
+    dyn Fn(&MarkdownNode, &mut Window, &mut App) -> AnyElement + Send + Sync;
+
+/// A reusable Markdown extension that parses and renders one custom node.
+pub trait MarkdownPlugin: Send + Sync + 'static {
+    /// Whether this plugin produces block-level nodes.
+    ///
+    /// Plugins are inline by default. TextView does not support inline custom
+    /// Markdown rendering yet, so block plugins should return `true`.
+    fn is_block(&self) -> bool {
+        false
+    }
+
+    /// Stable name for nodes produced by this plugin.
+    fn name(&self) -> &str;
+
+    /// Convert an mdast node into a custom Markdown node.
+    fn parse(&self, node: &mdast::Node, cx: &MarkdownParseContext<'_>) -> Option<MarkdownNode>;
+
+    /// Render a custom Markdown node produced by this plugin.
+    fn render(&self, node: &MarkdownNode, window: &mut Window, cx: &mut App) -> impl IntoElement;
+}
+
+/// Context passed to custom Markdown parsers.
+pub struct MarkdownParseContext<'a> {
+    source: &'a str,
+    offset: usize,
+}
+
+impl<'a> MarkdownParseContext<'a> {
+    pub(crate) fn new(source: &'a str, offset: usize) -> Self {
+        Self { source, offset }
+    }
+
+    /// Source text for the Markdown fragment currently being parsed.
+    pub fn source(&self) -> &'a str {
+        self.source
+    }
+
+    /// Byte offset of `source` in the full document when parsing an appended
+    /// fragment.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Source slice for a specific mdast node.
+    pub fn node_source(&self, node: &mdast::Node) -> Option<&'a str> {
+        let position = node.position()?;
+        self.source.get(position.start.offset..position.end.offset)
+    }
+}
+
+/// A custom Markdown node produced by [`MarkdownExtensions`].
+#[derive(Clone)]
+pub struct MarkdownNode {
+    name: SharedString,
+    text: SharedString,
+    markdown: SharedString,
+    data: Arc<dyn Any + Send + Sync>,
+    pub(crate) span: Option<Span>,
+}
+
+impl MarkdownNode {
+    /// Create a custom Markdown node with a stable name.
+    pub fn new(name: impl Into<SharedString>) -> Self {
+        Self {
+            name: name.into(),
+            text: SharedString::default(),
+            markdown: SharedString::default(),
+            data: Arc::new(()),
+            span: None,
+        }
+    }
+
+    /// Stable name for this custom node.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Text used for copy/select-all and fallback rendering.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Markdown used when converting the parsed document back to Markdown.
+    pub fn markdown(&self) -> &str {
+        &self.markdown
+    }
+
+    /// Attach text used for copy/select-all and fallback rendering.
+    pub fn with_text(mut self, text: impl Into<SharedString>) -> Self {
+        self.text = text.into();
+        self
+    }
+
+    /// Attach Markdown used when converting the parsed document back to
+    /// Markdown.
+    pub fn with_markdown(mut self, markdown: impl Into<SharedString>) -> Self {
+        self.markdown = markdown.into();
+        self
+    }
+
+    /// Attach typed data produced by the parser and consumed by the renderer.
+    pub fn with_data<T>(mut self, data: T) -> Self
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        self.data = Arc::new(data);
+        self
+    }
+
+    /// Read typed data attached by the parser.
+    pub fn data<T>(&self) -> Option<&T>
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        self.data.downcast_ref()
+    }
+
+    pub(crate) fn set_span(&mut self, span: Option<Span>) {
+        self.span = span;
+    }
+
+    pub(crate) fn to_markdown(&self) -> String {
+        if self.markdown.is_empty() {
+            self.text.to_string()
+        } else {
+            self.markdown.to_string()
+        }
+    }
+}
+
+impl fmt::Debug for MarkdownNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MarkdownNode")
+            .field("name", &self.name)
+            .field("text", &self.text)
+            .field("markdown", &self.markdown)
+            .field("span", &self.span)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for MarkdownNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.text == other.text
+            && self.markdown == other.markdown
+            && self.span == other.span
+    }
+}
+
+/// Registry for custom Markdown parsing and rendering.
+#[derive(Clone, Default)]
+pub struct MarkdownExtensions {
+    enable_mdx: bool,
+    block_parsers: Vec<Arc<MarkdownBlockParserFn>>,
+    block_renderers: HashMap<SharedString, Arc<MarkdownBlockRenderFn>>,
+    revision: u64,
+}
+
+impl MarkdownExtensions {
+    /// Enable MDX JSX/expression constructs.
+    ///
+    /// This disables raw HTML constructs because `markdown-rs` gives HTML
+    /// priority over MDX when both are enabled.
+    pub fn mdx(mut self) -> Self {
+        self.enable_mdx = true;
+        self.bump_revision();
+        self
+    }
+
+    /// Register a parser for block-level Markdown AST nodes.
+    pub fn block_parser<F>(mut self, parser: F) -> Self
+    where
+        F: for<'a> Fn(&mdast::Node, &MarkdownParseContext<'a>) -> Option<MarkdownNode>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.push_block_parser(parser);
+        self
+    }
+
+    /// Register a renderer for a custom block node name.
+    pub fn block_renderer<F, E>(mut self, name: impl Into<SharedString>, renderer: F) -> Self
+    where
+        F: Fn(&MarkdownNode, &mut Window, &mut App) -> E + Send + Sync + 'static,
+        E: IntoElement,
+    {
+        self.push_block_renderer(name, renderer);
+        self
+    }
+
+    /// Apply a reusable Markdown plugin.
+    pub fn plugin<P>(self, plugin: P) -> Self
+    where
+        P: MarkdownPlugin,
+    {
+        let plugin = Arc::new(plugin);
+        let name = SharedString::from(plugin.name().to_string());
+        let parser = plugin.clone();
+        let renderer = plugin;
+
+        if parser.is_block() {
+            let mut extensions = self.block_parser(move |node, cx| parser.parse(node, cx));
+            extensions.push_block_renderer(name, move |node, window, cx| {
+                renderer.render(node, window, cx).into_any_element()
+            });
+            extensions
+        } else {
+            panic!("inline Markdown plugins are not supported by TextView yet")
+        }
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub(crate) fn push_block_parser<F>(&mut self, parser: F)
+    where
+        F: for<'a> Fn(&mdast::Node, &MarkdownParseContext<'a>) -> Option<MarkdownNode>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.block_parsers.push(Arc::new(parser));
+        self.bump_revision();
+    }
+
+    pub(crate) fn push_block_renderer<F, E>(&mut self, name: impl Into<SharedString>, renderer: F)
+    where
+        F: Fn(&MarkdownNode, &mut Window, &mut App) -> E + Send + Sync + 'static,
+        E: IntoElement,
+    {
+        self.block_renderers.insert(
+            name.into(),
+            Arc::new(move |node, window, cx| renderer(node, window, cx).into_any_element()),
+        );
+        self.bump_revision();
+    }
+
+    pub(crate) fn parse_options(&self) -> ParseOptions {
+        let mut options = ParseOptions::gfm();
+        if self.enable_mdx {
+            options.constructs.html_flow = false;
+            options.constructs.html_text = false;
+            options.constructs.mdx_expression_flow = true;
+            options.constructs.mdx_expression_text = true;
+            options.constructs.mdx_jsx_flow = true;
+            options.constructs.mdx_jsx_text = true;
+        }
+        options
+    }
+
+    pub(crate) fn parse_block(
+        &self,
+        node: &mdast::Node,
+        cx: &MarkdownParseContext<'_>,
+    ) -> Option<MarkdownNode> {
+        for parser in &self.block_parsers {
+            if let Some(node) = parser(node, cx) {
+                return Some(node);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn render_block(
+        &self,
+        node: &MarkdownNode,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        self.block_renderers
+            .get(node.name())
+            .map(|render| render(node, window, cx))
+    }
+
+    fn bump_revision(&mut self) {
+        self.revision = MARKDOWN_EXTENSIONS_REVISION.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/crates/ui/src/text/mod.rs
+++ b/crates/ui/src/text/mod.rs
@@ -1,6 +1,7 @@
 mod document;
 mod format;
 mod inline;
+mod markdown_ext;
 mod node;
 pub(crate) mod selection;
 mod state;
@@ -10,6 +11,7 @@ mod utils;
 mod window_selection;
 
 use gpui::{App, ElementId, IntoElement, RenderOnce, SharedString, Window};
+pub use markdown_ext::*;
 pub use state::*;
 pub use style::*;
 pub use text_view::*;

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -211,7 +211,7 @@ impl BlockNode {
             }
             BlockNode::Custom(node) => {
                 if let BlockTextKind::All = kind {
-                    let content = node.text();
+                    let content = node.as_text();
                     if !content.is_empty() {
                         text.push_str(content);
                         text.push('\n');
@@ -1578,7 +1578,7 @@ impl BlockNode {
             BlockNode::Custom(node) => {
                 let inner = match node_cx.markdown_extensions.render_block(node, window, cx) {
                     Some(rendered) => rendered,
-                    None => div().child(node.text().to_string()).into_any_element(),
+                    None => div().child(node.as_text().to_string()).into_any_element(),
                 };
 
                 div().pb(mb).child(inner).into_any_element()

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -20,7 +20,7 @@ use crate::{
     input::{InputEdit, Point, RopeExt as _},
     scroll::horizontal_scroll_area,
     text::{
-        CodeBlockActionsFn, ElementRenderFn,
+        CodeBlockActionsFn, MarkdownExtensions, MarkdownNode,
         document::NodeRenderOptions,
         inline::{Inline, InlineState},
     },
@@ -67,9 +67,8 @@ pub(crate) enum BlockNode {
         span: Option<Span>,
     },
     CodeBlock(CodeBlock),
-    /// A custom element parsed from a hyphenated HTML tag, rendered by a
-    /// closure registered via [`TextView::element`](crate::text::TextView::element).
-    Custom(CustomElement),
+    /// A custom Markdown node produced by [`MarkdownExtensions`].
+    Custom(MarkdownNode),
     Table(Table),
     Break {
         html: bool,
@@ -210,11 +209,9 @@ impl BlockNode {
                     text.push('\n');
                 }
             }
-            BlockNode::Custom(el) => {
-                // Custom elements have no selectable inline text; only contribute
-                // their raw content to full-text extraction (e.g. copy / to_markdown).
+            BlockNode::Custom(node) => {
                 if let BlockTextKind::All = kind {
-                    let content = el.content();
+                    let content = node.text();
                     if !content.is_empty() {
                         text.push_str(content);
                         text.push('\n');
@@ -760,73 +757,6 @@ impl CodeBlock {
     }
 }
 
-/// A custom element parsed from a hyphenated HTML tag in the source
-/// (e.g. `<stock-quote symbol="AAPL"></stock-quote>`).
-///
-/// Rendered by a closure registered via [`TextView::element`], looked up by
-/// [`name`](Self::name). Unregistered elements fall back to their text content.
-///
-/// [`TextView::element`]: crate::text::TextView::element
-#[derive(Debug, Clone, PartialEq)]
-pub struct CustomElement {
-    name: SharedString,
-    attrs: Vec<(SharedString, SharedString)>,
-    content: SharedString,
-    pub(crate) span: Option<Span>,
-}
-
-impl CustomElement {
-    pub(crate) fn new(
-        name: impl Into<SharedString>,
-        attrs: Vec<(SharedString, SharedString)>,
-        content: impl Into<SharedString>,
-        span: Option<Span>,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            attrs,
-            content: content.into(),
-            span,
-        }
-    }
-
-    /// The tag name, e.g. `"stock-quote"`.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Get an attribute (prop) value by name.
-    pub fn attr(&self, name: &str) -> Option<&str> {
-        self.attrs
-            .iter()
-            .find(|(key, _)| key == name)
-            .map(|(_, value)| value.as_ref())
-    }
-
-    /// All attributes (props) in source order.
-    pub fn attrs(&self) -> &[(SharedString, SharedString)] {
-        &self.attrs
-    }
-
-    /// The raw inner text content of the element.
-    pub fn content(&self) -> &str {
-        &self.content
-    }
-
-    fn to_markdown(&self) -> String {
-        let attrs = self
-            .attrs
-            .iter()
-            .map(|(key, value)| {
-                // Escape so values containing `&` or `"` round-trip as valid markup.
-                let value = value.replace('&', "&amp;").replace('"', "&quot;");
-                format!(" {}=\"{}\"", key, value)
-            })
-            .collect::<String>();
-        format!("<{name}{attrs}>{}</{name}>", self.content, name = self.name)
-    }
-}
-
 /// A context for rendering nodes, contains link references.
 #[derive(Default, Clone)]
 pub(crate) struct NodeContext {
@@ -836,7 +766,7 @@ pub(crate) struct NodeContext {
     pub(crate) link_refs: HashMap<SharedString, LinkMark>,
     pub(crate) style: TextViewStyle,
     pub(crate) code_block_actions: Option<Arc<CodeBlockActionsFn>>,
-    pub(crate) elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
+    pub(crate) markdown_extensions: Arc<MarkdownExtensions>,
 }
 
 impl NodeContext {
@@ -848,8 +778,8 @@ impl NodeContext {
 impl PartialEq for NodeContext {
     fn eq(&self, other: &Self) -> bool {
         self.link_refs == other.link_refs && self.style == other.style
-        // Note: code_block_actions and elements are intentionally not compared
-        // (closures can't be compared)
+        // Note: code_block_actions and markdown_extensions are intentionally
+        // not compared (closures can't be compared)
     }
 }
 
@@ -1146,7 +1076,7 @@ impl BlockNode {
                 }
             }
             BlockNode::HorizontalRule { .. } => "---".to_string(),
-            BlockNode::Custom(el) => el.to_markdown(),
+            BlockNode::Custom(node) => node.to_markdown(),
             BlockNode::Definition {
                 identifier,
                 url,
@@ -1645,12 +1575,10 @@ impl BlockNode {
                 })
                 .into_any_element(),
             BlockNode::CodeBlock(code_block) => code_block.render(&options, node_cx, window, cx),
-            BlockNode::Custom(el) => {
-                // Dispatch to a renderer registered by tag name; unregistered
-                // custom elements fall back to their raw text content.
-                let inner = match node_cx.elements.get(el.name()) {
-                    Some(render) => render(el, window, cx),
-                    None => div().child(el.content().to_string()).into_any_element(),
+            BlockNode::Custom(node) => {
+                let inner = match node_cx.markdown_extensions.render_block(node, window, cx) {
+                    Some(rendered) => rendered,
+                    None => div().child(node.text().to_string()).into_any_element(),
                 };
 
                 div().pb(mb).child(inner).into_any_element()

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -20,7 +20,7 @@ use crate::{
     input::{InputEdit, Point, RopeExt as _},
     scroll::horizontal_scroll_area,
     text::{
-        CodeBlockActionsFn,
+        CodeBlockActionsFn, ElementRenderFn,
         document::NodeRenderOptions,
         inline::{Inline, InlineState},
     },
@@ -67,6 +67,9 @@ pub(crate) enum BlockNode {
         span: Option<Span>,
     },
     CodeBlock(CodeBlock),
+    /// A custom element parsed from a hyphenated HTML tag, rendered by a
+    /// closure registered via [`TextView::element`](crate::text::TextView::element).
+    Custom(CustomElement),
     Table(Table),
     Break {
         html: bool,
@@ -118,6 +121,7 @@ impl BlockNode {
             BlockNode::List { span, .. } => *span,
             BlockNode::ListItem { span, .. } => *span,
             BlockNode::CodeBlock(code_block) => code_block.span,
+            BlockNode::Custom(el) => el.span,
             BlockNode::Table(table) => table.span,
             BlockNode::Break { span, .. } => *span,
             BlockNode::HorizontalRule { span, .. } => *span,
@@ -206,6 +210,17 @@ impl BlockNode {
                     text.push('\n');
                 }
             }
+            BlockNode::Custom(el) => {
+                // Custom elements have no selectable inline text; only contribute
+                // their raw content to full-text extraction (e.g. copy / to_markdown).
+                if let BlockTextKind::All = kind {
+                    let content = el.content();
+                    if !content.is_empty() {
+                        text.push_str(content);
+                        text.push('\n');
+                    }
+                }
+            }
             BlockNode::Definition { .. }
             | BlockNode::Break { .. }
             | BlockNode::HorizontalRule { .. }
@@ -248,7 +263,8 @@ impl BlockNode {
                 }
             }
             BlockNode::CodeBlock(code_block) => code_block.clear_selection(),
-            BlockNode::Definition { .. }
+            BlockNode::Custom { .. }
+            | BlockNode::Definition { .. }
             | BlockNode::Break { .. }
             | BlockNode::HorizontalRule { .. }
             | BlockNode::Unknown { .. } => {}
@@ -744,6 +760,73 @@ impl CodeBlock {
     }
 }
 
+/// A custom element parsed from a hyphenated HTML tag in the source
+/// (e.g. `<stock-quote symbol="AAPL"></stock-quote>`).
+///
+/// Rendered by a closure registered via [`TextView::element`], looked up by
+/// [`name`](Self::name). Unregistered elements fall back to their text content.
+///
+/// [`TextView::element`]: crate::text::TextView::element
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomElement {
+    name: SharedString,
+    attrs: Vec<(SharedString, SharedString)>,
+    content: SharedString,
+    pub(crate) span: Option<Span>,
+}
+
+impl CustomElement {
+    pub(crate) fn new(
+        name: impl Into<SharedString>,
+        attrs: Vec<(SharedString, SharedString)>,
+        content: impl Into<SharedString>,
+        span: Option<Span>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            attrs,
+            content: content.into(),
+            span,
+        }
+    }
+
+    /// The tag name, e.g. `"stock-quote"`.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get an attribute (prop) value by name.
+    pub fn attr(&self, name: &str) -> Option<&str> {
+        self.attrs
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_ref())
+    }
+
+    /// All attributes (props) in source order.
+    pub fn attrs(&self) -> &[(SharedString, SharedString)] {
+        &self.attrs
+    }
+
+    /// The raw inner text content of the element.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    fn to_markdown(&self) -> String {
+        let attrs = self
+            .attrs
+            .iter()
+            .map(|(key, value)| {
+                // Escape so values containing `&` or `"` round-trip as valid markup.
+                let value = value.replace('&', "&amp;").replace('"', "&quot;");
+                format!(" {}=\"{}\"", key, value)
+            })
+            .collect::<String>();
+        format!("<{name}{attrs}>{}</{name}>", self.content, name = self.name)
+    }
+}
+
 /// A context for rendering nodes, contains link references.
 #[derive(Default, Clone)]
 pub(crate) struct NodeContext {
@@ -753,6 +836,7 @@ pub(crate) struct NodeContext {
     pub(crate) link_refs: HashMap<SharedString, LinkMark>,
     pub(crate) style: TextViewStyle,
     pub(crate) code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    pub(crate) elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
 }
 
 impl NodeContext {
@@ -764,7 +848,8 @@ impl NodeContext {
 impl PartialEq for NodeContext {
     fn eq(&self, other: &Self) -> bool {
         self.link_refs == other.link_refs && self.style == other.style
-        // Note: code_block_buttons is intentionally not compared (closures can't be compared)
+        // Note: code_block_actions and elements are intentionally not compared
+        // (closures can't be compared)
     }
 }
 
@@ -1061,6 +1146,7 @@ impl BlockNode {
                 }
             }
             BlockNode::HorizontalRule { .. } => "---".to_string(),
+            BlockNode::Custom(el) => el.to_markdown(),
             BlockNode::Definition {
                 identifier,
                 url,
@@ -1559,6 +1645,16 @@ impl BlockNode {
                 })
                 .into_any_element(),
             BlockNode::CodeBlock(code_block) => code_block.render(&options, node_cx, window, cx),
+            BlockNode::Custom(el) => {
+                // Dispatch to a renderer registered by tag name; unregistered
+                // custom elements fall back to their raw text content.
+                let inner = match node_cx.elements.get(el.name()) {
+                    Some(render) => render(el, window, cx),
+                    None => div().child(el.content().to_string()).into_any_element(),
+                };
+
+                div().pb(mb).child(inner).into_any_element()
+            }
             BlockNode::Table { .. } => {
                 Self::render_table(self, &options, node_cx, window, cx).into_any_element()
             }

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -1,5 +1,5 @@
 use futures::Stream as _;
-use std::{pin::Pin, task::Poll};
+use std::{collections::HashMap, pin::Pin, sync::Arc, task::Poll};
 
 use gpui::{
     App, AppContext as _, Bounds, Context, FocusHandle, IntoElement, KeyBinding, ListState,
@@ -14,7 +14,7 @@ use crate::{
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
-        CodeBlockActionsFn, TextViewStyle,
+        CodeBlockActionsFn, ElementRenderFn, TextViewStyle,
         document::ParsedDocument,
         format,
         node::{self, NodeContext},
@@ -58,6 +58,7 @@ pub struct TextViewState {
     pub(super) scrollable: bool,
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
+    pub(super) elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
 
     pub(super) is_selecting: bool,
     multi_click_selection: Option<TextViewMultiClickSelection>,
@@ -137,6 +138,7 @@ impl TextViewState {
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)).measure_all(),
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
+            elements: Arc::default(),
             is_selecting: false,
             auto_scroll: AutoScroll::default(),
             parsed_content: Default::default(),
@@ -413,6 +415,7 @@ impl Render for TextViewState {
         let mut node_cx = self.parsed_content.node_cx.clone();
 
         node_cx.code_block_actions = self.code_block_actions.clone();
+        node_cx.elements = self.elements.clone();
         node_cx.style = self.text_view_style.clone();
 
         v_flex()

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -1,5 +1,5 @@
 use futures::Stream as _;
-use std::{collections::HashMap, pin::Pin, sync::Arc, task::Poll};
+use std::{pin::Pin, sync::Arc, task::Poll};
 
 use gpui::{
     App, AppContext as _, Bounds, Context, FocusHandle, IntoElement, KeyBinding, ListState,
@@ -14,7 +14,7 @@ use crate::{
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
-        CodeBlockActionsFn, ElementRenderFn, TextViewStyle,
+        CodeBlockActionsFn, MarkdownExtensions, TextViewStyle,
         document::ParsedDocument,
         format,
         node::{self, NodeContext},
@@ -58,7 +58,7 @@ pub struct TextViewState {
     pub(super) scrollable: bool,
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
-    pub(super) elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
+    pub(super) markdown_extensions: Arc<MarkdownExtensions>,
 
     pub(super) is_selecting: bool,
     multi_click_selection: Option<TextViewMultiClickSelection>,
@@ -138,7 +138,7 @@ impl TextViewState {
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)).measure_all(),
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
-            elements: Arc::default(),
+            markdown_extensions: Arc::default(),
             is_selecting: false,
             auto_scroll: AutoScroll::default(),
             parsed_content: Default::default(),
@@ -206,6 +206,22 @@ impl TextViewState {
         self.increment_update(new_text, true, cx);
     }
 
+    pub(crate) fn set_markdown_extensions(
+        &mut self,
+        markdown_extensions: Arc<MarkdownExtensions>,
+        cx: &mut Context<Self>,
+    ) {
+        if self.markdown_extensions.revision() == markdown_extensions.revision() {
+            return;
+        }
+
+        self.markdown_extensions = markdown_extensions;
+        if self.format == TextViewFormat::Markdown {
+            let text = self.text.clone();
+            self.increment_update(&text, false, cx);
+        }
+    }
+
     /// Return the selected text.
     pub fn selected_text(&self) -> String {
         if self.select_all {
@@ -224,6 +240,7 @@ impl TextViewState {
             append,
             pending_text: text.to_string(),
             highlight_theme: cx.theme().highlight_theme.clone(),
+            markdown_extensions: self.markdown_extensions.clone(),
         };
 
         // Full-replace updates (initial content / `set_text`) parse
@@ -415,7 +432,7 @@ impl Render for TextViewState {
         let mut node_cx = self.parsed_content.node_cx.clone();
 
         node_cx.code_block_actions = self.code_block_actions.clone();
-        node_cx.elements = self.elements.clone();
+        node_cx.markdown_extensions = self.markdown_extensions.clone();
         node_cx.style = self.text_view_style.clone();
 
         v_flex()
@@ -485,6 +502,7 @@ impl UpdateFuture {
                 append: false,
                 pending_text: String::new(),
                 highlight_theme: cx.theme().highlight_theme.clone(),
+                markdown_extensions: Arc::default(),
             },
             rx: Box::pin(rx),
             tx_result,
@@ -531,6 +549,7 @@ struct UpdateOptions {
     pending_text: String,
     append: bool,
     highlight_theme: std::sync::Arc<HighlightTheme>,
+    markdown_extensions: Arc<MarkdownExtensions>,
 }
 
 fn parse_content(
@@ -539,6 +558,7 @@ fn parse_content(
     options: &UpdateOptions,
 ) -> Result<ParsedContent, SharedString> {
     let mut node_cx = NodeContext {
+        markdown_extensions: options.markdown_extensions.clone(),
         ..NodeContext::default()
     };
 
@@ -576,6 +596,7 @@ fn parse_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::text::MarkdownNode;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -629,6 +650,43 @@ mod tests {
         state.read_with(cx, |state, _| {
             assert!(!state.has_view_selection());
             assert_eq!(state.selected_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    fn set_markdown_extensions_reparses_existing_text(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let state = cx.update(|cx| cx.new(|cx| TextViewState::markdown("$TSLA.US", cx)));
+        cx.run_until_parked();
+
+        let extensions = MarkdownExtensions::default().block_parser(|node, cx| {
+            let markdown::mdast::Node::Paragraph(paragraph) = node else {
+                return None;
+            };
+            let [markdown::mdast::Node::Text(text)] = paragraph.children.as_slice() else {
+                return None;
+            };
+            let symbol = text.value.strip_prefix('$')?.to_string();
+
+            Some(
+                MarkdownNode::new("ticker")
+                    .with_text(format!("${symbol}"))
+                    .with_markdown(cx.node_source(node).unwrap_or_default())
+                    .with_data(symbol),
+            )
+        });
+
+        state.update(cx, |state, cx| {
+            state.set_markdown_extensions(Arc::new(extensions), cx);
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |state, _| {
+            let node::BlockNode::Custom(node) = &state.parsed_content.document.blocks[0] else {
+                panic!("expected custom markdown node");
+            };
+            assert_eq!(node.name(), "ticker");
+            assert_eq!(node.data::<String>().map(String::as_str), Some("TSLA.US"));
         });
     }
 }

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -667,12 +667,12 @@ mod tests {
                 return None;
             };
             let symbol = text.value.strip_prefix('$')?.to_string();
+            let node_text = format!("${symbol}");
 
             Some(
-                MarkdownNode::new("ticker")
-                    .with_text(format!("${symbol}"))
-                    .with_markdown(cx.node_source(node).unwrap_or_default())
-                    .with_data(symbol),
+                MarkdownNode::new("ticker", symbol)
+                    .text(node_text)
+                    .markdown(cx.node_source(node).unwrap_or_default()),
             )
         });
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use gpui::prelude::FluentBuilder as _;
@@ -11,21 +10,14 @@ use gpui::{
 use crate::StyledExt;
 use crate::scroll::ScrollableElement;
 use crate::text::TextViewFormat;
-use crate::text::node::{CodeBlock, CustomElement};
+use crate::text::markdown_ext::{MarkdownExtensions, MarkdownNode, MarkdownPlugin};
+use crate::text::node::CodeBlock;
 use crate::text::state::TextViewState;
 use crate::{global_state::GlobalState, text::TextViewStyle};
 
 /// Type for code block actions generator function.
 pub(crate) type CodeBlockActionsFn =
     dyn Fn(&CodeBlock, &mut Window, &mut App) -> AnyElement + Send + Sync;
-
-/// Type for a custom element renderer function.
-///
-/// Registered per custom element tag name. Receives the parsed
-/// [`CustomElement`] (tag name, attributes, raw content) and returns an element
-/// to render in place of the default rendering.
-pub(crate) type ElementRenderFn =
-    dyn Fn(&CustomElement, &mut Window, &mut App) -> AnyElement + Send + Sync;
 
 /// A text view that can render Markdown or HTML.
 ///
@@ -54,7 +46,24 @@ pub struct TextView {
     selectable: bool,
     scrollable: bool,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
-    elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
+    markdown_extensions: Arc<MarkdownExtensions>,
+}
+
+/// A plugin that can configure a [`TextView`].
+pub trait TextViewPlugin {
+    fn setup(self, text_view: TextView) -> TextView;
+}
+
+impl<P> TextViewPlugin for P
+where
+    P: MarkdownPlugin,
+{
+    fn setup(self, mut text_view: TextView) -> TextView {
+        let extensions = Arc::make_mut(&mut text_view.markdown_extensions);
+        let current = std::mem::take(extensions);
+        *extensions = current.plugin(self);
+        text_view
+    }
 }
 
 impl Styled for TextView {
@@ -76,7 +85,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
-            elements: Arc::default(),
+            markdown_extensions: Arc::default(),
         }
     }
 
@@ -92,7 +101,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
-            elements: Arc::default(),
+            markdown_extensions: Arc::default(),
         }
     }
 
@@ -108,7 +117,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
-            elements: Arc::default(),
+            markdown_extensions: Arc::default(),
         }
     }
 
@@ -156,49 +165,61 @@ impl TextView {
         self
     }
 
-    /// Register a renderer for a custom element, keyed by its tag `name`.
+    /// Replace the Markdown extension registry.
+    pub fn markdown_extensions(mut self, extensions: MarkdownExtensions) -> Self {
+        self.markdown_extensions = Arc::new(extensions);
+        self
+    }
+
+    /// Enable MDX JSX/expression parsing.
     ///
-    /// A custom element is written in the source as an HTML tag whose name
-    /// contains a hyphen (the W3C custom-element convention), e.g.
-    /// `<stock-quote symbol="AAPL"></stock-quote>`. Standard HTML tags never
-    /// contain a hyphen, so this never collides with normal markup. When the
-    /// tag name matches `name`, the given closure renders it; the closure
-    /// receives the parsed [`CustomElement`] (attributes / props and raw inner
-    /// content) and returns any element, so the result can be an arbitrary
-    /// component (an image, a tag, a stock card, a contact, ...).
+    /// This disables raw HTML parsing because `markdown-rs` gives HTML
+    /// priority over MDX when both are enabled.
+    pub fn markdown_mdx(mut self) -> Self {
+        let extensions = Arc::make_mut(&mut self.markdown_extensions);
+        *extensions = extensions.clone().mdx();
+        self
+    }
+
+    /// Register a custom block-level Markdown parser.
     ///
-    /// Call this multiple times to register different elements. Custom elements
-    /// without a registered renderer fall back to their raw text content.
-    ///
-    /// Currently only block-level custom elements are supported: write the tag
-    /// on its own line (with blank lines around it) so the parser treats it as
-    /// an HTML block, e.g. `<x-foo bar="1" />`. An open/close pair on a single
-    /// line (`<x-foo></x-foo>`) is parsed as inline HTML and won't match.
-    ///
-    /// To embed stateful / interactive components, create or reuse an `Entity`
-    /// inside the closure via [`Window::use_keyed_state`].
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// markdown(source)
-    ///     .element("stock-quote", |el, _window, _cx| {
-    ///         StockCard::new(el.attr("symbol").unwrap_or_default())
-    ///     })
-    ///     .element("contact-card", |el, _window, _cx| {
-    ///         ContactCard::new(el.attr("id").unwrap_or_default())
-    ///     });
-    /// ```
-    pub fn element<F, E>(mut self, name: impl Into<SharedString>, f: F) -> Self
+    /// The parser runs during Markdown AST conversion and must be independent
+    /// of [`Window`] / [`App`]. Store any parsed data in [`MarkdownNode`] and
+    /// render it later with [`Self::markdown_block_renderer`].
+    pub fn markdown_block_parser<F>(mut self, parser: F) -> Self
     where
-        F: Fn(&CustomElement, &mut Window, &mut App) -> E + Send + Sync + 'static,
+        F: for<'a> Fn(
+                &markdown::mdast::Node,
+                &crate::text::MarkdownParseContext<'a>,
+            ) -> Option<MarkdownNode>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Arc::make_mut(&mut self.markdown_extensions).push_block_parser(parser);
+        self
+    }
+
+    /// Register a renderer for a custom block-level Markdown node name.
+    pub fn markdown_block_renderer<F, E>(
+        mut self,
+        name: impl Into<SharedString>,
+        renderer: F,
+    ) -> Self
+    where
+        F: Fn(&MarkdownNode, &mut Window, &mut App) -> E + Send + Sync + 'static,
         E: IntoElement,
     {
-        Arc::make_mut(&mut self.elements).insert(
-            name.into(),
-            Arc::new(move |element, window, cx| f(element, window, cx).into_any_element()),
-        );
+        Arc::make_mut(&mut self.markdown_extensions).push_block_renderer(name, renderer);
         self
+    }
+
+    /// Apply a reusable text view plugin.
+    pub fn plugin<P>(self, plugin: P) -> Self
+    where
+        P: TextViewPlugin,
+    {
+        plugin.setup(self)
     }
 }
 
@@ -257,7 +278,7 @@ impl Element for TextView {
 
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
-            state.elements = self.elements.clone();
+            state.set_markdown_extensions(self.markdown_extensions.clone(), cx);
             state.selectable = self.selectable;
             state.scrollable = self.scrollable;
             state.text_view_style = self.text_view_style.clone();
@@ -334,7 +355,7 @@ impl Element for TextView {
 
 #[cfg(test)]
 mod tests {
-    use super::TextView;
+    use super::{TextView, TextViewPlugin};
     use crate::text::TextViewState;
     use gpui::{
         AppContext as _, Context, Entity, IntoElement, Modifiers, MouseButton, MouseDownEvent,
@@ -344,6 +365,15 @@ mod tests {
 
     struct TextViewTestRoot {
         text_view: Entity<TextViewState>,
+    }
+
+    struct DummyTextViewPlugin;
+
+    impl TextViewPlugin for DummyTextViewPlugin {
+        fn setup(self, mut text_view: TextView) -> TextView {
+            text_view.selectable = true;
+            text_view
+        }
     }
 
     impl TextViewTestRoot {
@@ -366,6 +396,13 @@ mod tests {
                 )
                 .child(div().h(px(40.)).child("footer"))
         }
+    }
+
+    #[test]
+    fn plugin_accepts_text_view_plugins_beyond_markdown() {
+        let view = TextView::markdown("plugin-test", "").plugin(DummyTextViewPlugin);
+
+        assert!(view.selectable);
     }
 
     #[gpui::test]

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use gpui::prelude::FluentBuilder as _;
@@ -10,13 +11,21 @@ use gpui::{
 use crate::StyledExt;
 use crate::scroll::ScrollableElement;
 use crate::text::TextViewFormat;
-use crate::text::node::CodeBlock;
+use crate::text::node::{CodeBlock, CustomElement};
 use crate::text::state::TextViewState;
 use crate::{global_state::GlobalState, text::TextViewStyle};
 
 /// Type for code block actions generator function.
 pub(crate) type CodeBlockActionsFn =
     dyn Fn(&CodeBlock, &mut Window, &mut App) -> AnyElement + Send + Sync;
+
+/// Type for a custom element renderer function.
+///
+/// Registered per custom element tag name. Receives the parsed
+/// [`CustomElement`] (tag name, attributes, raw content) and returns an element
+/// to render in place of the default rendering.
+pub(crate) type ElementRenderFn =
+    dyn Fn(&CustomElement, &mut Window, &mut App) -> AnyElement + Send + Sync;
 
 /// A text view that can render Markdown or HTML.
 ///
@@ -45,6 +54,7 @@ pub struct TextView {
     selectable: bool,
     scrollable: bool,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    elements: Arc<HashMap<SharedString, Arc<ElementRenderFn>>>,
 }
 
 impl Styled for TextView {
@@ -66,6 +76,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            elements: Arc::default(),
         }
     }
 
@@ -81,6 +92,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            elements: Arc::default(),
         }
     }
 
@@ -96,6 +108,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            elements: Arc::default(),
         }
     }
 
@@ -140,6 +153,51 @@ impl TextView {
         self.code_block_actions = Some(Arc::new(move |code_block, window, cx| {
             f(&code_block, window, cx).into_any_element()
         }));
+        self
+    }
+
+    /// Register a renderer for a custom element, keyed by its tag `name`.
+    ///
+    /// A custom element is written in the source as an HTML tag whose name
+    /// contains a hyphen (the W3C custom-element convention), e.g.
+    /// `<stock-quote symbol="AAPL"></stock-quote>`. Standard HTML tags never
+    /// contain a hyphen, so this never collides with normal markup. When the
+    /// tag name matches `name`, the given closure renders it; the closure
+    /// receives the parsed [`CustomElement`] (attributes / props and raw inner
+    /// content) and returns any element, so the result can be an arbitrary
+    /// component (an image, a tag, a stock card, a contact, ...).
+    ///
+    /// Call this multiple times to register different elements. Custom elements
+    /// without a registered renderer fall back to their raw text content.
+    ///
+    /// Currently only block-level custom elements are supported: write the tag
+    /// on its own line (with blank lines around it) so the parser treats it as
+    /// an HTML block, e.g. `<x-foo bar="1" />`. An open/close pair on a single
+    /// line (`<x-foo></x-foo>`) is parsed as inline HTML and won't match.
+    ///
+    /// To embed stateful / interactive components, create or reuse an `Entity`
+    /// inside the closure via [`Window::use_keyed_state`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// markdown(source)
+    ///     .element("stock-quote", |el, _window, _cx| {
+    ///         StockCard::new(el.attr("symbol").unwrap_or_default())
+    ///     })
+    ///     .element("contact-card", |el, _window, _cx| {
+    ///         ContactCard::new(el.attr("id").unwrap_or_default())
+    ///     });
+    /// ```
+    pub fn element<F, E>(mut self, name: impl Into<SharedString>, f: F) -> Self
+    where
+        F: Fn(&CustomElement, &mut Window, &mut App) -> E + Send + Sync + 'static,
+        E: IntoElement,
+    {
+        Arc::make_mut(&mut self.elements).insert(
+            name.into(),
+            Arc::new(move |element, window, cx| f(element, window, cx).into_any_element()),
+        );
         self
     }
 }
@@ -199,6 +257,7 @@ impl Element for TextView {
 
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
+            state.elements = self.elements.clone();
             state.selectable = self.selectable;
             state.scrollable = self.scrollable;
             state.text_view_style = self.text_view_style.clone();

--- a/docs/docs/components/index.md
+++ b/docs/docs/components/index.md
@@ -30,6 +30,7 @@ collapsed: false
 - [Stepper](stepper) - Step-by-step progress indicator
 - [Switch](switch) - Toggle on/off control
 - [Tag](tag) - Labels and categories
+- [TextView](text-view) - Markdown and HTML text rendering
 - [Toggle](toggle) - Toggle button states
 - [Tooltip](tooltip) - Helpful hints on hover
 

--- a/docs/docs/components/text-view.md
+++ b/docs/docs/components/text-view.md
@@ -1,0 +1,164 @@
+---
+title: TextView
+description: Renders Markdown and HTML text with optional custom Markdown plugins.
+---
+
+# TextView
+
+`TextView` renders formatted text in GPUI. It supports Markdown and simple HTML, text selection, code block actions, and custom Markdown plugins for project-specific syntax.
+
+## Import
+
+```rust
+use gpui_component::text::{markdown, TextView};
+```
+
+## Usage
+
+### Markdown
+
+Use the `markdown` helper when you only need to render Markdown text:
+
+```rust
+use gpui_component::text::markdown;
+
+markdown("# Hello\n\nThis is **Markdown**.")
+    .selectable(true)
+    .scrollable(true)
+```
+
+You can also construct a `TextView` directly when you need a stable id:
+
+```rust
+use gpui_component::text::TextView;
+
+TextView::markdown("preview", markdown_source)
+    .selectable(true)
+```
+
+### HTML
+
+```rust
+TextView::html("html-preview", "<strong>Hello</strong>")
+```
+
+## Markdown Plugins
+
+Use `.plugin(...)` to support custom Markdown formats. A plugin owns both parsing and rendering, so callers only need to attach it to the `TextView`:
+
+```rust
+markdown(source)
+    .plugin(TickerPlugin::new())
+```
+
+A Markdown plugin implements `MarkdownPlugin`:
+
+```rust
+use gpui::{App, IntoElement, ParentElement as _, Window};
+use gpui_component::text::{
+    markdown_ast, MarkdownNode, MarkdownParseContext, MarkdownPlugin,
+};
+
+struct TickerNode {
+    symbol: String,
+}
+
+struct TickerPlugin;
+
+impl TickerPlugin {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl MarkdownPlugin for TickerPlugin {
+    fn is_block(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        "ticker"
+    }
+
+    fn parse(
+        &self,
+        node: &markdown_ast::Node,
+        cx: &MarkdownParseContext<'_>,
+    ) -> Option<MarkdownNode> {
+        let markdown_ast::Node::Paragraph(paragraph) = node else {
+            return None;
+        };
+        let [markdown_ast::Node::Text(text)] = paragraph.children.as_slice() else {
+            return None;
+        };
+        let symbol = text.value.strip_prefix('$')?;
+
+        Some(
+            MarkdownNode::new(
+                "ticker",
+                TickerNode {
+                    symbol: symbol.to_string(),
+                },
+            )
+            .text(format!("${symbol}"))
+            .markdown(cx.node_source(node).unwrap_or(text.value.as_str())),
+        )
+    }
+
+    fn render(
+        &self,
+        node: &MarkdownNode,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> impl IntoElement {
+        let ticker = node.data::<TickerNode>().expect("ticker node data");
+
+        gpui::div().child(format!("${}", ticker.symbol))
+    }
+}
+```
+
+Then attach it to a Markdown `TextView`:
+
+```rust
+markdown("$AAPL.US")
+    .plugin(TickerPlugin::new())
+```
+
+## MarkdownNode
+
+`MarkdownNode` is the neutral data passed between `parse` and `render`.
+
+```rust
+MarkdownNode::new("ticker", TickerNode { symbol })
+    .text("$AAPL.US")
+    .markdown("$AAPL.US")
+```
+
+- `name` is the stable node name used to match the renderer.
+- `data` is typed parser output read with `node.data::<T>()`.
+- `text` is the plain text representation used by selection and fallback rendering.
+- `markdown` is the Markdown representation used when the document is serialized back to Markdown.
+
+## Block Plugins
+
+Custom Markdown rendering currently supports block plugins. Return `true` from `is_block()` for plugins that should be registered today:
+
+```rust
+fn is_block(&self) -> bool {
+    true
+}
+```
+
+Inline plugins are reserved for future `TextView` support.
+
+## Code Block Actions
+
+You can render controls for Markdown code blocks:
+
+```rust
+markdown(source)
+    .code_block_actions(|code_block, _window, _cx| {
+        gpui::div().child(format!("Run {}", code_block.lang().unwrap_or_default()))
+    })
+```

--- a/docs/zh-CN/docs/components/index.md
+++ b/docs/zh-CN/docs/components/index.md
@@ -16,6 +16,7 @@ collapsed: false
 - [Checkbox](checkbox) - 二元选择控件
 - [Icon](icon) - 图标展示组件
 - [Image](image) - 带回退能力的图片展示
+- [TextView](text-view) - Markdown 与 HTML 文本渲染
 - [Tooltip](tooltip) - 悬浮提示
 
 ## 表单组件
@@ -48,4 +49,3 @@ collapsed: false
 组件页已经预置中文路由结构，尚未完成的页面会先显示中文占位说明，并回链到英文原文：
 
 - [English version](/docs/components/index)
-

--- a/docs/zh-CN/docs/components/text-view.md
+++ b/docs/zh-CN/docs/components/text-view.md
@@ -1,0 +1,164 @@
+---
+title: TextView
+description: 渲染 Markdown 与 HTML 文本，并支持自定义 Markdown 插件。
+---
+
+# TextView
+
+`TextView` 用于在 GPUI 中渲染格式化文本。它支持 Markdown、简单 HTML、文本选择、代码块操作，以及通过 Markdown 插件解析和渲染项目自定义语法。
+
+## 导入
+
+```rust
+use gpui_component::text::{markdown, TextView};
+```
+
+## 用法
+
+### Markdown
+
+只需要渲染 Markdown 时，可以使用 `markdown` helper：
+
+```rust
+use gpui_component::text::markdown;
+
+markdown("# Hello\n\nThis is **Markdown**.")
+    .selectable(true)
+    .scrollable(true)
+```
+
+如果需要稳定 id，也可以直接构造 `TextView`：
+
+```rust
+use gpui_component::text::TextView;
+
+TextView::markdown("preview", markdown_source)
+    .selectable(true)
+```
+
+### HTML
+
+```rust
+TextView::html("html-preview", "<strong>Hello</strong>")
+```
+
+## Markdown 插件
+
+使用 `.plugin(...)` 支持自定义 Markdown 格式。插件同时拥有解析和渲染逻辑，调用方只需要把它挂到 `TextView` 上：
+
+```rust
+markdown(source)
+    .plugin(TickerPlugin::new())
+```
+
+Markdown 插件实现 `MarkdownPlugin`：
+
+```rust
+use gpui::{App, IntoElement, ParentElement as _, Window};
+use gpui_component::text::{
+    markdown_ast, MarkdownNode, MarkdownParseContext, MarkdownPlugin,
+};
+
+struct TickerNode {
+    symbol: String,
+}
+
+struct TickerPlugin;
+
+impl TickerPlugin {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl MarkdownPlugin for TickerPlugin {
+    fn is_block(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        "ticker"
+    }
+
+    fn parse(
+        &self,
+        node: &markdown_ast::Node,
+        cx: &MarkdownParseContext<'_>,
+    ) -> Option<MarkdownNode> {
+        let markdown_ast::Node::Paragraph(paragraph) = node else {
+            return None;
+        };
+        let [markdown_ast::Node::Text(text)] = paragraph.children.as_slice() else {
+            return None;
+        };
+        let symbol = text.value.strip_prefix('$')?;
+
+        Some(
+            MarkdownNode::new(
+                "ticker",
+                TickerNode {
+                    symbol: symbol.to_string(),
+                },
+            )
+            .text(format!("${symbol}"))
+            .markdown(cx.node_source(node).unwrap_or(text.value.as_str())),
+        )
+    }
+
+    fn render(
+        &self,
+        node: &MarkdownNode,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> impl IntoElement {
+        let ticker = node.data::<TickerNode>().expect("ticker node data");
+
+        gpui::div().child(format!("${}", ticker.symbol))
+    }
+}
+```
+
+然后挂到 Markdown `TextView`：
+
+```rust
+markdown("$AAPL.US")
+    .plugin(TickerPlugin::new())
+```
+
+## MarkdownNode
+
+`MarkdownNode` 是 `parse` 和 `render` 之间传递的中性数据结构。
+
+```rust
+MarkdownNode::new("ticker", TickerNode { symbol })
+    .text("$AAPL.US")
+    .markdown("$AAPL.US")
+```
+
+- `name` 是稳定的节点名称，用于匹配 renderer。
+- `data` 是 parser 产生的类型化数据，通过 `node.data::<T>()` 读取。
+- `text` 是纯文本表示，用于选择和未注册 renderer 时的回退渲染。
+- `markdown` 是 Markdown 表示，用于将文档重新序列化为 Markdown。
+
+## Block 插件
+
+当前自定义 Markdown 渲染支持 block 插件。现在可注册的插件需要在 `is_block()` 中返回 `true`：
+
+```rust
+fn is_block(&self) -> bool {
+    true
+}
+```
+
+Inline 插件保留给未来的 `TextView` 支持。
+
+## 代码块操作
+
+可以为 Markdown 代码块渲染操作控件：
+
+```rust
+markdown(source)
+    .code_block_actions(|code_block, _window, _cx| {
+        gpui::div().child(format!("Run {}", code_block.lang().unwrap_or_default()))
+    })
+```


### PR DESCRIPTION
<img width="1712" height="1312" alt="image" src="https://github.com/user-attachments/assets/df2b8126-6339-4324-8557-282bb01048d9" />

## Description

Adds `TextView::element(name, closure)`, which renders **custom components** embedded in markdown. A custom element is written as a **hyphenated HTML tag on its own line** (the W3C custom-element convention), e.g.:

```markdown
<stock-quote symbol="AAPL" />

<contact-card id="madcodelife" />
```

The parser turns such a tag into a first-class `BlockNode::Custom(CustomElement)` node carrying the tag name, attributes (props) and raw inner content. Rendering is dispatched by tag name through a registry on `NodeContext`; an element with no registered renderer falls back to its raw text content. The closure receives the parsed `CustomElement` plus `&mut Window, &mut App`, so stateful/interactive components can persist an `Entity` via `window.use_keyed_state`.

```rust
markdown(source)
    .element("stock-quote", |el, _w, _cx| StockCard::new(el.attr("symbol").unwrap_or_default()))
    .element("contact-card", |el, _w, _cx| ContactCard::new(el.attr("id").unwrap_or_default()))
```