### PR TITLE
select: Don't show focus border when appearance is false

### DIFF
--- a/crates/story/src/stories/select_story.rs
+++ b/crates/story/src/stories/select_story.rs
@@ -1,4 +1,4 @@
-use gpui::*;
+use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{button::*, checkbox::*, input::*, select::*, separator::*, *};
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
@@ -190,7 +190,7 @@ impl SelectStory {
 }
 
 impl Render for SelectStory {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .size_full()
             .gap_4()
@@ -275,6 +275,11 @@ impl Render for SelectStory {
                         .text_color(cx.theme().secondary_foreground)
                         .w_full()
                         .gap_1()
+                        .when(
+                            self.appearance_select.focus_handle(cx).is_focused(window)
+                                || self.input_state.focus_handle(cx).is_focused(window),
+                            |this| this.focused_border(cx),
+                        )
                         .child(
                             div().w(px(140.)).child(
                                 Select::new(&self.appearance_select)

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -173,11 +173,8 @@ where
                         let new_selection = weak_confirm.update(cx, |this, cx| {
                             this.state.selection = selection;
 
-                            let final_value = this
-                                .state
-                                .selection
-                                .first()
-                                .map(|(_, i)| i.value().clone());
+                            let final_value =
+                                this.state.selection.first().map(|(_, i)| i.value().clone());
 
                             cx.emit(SelectEvent::Confirm(final_value));
                             cx.notify();
@@ -207,9 +204,7 @@ where
                     move |list_state, window, cx| {
                         let committed_ix = weak_cancel
                             .upgrade()
-                            .and_then(|e| {
-                                e.read(cx).state.selection.first().map(|(ix, _)| *ix)
-                            });
+                            .and_then(|e| e.read(cx).state.selection.first().map(|(ix, _)| *ix));
 
                         list_state.set_selected_index(committed_ix, window, cx);
 
@@ -494,6 +489,7 @@ where
                             .border_color(cx.theme().input)
                             .rounded(cx.theme().radius)
                             .when(cx.theme().shadow, |this| this.shadow_xs())
+                            .when(outline_visible, |this| this.focused_border(cx))
                     })
                     .map(|this| {
                         if self.state.disabled {
@@ -506,7 +502,6 @@ where
                     .input_size(self.state.size)
                     .input_text_size(self.state.size)
                     .refine_style(&self.state.style)
-                    .when(outline_visible, |this| this.focused_border(cx))
                     .when(allow_open, |this| {
                         this.on_click(cx.listener(Self::toggle_menu))
                     })
@@ -661,7 +656,9 @@ where
         mut self,
         builder: impl Fn(&mut Window, &App) -> E + 'static,
     ) -> Self {
-        self.empty = Some(Box::new(move |window, cx| builder(window, cx).into_any_element()));
+        self.empty = Some(Box::new(move |window, cx| {
+            builder(window, cx).into_any_element()
+        }));
         self
     }
 


### PR DESCRIPTION
`Select` now behaves like `Input` does and will not show the focus ring border when `appearance` is `false`.

## How to Test

Observe the `Appearance false with Input` section in the `Select` story. When the select is clicked the focus ring is not shown.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
