### PR TITLE
native_menu: Align native menu icon handling

### DIFF
--- a/crates/story/src/stories/native_menu_story.rs
+++ b/crates/story/src/stories/native_menu_story.rs
@@ -6,7 +6,9 @@ use gpui::{
     InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement as _, Pixels,
     Point, Render, SharedString, Styled as _, Window, div, px,
 };
-use gpui_component::{ActiveTheme as _, ElementExt, button::Button, native_menu::NativeMenu, v_flex};
+use gpui_component::{
+    ActiveTheme as _, ElementExt, IconName, button::Button, native_menu::NativeMenu, v_flex,
+};
 use serde::Deserialize;
 
 use crate::section;
@@ -28,15 +30,6 @@ fn click(label: &str) -> Box<dyn Action> {
     Box::new(MenuClick(label.to_string().into()))
 }
 
-/// Absolute path to a bounded icon.
-fn icon_path(name: &str) -> String {
-    format!(
-        "{}/../assets/assets/icons/{}",
-        env!("CARGO_MANIFEST_DIR"),
-        name
-    )
-}
-
 /// Demo menu: normal items, a disabled item, a checked item (reflecting
 /// `word_wrap`, which the story toggles), and nested submenus.
 fn demo_menu(word_wrap: bool) -> NativeMenu {
@@ -45,8 +38,8 @@ fn demo_menu(word_wrap: bool) -> NativeMenu {
         .menu("Copy", click("Copy"))
         .menu("Paste", click("Paste"))
         .separator()
-        .menu_with_image("Github", icon_path("github.svg"), Box::new(OpenGitHub))
-        .menu_with_image("Inbox", icon_path("inbox.svg"), click("Inbox"))
+        .menu_with_icon("Github", IconName::Github, Box::new(OpenGitHub))
+        .menu_with_icon("Inbox", IconName::Inbox, click("Inbox"))
         .separator()
         .menu_with_disabled("Disabled item", true, click("Disabled"))
         .menu_with_check("Word Wrap", word_wrap, click("Word Wrap"))

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -196,7 +196,7 @@ objc2-app-kit = { version = "0.3", features = [
     "NSEvent",
     "NSImage",
 ] }
-objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
+objc2-foundation = { version = "0.3", features = ["NSData", "NSString", "NSGeometry"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native menu (NativeMenu) — drives Win32 popup menus.
@@ -206,6 +206,9 @@ windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_Graphics_GdiPlus",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Memory",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -1330,7 +1330,7 @@ $x = 1;
     #[test]
     #[cfg(feature = "tree-sitter-languages")]
     fn test_highlight_allow_overlap_property_combines_nested_captures() {
-        let markdown = "This has ***bold and italic*** and **bold _with_ italic** text.";
+        let markdown = "This has **_bold and italic_** and **bold _with_ italic** text.";
         let rope = Rope::from_str(markdown);
         let mut highlighter = SyntaxHighlighter::new("markdown");
         highlighter.update(None, &rope, None);

--- a/crates/ui/src/icon.rs
+++ b/crates/ui/src/icon.rs
@@ -98,6 +98,11 @@ impl Icon {
         self
     }
 
+    #[cfg(any(target_os = "macos", target_os = "windows", test))]
+    pub(crate) fn path_ref(&self) -> &SharedString {
+        &self.path
+    }
+
     /// Create a new view for the icon
     pub fn view(self, cx: &mut App) -> Entity<Icon> {
         cx.new(|_| self)

--- a/crates/ui/src/native_menu/fallback.rs
+++ b/crates/ui/src/native_menu/fallback.rs
@@ -9,7 +9,6 @@ use gpui::{
     Point, Render, Subscription, Window, anchored, deferred, div, px,
 };
 
-use crate::Icon;
 use crate::menu::{PopupMenu, PopupMenuItem};
 use crate::root::Root;
 
@@ -79,20 +78,21 @@ fn build_popup(
                 NativeMenuItem::Item {
                     label,
                     disabled,
-                    checked: _,
-                    image: Some(image),
+                    checked,
+                    icon: Some(icon),
                     action: Some(action),
-                } => menu.menu_with_icon_and_disabled(
-                    label,
-                    Icon::default().path(image),
-                    action,
-                    disabled,
+                } => menu.item(
+                    PopupMenuItem::new(label)
+                        .icon(*icon)
+                        .action(action)
+                        .disabled(disabled)
+                        .checked(checked),
                 ),
                 NativeMenuItem::Item {
                     label,
                     disabled,
                     checked,
-                    image: None,
+                    icon: None,
                     action: Some(action),
                 } => menu.menu_with_check_and_disabled(label, checked, action, disabled),
                 NativeMenuItem::Item { action: None, .. } => menu,

--- a/crates/ui/src/native_menu/fallback.rs
+++ b/crates/ui/src/native_menu/fallback.rs
@@ -83,7 +83,7 @@ fn build_popup(
                     action: Some(action),
                 } => menu.item(
                     PopupMenuItem::new(label)
-                        .icon(*icon)
+                        .icon((*icon).into_icon())
                         .action(action)
                         .disabled(disabled)
                         .checked(checked),

--- a/crates/ui/src/native_menu/fallback.rs
+++ b/crates/ui/src/native_menu/fallback.rs
@@ -83,7 +83,7 @@ fn build_popup(
                     action: Some(action),
                 } => menu.item(
                     PopupMenuItem::new(label)
-                        .icon((*icon).into_icon())
+                        .icon(*icon)
                         .action(action)
                         .disabled(disabled)
                         .checked(checked),

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -2,7 +2,7 @@
 
 use std::cell::Cell;
 
-use gpui::{Action, App, Pixels, Point, Window};
+use gpui::{Action, App, Image, Pixels, Point, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send, sel};
@@ -10,7 +10,7 @@ use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
 use objc2_foundation::{NSData, NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use super::{NativeMenuIconSource, NativeMenuItem};
+use super::NativeMenuItem;
 
 /// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
 /// the row, so a large file would otherwise overflow it.
@@ -142,7 +142,7 @@ fn build_menu<'a>(
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
                     if let Some(icon) = icon {
-                        if let Some(ns_image) = ns_image_for_icon(icon.source()) {
+                        if let Some(ns_image) = ns_image_for_icon(icon.image()) {
                             ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
                             ns_image.setTemplate(true);
                             ns_item.setImage(Some(&ns_image));
@@ -182,21 +182,16 @@ fn build_menu<'a>(
     menu
 }
 
-fn ns_image_for_icon(source: Option<&NativeMenuIconSource>) -> Option<Retained<NSImage>> {
-    match source? {
-        NativeMenuIconSource::File(path) => {
-            NSImage::initWithContentsOfFile(NSImage::alloc(), &NSString::from_str(path))
-        }
-        NativeMenuIconSource::Bytes(bytes) => {
-            if bytes.is_empty() {
-                return None;
-            }
-
-            let data =
-                unsafe { NSData::dataWithBytes_length(bytes.as_ptr().cast(), bytes.len() as _) };
-            NSImage::initWithData(NSImage::alloc(), &data)
-        }
+fn ns_image_for_icon(image: Option<&Image>) -> Option<Retained<NSImage>> {
+    let image = image?;
+    if image.bytes.is_empty() {
+        return None;
     }
+
+    let data = unsafe {
+        NSData::dataWithBytes_length(image.bytes.as_ptr().cast(), image.bytes.len() as _)
+    };
+    NSImage::initWithData(NSImage::alloc(), &data)
 }
 
 /// Extract the AppKit `NSView` pointer from the window's raw handle.

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -10,7 +10,7 @@ use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
 use objc2_foundation::{NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use super::NativeMenuItem;
+use super::ResolvedNativeMenuItem;
 
 /// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
 /// the row, so a large file would otherwise overflow it.
@@ -51,7 +51,7 @@ impl MenuTarget {
 /// The AppKit tracking loop is run from a foreground task so that GPUI is not
 /// borrowed while the menu is open.
 pub(super) fn show(
-    items: Vec<NativeMenuItem>,
+    items: Vec<ResolvedNativeMenuItem>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -86,7 +86,7 @@ pub(super) fn show(
 /// selected item's action.
 fn run_menu(
     view_ptr: usize,
-    items: &[NativeMenuItem],
+    items: &[ResolvedNativeMenuItem],
     position: Point<Pixels>,
 ) -> Option<Box<dyn Action>> {
     let mtm = MainThreadMarker::new()?;
@@ -118,7 +118,7 @@ fn run_menu(
 /// Recursively build an `NSMenu`. Each actionable leaf item is given a tag equal
 /// to its index in `actions`, so the selected tag maps back to its action.
 fn build_menu<'a>(
-    items: &'a [NativeMenuItem],
+    items: &'a [ResolvedNativeMenuItem],
     target: &MenuTarget,
     mtm: MainThreadMarker,
     actions: &mut Vec<&'a Box<dyn Action>>,
@@ -129,8 +129,8 @@ fn build_menu<'a>(
 
     for item in items {
         match item {
-            NativeMenuItem::Separator => menu.addItem(&NSMenuItem::separatorItem(mtm)),
-            NativeMenuItem::Item {
+            ResolvedNativeMenuItem::Separator => menu.addItem(&NSMenuItem::separatorItem(mtm)),
+            ResolvedNativeMenuItem::Item {
                 label,
                 disabled,
                 checked,
@@ -167,7 +167,7 @@ fn build_menu<'a>(
                 }
                 menu.addItem(&ns_item);
             }
-            NativeMenuItem::Submenu {
+            ResolvedNativeMenuItem::Submenu {
                 label,
                 disabled,
                 items,

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -1,8 +1,8 @@
 //! macOS native menu implementation (AppKit `NSMenu` via objc2).
 
-use std::cell::Cell;
+use std::{cell::Cell, sync::Arc};
 
-use gpui::{Action, App, Image, Pixels, Point, Window};
+use gpui::{Action, App, AssetSource, Pixels, Point, SharedString, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send, sel};
@@ -10,7 +10,7 @@ use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
 use objc2_foundation::{NSData, NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use super::NativeMenuItem;
+use super::{NativeMenuItem, resolve_icon_image};
 
 /// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
 /// the row, so a large file would otherwise overflow it.
@@ -52,6 +52,7 @@ impl MenuTarget {
 /// borrowed while the menu is open.
 pub(super) fn show(
     items: Vec<NativeMenuItem>,
+    asset_source: Arc<dyn AssetSource>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -64,7 +65,7 @@ pub(super) fn show(
     let handle = Window::window_handle(window);
 
     cx.spawn(async move |cx| {
-        let action = run_menu(view_ptr, &items, position);
+        let action = run_menu(view_ptr, &items, asset_source.as_ref(), position);
         let _ = cx.update(move |app| {
             let _ = handle.update(app, move |_, window, app| {
                 if let Some(action) = action {
@@ -87,6 +88,7 @@ pub(super) fn show(
 fn run_menu(
     view_ptr: usize,
     items: &[NativeMenuItem],
+    asset_source: &dyn AssetSource,
     position: Point<Pixels>,
 ) -> Option<Box<dyn Action>> {
     let mtm = MainThreadMarker::new()?;
@@ -96,7 +98,7 @@ fn run_menu(
 
     let target = MenuTarget::new();
     let mut actions: Vec<&Box<dyn Action>> = Vec::new();
-    let ns_menu = build_menu(items, &target, mtm, &mut actions);
+    let ns_menu = build_menu(items, asset_source, &target, mtm, &mut actions);
 
     // `position` is window-relative, logical pixels, origin top-left (GPUI).
     // AppKit view coordinates have their origin at the bottom-left, so flip y.
@@ -119,6 +121,7 @@ fn run_menu(
 /// to its index in `actions`, so the selected tag maps back to its action.
 fn build_menu<'a>(
     items: &'a [NativeMenuItem],
+    asset_source: &dyn AssetSource,
     target: &MenuTarget,
     mtm: MainThreadMarker,
     actions: &mut Vec<&'a Box<dyn Action>>,
@@ -142,7 +145,7 @@ fn build_menu<'a>(
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
                     if let Some(icon) = icon {
-                        if let Some(ns_image) = ns_image_for_icon(icon.image()) {
+                        if let Some(ns_image) = ns_image_for_icon(icon.path_ref(), asset_source) {
                             ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
                             ns_image.setTemplate(true);
                             ns_item.setImage(Some(&ns_image));
@@ -170,7 +173,7 @@ fn build_menu<'a>(
                 items,
             } => {
                 let ns_item = NSMenuItem::new(mtm);
-                let submenu = build_menu(items, target, mtm, actions);
+                let submenu = build_menu(items, asset_source, target, mtm, actions);
                 ns_item.setTitle(&NSString::from_str(label));
                 ns_item.setEnabled(!*disabled);
                 ns_item.setSubmenu(Some(&submenu));
@@ -182,8 +185,11 @@ fn build_menu<'a>(
     menu
 }
 
-fn ns_image_for_icon(image: Option<&Image>) -> Option<Retained<NSImage>> {
-    let image = image?;
+fn ns_image_for_icon(
+    path: &SharedString,
+    asset_source: &dyn AssetSource,
+) -> Option<Retained<NSImage>> {
+    let image = resolve_icon_image(path, asset_source)?;
     if image.bytes.is_empty() {
         return None;
     }

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -10,7 +10,7 @@ use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
 use objc2_foundation::{NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use super::ResolvedNativeMenuItem;
+use super::NativeMenuItem;
 
 /// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
 /// the row, so a large file would otherwise overflow it.
@@ -51,7 +51,7 @@ impl MenuTarget {
 /// The AppKit tracking loop is run from a foreground task so that GPUI is not
 /// borrowed while the menu is open.
 pub(super) fn show(
-    items: Vec<ResolvedNativeMenuItem>,
+    items: Vec<NativeMenuItem>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -86,7 +86,7 @@ pub(super) fn show(
 /// selected item's action.
 fn run_menu(
     view_ptr: usize,
-    items: &[ResolvedNativeMenuItem],
+    items: &[NativeMenuItem],
     position: Point<Pixels>,
 ) -> Option<Box<dyn Action>> {
     let mtm = MainThreadMarker::new()?;
@@ -118,7 +118,7 @@ fn run_menu(
 /// Recursively build an `NSMenu`. Each actionable leaf item is given a tag equal
 /// to its index in `actions`, so the selected tag maps back to its action.
 fn build_menu<'a>(
-    items: &'a [ResolvedNativeMenuItem],
+    items: &'a [NativeMenuItem],
     target: &MenuTarget,
     mtm: MainThreadMarker,
     actions: &mut Vec<&'a Box<dyn Action>>,
@@ -129,22 +129,22 @@ fn build_menu<'a>(
 
     for item in items {
         match item {
-            ResolvedNativeMenuItem::Separator => menu.addItem(&NSMenuItem::separatorItem(mtm)),
-            ResolvedNativeMenuItem::Item {
+            NativeMenuItem::Separator => menu.addItem(&NSMenuItem::separatorItem(mtm)),
+            NativeMenuItem::Item {
                 label,
                 disabled,
                 checked,
-                image,
+                icon,
                 action,
             } => {
                 let ns_item = NSMenuItem::new(mtm);
                 unsafe {
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
-                    if let Some(image) = image {
+                    if let Some(icon) = icon {
                         if let Some(ns_image) = NSImage::initWithContentsOfFile(
                             NSImage::alloc(),
-                            &NSString::from_str(image),
+                            &NSString::from_str(icon.path_ref()),
                         ) {
                             ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
                             ns_image.setTemplate(true);
@@ -167,7 +167,7 @@ fn build_menu<'a>(
                 }
                 menu.addItem(&ns_item);
             }
-            ResolvedNativeMenuItem::Submenu {
+            NativeMenuItem::Submenu {
                 label,
                 disabled,
                 items,

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -7,10 +7,10 @@ use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send, sel};
 use objc2_app_kit::{NSImage, NSMenu, NSMenuItem, NSView};
-use objc2_foundation::{NSPoint, NSSize, NSString};
+use objc2_foundation::{NSData, NSPoint, NSSize, NSString};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-use super::NativeMenuItem;
+use super::{NativeMenuIconSource, NativeMenuItem};
 
 /// Side length (in points) menu item images are scaled to. AppKit does not resize the image to fit
 /// the row, so a large file would otherwise overflow it.
@@ -142,10 +142,7 @@ fn build_menu<'a>(
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
                     if let Some(icon) = icon {
-                        if let Some(ns_image) = NSImage::initWithContentsOfFile(
-                            NSImage::alloc(),
-                            &NSString::from_str(icon.path_ref()),
-                        ) {
+                        if let Some(ns_image) = ns_image_for_icon(icon.source()) {
                             ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
                             ns_image.setTemplate(true);
                             ns_item.setImage(Some(&ns_image));
@@ -183,6 +180,23 @@ fn build_menu<'a>(
     }
 
     menu
+}
+
+fn ns_image_for_icon(source: Option<&NativeMenuIconSource>) -> Option<Retained<NSImage>> {
+    match source? {
+        NativeMenuIconSource::File(path) => {
+            NSImage::initWithContentsOfFile(NSImage::alloc(), &NSString::from_str(path))
+        }
+        NativeMenuIconSource::Bytes(bytes) => {
+            if bytes.is_empty() {
+                return None;
+            }
+
+            let data =
+                unsafe { NSData::dataWithBytes_length(bytes.as_ptr().cast(), bytes.len() as _) };
+            NSImage::initWithData(NSImage::alloc(), &data)
+        }
+    }
 }
 
 /// Extract the AppKit `NSView` pointer from the window's raw handle.

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -49,7 +49,7 @@ enum NativeMenuItem {
         disabled: bool,
         checked: bool,
         /// Icon shown next to the label.
-        icon: Option<Box<NativeMenuIcon>>,
+        icon: Option<Box<Icon>>,
         /// Action dispatched when the item is selected.
         action: Option<Box<dyn Action>>,
     },
@@ -58,36 +58,6 @@ enum NativeMenuItem {
         disabled: bool,
         items: Vec<NativeMenuItem>,
     },
-}
-
-struct NativeMenuIcon {
-    icon: Icon,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    image: Option<Arc<Image>>,
-}
-
-impl NativeMenuIcon {
-    fn new(icon: Icon) -> Self {
-        Self {
-            icon,
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            image: None,
-        }
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "windows", test))]
-    fn path_ref(&self) -> &SharedString {
-        self.icon.path_ref()
-    }
-
-    fn into_icon(self) -> Icon {
-        self.icon
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    fn image(&self) -> Option<&Image> {
-        self.image.as_deref()
-    }
 }
 
 /// A menu rendered by the operating system.
@@ -190,7 +160,7 @@ impl NativeMenu {
             label: label.into(),
             disabled,
             checked,
-            icon: icon.map(NativeMenuIcon::new).map(Box::new),
+            icon: icon.map(Box::new),
             action,
         });
         self
@@ -229,15 +199,11 @@ impl NativeMenu {
 
         #[cfg(target_os = "macos")]
         {
-            let mut items = self.items;
-            resolve_platform_icons(&mut items, cx.asset_source().as_ref());
-            macos::show(items, position, window, cx);
+            macos::show(self.items, cx.asset_source().clone(), position, window, cx);
         }
         #[cfg(target_os = "windows")]
         {
-            let mut items = self.items;
-            resolve_platform_icons(&mut items, cx.asset_source().as_ref());
-            windows::show(items, position, window, cx);
+            windows::show(self.items, cx.asset_source().clone(), position, window, cx);
         }
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         fallback::show(self.items, position, window, cx);
@@ -245,30 +211,10 @@ impl NativeMenu {
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn AssetSource) {
-    for item in items {
-        match item {
-            NativeMenuItem::Separator => {}
-            NativeMenuItem::Item {
-                icon: icon_slot, ..
-            } => {
-                let Some(icon) = icon_slot.as_mut() else {
-                    continue;
-                };
-                let image = resolve_icon_image(icon.path_ref(), asset_source);
-                if image.is_some() {
-                    icon.image = image;
-                } else {
-                    *icon_slot = None;
-                }
-            }
-            NativeMenuItem::Submenu { items, .. } => resolve_platform_icons(items, asset_source),
-        }
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-fn resolve_icon_image(path: &SharedString, asset_source: &dyn AssetSource) -> Option<Arc<Image>> {
+pub(super) fn resolve_icon_image(
+    path: &SharedString,
+    asset_source: &dyn AssetSource,
+) -> Option<Arc<Image>> {
     if path.is_empty() {
         return None;
     }

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -150,33 +150,6 @@ impl NativeMenu {
         self.menu_with_icon_disabled(label, icon, disabled, action)
     }
 
-    /// Append an item showing an image file next to its label.
-    ///
-    /// Prefer [`Self::menu_with_icon`] for consistency with [`crate::menu::PopupMenu`].
-    #[deprecated(note = "use NativeMenu::menu_with_icon instead")]
-    pub fn menu_with_image(
-        self,
-        label: impl Into<SharedString>,
-        image: impl Into<SharedString>,
-        action: Box<dyn Action>,
-    ) -> Self {
-        self.menu_with_icon(label, Icon::default().path(image), action)
-    }
-
-    /// Append an item showing an image file next to its label, controlling its `disabled` state.
-    ///
-    /// Prefer [`Self::menu_with_icon_disabled`] for consistency with [`crate::menu::PopupMenu`].
-    #[deprecated(note = "use NativeMenu::menu_with_icon_disabled instead")]
-    pub fn menu_with_image_disabled(
-        self,
-        label: impl Into<SharedString>,
-        image: impl Into<SharedString>,
-        disabled: bool,
-        action: Box<dyn Action>,
-    ) -> Self {
-        self.menu_with_icon_disabled(label, Icon::default().path(image), disabled, action)
-    }
-
     fn menu_with(
         mut self,
         label: impl Into<SharedString>,

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -22,7 +22,17 @@
 //!     .show(position, window, cx);
 //! ```
 
+use crate::Icon;
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use gpui::AssetSource;
 use gpui::{Action, App, Pixels, Point, SharedString, Window};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    path::Path,
+};
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -40,8 +50,8 @@ enum NativeMenuItem {
         label: SharedString,
         disabled: bool,
         checked: bool,
-        /// Path to an image shown next to the label
-        image: Option<SharedString>,
+        /// Icon shown next to the label.
+        icon: Option<Box<Icon>>,
         /// Action dispatched when the item is selected.
         action: Option<Box<dyn Action>>,
     },
@@ -49,6 +59,25 @@ enum NativeMenuItem {
         label: SharedString,
         disabled: bool,
         items: Vec<NativeMenuItem>,
+    },
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+enum ResolvedNativeMenuItem {
+    Separator,
+    Item {
+        label: SharedString,
+        disabled: bool,
+        checked: bool,
+        /// Filesystem path to an image shown next to the label.
+        image: Option<SharedString>,
+        /// Action dispatched when the item is selected.
+        action: Option<Box<dyn Action>>,
+    },
+    Submenu {
+        label: SharedString,
+        disabled: bool,
+        items: Vec<ResolvedNativeMenuItem>,
     },
 }
 
@@ -92,31 +121,71 @@ impl NativeMenu {
         self.menu_with(label, false, checked, None, Some(action))
     }
 
-    /// Append an item showing `image` next to its label.
+    /// Append an item showing `icon` next to its label.
     ///
-    /// `image` is a filesystem path to an image file.
-    /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item text
-    /// and assigned to the item ([`NSMenuItem::image`]).
+    /// Native platform menus render the icon by loading the [`Icon`]'s path.
+    /// File-backed icons such as [`crate::IconName`] work across all backends.
+    /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item
+    /// text and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
     /// content bitmap (`MENUITEMINFOW::hbmpItem`), shown beside the label. SVG files are
     /// rasterized, with `resvg`; other formats (PNG, JPEG, BMP, ...) are decoded by GDI+.
-    /// **Other platforms** (fallback): rendered as the menu item's [`crate::Icon`]; works best
-    /// with SVG assets.
+    /// **Other platforms** (fallback): rendered as the menu item's [`crate::Icon`].
     ///
-    /// Note: this is the menu item's *content* image, not its state/check-mark indicator.
+    /// Note: this is the menu item's *content* icon, not its state/check-mark indicator.
+    pub fn menu_with_icon(
+        self,
+        label: impl Into<SharedString>,
+        icon: impl Into<Icon>,
+        action: Box<dyn Action>,
+    ) -> Self {
+        self.menu_with(label, false, false, Some(icon.into()), Some(action))
+    }
+
+    /// Append an item showing `icon` next to its label, controlling its `disabled` state.
+    ///
+    /// Same icon behavior as [`Self::menu_with_icon`]. Use this when an item
+    /// carries an icon but should be greyed out.
+    pub fn menu_with_icon_disabled(
+        self,
+        label: impl Into<SharedString>,
+        icon: impl Into<Icon>,
+        disabled: bool,
+        action: Box<dyn Action>,
+    ) -> Self {
+        self.menu_with(label, disabled, false, Some(icon.into()), Some(action))
+    }
+
+    /// Add Menu Item with Icon and disabled state.
+    ///
+    /// Alias for [`Self::menu_with_icon_disabled`], matching [`crate::menu::PopupMenu`].
+    pub fn menu_with_icon_and_disabled(
+        self,
+        label: impl Into<SharedString>,
+        icon: impl Into<Icon>,
+        action: Box<dyn Action>,
+        disabled: bool,
+    ) -> Self {
+        self.menu_with_icon_disabled(label, icon, disabled, action)
+    }
+
+    /// Append an item showing an image file next to its label.
+    ///
+    /// Prefer [`Self::menu_with_icon`] for consistency with [`crate::menu::PopupMenu`].
+    #[deprecated(note = "use NativeMenu::menu_with_icon instead")]
     pub fn menu_with_image(
         self,
         label: impl Into<SharedString>,
         image: impl Into<SharedString>,
         action: Box<dyn Action>,
     ) -> Self {
-        self.menu_with(label, false, false, Some(image.into()), Some(action))
+        self.menu_with_icon(label, Icon::default().path(image), action)
     }
 
-    /// Append an item showing `image` next to its label, controlling its `disabled` state.
+    /// Append an item showing an image file next to its label, controlling its `disabled` state.
     ///
-    /// Same image behavior as [`Self::menu_with_image`]. Use this when an item
-    /// carries an icon but should be greyed out.
+    /// Prefer [`Self::menu_with_icon_disabled`] for consistency with [`crate::menu::PopupMenu`].
+    #[deprecated(note = "use NativeMenu::menu_with_icon_disabled instead")]
     pub fn menu_with_image_disabled(
         self,
         label: impl Into<SharedString>,
@@ -124,7 +193,7 @@ impl NativeMenu {
         disabled: bool,
         action: Box<dyn Action>,
     ) -> Self {
-        self.menu_with(label, disabled, false, Some(image.into()), Some(action))
+        self.menu_with_icon_disabled(label, Icon::default().path(image), disabled, action)
     }
 
     fn menu_with(
@@ -132,14 +201,14 @@ impl NativeMenu {
         label: impl Into<SharedString>,
         disabled: bool,
         checked: bool,
-        image: Option<SharedString>,
+        icon: Option<Icon>,
         action: Option<Box<dyn Action>>,
     ) -> Self {
         self.items.push(NativeMenuItem::Item {
             label: label.into(),
             disabled,
             checked,
-            image,
+            icon: icon.map(Box::new),
             action,
         });
         self
@@ -177,12 +246,95 @@ impl NativeMenu {
         }
 
         #[cfg(target_os = "macos")]
-        macos::show(self.items, position, window, cx);
+        macos::show(
+            resolve_platform_items(self.items, cx.asset_source().as_ref()),
+            position,
+            window,
+            cx,
+        );
         #[cfg(target_os = "windows")]
-        windows::show(self.items, position, window, cx);
+        windows::show(
+            resolve_platform_items(self.items, cx.asset_source().as_ref()),
+            position,
+            window,
+            cx,
+        );
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         fallback::show(self.items, position, window, cx);
     }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn resolve_platform_items(
+    items: Vec<NativeMenuItem>,
+    asset_source: &dyn AssetSource,
+) -> Vec<ResolvedNativeMenuItem> {
+    items
+        .into_iter()
+        .map(|item| match item {
+            NativeMenuItem::Separator => ResolvedNativeMenuItem::Separator,
+            NativeMenuItem::Item {
+                label,
+                disabled,
+                checked,
+                icon,
+                action,
+            } => ResolvedNativeMenuItem::Item {
+                label,
+                disabled,
+                checked,
+                image: icon
+                    .as_deref()
+                    .and_then(|icon| resolve_icon_path(icon, asset_source)),
+                action,
+            },
+            NativeMenuItem::Submenu {
+                label,
+                disabled,
+                items,
+            } => ResolvedNativeMenuItem::Submenu {
+                label,
+                disabled,
+                items: resolve_platform_items(items, asset_source),
+            },
+        })
+        .collect()
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn resolve_icon_path(icon: &Icon, asset_source: &dyn AssetSource) -> Option<SharedString> {
+    let path = icon.path_ref();
+    if path.is_empty() {
+        return None;
+    }
+
+    if Path::new(path.as_ref()).is_file() {
+        return Some(path.clone());
+    }
+
+    let bytes = asset_source.load(path.as_ref()).ok().flatten()?;
+    materialize_icon_asset(path, &bytes).ok()
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn materialize_icon_asset(path: &str, bytes: &[u8]) -> std::io::Result<SharedString> {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    bytes.hash(&mut hasher);
+
+    let extension = Path::new(path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("img");
+    let dir = std::env::temp_dir().join("gpui-component-native-menu-icons");
+    std::fs::create_dir_all(&dir)?;
+
+    let file = dir.join(format!("{:016x}.{}", hasher.finish(), extension));
+    if !file.is_file() {
+        std::fs::write(&file, bytes)?;
+    }
+
+    Ok(file.to_string_lossy().to_string().into())
 }
 
 /// Reuse an existing GPUI menu definition as a native menu.
@@ -206,7 +358,7 @@ impl From<gpui::Menu> for NativeMenu {
                     label: name,
                     disabled,
                     checked,
-                    image: None,
+                    icon: None,
                     action: Some(action),
                 }),
                 gpui::MenuItem::Submenu(submenu) => native.items.push(NativeMenuItem::Submenu {
@@ -218,5 +370,77 @@ impl From<gpui::Menu> for NativeMenu {
             }
         }
         native
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IconName;
+    use serde::Deserialize;
+
+    #[derive(Action, Clone, PartialEq, Deserialize)]
+    #[action(namespace = native_menu_tests, no_json)]
+    struct TestAction;
+
+    #[test]
+    fn test_native_menu_builder_accepts_icon() {
+        let menu =
+            NativeMenu::new().menu_with_icon("Github", IconName::Github, Box::new(TestAction));
+
+        assert_eq!(menu.items.len(), 1);
+        let NativeMenuItem::Item {
+            label,
+            disabled,
+            checked,
+            icon: Some(icon),
+            action: Some(_),
+        } = &menu.items[0]
+        else {
+            panic!("expected an actionable item with an icon");
+        };
+
+        assert_eq!(label, "Github");
+        assert!(!disabled);
+        assert!(!checked);
+        assert!(icon.path_ref().ends_with("github.svg"));
+    }
+
+    #[test]
+    fn test_native_menu_builder_accepts_icon_and_disabled_alias() {
+        let menu = NativeMenu::new().menu_with_icon_and_disabled(
+            "Inbox",
+            IconName::Inbox,
+            Box::new(TestAction),
+            true,
+        );
+
+        assert_eq!(menu.items.len(), 1);
+        let NativeMenuItem::Item {
+            label,
+            disabled,
+            checked,
+            icon: Some(icon),
+            action: Some(_),
+        } = &menu.items[0]
+        else {
+            panic!("expected a disabled actionable item with an icon");
+        };
+
+        assert_eq!(label, "Inbox");
+        assert!(disabled);
+        assert!(!checked);
+        assert!(icon.path_ref().ends_with("inbox.svg"));
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn test_native_menu_icon_asset_resolves_to_file_path() {
+        let icon = Icon::new(IconName::Github);
+        let path = resolve_icon_path(&icon, &gpui_component_assets::Assets)
+            .expect("icon asset should resolve");
+
+        assert_ne!(path.as_ref(), icon.path_ref().as_ref());
+        assert!(std::path::Path::new(path.as_ref()).is_file());
     }
 }

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -28,7 +28,9 @@ use crate::Icon;
 use gpui::AssetSource;
 use gpui::{Action, App, Pixels, Point, SharedString, Window};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::path::Path;
+use gpui::{Image, ImageFormat};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::{path::Path, sync::Arc};
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -61,13 +63,7 @@ enum NativeMenuItem {
 struct NativeMenuIcon {
     icon: Icon,
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    source: Option<NativeMenuIconSource>,
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-enum NativeMenuIconSource {
-    File(SharedString),
-    Bytes(Vec<u8>),
+    image: Option<Arc<Image>>,
 }
 
 impl NativeMenuIcon {
@@ -75,7 +71,7 @@ impl NativeMenuIcon {
         Self {
             icon,
             #[cfg(any(target_os = "macos", target_os = "windows"))]
-            source: None,
+            image: None,
         }
     }
 
@@ -89,8 +85,8 @@ impl NativeMenuIcon {
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    fn source(&self) -> Option<&NativeMenuIconSource> {
-        self.source.as_ref()
+    fn image(&self) -> Option<&Image> {
+        self.image.as_deref()
     }
 }
 
@@ -259,9 +255,9 @@ fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn Asset
                 let Some(icon) = icon_slot.as_mut() else {
                     continue;
                 };
-                let source = resolve_icon_source(icon.path_ref(), asset_source);
-                if source.is_some() {
-                    icon.source = source;
+                let image = resolve_icon_image(icon.path_ref(), asset_source);
+                if image.is_some() {
+                    icon.image = image;
                 } else {
                     *icon_slot = None;
                 }
@@ -272,20 +268,84 @@ fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn Asset
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn resolve_icon_source(
-    path: &SharedString,
-    asset_source: &dyn AssetSource,
-) -> Option<NativeMenuIconSource> {
+fn resolve_icon_image(path: &SharedString, asset_source: &dyn AssetSource) -> Option<Arc<Image>> {
     if path.is_empty() {
         return None;
     }
 
-    if Path::new(path.as_ref()).is_file() {
-        return Some(NativeMenuIconSource::File(path.clone()));
+    let bytes = if Path::new(path.as_ref()).is_file() {
+        std::fs::read(path.as_ref()).ok()?
+    } else {
+        asset_source
+            .load(path.as_ref())
+            .ok()
+            .flatten()?
+            .into_owned()
+    };
+    let format = image_format(path.as_ref(), &bytes)?;
+    Some(Arc::new(Image::from_bytes(format, bytes)))
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn image_format(path: &str, bytes: &[u8]) -> Option<ImageFormat> {
+    if let Some(extension) = Path::new(path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+    {
+        let format = match extension.to_ascii_lowercase().as_str() {
+            "png" => ImageFormat::Png,
+            "jpg" | "jpeg" => ImageFormat::Jpeg,
+            "webp" => ImageFormat::Webp,
+            "gif" => ImageFormat::Gif,
+            "svg" => ImageFormat::Svg,
+            "bmp" => ImageFormat::Bmp,
+            "tif" | "tiff" => ImageFormat::Tiff,
+            "ico" => ImageFormat::Ico,
+            "pbm" | "pgm" | "ppm" | "pnm" => ImageFormat::Pnm,
+            _ => return None,
+        };
+        return Some(format);
     }
 
-    let bytes = asset_source.load(path.as_ref()).ok().flatten()?;
-    Some(NativeMenuIconSource::Bytes(bytes.into_owned()))
+    image_format_from_bytes(bytes)
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn image_format_from_bytes(bytes: &[u8]) -> Option<ImageFormat> {
+    let bytes = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes);
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some(ImageFormat::Png)
+    } else if bytes.starts_with(b"\xff\xd8\xff") {
+        Some(ImageFormat::Jpeg)
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some(ImageFormat::Gif)
+    } else if bytes.starts_with(b"BM") {
+        Some(ImageFormat::Bmp)
+    } else if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP") {
+        Some(ImageFormat::Webp)
+    } else if bytes.starts_with(b"II*\0") || bytes.starts_with(b"MM\0*") {
+        Some(ImageFormat::Tiff)
+    } else if bytes.starts_with(b"\0\0\x01\0") || bytes.starts_with(b"\0\0\x02\0") {
+        Some(ImageFormat::Ico)
+    } else if is_svg_bytes(bytes) {
+        Some(ImageFormat::Svg)
+    } else if matches!(
+        bytes.get(0..2),
+        Some(b"P1" | b"P2" | b"P3" | b"P4" | b"P5" | b"P6")
+    ) {
+        Some(ImageFormat::Pnm)
+    } else {
+        None
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn is_svg_bytes(bytes: &[u8]) -> bool {
+    let text = match std::str::from_utf8(&bytes[..bytes.len().min(256)]) {
+        Ok(text) => text.trim_start(),
+        Err(_) => return false,
+    };
+    text.starts_with("<svg") || text.starts_with("<?xml")
 }
 
 /// Reuse an existing GPUI menu definition as a native menu.
@@ -388,12 +448,10 @@ mod tests {
     #[test]
     fn test_native_menu_icon_asset_resolves_to_bytes() {
         let icon = Icon::new(IconName::Github);
-        let source = resolve_icon_source(icon.path_ref(), &gpui_component_assets::Assets)
+        let image = resolve_icon_image(icon.path_ref(), &gpui_component_assets::Assets)
             .expect("icon asset should resolve");
 
-        let NativeMenuIconSource::Bytes(bytes) = source else {
-            panic!("expected asset-backed icon to resolve to bytes");
-        };
-        assert!(!bytes.is_empty());
+        assert_eq!(image.format, ImageFormat::Svg);
+        assert!(!image.bytes.is_empty());
     }
 }

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -28,11 +28,7 @@ use crate::Icon;
 use gpui::AssetSource;
 use gpui::{Action, App, Pixels, Point, SharedString, Window};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-    path::Path,
-};
+use std::path::Path;
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -51,7 +47,7 @@ enum NativeMenuItem {
         disabled: bool,
         checked: bool,
         /// Icon shown next to the label.
-        icon: Option<Box<Icon>>,
+        icon: Option<Box<NativeMenuIcon>>,
         /// Action dispatched when the item is selected.
         action: Option<Box<dyn Action>>,
     },
@@ -60,6 +56,42 @@ enum NativeMenuItem {
         disabled: bool,
         items: Vec<NativeMenuItem>,
     },
+}
+
+struct NativeMenuIcon {
+    icon: Icon,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    source: Option<NativeMenuIconSource>,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+enum NativeMenuIconSource {
+    File(SharedString),
+    Bytes(Vec<u8>),
+}
+
+impl NativeMenuIcon {
+    fn new(icon: Icon) -> Self {
+        Self {
+            icon,
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            source: None,
+        }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows", test))]
+    fn path_ref(&self) -> &SharedString {
+        self.icon.path_ref()
+    }
+
+    fn into_icon(self) -> Icon {
+        self.icon
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn source(&self) -> Option<&NativeMenuIconSource> {
+        self.source.as_ref()
+    }
 }
 
 /// A menu rendered by the operating system.
@@ -104,8 +136,8 @@ impl NativeMenu {
 
     /// Append an item showing `icon` next to its label.
     ///
-    /// Native platform menus render the icon by loading the [`Icon`]'s path.
-    /// File-backed icons such as [`crate::IconName`] work across all backends.
+    /// Native platform menus render file-backed icons from their filesystem path
+    /// and asset-backed icons from memory. [`crate::IconName`] works across all backends.
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item
     /// text and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
@@ -162,7 +194,7 @@ impl NativeMenu {
             label: label.into(),
             disabled,
             checked,
-            icon: icon.map(Box::new),
+            icon: icon.map(NativeMenuIcon::new).map(Box::new),
             action,
         });
         self
@@ -221,16 +253,17 @@ fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn Asset
     for item in items {
         match item {
             NativeMenuItem::Separator => {}
-            NativeMenuItem::Item { icon, .. } => {
-                let resolved_path = icon
-                    .as_deref()
-                    .and_then(|icon| resolve_icon_path(icon, asset_source));
-                if let Some(resolved_path) = resolved_path {
-                    if let Some(icon) = icon.as_mut() {
-                        **icon = icon.as_ref().clone().path(resolved_path);
-                    }
+            NativeMenuItem::Item {
+                icon: icon_slot, ..
+            } => {
+                let Some(icon) = icon_slot.as_mut() else {
+                    continue;
+                };
+                let source = resolve_icon_source(icon.path_ref(), asset_source);
+                if source.is_some() {
+                    icon.source = source;
                 } else {
-                    *icon = None;
+                    *icon_slot = None;
                 }
             }
             NativeMenuItem::Submenu { items, .. } => resolve_platform_icons(items, asset_source),
@@ -239,39 +272,20 @@ fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn Asset
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn resolve_icon_path(icon: &Icon, asset_source: &dyn AssetSource) -> Option<SharedString> {
-    let path = icon.path_ref();
+fn resolve_icon_source(
+    path: &SharedString,
+    asset_source: &dyn AssetSource,
+) -> Option<NativeMenuIconSource> {
     if path.is_empty() {
         return None;
     }
 
     if Path::new(path.as_ref()).is_file() {
-        return Some(path.clone());
+        return Some(NativeMenuIconSource::File(path.clone()));
     }
 
     let bytes = asset_source.load(path.as_ref()).ok().flatten()?;
-    materialize_icon_asset(path, &bytes).ok()
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-fn materialize_icon_asset(path: &str, bytes: &[u8]) -> std::io::Result<SharedString> {
-    let mut hasher = DefaultHasher::new();
-    path.hash(&mut hasher);
-    bytes.hash(&mut hasher);
-
-    let extension = Path::new(path)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .unwrap_or("img");
-    let dir = std::env::temp_dir().join("gpui-component-native-menu-icons");
-    std::fs::create_dir_all(&dir)?;
-
-    let file = dir.join(format!("{:016x}.{}", hasher.finish(), extension));
-    if !file.is_file() {
-        std::fs::write(&file, bytes)?;
-    }
-
-    Ok(file.to_string_lossy().to_string().into())
+    Some(NativeMenuIconSource::Bytes(bytes.into_owned()))
 }
 
 /// Reuse an existing GPUI menu definition as a native menu.
@@ -372,12 +386,14 @@ mod tests {
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     #[test]
-    fn test_native_menu_icon_asset_resolves_to_file_path() {
+    fn test_native_menu_icon_asset_resolves_to_bytes() {
         let icon = Icon::new(IconName::Github);
-        let path = resolve_icon_path(&icon, &gpui_component_assets::Assets)
+        let source = resolve_icon_source(icon.path_ref(), &gpui_component_assets::Assets)
             .expect("icon asset should resolve");
 
-        assert_ne!(path.as_ref(), icon.path_ref().as_ref());
-        assert!(std::path::Path::new(path.as_ref()).is_file());
+        let NativeMenuIconSource::Bytes(bytes) = source else {
+            panic!("expected asset-backed icon to resolve to bytes");
+        };
+        assert!(!bytes.is_empty());
     }
 }

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -62,25 +62,6 @@ enum NativeMenuItem {
     },
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-enum ResolvedNativeMenuItem {
-    Separator,
-    Item {
-        label: SharedString,
-        disabled: bool,
-        checked: bool,
-        /// Filesystem path to an image shown next to the label.
-        image: Option<SharedString>,
-        /// Action dispatched when the item is selected.
-        action: Option<Box<dyn Action>>,
-    },
-    Submenu {
-        label: SharedString,
-        disabled: bool,
-        items: Vec<ResolvedNativeMenuItem>,
-    },
-}
-
 /// A menu rendered by the operating system.
 ///
 /// Build it with the [`NativeMenu::menu`] / [`NativeMenu::separator`] builders,
@@ -246,59 +227,42 @@ impl NativeMenu {
         }
 
         #[cfg(target_os = "macos")]
-        macos::show(
-            resolve_platform_items(self.items, cx.asset_source().as_ref()),
-            position,
-            window,
-            cx,
-        );
+        {
+            let mut items = self.items;
+            resolve_platform_icons(&mut items, cx.asset_source().as_ref());
+            macos::show(items, position, window, cx);
+        }
         #[cfg(target_os = "windows")]
-        windows::show(
-            resolve_platform_items(self.items, cx.asset_source().as_ref()),
-            position,
-            window,
-            cx,
-        );
+        {
+            let mut items = self.items;
+            resolve_platform_icons(&mut items, cx.asset_source().as_ref());
+            windows::show(items, position, window, cx);
+        }
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         fallback::show(self.items, position, window, cx);
     }
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-fn resolve_platform_items(
-    items: Vec<NativeMenuItem>,
-    asset_source: &dyn AssetSource,
-) -> Vec<ResolvedNativeMenuItem> {
-    items
-        .into_iter()
-        .map(|item| match item {
-            NativeMenuItem::Separator => ResolvedNativeMenuItem::Separator,
-            NativeMenuItem::Item {
-                label,
-                disabled,
-                checked,
-                icon,
-                action,
-            } => ResolvedNativeMenuItem::Item {
-                label,
-                disabled,
-                checked,
-                image: icon
+fn resolve_platform_icons(items: &mut [NativeMenuItem], asset_source: &dyn AssetSource) {
+    for item in items {
+        match item {
+            NativeMenuItem::Separator => {}
+            NativeMenuItem::Item { icon, .. } => {
+                let resolved_path = icon
                     .as_deref()
-                    .and_then(|icon| resolve_icon_path(icon, asset_source)),
-                action,
-            },
-            NativeMenuItem::Submenu {
-                label,
-                disabled,
-                items,
-            } => ResolvedNativeMenuItem::Submenu {
-                label,
-                disabled,
-                items: resolve_platform_items(items, asset_source),
-            },
-        })
-        .collect()
+                    .and_then(|icon| resolve_icon_path(icon, asset_source));
+                if let Some(resolved_path) = resolved_path {
+                    if let Some(icon) = icon.as_mut() {
+                        **icon = icon.as_ref().clone().path(resolved_path);
+                    }
+                } else {
+                    *icon = None;
+                }
+            }
+            NativeMenuItem::Submenu { items, .. } => resolve_platform_icons(items, asset_source),
+        }
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -4,15 +4,18 @@ use std::ffi::c_void;
 
 use gpui::{Action, App, Pixels, Point, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use windows::Win32::Foundation::{BOOL, HANDLE, HWND, LPARAM, POINT, WPARAM};
+use windows::Win32::Foundation::{BOOL, GlobalFree, HANDLE, HWND, LPARAM, POINT, WPARAM};
 use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, ClientToScreen, CreateDIBSection, DIB_RGB_COLORS,
     DeleteObject, HBITMAP, HDC, HGDIOBJ,
 };
 use windows::Win32::Graphics::GdiPlus::{
-    GdipCreateBitmapFromFile, GdipCreateHBITMAPFromBitmap, GdipDisposeImage, GdipGetImageThumbnail,
-    GdiplusShutdown, GdiplusStartup, GdiplusStartupInput, GpBitmap, GpImage,
+    GdipCreateBitmapFromFile, GdipCreateBitmapFromStream, GdipCreateHBITMAPFromBitmap,
+    GdipDisposeImage, GdipGetImageThumbnail, GdiplusShutdown, GdiplusStartup, GdiplusStartupInput,
+    GpBitmap, GpImage,
 };
+use windows::Win32::System::Com::StructuredStorage::CreateStreamOnHGlobal;
+use windows::Win32::System::Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalUnlock};
 use windows::Win32::UI::Input::KeyboardAndMouse::SetCapture;
 use windows::Win32::UI::WindowsAndMessaging::{
     AppendMenuW, CreatePopupMenu, DestroyMenu, HMENU, MENUITEMINFOW, MF_CHECKED, MF_GRAYED,
@@ -22,7 +25,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::PCWSTR;
 
-use super::NativeMenuItem;
+use super::{NativeMenuIconSource, NativeMenuItem};
 
 /// Side length (in **logical pixels**) menu item images are scaled to. The
 /// physical bitmap size is this multiplied by the window's scale factor (see
@@ -175,7 +178,7 @@ unsafe fn build_menu<'a>(
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
                 if let Some(icon) = icon {
-                    if let Some(bitmap) = unsafe { load_hbitmap(icon.path_ref(), image_px) } {
+                    if let Some(bitmap) = unsafe { load_hbitmap(icon.source(), image_px) } {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -247,7 +250,7 @@ impl Drop for GdiplusSession {
     }
 }
 
-/// Load an image file into an `HBITMAP`, scaled to `image_px` square so it
+/// Load an image into an `HBITMAP`, scaled to `image_px` square so it
 /// doesn't overflow the menu row.
 ///
 /// SVG files are rasterized with `resvg` (see [`rasterize_svg`]); GDI+ has no
@@ -259,13 +262,18 @@ impl Drop for GdiplusSession {
 ///
 /// # Safety
 /// Calls GDI+ /GDI flat APIs; the returned handle is owned by the caller.
-unsafe fn load_hbitmap(path: &str, image_px: u32) -> Option<HBITMAP> {
+unsafe fn load_hbitmap(source: Option<&NativeMenuIconSource>, image_px: u32) -> Option<HBITMAP> {
+    match source? {
+        NativeMenuIconSource::File(path) => unsafe { load_hbitmap_from_file(path, image_px) },
+        NativeMenuIconSource::Bytes(bytes) => unsafe { load_hbitmap_from_bytes(bytes, image_px) },
+    }
+}
+
+unsafe fn load_hbitmap_from_file(path: &str, image_px: u32) -> Option<HBITMAP> {
     // GDI+ can't decode SVG, so rasterize it ourselves.
-    if std::path::Path::new(path)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
-    {
-        return unsafe { rasterize_svg(path, image_px) };
+    if is_svg_path(path) {
+        let data = std::fs::read(path).ok()?;
+        return unsafe { rasterize_svg(&data, image_px) };
     }
 
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
@@ -275,6 +283,29 @@ unsafe fn load_hbitmap(path: &str, image_px: u32) -> Option<HBITMAP> {
         return None;
     }
 
+    unsafe { thumbnail_hbitmap(gp_bitmap, image_px) }
+}
+
+unsafe fn load_hbitmap_from_bytes(bytes: &[u8], image_px: u32) -> Option<HBITMAP> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    if is_svg_bytes(bytes) {
+        return unsafe { rasterize_svg(bytes, image_px) };
+    }
+
+    let stream = unsafe { stream_from_bytes(bytes) }?;
+    let mut gp_bitmap: *mut GpBitmap = std::ptr::null_mut();
+    let status = unsafe { GdipCreateBitmapFromStream(&stream, &mut gp_bitmap) };
+    if status.0 != 0 || gp_bitmap.is_null() {
+        return None;
+    }
+
+    unsafe { thumbnail_hbitmap(gp_bitmap, image_px) }
+}
+
+unsafe fn thumbnail_hbitmap(gp_bitmap: *mut GpBitmap, image_px: u32) -> Option<HBITMAP> {
     // Scale to a menu icon sized thumbnail; GDI+ does not resize on display.
     let mut thumb: *mut GpImage = std::ptr::null_mut();
     let status = unsafe {
@@ -306,6 +337,41 @@ unsafe fn load_hbitmap(path: &str, image_px: u32) -> Option<HBITMAP> {
     }
 }
 
+unsafe fn stream_from_bytes(bytes: &[u8]) -> Option<windows::Win32::System::Com::IStream> {
+    let hglobal = unsafe { GlobalAlloc(GMEM_MOVEABLE, bytes.len()) }.ok()?;
+    let data = unsafe { GlobalLock(hglobal) };
+    if data.is_null() {
+        let _ = unsafe { GlobalFree(hglobal) };
+        return None;
+    }
+
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), data.cast::<u8>(), bytes.len()) };
+    let _ = unsafe { GlobalUnlock(hglobal) };
+
+    match unsafe { CreateStreamOnHGlobal(hglobal, BOOL(1)) } {
+        Ok(stream) => Some(stream),
+        Err(_) => {
+            let _ = unsafe { GlobalFree(hglobal) };
+            None
+        }
+    }
+}
+
+fn is_svg_path(path: &str) -> bool {
+    std::path::Path::new(path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+}
+
+fn is_svg_bytes(bytes: &[u8]) -> bool {
+    let bytes = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes);
+    let text = match std::str::from_utf8(&bytes[..bytes.len().min(256)]) {
+        Ok(text) => text.trim_start(),
+        Err(_) => return false,
+    };
+    text.starts_with("<svg") || text.starts_with("<?xml")
+}
+
 /// Extract the Win32 `HWND` (as an `isize`) from the window's raw handle.
 fn hwnd_ptr(window: &Window) -> Option<isize> {
     let handle = HasWindowHandle::window_handle(window).ok()?;
@@ -315,20 +381,19 @@ fn hwnd_ptr(window: &Window) -> Option<isize> {
     Some(handle.hwnd.get())
 }
 
-/// Rasterize an SVG file into an `HBITMAP`, scaled to `image_px` square.
+/// Rasterize SVG bytes into an `HBITMAP`, scaled to `image_px` square.
 ///
-/// GDI+ has no SVG codec, so SVG paths are rendered with `resvg` and wrapped in
-/// a 32-bit DIB section. The SVG is scaled uniformly to fit the square and
-/// centered. Returns `None` if the file can't be read or parsed. The returned
-/// bitmap must be freed with `DeleteObject`.
+/// GDI+ has no SVG codec, so SVG data is rendered with `resvg` and wrapped in a
+/// 32-bit DIB section. The SVG is scaled uniformly to fit the square and centered.
+/// Returns `None` if the SVG can't be parsed. The returned bitmap must be freed
+/// with `DeleteObject`.
 ///
 /// # Safety
 /// Creates a GDI DIB section; the returned handle is owned by the caller.
-unsafe fn rasterize_svg(path: &str, image_px: u32) -> Option<HBITMAP> {
+unsafe fn rasterize_svg(data: &[u8], image_px: u32) -> Option<HBITMAP> {
     use resvg::{tiny_skia, usvg};
 
-    let data = std::fs::read(path).ok()?;
-    let tree = usvg::Tree::from_data(&data, &usvg::Options::default()).ok()?;
+    let tree = usvg::Tree::from_data(data, &usvg::Options::default()).ok()?;
 
     let size = image_px;
     let mut pixmap = tiny_skia::Pixmap::new(size, size)?;

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -1,8 +1,8 @@
 //! Windows native menu implementation (Win32 popup menus).
 
-use std::ffi::c_void;
+use std::{ffi::c_void, sync::Arc};
 
-use gpui::{Action, App, Image, ImageFormat, Pixels, Point, Window};
+use gpui::{Action, App, AssetSource, ImageFormat, Pixels, Point, SharedString, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use windows::Win32::Foundation::{BOOL, GlobalFree, HANDLE, HWND, LPARAM, POINT, WPARAM};
 use windows::Win32::Graphics::Gdi::{
@@ -24,7 +24,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::PCWSTR;
 
-use super::NativeMenuItem;
+use super::{NativeMenuItem, resolve_icon_image};
 
 /// Side length (in **logical pixels**) menu item images are scaled to. The
 /// physical bitmap size is this multiplied by the window's scale factor (see
@@ -37,6 +37,7 @@ const MENU_IMAGE_SIZE: u32 = 16;
 /// run from a foreground task to avoid re-entering GPUI while it is borrowed.
 pub(super) fn show(
     items: Vec<NativeMenuItem>,
+    asset_source: Arc<dyn AssetSource>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -56,7 +57,14 @@ pub(super) fn show(
     let handle = Window::window_handle(window);
 
     cx.spawn(async move |cx| {
-        let Some(action) = run_menu(hwnd, &items, client_x, client_y, image_px) else {
+        let Some(action) = run_menu(
+            hwnd,
+            &items,
+            asset_source.as_ref(),
+            client_x,
+            client_y,
+            image_px,
+        ) else {
             return;
         };
         cx.update(move |app| {
@@ -73,6 +81,7 @@ pub(super) fn show(
 fn run_menu(
     hwnd: isize,
     items: &[NativeMenuItem],
+    asset_source: &dyn AssetSource,
     client_x: i32,
     client_y: i32,
     image_px: u32,
@@ -89,7 +98,7 @@ fn run_menu(
 
         // Bitmaps attached to menu items must outlive the menu; freed below.
         let mut bitmaps: Vec<HBITMAP> = Vec::new();
-        let menu = build_menu(items, &mut actions, &mut bitmaps, image_px)?;
+        let menu = build_menu(items, asset_source, &mut actions, &mut bitmaps, image_px)?;
 
         let mut point = POINT {
             x: client_x,
@@ -137,6 +146,7 @@ fn run_menu(
 /// Win32 menu creation; the returned `HMENU` must be destroyed by the caller.
 unsafe fn build_menu<'a>(
     items: &'a [NativeMenuItem],
+    asset_source: &dyn AssetSource,
     actions: &mut Vec<&'a Box<dyn Action>>,
     bitmaps: &mut Vec<HBITMAP>,
     image_px: u32,
@@ -177,7 +187,9 @@ unsafe fn build_menu<'a>(
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
                 if let Some(icon) = icon {
-                    if let Some(bitmap) = unsafe { load_hbitmap(icon.image(), image_px) } {
+                    if let Some(bitmap) =
+                        unsafe { load_hbitmap(icon.path_ref(), asset_source, image_px) }
+                    {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -195,7 +207,8 @@ unsafe fn build_menu<'a>(
                 disabled,
                 items,
             } => {
-                let Some(submenu) = (unsafe { build_menu(items, actions, bitmaps, image_px) })
+                let Some(submenu) =
+                    (unsafe { build_menu(items, asset_source, actions, bitmaps, image_px) })
                 else {
                     continue;
                 };
@@ -261,8 +274,12 @@ impl Drop for GdiplusSession {
 ///
 /// # Safety
 /// Calls GDI+ /GDI flat APIs; the returned handle is owned by the caller.
-unsafe fn load_hbitmap(image: Option<&Image>, image_px: u32) -> Option<HBITMAP> {
-    let image = image?;
+unsafe fn load_hbitmap(
+    path: &SharedString,
+    asset_source: &dyn AssetSource,
+    image_px: u32,
+) -> Option<HBITMAP> {
+    let image = resolve_icon_image(path, asset_source)?;
     if image.bytes.is_empty() {
         return None;
     }

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -22,7 +22,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::PCWSTR;
 
-use super::NativeMenuItem;
+use super::ResolvedNativeMenuItem;
 
 /// Side length (in **logical pixels**) menu item images are scaled to. The
 /// physical bitmap size is this multiplied by the window's scale factor (see
@@ -34,7 +34,7 @@ const MENU_IMAGE_SIZE: u32 = 16;
 /// The Win32 tracking loop (`TrackPopupMenuEx`) blocks, so — like macOS — it is
 /// run from a foreground task to avoid re-entering GPUI while it is borrowed.
 pub(super) fn show(
-    items: Vec<NativeMenuItem>,
+    items: Vec<ResolvedNativeMenuItem>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -70,7 +70,7 @@ pub(super) fn show(
 /// selected item's action.
 fn run_menu(
     hwnd: isize,
-    items: &[NativeMenuItem],
+    items: &[ResolvedNativeMenuItem],
     client_x: i32,
     client_y: i32,
     image_px: u32,
@@ -134,7 +134,7 @@ fn run_menu(
 /// # Safety
 /// Win32 menu creation; the returned `HMENU` must be destroyed by the caller.
 unsafe fn build_menu<'a>(
-    items: &'a [NativeMenuItem],
+    items: &'a [ResolvedNativeMenuItem],
     actions: &mut Vec<&'a Box<dyn Action>>,
     bitmaps: &mut Vec<HBITMAP>,
     image_px: u32,
@@ -146,11 +146,11 @@ unsafe fn build_menu<'a>(
     let mut position: u32 = 0;
     for item in items {
         match item {
-            NativeMenuItem::Separator => {
+            ResolvedNativeMenuItem::Separator => {
                 let _ = unsafe { AppendMenuW(menu, MF_SEPARATOR, 0, PCWSTR::null()) };
                 position += 1;
             }
-            NativeMenuItem::Item {
+            ResolvedNativeMenuItem::Item {
                 label,
                 disabled,
                 checked,
@@ -188,7 +188,7 @@ unsafe fn build_menu<'a>(
                 }
                 position += 1;
             }
-            NativeMenuItem::Submenu {
+            ResolvedNativeMenuItem::Submenu {
                 label,
                 disabled,
                 items,

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::c_void;
 
-use gpui::{Action, App, Pixels, Point, Window};
+use gpui::{Action, App, Image, ImageFormat, Pixels, Point, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use windows::Win32::Foundation::{BOOL, GlobalFree, HANDLE, HWND, LPARAM, POINT, WPARAM};
 use windows::Win32::Graphics::Gdi::{
@@ -10,9 +10,8 @@ use windows::Win32::Graphics::Gdi::{
     DeleteObject, HBITMAP, HDC, HGDIOBJ,
 };
 use windows::Win32::Graphics::GdiPlus::{
-    GdipCreateBitmapFromFile, GdipCreateBitmapFromStream, GdipCreateHBITMAPFromBitmap,
-    GdipDisposeImage, GdipGetImageThumbnail, GdiplusShutdown, GdiplusStartup, GdiplusStartupInput,
-    GpBitmap, GpImage,
+    GdipCreateBitmapFromStream, GdipCreateHBITMAPFromBitmap, GdipDisposeImage,
+    GdipGetImageThumbnail, GdiplusShutdown, GdiplusStartup, GdiplusStartupInput, GpBitmap, GpImage,
 };
 use windows::Win32::System::Com::StructuredStorage::CreateStreamOnHGlobal;
 use windows::Win32::System::Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalUnlock};
@@ -25,7 +24,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::PCWSTR;
 
-use super::{NativeMenuIconSource, NativeMenuItem};
+use super::NativeMenuItem;
 
 /// Side length (in **logical pixels**) menu item images are scaled to. The
 /// physical bitmap size is this multiplied by the window's scale factor (see
@@ -178,7 +177,7 @@ unsafe fn build_menu<'a>(
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
                 if let Some(icon) = icon {
-                    if let Some(bitmap) = unsafe { load_hbitmap(icon.source(), image_px) } {
+                    if let Some(bitmap) = unsafe { load_hbitmap(icon.image(), image_px) } {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -262,40 +261,17 @@ impl Drop for GdiplusSession {
 ///
 /// # Safety
 /// Calls GDI+ /GDI flat APIs; the returned handle is owned by the caller.
-unsafe fn load_hbitmap(source: Option<&NativeMenuIconSource>, image_px: u32) -> Option<HBITMAP> {
-    match source? {
-        NativeMenuIconSource::File(path) => unsafe { load_hbitmap_from_file(path, image_px) },
-        NativeMenuIconSource::Bytes(bytes) => unsafe { load_hbitmap_from_bytes(bytes, image_px) },
-    }
-}
-
-unsafe fn load_hbitmap_from_file(path: &str, image_px: u32) -> Option<HBITMAP> {
-    // GDI+ can't decode SVG, so rasterize it ourselves.
-    if is_svg_path(path) {
-        let data = std::fs::read(path).ok()?;
-        return unsafe { rasterize_svg(&data, image_px) };
-    }
-
-    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
-    let mut gp_bitmap: *mut GpBitmap = std::ptr::null_mut();
-    let status = unsafe { GdipCreateBitmapFromFile(PCWSTR(wide.as_ptr()), &mut gp_bitmap) };
-    if status.0 != 0 || gp_bitmap.is_null() {
+unsafe fn load_hbitmap(image: Option<&Image>, image_px: u32) -> Option<HBITMAP> {
+    let image = image?;
+    if image.bytes.is_empty() {
         return None;
     }
 
-    unsafe { thumbnail_hbitmap(gp_bitmap, image_px) }
-}
-
-unsafe fn load_hbitmap_from_bytes(bytes: &[u8], image_px: u32) -> Option<HBITMAP> {
-    if bytes.is_empty() {
-        return None;
+    if image.format == ImageFormat::Svg {
+        return unsafe { rasterize_svg(&image.bytes, image_px) };
     }
 
-    if is_svg_bytes(bytes) {
-        return unsafe { rasterize_svg(bytes, image_px) };
-    }
-
-    let stream = unsafe { stream_from_bytes(bytes) }?;
+    let stream = unsafe { stream_from_bytes(&image.bytes) }?;
     let mut gp_bitmap: *mut GpBitmap = std::ptr::null_mut();
     let status = unsafe { GdipCreateBitmapFromStream(&stream, &mut gp_bitmap) };
     if status.0 != 0 || gp_bitmap.is_null() {
@@ -355,21 +331,6 @@ unsafe fn stream_from_bytes(bytes: &[u8]) -> Option<windows::Win32::System::Com:
             None
         }
     }
-}
-
-fn is_svg_path(path: &str) -> bool {
-    std::path::Path::new(path)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
-}
-
-fn is_svg_bytes(bytes: &[u8]) -> bool {
-    let bytes = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes);
-    let text = match std::str::from_utf8(&bytes[..bytes.len().min(256)]) {
-        Ok(text) => text.trim_start(),
-        Err(_) => return false,
-    };
-    text.starts_with("<svg") || text.starts_with("<?xml")
 }
 
 /// Extract the Win32 `HWND` (as an `isize`) from the window's raw handle.

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -22,7 +22,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 use windows::core::PCWSTR;
 
-use super::ResolvedNativeMenuItem;
+use super::NativeMenuItem;
 
 /// Side length (in **logical pixels**) menu item images are scaled to. The
 /// physical bitmap size is this multiplied by the window's scale factor (see
@@ -34,7 +34,7 @@ const MENU_IMAGE_SIZE: u32 = 16;
 /// The Win32 tracking loop (`TrackPopupMenuEx`) blocks, so — like macOS — it is
 /// run from a foreground task to avoid re-entering GPUI while it is borrowed.
 pub(super) fn show(
-    items: Vec<ResolvedNativeMenuItem>,
+    items: Vec<NativeMenuItem>,
     position: Point<Pixels>,
     window: &mut Window,
     cx: &mut App,
@@ -70,7 +70,7 @@ pub(super) fn show(
 /// selected item's action.
 fn run_menu(
     hwnd: isize,
-    items: &[ResolvedNativeMenuItem],
+    items: &[NativeMenuItem],
     client_x: i32,
     client_y: i32,
     image_px: u32,
@@ -134,7 +134,7 @@ fn run_menu(
 /// # Safety
 /// Win32 menu creation; the returned `HMENU` must be destroyed by the caller.
 unsafe fn build_menu<'a>(
-    items: &'a [ResolvedNativeMenuItem],
+    items: &'a [NativeMenuItem],
     actions: &mut Vec<&'a Box<dyn Action>>,
     bitmaps: &mut Vec<HBITMAP>,
     image_px: u32,
@@ -146,15 +146,15 @@ unsafe fn build_menu<'a>(
     let mut position: u32 = 0;
     for item in items {
         match item {
-            ResolvedNativeMenuItem::Separator => {
+            NativeMenuItem::Separator => {
                 let _ = unsafe { AppendMenuW(menu, MF_SEPARATOR, 0, PCWSTR::null()) };
                 position += 1;
             }
-            ResolvedNativeMenuItem::Item {
+            NativeMenuItem::Item {
                 label,
                 disabled,
                 checked,
-                image,
+                icon,
                 action,
             } => {
                 let mut flags = MF_STRING;
@@ -174,8 +174,8 @@ unsafe fn build_menu<'a>(
                     _ => 0,
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
-                if let Some(image) = image {
-                    if let Some(bitmap) = unsafe { load_hbitmap(image, image_px) } {
+                if let Some(icon) = icon {
+                    if let Some(bitmap) = unsafe { load_hbitmap(icon.path_ref(), image_px) } {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -188,7 +188,7 @@ unsafe fn build_menu<'a>(
                 }
                 position += 1;
             }
-            ResolvedNativeMenuItem::Submenu {
+            NativeMenuItem::Submenu {
                 label,
                 disabled,
                 items,


### PR DESCRIPTION
## Summary
- align `NativeMenu` icon storage with the existing `Icon` API instead of adding a native-menu-specific icon source type
- remove `ResolvedNativeMenuItem`, `NativeMenuIcon`, deprecated image builders, and temporary-file materialization
- resolve native menu icon image data on demand inside macOS/Windows menu construction, avoiding the separate `resolve_platform_icons` pre-show traversal

## Test Plan
- `RUSTC_WRAPPER= cargo check -p gpui-component`
- `RUSTC_WRAPPER= cargo test -p gpui-component native_menu::tests`
- `RUSTC_WRAPPER= cargo clippy -p gpui-component -- --deny warnings`
- `RUSTC_WRAPPER= cargo check -p gpui-component --target wasm32-unknown-unknown`
- `RUSTC_WRAPPER= cargo check -p gpui-component-story`
- `git diff --check`
- `rustfmt --check crates/ui/src/native_menu/mod.rs crates/ui/src/native_menu/macos.rs crates/ui/src/native_menu/windows.rs crates/ui/src/native_menu/fallback.rs`

Windows target check attempted with `RUSTC_WRAPPER= cargo check -p gpui-component --target x86_64-pc-windows-msvc`, but this local machine lacks the Windows MSVC toolchain (`lib.exe`) and Windows headers (`windows.h`), so it fails before checking this crate's Windows backend.
