### PR TITLE
number_input: Match stepper button variant to appearance

### DIFF
--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -9,7 +9,11 @@ use gpui::{
     StyleRefinement, Styled, TextAlign, actions, prelude::FluentBuilder as _,
 };
 
-use crate::{Disableable, IconName, Sizable, Size, StyledExt as _, button::Button, h_flex};
+use crate::{
+    Disableable, IconName, Sizable, Size, StyledExt as _,
+    button::{Button, ButtonVariants as _},
+    h_flex,
+};
 
 use super::{Input, InputState, MaskPattern};
 
@@ -303,7 +307,13 @@ impl RenderOnce for NumberInput {
             .when(self.disabled, |this| this.opacity(0.5))
             .child(
                 Button::new("minus")
-                    .outline()
+                    .map(|this| {
+                        if self.appearance {
+                            this.outline()
+                        } else {
+                            this.ghost()
+                        }
+                    })
                     .with_size(self.size)
                     .icon(IconName::Minus)
                     .compact()
@@ -342,7 +352,13 @@ impl RenderOnce for NumberInput {
             )
             .child(
                 Button::new("plus")
-                    .outline()
+                    .map(|this| {
+                        if self.appearance {
+                            this.outline()
+                        } else {
+                            this.ghost()
+                        }
+                    })
                     .with_size(self.size)
                     .icon(IconName::Plus)
                     .compact()


### PR DESCRIPTION
## Description

The `NumberInput` increment/decrement (minus/plus) buttons previously always used the `outline` button variant regardless of the `appearance` setting. They now follow `appearance`: the `outline` variant when `appearance` is enabled, and the `ghost` variant when it is disabled. This keeps the stepper buttons visually consistent with the borderless input look when `appearance(false)` is used.
