### PR TITLE
native_menu: Native menu item image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,7 +2396,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -3067,7 +3067,7 @@ dependencies = [
  "raw-window-handle",
  "refineable",
  "regex",
- "resvg",
+ "resvg 0.45.1",
  "scheduler",
  "schemars",
  "seahash",
@@ -3083,7 +3083,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "url",
- "usvg",
+ "usvg 0.45.1",
  "util_macros",
  "uuid",
  "waker-fn",
@@ -3125,7 +3125,7 @@ dependencies = [
  "paste",
  "raw-window-handle",
  "regex",
- "resvg",
+ "resvg 0.47.0",
  "ropey",
  "rust-i18n",
  "rust_decimal",
@@ -4058,6 +4058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,6 +4379,18 @@ checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
  "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
  "smallvec",
 ]
 
@@ -5240,7 +5258,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6139,6 +6157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6880,10 +6907,27 @@ dependencies = [
  "log",
  "pico-args",
  "rgb",
- "svgtypes",
- "tiny-skia",
- "usvg",
+ "svgtypes 0.15.3",
+ "tiny-skia 0.11.4",
+ "usvg 0.45.1",
  "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif 0.14.2",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes 0.16.1",
+ "tiny-skia 0.12.0",
+ "usvg 0.47.0",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -6961,6 +7005,15 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rust-embed"
@@ -8001,7 +8054,17 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo 0.13.1",
  "siphasher 1.0.2",
 ]
 
@@ -8358,7 +8421,22 @@ dependencies = [
  "cfg-if",
  "log",
  "png 0.17.16",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -8366,6 +8444,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -9300,17 +9389,45 @@ dependencies = [
  "data-url",
  "flate2",
  "fontdb",
- "imagesize",
- "kurbo",
+ "imagesize 0.13.0",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz",
  "simplecss",
  "siphasher 1.0.2",
  "strict-num",
- "svgtypes",
- "tiny-skia-path",
+ "svgtypes 0.15.3",
+ "tiny-skia-path 0.11.4",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.14.0",
+ "kurbo 0.13.1",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.2",
+ "strict-num",
+ "svgtypes 0.16.1",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,7 +2396,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree 0.20.0",
+ "roxmltree",
 ]
 
 [[package]]
@@ -3067,7 +3067,7 @@ dependencies = [
  "raw-window-handle",
  "refineable",
  "regex",
- "resvg 0.45.1",
+ "resvg",
  "scheduler",
  "schemars",
  "seahash",
@@ -3083,7 +3083,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "url",
- "usvg 0.45.1",
+ "usvg",
  "util_macros",
  "uuid",
  "waker-fn",
@@ -3125,7 +3125,7 @@ dependencies = [
  "paste",
  "raw-window-handle",
  "regex",
- "resvg 0.47.0",
+ "resvg",
  "ropey",
  "rust-i18n",
  "rust_decimal",
@@ -4058,12 +4058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
-name = "imagesize"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
-
-[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,18 +4373,6 @@ checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
  "euclid",
- "smallvec",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
  "smallvec",
 ]
 
@@ -6157,15 +6139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6907,27 +6880,10 @@ dependencies = [
  "log",
  "pico-args",
  "rgb",
- "svgtypes 0.15.3",
- "tiny-skia 0.11.4",
- "usvg 0.45.1",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
  "zune-jpeg 0.4.21",
-]
-
-[[package]]
-name = "resvg"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
-dependencies = [
- "gif 0.14.2",
- "image-webp",
- "log",
- "pico-args",
- "rgb",
- "svgtypes 0.16.1",
- "tiny-skia 0.12.0",
- "usvg 0.47.0",
- "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -7005,15 +6961,6 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
-name = "roxmltree"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "rust-embed"
@@ -8054,17 +8001,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo 0.11.3",
- "siphasher 1.0.2",
-]
-
-[[package]]
-name = "svgtypes"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
-dependencies = [
- "kurbo 0.13.1",
+ "kurbo",
  "siphasher 1.0.2",
 ]
 
@@ -8421,22 +8358,7 @@ dependencies = [
  "cfg-if",
  "log",
  "png 0.17.16",
- "tiny-skia-path 0.11.4",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png 0.18.1",
- "tiny-skia-path 0.12.0",
+ "tiny-skia-path",
 ]
 
 [[package]]
@@ -8444,17 +8366,6 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -9389,45 +9300,17 @@ dependencies = [
  "data-url",
  "flate2",
  "fontdb",
- "imagesize 0.13.0",
- "kurbo 0.11.3",
+ "imagesize",
+ "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.20.0",
+ "roxmltree",
  "rustybuzz",
  "simplecss",
  "siphasher 1.0.2",
  "strict-num",
- "svgtypes 0.15.3",
- "tiny-skia-path 0.11.4",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
-dependencies = [
- "base64",
- "data-url",
- "flate2",
- "fontdb",
- "imagesize 0.14.0",
- "kurbo 0.13.1",
- "log",
- "pico-args",
- "roxmltree 0.21.1",
- "rustybuzz",
- "simplecss",
- "siphasher 1.0.2",
- "strict-num",
- "svgtypes 0.16.1",
- "tiny-skia-path 0.12.0",
- "ttf-parser",
+ "svgtypes",
+ "tiny-skia-path",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "paste",
  "raw-window-handle",
  "regex",
+ "resvg",
  "ropey",
  "rust-i18n",
  "rust_decimal",

--- a/crates/story/src/stories/native_menu_story.rs
+++ b/crates/story/src/stories/native_menu_story.rs
@@ -24,6 +24,15 @@ fn click(label: &str) -> Box<dyn Action> {
     Box::new(MenuClick(label.to_string().into()))
 }
 
+/// Absolute path to a bounded icon.
+fn icon_path(name: &str) -> String {
+  format!(
+    "{}/../assets/assets/icons/{}",
+    env!("CARGO_MANIFEST_DIR"),
+    name
+  )
+}
+
 /// Demo menu: normal items, a disabled item, a checked item (reflecting
 /// `word_wrap`, which the story toggles), and nested submenus.
 fn demo_menu(word_wrap: bool) -> NativeMenu {
@@ -31,6 +40,9 @@ fn demo_menu(word_wrap: bool) -> NativeMenu {
         .menu("Cut", click("Cut"))
         .menu("Copy", click("Copy"))
         .menu("Paste", click("Paste"))
+        .separator()
+        .menu_with_image("Github", icon_path("github.svg"), click("Disabled"))
+        .menu_with_image("Inbox", icon_path("inbox.svg"), click("Inbox"))
         .separator()
         .menu_with_disabled("Disabled item", true, click("Disabled"))
         .menu_with_check("Word Wrap", word_wrap, click("Word Wrap"))

--- a/crates/story/src/stories/native_menu_story.rs
+++ b/crates/story/src/stories/native_menu_story.rs
@@ -17,6 +17,10 @@ use crate::section;
 #[action(namespace = native_menu_story, no_json)]
 struct MenuClick(SharedString);
 
+#[derive(Action, Clone, PartialEq, Deserialize)]
+#[action(namespace = native_menu_story, no_json)]
+struct OpenGitHub;
+
 const CONTEXT: &str = "NativeMenuStory";
 
 /// A menu item dispatching `MenuClick(label)`.
@@ -26,11 +30,11 @@ fn click(label: &str) -> Box<dyn Action> {
 
 /// Absolute path to a bounded icon.
 fn icon_path(name: &str) -> String {
-  format!(
-    "{}/../assets/assets/icons/{}",
-    env!("CARGO_MANIFEST_DIR"),
-    name
-  )
+    format!(
+        "{}/../assets/assets/icons/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    )
 }
 
 /// Demo menu: normal items, a disabled item, a checked item (reflecting
@@ -41,7 +45,7 @@ fn demo_menu(word_wrap: bool) -> NativeMenu {
         .menu("Copy", click("Copy"))
         .menu("Paste", click("Paste"))
         .separator()
-        .menu_with_image("Github", icon_path("github.svg"), click("Disabled"))
+        .menu_with_image("Github", icon_path("github.svg"), Box::new(OpenGitHub))
         .menu_with_image("Inbox", icon_path("inbox.svg"), click("Inbox"))
         .separator()
         .menu_with_disabled("Disabled item", true, click("Disabled"))
@@ -107,6 +111,10 @@ impl NativeMenuStory {
         cx.notify();
     }
 
+    fn open_github(&mut self, _: &OpenGitHub, _: &mut Window, cx: &mut Context<Self>) {
+        cx.open_url("https://github.com");
+    }
+
     fn trigger(&self, label: &str, cx: &mut App) -> Div {
         div()
             .flex()
@@ -142,6 +150,7 @@ impl Render for NativeMenuStory {
             .track_focus(&self.focus_handle)
             .key_context(CONTEXT)
             .on_action(cx.listener(Self::on_click))
+            .on_action(cx.listener(Self::open_github))
             .size_full()
             .gap_6()
             .child(

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -201,6 +201,7 @@ objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native menu (NativeMenu) — drives Win32 popup menus.
 raw-window-handle = { workspace = true }
+resvg = "0.45"
 windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -201,7 +201,7 @@ objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native menu (NativeMenu) — drives Win32 popup menus.
 raw-window-handle = { workspace = true }
-resvg = "0.45"
+resvg = "0.47"
 windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -194,6 +194,7 @@ objc2-app-kit = { version = "0.3", features = [
     "NSView",
     "NSResponder",
     "NSEvent",
+    "NSImage",
 ] }
 objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
 
@@ -203,6 +204,7 @@ raw-window-handle = { workspace = true }
 windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_Graphics_GdiPlus",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -201,7 +201,7 @@ objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native menu (NativeMenu) — drives Win32 popup menus.
 raw-window-handle = { workspace = true }
-resvg = "0.47"
+resvg = "0.45.1"
 windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/ui/src/native_menu/fallback.rs
+++ b/crates/ui/src/native_menu/fallback.rs
@@ -11,6 +11,7 @@ use gpui::{
 
 use crate::menu::{PopupMenu, PopupMenuItem};
 use crate::root::Root;
+use crate::Icon;
 
 use super::NativeMenuItem;
 
@@ -78,7 +79,15 @@ fn build_popup(
                 NativeMenuItem::Item {
                     label,
                     disabled,
+                    checked: _,
+                    image: Some(image),
+                    action: Some(action),
+                } => menu.menu_with_icon_and_disabled(label, Icon::default().path(image), action, disabled),
+                NativeMenuItem::Item {
+                    label,
+                    disabled,
                     checked,
+                    image: None,
                     action: Some(action),
                 } => menu.menu_with_check_and_disabled(label, checked, action, disabled),
                 NativeMenuItem::Item { action: None, .. } => menu,

--- a/crates/ui/src/native_menu/fallback.rs
+++ b/crates/ui/src/native_menu/fallback.rs
@@ -5,13 +5,13 @@
 //! the [`super::NativeMenu`] API working on every platform.
 
 use gpui::{
-    App, Context, DismissEvent, Entity, FocusHandle, Focusable, IntoElement, ParentElement,
-    Pixels, Point, Render, Subscription, Window, anchored, deferred, div, px,
+    App, Context, DismissEvent, Entity, FocusHandle, Focusable, IntoElement, ParentElement, Pixels,
+    Point, Render, Subscription, Window, anchored, deferred, div, px,
 };
 
+use crate::Icon;
 use crate::menu::{PopupMenu, PopupMenuItem};
 use crate::root::Root;
-use crate::Icon;
 
 use super::NativeMenuItem;
 
@@ -82,7 +82,12 @@ fn build_popup(
                     checked: _,
                     image: Some(image),
                     action: Some(action),
-                } => menu.menu_with_icon_and_disabled(label, Icon::default().path(image), action, disabled),
+                } => menu.menu_with_icon_and_disabled(
+                    label,
+                    Icon::default().path(image),
+                    action,
+                    disabled,
+                ),
                 NativeMenuItem::Item {
                     label,
                     disabled,

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -6,11 +6,15 @@ use gpui::{Action, App, Pixels, Point, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send, sel};
-use objc2_app_kit::{NSMenu, NSMenuItem, NSView};
-use objc2_foundation::{NSPoint, NSString};
+use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
+use objc2_foundation::{NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use super::NativeMenuItem;
+
+/// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
+/// the row, so a large file would otherwise overflow it.
+const MENU_IMAGE_SIZE: f64 = 16.0;
 
 /// Ivars for [`MenuTarget`]: the tag of the selected item, or `-1` if none.
 struct MenuTargetIvars {
@@ -130,12 +134,24 @@ fn build_menu<'a>(
                 label,
                 disabled,
                 checked,
+                image,
                 action,
             } => {
                 let ns_item = NSMenuItem::new(mtm);
                 unsafe {
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
+                    if let Some(image) = image {
+                        if let Some(ns_image) = NSImage::initWithContentsOfFile(
+                            NSImage::alloc(),
+                            &NSString::from_str(image),
+                        ) {
+                            ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
+                            ns_image.setTemplate(true);
+                            ns_item.setImage(Some(&ns_image));
+                        }
+                    }
+
                     if *checked {
                         // `NSControlStateValueOn`
                         ns_item.setState(1);

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -98,7 +98,8 @@ impl NativeMenu {
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item text
     /// and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
-    /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. SVG files are rasterized, with `resvg`; other formats (PNG, JPEG, BMP, ...) are decoded by GDI+.
+    /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. SVG files are
+    /// rasterized, with `resvg`; other formats (PNG, JPEG, BMP, ...) are decoded by GDI+.
     /// **Other platforms** (fallback): rendered as the menu item's [`crate::Icon`]; works best
     /// with SVG assets.
     ///

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -98,8 +98,7 @@ impl NativeMenu {
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item text
     /// and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
-    /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. GDI+ is used to decode,
-    /// so common raster formats (PNG, JPEG, BMP,...) work but SVG doesn't.
+    /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. SVG files are rasterized, with `resvg`; other formats (PNG, JPEG, BMP, ...) are decoded by GDI+.
     /// **Other platforms** (fallback): rendered as the menu item's [`crate::Icon`]; works best
     /// with SVG assets.
     ///

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -40,6 +40,8 @@ enum NativeMenuItem {
         label: SharedString,
         disabled: bool,
         checked: bool,
+        /// Path to an image shown next to the label
+        image: Option<SharedString>,
         /// Action dispatched when the item is selected.
         action: Option<Box<dyn Action>>,
     },
@@ -67,7 +69,7 @@ impl NativeMenu {
 
     /// Append a clickable item that dispatches `action` when selected.
     pub fn menu(self, label: impl Into<SharedString>, action: Box<dyn Action>) -> Self {
-        self.menu_with(label, false, false, Some(action))
+        self.menu_with(label, false, false, None, Some(action))
     }
 
     /// Append an item, controlling its `disabled` state.
@@ -77,7 +79,7 @@ impl NativeMenu {
         disabled: bool,
         action: Box<dyn Action>,
     ) -> Self {
-        self.menu_with(label, disabled, false, Some(action))
+        self.menu_with(label, disabled, false, None, Some(action))
     }
 
     /// Append an item, controlling its `checked` state (a check mark is shown).
@@ -87,7 +89,42 @@ impl NativeMenu {
         checked: bool,
         action: Box<dyn Action>,
     ) -> Self {
-        self.menu_with(label, false, checked, Some(action))
+        self.menu_with(label, false, checked, None, Some(action))
+    }
+
+    /// Append an item showing `image` next to its label.
+    ///
+    /// `image` is a filesystem path to an image file.
+    /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item text
+    /// and assigned to the item ([`NSMenuItem::image`]).
+    /// - **Windows**: loaded into an `HBITMAP` and set as the item's
+    /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. GDI+ is used to decode,
+    /// so common raster formats (PNG, JPEG, BMP,...) work but SVG doesn't.
+    /// **Other platforms** (fallback): rendered as the menu item's [`crate::Icon`]; works best
+    /// with SVG assets.
+    ///
+    /// Note: this is the menu item's *content* image, not its state/check-mark indicator.
+    pub fn menu_with_image(
+        self,
+        label: impl Into<SharedString>,
+        image: impl Into<SharedString>,
+        action: Box<dyn Action>,
+    ) -> Self {
+        self.menu_with(label, false, false, Some(image.into()), Some(action))
+    }
+
+    /// Append an item showing `image` next to its label, controlling its `disabled` state.
+    ///
+    /// Same image behavior as [`Self::menu_with_image`]. Use this when an item
+    /// carries an icon but should be greyed out.
+    pub fn menu_with_image_disabled(
+        self,
+        label: impl Into<SharedString>,
+        image: impl Into<SharedString>,
+        disabled: bool,
+        action: Box<dyn Action>,
+    ) -> Self {
+        self.menu_with(label, disabled, false, Some(image.into()), Some(action))
     }
 
     fn menu_with(
@@ -95,12 +132,14 @@ impl NativeMenu {
         label: impl Into<SharedString>,
         disabled: bool,
         checked: bool,
+        image: Option<SharedString>,
         action: Option<Box<dyn Action>>,
     ) -> Self {
         self.items.push(NativeMenuItem::Item {
             label: label.into(),
             disabled,
             checked,
+            image,
             action,
         });
         self
@@ -167,6 +206,7 @@ impl From<gpui::Menu> for NativeMenu {
                     label: name,
                     disabled,
                     checked,
+                    image: None,
                     action: Some(action),
                 }),
                 gpui::MenuItem::Submenu(submenu) => native.items.push(NativeMenuItem::Submenu {

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -4,8 +4,11 @@ use std::ffi::c_void;
 
 use gpui::{Action, App, Pixels, Point, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use windows::Win32::Foundation::{BOOL, HWND, LPARAM, POINT, WPARAM};
-use windows::Win32::Graphics::Gdi::{ClientToScreen, DeleteObject, HBITMAP, HGDIOBJ};
+use windows::Win32::Foundation::{BOOL, HANDLE, HWND, LPARAM, POINT, WPARAM};
+use windows::Win32::Graphics::Gdi::{
+    BI_RGB, BITMAPINFO, BITMAPINFOHEADER, ClientToScreen, CreateDIBSection, DIB_RGB_COLORS,
+    DeleteObject, HBITMAP, HDC, HGDIOBJ,
+};
 use windows::Win32::Graphics::GdiPlus::{
     GdipCreateBitmapFromFile, GdipCreateHBITMAPFromBitmap, GdipDisposeImage, GdipGetImageThumbnail,
     GdiplusShutdown, GdiplusStartup, GdiplusStartupInput, GpBitmap, GpImage,
@@ -21,7 +24,9 @@ use windows::core::PCWSTR;
 
 use super::NativeMenuItem;
 
-/// Side length (in points) menu item images are scaled to.
+/// Side length (in **logical pixels**) menu item images are scaled to. The
+/// physical bitmap size is this multiplied by the window's scale factor (see
+/// [`show`]), so images stay sharp on the HiDPI displays.
 const MENU_IMAGE_SIZE: u32 = 16;
 
 /// Show a native popup menu and dispatch the selected item's action.
@@ -41,12 +46,15 @@ pub(super) fn show(
     let scale = window.scale_factor();
     let client_x = (f32::from(position.x) * scale).round() as i32;
     let client_y = (f32::from(position.y) * scale).round() as i32;
+    // The menu draws item bitmaps at their native pixel size, so rasterize them
+    // at the device pixel size to keep them sharp on HiDPI displays.
+    let image_px = (MENU_IMAGE_SIZE as f32 * scale).round().max(1.0) as u32;
     // Inherent `Window::window_handle` (GPUI's `AnyWindowHandle`), not the
     // `raw_window_handle::HasWindowHandle` trait method in scope below.
     let handle = Window::window_handle(window);
 
     cx.spawn(async move |cx| {
-        let Some(action) = run_menu(hwnd, &items, client_x, client_y) else {
+        let Some(action) = run_menu(hwnd, &items, client_x, client_y, image_px) else {
             return;
         };
         cx.update(move |app| {
@@ -65,6 +73,7 @@ fn run_menu(
     items: &[NativeMenuItem],
     client_x: i32,
     client_y: i32,
+    image_px: u32,
 ) -> Option<Box<dyn Action>> {
     let hwnd = HWND(hwnd as *mut c_void);
 
@@ -78,7 +87,7 @@ fn run_menu(
 
         // Bitmaps attached to menu items must outlive the menu; freed below.
         let mut bitmaps: Vec<HBITMAP> = Vec::new();
-        let menu = build_menu(items, &mut actions, &mut bitmaps)?;
+        let menu = build_menu(items, &mut actions, &mut bitmaps, image_px)?;
 
         let mut point = POINT {
             x: client_x,
@@ -118,14 +127,17 @@ fn run_menu(
 /// Recursively create an `HMENU`. Each actionable leaf gets a 1-based id equal
 /// to its index in `actions` plus one, so the returned id maps back to its action.
 ///
-/// Any bitmaps created for item images are pushed onto `bitmaps`; the caller must free them after
-/// destroying the menu with `DeleteObject`.
+/// Any bitmaps created for item images are pushed onto `bitmaps`; the caller
+/// must free them after destroying the menu with `DeleteObject`. Item images
+/// are sized to `image_px` (physical pixels).
+///
 /// # Safety
 /// Win32 menu creation; the returned `HMENU` must be destroyed by the caller.
 unsafe fn build_menu<'a>(
     items: &'a [NativeMenuItem],
     actions: &mut Vec<&'a Box<dyn Action>>,
     bitmaps: &mut Vec<HBITMAP>,
+    image_px: u32,
 ) -> Option<HMENU> {
     let menu = unsafe { CreatePopupMenu() }.ok()?;
 
@@ -163,7 +175,7 @@ unsafe fn build_menu<'a>(
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
                 if let Some(image) = image {
-                    if let Some(bitmap) = unsafe { load_hbitmap(image) } {
+                    if let Some(bitmap) = unsafe { load_hbitmap(image, image_px) } {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -181,7 +193,7 @@ unsafe fn build_menu<'a>(
                 disabled,
                 items,
             } => {
-                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps) }) else {
+                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps, image_px) }) else {
                     continue;
                 };
                 let mut flags = MF_POPUP;
@@ -234,15 +246,27 @@ impl Drop for GdiplusSession {
     }
 }
 
-/// Load an image file into an `HBITMAP` via GDI+ (supports BMP, PNG, JPEG, ...). SVG is not supported.
+/// Load an image file into an `HBITMAP`, scaled to `image_px` square so it
+/// doesn't overflow the menu row.
 ///
-/// This image is scaled to [`MENU_IMAGE_SIZE`] so it doesn't overflow the menu row. Returns `None`
-/// if the file can't be read or decoded. GDI+ must already be initialized (see [`GdiplusSession`]).
-/// The returned bitmap must be freed with `DeleteObject`.
+/// SVG files are rasterized with `resvg` (see [`rasterize_svg`]); GDI+ has no
+/// SVG codec. Every other format (PNG, JPEG, BMP, ...) is decoded by GDI+, which
+/// must already be initialized (see [`GdiplusSession`]).
+///
+/// Returns `None` if the file can't be read or decoded. The returned bitmap
+/// must be freed with `DeleteObject`.
 ///
 /// # Safety
-/// Calls GDI+ flat APIs; the returned handle is owned by the caller.
-unsafe fn load_hbitmap(path: &str) -> Option<HBITMAP> {
+/// Calls GDI+ /GDI flat APIs; the returned handle is owned by the caller.
+unsafe fn load_hbitmap(path: &str, image_px: u32) -> Option<HBITMAP> {
+    // GDI+ can't decode SVG, so rasterize it ourselves.
+    if std::path::Path::new(path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+    {
+        return unsafe { rasterize_svg(path, image_px) };
+    }
+
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
     let mut gp_bitmap: *mut GpBitmap = std::ptr::null_mut();
     let status = unsafe { GdipCreateBitmapFromFile(PCWSTR(wide.as_ptr()), &mut gp_bitmap) };
@@ -255,8 +279,8 @@ unsafe fn load_hbitmap(path: &str) -> Option<HBITMAP> {
     let status = unsafe {
         GdipGetImageThumbnail(
             gp_bitmap.cast(),
-            MENU_IMAGE_SIZE,
-            MENU_IMAGE_SIZE,
+            image_px,
+            image_px,
             &mut thumb,
             0,
             std::ptr::null_mut(),
@@ -288,4 +312,88 @@ fn hwnd_ptr(window: &Window) -> Option<isize> {
         return None;
     };
     Some(handle.hwnd.get())
+}
+
+/// Rasterize an SVG file into an `HBITMAP`, scaled to `image_px` square.
+///
+/// GDI+ has no SVG codec, so SVG paths are rendered with `resvg` and wrapped in
+/// a 32-bit DIB section. The SVG is scaled uniformly to fit the square and
+/// centered. Returns `None` if the file can't be read or parsed. The returned
+/// bitmap must be freed with `DeleteObject`.
+///
+/// # Safety
+/// Creates a GDI DIB section; the returned handle is owned by the caller.
+unsafe fn rasterize_svg(path: &str, image_px: u32) -> Option<HBITMAP> {
+    use resvg::{tiny_skia, usvg};
+
+    let data = std::fs::read(path).ok()?;
+    let tree = usvg::Tree::from_data(&data, &usvg::Options::default()).ok()?;
+
+    let size = image_px;
+    let mut pixmap = tiny_skia::Pixmap::new(size, size)?;
+
+    // Fit the SVG into square without distortion, then center it.
+    let svg = tree.size();
+    let scale = (size as f32 / svg.width()).min(size as f32 / svg.height());
+    let tx = (size as f32 - svg.width() * scale) / 2.0;
+    let ty = (size as f32 - svg.height() * scale) / 2.0;
+    let transform = tiny_skia::Transform::from_scale(scale, scale).post_translate(tx, ty);
+
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    // tiny-skia produces premultiplied RGBA; a 32 bit DIB is laid out RGBA, so
+    // swap the red and blue channels in place. The alpha is already
+    // premultiplied, which is what the menu's alpha blending expects.
+    let mut pixels = pixmap.take();
+    for px in pixels.chunks_exact_mut(4) {
+        px.swap(0, 2)
+    }
+
+    unsafe { create_dib(&pixels, size, size) }
+}
+
+/// Wrap premultiplied-RGBA `pixels` (top-down, `width` x `height`) in a 32-bit
+/// DIB section `HBITMAP`. Returns `None` if creation fails; the returned bitmap
+/// must be freed with `DeleteObject`.
+///
+/// # Safety
+/// Calls GDI flat APIs and copies `pixels` into the section's backing store,
+/// which must be `width * height * 4` bytes.
+unsafe fn create_dib(pixels: &[u8], width: u32, height: u32) -> Option<HBITMAP> {
+    let info = BITMAPINFO {
+        bmiHeader: BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: width as i32,
+            // Negative height selects a top-down DIB (origin at top-left), matching
+            // tiny-skia's row order.
+            biHeight: -(height as i32),
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut bits: *mut c_void = std::ptr::null_mut();
+    // A null `HDC` is fine with `DIB_RGB_COLORS` (no palette to resolve).
+    let hbitmap = unsafe {
+        CreateDIBSection(
+            HDC::default(),
+            &info,
+            DIB_RGB_COLORS,
+            &mut bits,
+            HANDLE::default(),
+            0,
+        )
+    }
+    .ok()?;
+
+    if bits.is_null() {
+        let _ = unsafe { DeleteObject(HGDIOBJ(hbitmap.0)) };
+        return None;
+    }
+
+    unsafe { std::ptr::copy_nonoverlapping(pixels.as_ptr(), bits as *mut u8, pixels.len()) };
+    Some(hbitmap)
 }

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -193,7 +193,8 @@ unsafe fn build_menu<'a>(
                 disabled,
                 items,
             } => {
-                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps, image_px) }) else {
+                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps, image_px) })
+                else {
                     continue;
                 };
                 let mut flags = MF_POPUP;

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -4,17 +4,25 @@ use std::ffi::c_void;
 
 use gpui::{Action, App, Pixels, Point, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use windows::Win32::Foundation::{HWND, LPARAM, POINT, WPARAM};
-use windows::Win32::Graphics::Gdi::ClientToScreen;
+use windows::Win32::Foundation::{BOOL, HWND, LPARAM, POINT, WPARAM};
+use windows::Win32::Graphics::Gdi::{ClientToScreen, DeleteObject, HBITMAP, HGDIOBJ};
+use windows::Win32::Graphics::GdiPlus::{
+    GdipCreateBitmapFromFile, GdipCreateHBITMAPFromBitmap, GdipDisposeImage, GdipGetImageThumbnail,
+    GdiplusShutdown, GdiplusStartup, GdiplusStartupInput, GpBitmap, GpImage,
+};
 use windows::Win32::UI::Input::KeyboardAndMouse::SetCapture;
 use windows::Win32::UI::WindowsAndMessaging::{
-    AppendMenuW, CreatePopupMenu, DestroyMenu, HMENU, MF_CHECKED, MF_GRAYED, MF_POPUP, MF_SEPARATOR,
-    MF_STRING, PostMessageW, SetForegroundWindow, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD,
-    TPM_TOPALIGN, TrackPopupMenuEx, WM_NULL,
+    AppendMenuW, CreatePopupMenu, DestroyMenu, HMENU, MENUITEMINFOW, MF_CHECKED, MF_GRAYED,
+    MF_POPUP, MF_SEPARATOR, MF_STRING, MIIM_BITMAP, PostMessageW, SetForegroundWindow,
+    SetMenuItemInfoW, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD, TPM_TOPALIGN, TrackPopupMenuEx,
+    WM_NULL,
 };
 use windows::core::PCWSTR;
 
 use super::NativeMenuItem;
+
+/// Side length (in points) menu item images are scaled to.
+const MENU_IMAGE_SIZE: u32 = 16;
 
 /// Show a native popup menu and dispatch the selected item's action.
 ///
@@ -63,8 +71,14 @@ fn run_menu(
     // SAFETY: Win32 menu calls on a live window owned by the calling (main)
     // thread. The menu (and its submenus) is destroyed before returning.
     unsafe {
+        // Start GDI+ so item images can be loaded into bitmaps. If it fails, the menu is still
+        // built (images are skipped).
+        let gdiplus = GdiplusSession::start();
         let mut actions: Vec<&Box<dyn Action>> = Vec::new();
-        let menu = build_menu(items, &mut actions)?;
+
+        // Bitmaps attached to menu items must outlive the menu; freed below.
+        let mut bitmaps: Vec<HBITMAP> = Vec::new();
+        let menu = build_menu(items, &mut actions, &mut bitmaps)?;
 
         let mut point = POINT {
             x: client_x,
@@ -79,6 +93,12 @@ fn run_menu(
         // Destroying the top menu also destroys its attached submenus.
         let _ = DestroyMenu(menu);
 
+        // The menu no longer references the bitmaps, so they can be freed.
+        for bitmap in &bitmaps {
+            let _ = DeleteObject(HGDIOBJ(bitmap.0));
+        }
+        drop(gdiplus);
+
         // The menu's modal loop cleared the capture GPUI set on mouse-down;
         // restore it so GPUI's mouse-up `ReleaseCapture` succeeds and doesn't
         // log a spurious "operation completed successfully" (GetLastError == 0).
@@ -87,7 +107,9 @@ fn run_menu(
 
         // Ids are 1-based (0 means "no selection"); map back to `actions`.
         match selected.0 {
-            id if id > 0 => actions.get((id - 1) as usize).map(|action| action.boxed_clone()),
+            id if id > 0 => actions
+                .get((id - 1) as usize)
+                .map(|action| action.boxed_clone()),
             _ => None,
         }
     }
@@ -96,23 +118,31 @@ fn run_menu(
 /// Recursively create an `HMENU`. Each actionable leaf gets a 1-based id equal
 /// to its index in `actions` plus one, so the returned id maps back to its action.
 ///
+/// Any bitmaps created for item images are pushed onto `bitmaps`; the caller must free them after
+/// destroying the menu with `DeleteObject`.
 /// # Safety
 /// Win32 menu creation; the returned `HMENU` must be destroyed by the caller.
 unsafe fn build_menu<'a>(
     items: &'a [NativeMenuItem],
     actions: &mut Vec<&'a Box<dyn Action>>,
+    bitmaps: &mut Vec<HBITMAP>,
 ) -> Option<HMENU> {
     let menu = unsafe { CreatePopupMenu() }.ok()?;
 
+    // 0-based position of the next item appended, used to attach bitmaps by position (separators
+    // and submenus advance it too).
+    let mut position: u32 = 0;
     for item in items {
         match item {
             NativeMenuItem::Separator => {
                 let _ = unsafe { AppendMenuW(menu, MF_SEPARATOR, 0, PCWSTR::null()) };
+                position += 1;
             }
             NativeMenuItem::Item {
                 label,
                 disabled,
                 checked,
+                image,
                 action,
             } => {
                 let mut flags = MF_STRING;
@@ -132,13 +162,26 @@ unsafe fn build_menu<'a>(
                     _ => 0,
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
+                if let Some(image) = image {
+                    if let Some(bitmap) = unsafe { load_hbitmap(image) } {
+                        let info = MENUITEMINFOW {
+                            cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
+                            fMask: MIIM_BITMAP,
+                            hbmpItem: bitmap,
+                            ..Default::default()
+                        };
+                        let _ = unsafe { SetMenuItemInfoW(menu, position, true, &info) };
+                        bitmaps.push(bitmap);
+                    }
+                }
+                position += 1;
             }
             NativeMenuItem::Submenu {
                 label,
                 disabled,
                 items,
             } => {
-                let Some(submenu) = (unsafe { build_menu(items, actions) }) else {
+                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps) }) else {
                     continue;
                 };
                 let mut flags = MF_POPUP;
@@ -147,14 +190,95 @@ unsafe fn build_menu<'a>(
                 }
                 let wide: Vec<u16> = label.encode_utf16().chain(std::iter::once(0)).collect();
                 // For MF_POPUP, the id parameter is the submenu handle.
-                let _ = unsafe {
-                    AppendMenuW(menu, flags, submenu.0 as usize, PCWSTR(wide.as_ptr()))
-                };
+                let _ =
+                    unsafe { AppendMenuW(menu, flags, submenu.0 as usize, PCWSTR(wide.as_ptr())) };
+                position += 1;
             }
         }
     }
 
     Some(menu)
+}
+
+/// RAII guard for a GDI+ session (`GdiplusStartup` / `GdiplusShutdown`).
+///
+/// Loading image files into bitmaps requires GDI+ to be initialized. A `None` token means startup
+/// failed; image loading is then skipped gracefully.
+struct GdiplusSession {
+    token: usize,
+}
+
+impl GdiplusSession {
+    /// Start GDI+. Returns a guard whose `Drop` calls `GdiplusShutdown`.
+    unsafe fn start() -> Option<Self> {
+        let input = GdiplusStartupInput {
+            GdiplusVersion: 1,
+            DebugEventCallback: 0,
+            SuppressBackgroundThread: BOOL(0),
+            SuppressExternalCodecs: BOOL(0),
+        };
+
+        let mut token: usize = 0;
+        let status = unsafe { GdiplusStartup(&mut token, &input, std::ptr::null_mut()) };
+        if status.0 == 0 {
+            Some(Self { token })
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for GdiplusSession {
+    fn drop(&mut self) {
+        unsafe { GdiplusShutdown(self.token) };
+    }
+}
+
+/// Load an image file into an `HBITMAP` via GDI+ (supports BMP, PNG, JPEG, ...). SVG is not supported.
+///
+/// This image is scaled to [`MENU_IMAGE_SIZE`] so it doesn't overflow the menu row. Returns `None`
+/// if the file can't be read or decoded. GDI+ must already be initialized (see [`GdiplusSession`]).
+/// The returned bitmap must be freed with `DeleteObject`.
+///
+/// # Safety
+/// Calls GDI+ flat APIs; the returned handle is owned by the caller.
+unsafe fn load_hbitmap(path: &str) -> Option<HBITMAP> {
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut gp_bitmap: *mut GpBitmap = std::ptr::null_mut();
+    let status = unsafe { GdipCreateBitmapFromFile(PCWSTR(wide.as_ptr()), &mut gp_bitmap) };
+    if status.0 != 0 || gp_bitmap.is_null() {
+        return None;
+    }
+
+    // Scale to a menu icon sized thumbnail; GDI+ does not resize on display.
+    let mut thumb: *mut GpImage = std::ptr::null_mut();
+    let status = unsafe {
+        GdipGetImageThumbnail(
+            gp_bitmap.cast(),
+            MENU_IMAGE_SIZE,
+            MENU_IMAGE_SIZE,
+            &mut thumb,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+
+    unsafe { GdipDisposeImage(gp_bitmap.cast()) };
+    if status.0 != 0 || thumb.is_null() {
+        return None;
+    }
+
+    let mut hbitmap = HBITMAP::default();
+    // ARGB background 0 (fully transparent) for the alpha conversion.
+    let status = unsafe { GdipCreateHBITMAPFromBitmap(thumb.cast(), &mut hbitmap, 0) };
+
+    unsafe { GdipDisposeImage(thumb) };
+
+    if status.0 != 0 || hbitmap.is_invalid() {
+        None
+    } else {
+        Some(hbitmap)
+    }
 }
 
 /// Extract the Win32 `HWND` (as an `isize`) from the window's raw handle.


### PR DESCRIPTION
## Description

Support the image for native menu item. 

macOS (`NSImage`) supports using SVG for menu item, however Windows does not, hence adding `resvg` to rasterize the images before rendering.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1582" height="1062" alt="Screenshot 2026-06-20 at 8 14 47 AM" src="https://github.com/user-attachments/assets/65290a2c-d989-491a-8691-e3158ccaaa1a" /> | <img width="1582" height="1062" alt="Screenshot 2026-06-20 at 8 14 18 AM" src="https://github.com/user-attachments/assets/716214d8-bd82-47b1-9d93-6eda53d780ed" /> |
| <img width="2002" height="1225" alt="Screenshot 2026-06-19 233118" src="https://github.com/user-attachments/assets/10bd5ebb-d800-4f89-80fc-7339a8e1e7b1" /> | <img width="2002" height="1225" alt="Screenshot 2026-06-19 233259" src="https://github.com/user-attachments/assets/3e0adc64-1c57-4b08-94d2-ff4dbcf32cd1" /> |






## Break Changes

Added new APIs to render a menu item with image
- menu_with_image
- menu_with_image_disabled

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
