### PR TITLE
theme: Fix Aurora theme syntax highlights

### DIFF
--- a/themes/aurora.json
+++ b/themes/aurora.json
@@ -156,7 +156,91 @@
         "editor.line_number": "#94A3B8",
         "editor.active_line_number": "#0F172A",
         "editor.invisible": "#64748B66",
-        "syntax": {}
+        "syntax": {
+          "attribute": {
+            "color": "#957931"
+          },
+          "boolean": {
+            "color": "#C5060B"
+          },
+          "comment": {
+            "color": "#007fff"
+          },
+          "comment.doc": {
+            "color": "#007fff"
+          },
+          "constant": {
+            "color": "#C5060B"
+          },
+          "constructor": {
+            "color": "#0433ff"
+          },
+          "embedded": {
+            "color": "#333333"
+          },
+          "emphasis": {
+            "font_style": "italic"
+          },
+          "emphasis.strong": {
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#0000A2"
+          },
+          "keyword": {
+            "color": "#0433ff"
+          },
+          "link_text": {
+            "color": "#0000A2",
+            "font_style": "normal"
+          },
+          "link_uri": {
+            "color": "#6A7293",
+            "font_style": "italic"
+          },
+          "number": {
+            "color": "#0433ff"
+          },
+          "string": {
+            "color": "#036A07"
+          },
+          "string.escape": {
+            "color": "#036A07"
+          },
+          "string.regex": {
+            "color": "#036A07"
+          },
+          "string.special": {
+            "color": "#d21f07"
+          },
+          "string.special.symbol": {
+            "color": "#d21f07"
+          },
+          "tag": {
+            "color": "#0433ff"
+          },
+          "text.literal": {
+            "color": "#6F42C1"
+          },
+          "text.code.span": {
+            "color": "#6F42C1"
+          },
+          "title": {
+            "color": "#0433FF"
+          },
+          "type": {
+            "color": "#6f42c1"
+          },
+          "property": {
+            "color": "#333333"
+          },
+          "variable": {
+            "color": "#333333"
+          },
+          "variable.special": {
+            "color": "#C5060B"
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Add syntax highlight colors to the Aurora Light theme
- Restore editor code highlighting when Aurora is selected

## Test Plan
- jq empty themes/aurora.json
- jq -e '.themes[] | select(.name == "Aurora Light") | (.highlight.syntax | length > 0) and .highlight.syntax.keyword.color == "#0433ff" and .highlight.syntax.string.color == "#036A07"' themes/aurora.json
- cargo test -p gpui-component aurora