### PR TITLE
input: add InputState::refresh to apply runtime LSP provider changes

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1206,6 +1206,24 @@ impl InputState {
         });
     }
 
+    /// Refresh the input, so the next render re-runs syntax highlighting and
+    /// the LSP providers, not just a redraw.
+    ///
+    /// Assigning the `lsp` providers (or other render-affecting state) at
+    /// runtime does not take effect until the text next changes. Call this
+    /// afterwards to force the refresh on the next render.
+    ///
+    /// ```ignore
+    /// input.update(cx, |state, cx| {
+    ///     state.lsp.hover_provider = Some(provider);
+    ///     state.refresh(cx);
+    /// });
+    /// ```
+    pub fn refresh(&mut self, cx: &mut Context<Self>) {
+        self._pending_update = true;
+        cx.notify();
+    }
+
     pub(super) fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
         self.select_to(self.previous_boundary(self.cursor()), cx);
     }


### PR DESCRIPTION
Closes #2476

## Description

The `InputState.lsp` provider fields are public, but assigning them at runtime does not refresh the editor until the text next changes.

This adds `InputState::refresh(cx)`, which flags a pending update so the next render re-runs syntax highlighting and the LSP providers (not just a redraw).

```rust
input.update(cx, |state, cx| {
    state.lsp.hover_provider = Some(provider);
    state.refresh(cx);
});
```

## How to Test

Create an InputState, assign an `lsp` provider at runtime, then call `refresh` and watch the input update without editing text.

- Attach an LSP provider (hover / document color / semantic tokens) at runtime, call `refresh`, confirm it takes effect without editing text
- Swap providers at runtime and `refresh`; confirm old results clear and the new provider runs

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)