### PR TITLE
input: Add `refresh_lsp` method to re-run LSP state without altering …

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -844,6 +844,13 @@ impl InputState {
         self.disabled = was_disabled;
     }
 
+    /// Refresh Editor LSP state
+    /// 
+    /// This will not trigger any selection changes.
+    pub fn refresh_lsp(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.lsp.update(&self.text, window, cx);
+    }
+
     fn replace_text(
         &mut self,
         text: impl Into<SharedString>,


### PR DESCRIPTION
input: Add `refresh_lsp` method to re-run LSP state without altering text or selection

Closes #2476

## Description

Adds a public `InputState::refresh_lsp` method so callers can re-run LSP updates (document colors and semantic tokens) for the current editor text without modifying the value, selection, or scroll position.

As described in [#2476](https://github.com/longbridge/gpui-component/issues/2476), `InputState` only refreshes LSP state as a side effect of text edits. APIs like `set_value` do refresh LSP, but they also reset the cursor, scroll, and undo history. I didn't see another way to refresh LSP decorations after external changes —such as a theme theme switching, provider reconfiguration, or server reconnect—without disturbing the user's editing position.

This PR adds the small, additive API proposed in the issue:

```rust
pub fn refresh_lsp(&mut self, window: &mut Window, cx: &mut Context<Self>) {
    self.lsp.update(&self.text, window, cx);
}
```

## Screenshot

N/A — no visible UI change; this exposes a programmatic API on `InputState`.

## How to Test

1. Build the crate:
   ```bash
   cargo build -p gpui-component
   ```

2. In an app using a code-editor `InputState` with LSP providers configured, call `refresh_lsp` after an external change and confirm document colors / semantic token highlighting refresh without the cursor or selection moving.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)