### PR TITLE
docs: Reduce ambiguity in theme docs

### DIFF
--- a/docs/docs/theme.md
+++ b/docs/docs/theme.md
@@ -25,13 +25,15 @@ https://github.com/longbridge/gpui-component/tree/main/themes
 
 And we have a [ThemeRegistry] to help us to load themes.
 
+Use the `name` of an entry in the `themes` array, such as `Ayu Light`, when looking up a theme from the registry.
+
 ```rs
 use std::path::PathBuf;
 use gpui::{App, SharedString};
 use gpui_component::{Theme, ThemeRegistry};
 
-pub fn stage_theme(cx: &mut App) {
-    let theme_name = SharedString::from("Mellifluous Light");
+pub fn init(cx: &mut App) {
+    let theme_name = SharedString::from("Ayu Light");
     // Load and watch themes from ./themes directory
     if let Err(err) = ThemeRegistry::watch_dir(PathBuf::from("./themes"), cx, move |cx| {
         if let Some(theme) = ThemeRegistry::global(cx)

--- a/docs/docs/theme.md
+++ b/docs/docs/theme.md
@@ -30,8 +30,8 @@ use std::path::PathBuf;
 use gpui::{App, SharedString};
 use gpui_component::{Theme, ThemeRegistry};
 
-pub fn init(cx: &mut App) {
-    let theme_name = SharedString::from("Ayu Light");
+pub fn stage_theme(cx: &mut App) {
+    let theme_name = SharedString::from("Mellifluous Light");
     // Load and watch themes from ./themes directory
     if let Err(err) = ThemeRegistry::watch_dir(PathBuf::from("./themes"), cx, move |cx| {
         if let Some(theme) = ThemeRegistry::global(cx)

--- a/docs/zh-CN/docs/theme.md
+++ b/docs/zh-CN/docs/theme.md
@@ -23,6 +23,8 @@ cx.theme().foreground
 
 你可以通过 [ThemeRegistry] 来加载和监听这些主题文件：
 
+从 registry 查找主题时使用 `themes` 数组中条目的 `name`，例如 `Ayu Light`。
+
 ```rs
 use std::path::PathBuf;
 use gpui::{App, SharedString};

--- a/themes/ayu.json
+++ b/themes/ayu.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://github.com/longbridge/gpui-component/raw/refs/heads/main/.theme-schema.json",
-  "name": "Ayu Light",
+  "name": "Ayu",
   "author": "Zed Industries",
   "url": "https://github.com/zed-industries/zed/blob/e62dd2a0e584154886ff86cc1e9e3e060558b977/assets/themes/ayu",
   "themes": [


### PR DESCRIPTION
## Description
The theme docs were quite confusing for me, I've made two subtle changes to make it more clear
- By switching away from Ayu Light as the example, it becomes clear that the string is referring to the _theme name_ rather than the name field at the top of the json field. Ayu Light's theme name is the same as the name of the collection of themes if that makes sense?
- Rename init -> 'stage_theme', this hints at the concept of having multiple themes staged that you can switch between with a mode. <-- honestly this might need more explaining to users

This solves my confusion where I loaded Ayu Light, and attempted to use Theme::change to switch the mode between dark and light and was confused why it wasn't working. 

## How to Test
These are changes to docs, I've dropped the irrelevant parts of the PR template.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines. - this doc is missing
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
