### PR TITLE
plot: Add interactive hover tooltips to charts

### DIFF
--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -69,16 +69,75 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     (cell.get(), cell)
                 });
 
+                // Per-plot slide-animation state: (last hovered index, that point's x, a
+                // monotonic epoch, and the slide's start offset for the current epoch).
+                let anim = window.with_element_state::<
+                    std::rc::Rc<std::cell::Cell<Option<(usize, gpui::Pixels, u64, gpui::Pixels)>>>,
+                    _,
+                >(global_id, |prev, _| {
+                    let cell = prev.unwrap_or_default();
+                    (cell.clone(), cell)
+                });
+
                 let Some(position) = position else {
+                    anim.set(None);
                     return None;
                 };
                 let Some(state) = <Self as Plot>::hit_test(self, position, bounds, cx) else {
+                    anim.set(None);
                     return None;
                 };
-                let Some(mut overlay) =
+
+                // Start a fresh eased slide (from the previous data point's x to the new one,
+                // under a new epoch id) only when the hovered data point changes; otherwise keep
+                // the current epoch so an in-flight slide runs to completion. The vertical axis
+                // follows the cursor directly, so only the horizontal jump is animated.
+                let (epoch, slide_from) = match anim.get() {
+                    Some((last_index, _, epoch, slide_from)) if last_index == state.index => {
+                        (epoch, slide_from)
+                    }
+                    Some((_, prev_x, epoch, _)) => {
+                        let next = (epoch.wrapping_add(1), prev_x - state.cross_line.x);
+                        anim.set(Some((state.index, state.cross_line.x, next.0, next.1)));
+                        next
+                    }
+                    None => {
+                        anim.set(Some((state.index, state.cross_line.x, 0, gpui::px(0.))));
+                        (0, gpui::px(0.))
+                    }
+                };
+
+                let Some(overlay) =
                     <Self as Plot>::render_tooltip(self, &state, bounds, window, cx)
                 else {
                     return None;
+                };
+
+                let mut overlay = if slide_from.abs() > gpui::px(0.5) {
+                    // Ease the whole overlay horizontally from the previous data point to the
+                    // new one (self-driving via the animation's `request_animation_frame`).
+                    use gpui::{
+                        AnimationExt as _, IntoElement as _, ParentElement as _, Styled as _,
+                    };
+                    let animated = gpui::div()
+                        .absolute()
+                        .size_full()
+                        .child(overlay)
+                        .with_animation(
+                            gpui::ElementId::NamedInteger("plot-tooltip-slide".into(), epoch),
+                            gpui::Animation::new(std::time::Duration::from_millis(300))
+                                .with_easing(gpui::ease_in_out),
+                            move |el, delta| el.left(slide_from * (1.0 - delta)),
+                        );
+                    // Wrap in a root container so the animated child's `left` offset is honored:
+                    // a root element's own position insets are dropped by `prepaint_as_root`.
+                    gpui::div()
+                        .absolute()
+                        .size_full()
+                        .child(animated)
+                        .into_any_element()
+                } else {
+                    overlay
                 };
 
                 overlay.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -24,7 +24,7 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
             fn id(&self) -> Option<gpui::ElementId> {
                 // `Some` opts the plot in to interactive tooltips; `None` (the default)
                 // keeps the element a pure, non-interactive plot identical to before.
-                <Self as Plot>::plot_id(self)
+                <Self as Plot>::id(self)
             }
 
             fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
@@ -83,7 +83,7 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     anim.set(None);
                     return None;
                 };
-                let Some(state) = <Self as Plot>::hit_test(self, position, bounds, cx) else {
+                let Some(state) = <Self as Plot>::tooltip_state(self, position, bounds, cx) else {
                     anim.set(None);
                     return None;
                 };
@@ -107,9 +107,7 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     }
                 };
 
-                let Some(overlay) =
-                    <Self as Plot>::render_tooltip(self, &state, bounds, window, cx)
-                else {
+                let Some(overlay) = <Self as Plot>::tooltip(self, &state, bounds, window, cx) else {
                     return None;
                 };
 

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -16,6 +16,23 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
             }
         }
 
+        impl #impl_generics #type_name #type_generics #where_clause {
+            /// Element-local cell holding the last cursor position (plot-relative), shared by
+            /// the generated `prepaint`/`paint` so the cell type lives in a single place.
+            #[doc(hidden)]
+            fn __plot_tooltip_cursor(
+                global_id: &gpui::GlobalElementId,
+                window: &mut gpui::Window,
+            ) -> std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>> {
+                window.with_element_state(global_id, |prev, _| {
+                    let cell: std::rc::Rc<
+                        std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>,
+                    > = prev.unwrap_or_default();
+                    (cell.clone(), cell)
+                })
+            }
+        }
+
         impl #impl_generics gpui::Element for #type_name #type_generics #where_clause {
             type RequestLayoutState = ();
             // Carries the prepainted tooltip overlay (if any) from `prepaint` to `paint`.
@@ -61,27 +78,18 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 };
 
                 // Read the cursor position recorded by the previous frame's mouse handler.
-                let position = window.with_element_state::<
-                    std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
-                    _,
-                >(global_id, |prev, _| {
-                    let cell = prev.unwrap_or_default();
-                    (cell.get(), cell)
-                });
-
-                let Some(position) = position else {
+                let Some(position) = Self::__plot_tooltip_cursor(global_id, window).get() else {
                     return None;
                 };
-                let Some(mut state) = <Self as Plot>::tooltip_state(self, position, bounds, cx)
+                let Some(state) = <Self as Plot>::tooltip_state(self, position, bounds, cx)
                 else {
                     return None;
                 };
 
-                // Anchor the tooltip box to the live cursor so it follows smoothly; the
-                // crosshair and dots stay snapped to the data point by `tooltip_state`.
-                state.cursor = position;
-
-                let Some(mut overlay) = <Self as Plot>::tooltip(self, &state, bounds, window, cx)
+                // Pass the live cursor so the tooltip box can follow it; the crosshair and
+                // dots in `state` stay snapped to the data point by `tooltip_state`.
+                let Some(mut overlay) =
+                    <Self as Plot>::tooltip(self, &state, position, bounds, window, cx)
                 else {
                     return None;
                 };
@@ -106,13 +114,7 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     // Record the cursor position into element-local state on every move so the
                     // next frame can hit-test it. The handler never touches `self`, satisfying
                     // the `'static` bound; it only captures the (Copy) bounds and the state cell.
-                    let cell = window.with_element_state::<
-                        std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
-                        _,
-                    >(global_id, |prev, _| {
-                        let cell = prev.unwrap_or_default();
-                        (cell.clone(), cell)
-                    });
+                    let cell = Self::__plot_tooltip_cursor(global_id, window);
 
                     window.on_mouse_event(
                         move |e: &gpui::MouseMoveEvent, _, window: &mut gpui::Window, _| {

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -92,17 +92,25 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 // under a new epoch id) only when the hovered data point changes; otherwise keep
                 // the current epoch so an in-flight slide runs to completion. The vertical axis
                 // follows the cursor directly, so only the horizontal jump is animated.
+                // Animate along whichever axis the plot's data points snap along.
+                let vertical = state.slides_vertically();
+                let coord = if vertical {
+                    state.cross_line.y
+                } else {
+                    state.cross_line.x
+                };
+
                 let (epoch, slide_from) = match anim.get() {
                     Some((last_index, _, epoch, slide_from)) if last_index == state.index => {
                         (epoch, slide_from)
                     }
-                    Some((_, prev_x, epoch, _)) => {
-                        let next = (epoch.wrapping_add(1), prev_x - state.cross_line.x);
-                        anim.set(Some((state.index, state.cross_line.x, next.0, next.1)));
+                    Some((_, prev_coord, epoch, _)) => {
+                        let next = (epoch.wrapping_add(1), prev_coord - coord);
+                        anim.set(Some((state.index, coord, next.0, next.1)));
                         next
                     }
                     None => {
-                        anim.set(Some((state.index, state.cross_line.x, 0, gpui::px(0.))));
+                        anim.set(Some((state.index, coord, 0, gpui::px(0.))));
                         (0, gpui::px(0.))
                     }
                 };
@@ -112,8 +120,8 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 };
 
                 let mut overlay = if slide_from.abs() > gpui::px(0.5) {
-                    // Ease the whole overlay horizontally from the previous data point to the
-                    // new one (self-driving via the animation's `request_animation_frame`).
+                    // Ease the whole overlay from the previous data point to the new one along
+                    // the snap axis (self-driving via the animation's `request_animation_frame`).
                     use gpui::{
                         AnimationExt as _, IntoElement as _, ParentElement as _, Styled as _,
                     };
@@ -125,7 +133,14 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                             gpui::ElementId::NamedInteger("plot-tooltip-slide".into(), epoch),
                             gpui::Animation::new(std::time::Duration::from_millis(300))
                                 .with_easing(gpui::ease_in_out),
-                            move |el, delta| el.left(slide_from * (1.0 - delta)),
+                            move |el, delta| {
+                                let offset = slide_from * (1.0 - delta);
+                                if vertical {
+                                    el.top(offset)
+                                } else {
+                                    el.left(offset)
+                                }
+                            },
                         );
                     // Wrap in a root container so the animated child's `left` offset is honored:
                     // a root element's own position insets are dropped by `prepaint_as_root`.

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -69,88 +69,21 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     (cell.get(), cell)
                 });
 
-                // Per-plot slide-animation state: (last hovered index, that point's x, a
-                // monotonic epoch, and the slide's start offset for the current epoch).
-                let anim = window.with_element_state::<
-                    std::rc::Rc<std::cell::Cell<Option<(usize, gpui::Pixels, u64, gpui::Pixels)>>>,
-                    _,
-                >(global_id, |prev, _| {
-                    let cell = prev.unwrap_or_default();
-                    (cell.clone(), cell)
-                });
-
                 let Some(position) = position else {
-                    anim.set(None);
                     return None;
                 };
-                let Some(state) = <Self as Plot>::tooltip_state(self, position, bounds, cx) else {
-                    anim.set(None);
-                    return None;
-                };
-
-                // Start a fresh eased slide (from the previous data point's x to the new one,
-                // under a new epoch id) only when the hovered data point changes; otherwise keep
-                // the current epoch so an in-flight slide runs to completion. The vertical axis
-                // follows the cursor directly, so only the horizontal jump is animated.
-                // Animate along whichever axis the plot's data points snap along.
-                let vertical = state.slides_vertically();
-                let coord = if vertical {
-                    state.cross_line.y
-                } else {
-                    state.cross_line.x
-                };
-
-                let (epoch, slide_from) = match anim.get() {
-                    Some((last_index, _, epoch, slide_from)) if last_index == state.index => {
-                        (epoch, slide_from)
-                    }
-                    Some((_, prev_coord, epoch, _)) => {
-                        let next = (epoch.wrapping_add(1), prev_coord - coord);
-                        anim.set(Some((state.index, coord, next.0, next.1)));
-                        next
-                    }
-                    None => {
-                        anim.set(Some((state.index, coord, 0, gpui::px(0.))));
-                        (0, gpui::px(0.))
-                    }
-                };
-
-                let Some(overlay) = <Self as Plot>::tooltip(self, &state, bounds, window, cx) else {
+                let Some(mut state) = <Self as Plot>::tooltip_state(self, position, bounds, cx)
+                else {
                     return None;
                 };
 
-                let mut overlay = if slide_from.abs() > gpui::px(0.5) {
-                    // Ease the whole overlay from the previous data point to the new one along
-                    // the snap axis (self-driving via the animation's `request_animation_frame`).
-                    use gpui::{
-                        AnimationExt as _, IntoElement as _, ParentElement as _, Styled as _,
-                    };
-                    let animated = gpui::div()
-                        .absolute()
-                        .size_full()
-                        .child(overlay)
-                        .with_animation(
-                            gpui::ElementId::NamedInteger("plot-tooltip-slide".into(), epoch),
-                            gpui::Animation::new(std::time::Duration::from_millis(300))
-                                .with_easing(gpui::ease_in_out),
-                            move |el, delta| {
-                                let offset = slide_from * (1.0 - delta);
-                                if vertical {
-                                    el.top(offset)
-                                } else {
-                                    el.left(offset)
-                                }
-                            },
-                        );
-                    // Wrap in a root container so the animated child's `left` offset is honored:
-                    // a root element's own position insets are dropped by `prepaint_as_root`.
-                    gpui::div()
-                        .absolute()
-                        .size_full()
-                        .child(animated)
-                        .into_any_element()
-                } else {
-                    overlay
+                // Anchor the tooltip box to the live cursor so it follows smoothly; the
+                // crosshair and dots stay snapped to the data point by `tooltip_state`.
+                state.cursor = position;
+
+                let Some(mut overlay) = <Self as Plot>::tooltip(self, &state, bounds, window, cx)
+                else {
+                    return None;
                 };
 
                 overlay.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -75,7 +75,8 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 let Some(state) = <Self as Plot>::hit_test(self, position, bounds, cx) else {
                     return None;
                 };
-                let Some(mut overlay) = <Self as Plot>::render_tooltip(self, &state, window, cx)
+                let Some(mut overlay) =
+                    <Self as Plot>::render_tooltip(self, &state, bounds, window, cx)
                 else {
                     return None;
                 };

--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 pub fn derive_into_plot(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -18,10 +18,13 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
 
         impl #impl_generics gpui::Element for #type_name #type_generics #where_clause {
             type RequestLayoutState = ();
-            type PrepaintState = ();
+            // Carries the prepainted tooltip overlay (if any) from `prepaint` to `paint`.
+            type PrepaintState = Option<gpui::AnyElement>;
 
             fn id(&self) -> Option<gpui::ElementId> {
-                None
+                // `Some` opts the plot in to interactive tooltips; `None` (the default)
+                // keeps the element a pure, non-interactive plot identical to before.
+                <Self as Plot>::plot_id(self)
             }
 
             fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
@@ -45,26 +48,86 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
 
             fn prepaint(
                 &mut self,
-                _: Option<&gpui::GlobalElementId>,
+                global_id: Option<&gpui::GlobalElementId>,
                 _: Option<&gpui::InspectorElementId>,
-                _: gpui::Bounds<gpui::Pixels>,
+                bounds: gpui::Bounds<gpui::Pixels>,
                 _: &mut Self::RequestLayoutState,
-                _: &mut gpui::Window,
-                _: &mut gpui::App,
+                window: &mut gpui::Window,
+                cx: &mut gpui::App,
             ) -> Self::PrepaintState {
+                // No id => tooltips disabled => behave exactly like a non-interactive plot.
+                let Some(global_id) = global_id else {
+                    return None;
+                };
+
+                // Read the cursor position recorded by the previous frame's mouse handler.
+                let position = window.with_element_state::<
+                    std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
+                    _,
+                >(global_id, |prev, _| {
+                    let cell = prev.unwrap_or_default();
+                    (cell.get(), cell)
+                });
+
+                let Some(position) = position else {
+                    return None;
+                };
+                let Some(state) = <Self as Plot>::hit_test(self, position, bounds, cx) else {
+                    return None;
+                };
+                let Some(mut overlay) = <Self as Plot>::render_tooltip(self, &state, window, cx)
+                else {
+                    return None;
+                };
+
+                overlay.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);
+                Some(overlay)
             }
 
             fn paint(
                 &mut self,
-                _: Option<&gpui::GlobalElementId>,
+                global_id: Option<&gpui::GlobalElementId>,
                 _: Option<&gpui::InspectorElementId>,
                 bounds: gpui::Bounds<gpui::Pixels>,
                 _: &mut Self::RequestLayoutState,
-                _: &mut Self::PrepaintState,
+                overlay: &mut Self::PrepaintState,
                 window: &mut gpui::Window,
                 cx: &mut gpui::App,
             ) {
-                <Self as Plot>::paint(self, bounds, window, cx)
+                <Self as Plot>::paint(self, bounds, window, cx);
+
+                if let Some(global_id) = global_id {
+                    // Record the cursor position into element-local state on every move so the
+                    // next frame can hit-test it. The handler never touches `self`, satisfying
+                    // the `'static` bound; it only captures the (Copy) bounds and the state cell.
+                    let cell = window.with_element_state::<
+                        std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
+                        _,
+                    >(global_id, |prev, _| {
+                        let cell = prev.unwrap_or_default();
+                        (cell.clone(), cell)
+                    });
+
+                    window.on_mouse_event(
+                        move |e: &gpui::MouseMoveEvent, _, window: &mut gpui::Window, _| {
+                            let next = if bounds.contains(&e.position) {
+                                Some(e.position - bounds.origin)
+                            } else {
+                                None
+                            };
+
+                            if cell.get() != next {
+                                cell.set(next);
+                                window.refresh();
+                            }
+                        },
+                    );
+                }
+
+                // Paint the tooltip overlay (crosshair, dots, box) above the plot graphics.
+                if let Some(overlay) = overlay.as_mut() {
+                    overlay.paint(window, cx);
+                }
             }
         }
     };

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -169,6 +169,7 @@ impl Render for ChartStory {
                             linear_color_stop(cx.theme().chart_1.opacity(0.4), 1.),
                             linear_color_stop(cx.theme().background.opacity(0.3), 0.),
                         ))
+                        .label("Desktop")
                         .y(|d| d.mobile)
                         .stroke(cx.theme().chart_2)
                         .fill(linear_gradient(
@@ -176,7 +177,9 @@ impl Render for ChartStory {
                             linear_color_stop(cx.theme().chart_2.opacity(0.4), 1.),
                             linear_color_stop(cx.theme().background.opacity(0.3), 0.),
                         ))
-                        .tick_margin(8),
+                        .label("Mobile")
+                        .tick_margin(8)
+                        .id("area-chart-tooltip"),
                     false,
                     cx,
                 )),

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -303,6 +303,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Left aligned",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-left")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .label(|d| d.desktop.to_string())
@@ -313,6 +315,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Right aligned",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-right")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .label(|d| d.desktop.to_string())
@@ -372,6 +376,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Left)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-left")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())
@@ -394,6 +400,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Right)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-right")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -169,7 +169,7 @@ impl Render for ChartStory {
                             linear_color_stop(cx.theme().chart_1.opacity(0.4), 1.),
                             linear_color_stop(cx.theme().background.opacity(0.3), 0.),
                         ))
-                        .label("Desktop")
+                        .name("Desktop")
                         .y(|d| d.mobile)
                         .stroke(cx.theme().chart_2)
                         .fill(linear_gradient(
@@ -177,7 +177,7 @@ impl Render for ChartStory {
                             linear_color_stop(cx.theme().chart_2.opacity(0.4), 1.),
                             linear_color_stop(cx.theme().background.opacity(0.3), 0.),
                         ))
-                        .label("Mobile")
+                        .name("Mobile")
                         .tick_margin(8)
                         .id("area-chart-tooltip"),
                     false,
@@ -240,6 +240,7 @@ impl Render for ChartStory {
                         BarChart::new(self.monthly_devices.clone())
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
+                            .name("Desktop")
                             .id("bar-chart-tooltip"),
                         false,
                         cx,
@@ -247,6 +248,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Mixed",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-mixed")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .fill(move |d, _, _, _| d.color(color)),
@@ -265,6 +268,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Rounded corners",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-rounded")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .label(|d| d.desktop.to_string())
@@ -275,6 +280,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Bottom aligned",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-bottom")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .label(|d| d.desktop.to_string()),
@@ -284,6 +291,8 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Bar Chart - Top aligned",
                         BarChart::new(self.monthly_devices.clone())
+                            .id("bar-chart-top")
+                            .name("Desktop")
                             .band(|d| d.month.clone())
                             .value(|d| d.desktop)
                             .label(|d| d.desktop.to_string())
@@ -316,6 +325,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Bottom)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-bottom")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())
@@ -337,6 +348,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Top)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-top")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())
@@ -403,6 +416,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Per-bar)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-per-bar")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())
@@ -422,6 +437,8 @@ impl Render for ChartStory {
                         chart_container(
                             "Bar Chart - Gradient (Diagonal, across bars)",
                             BarChart::new(self.monthly_devices.clone())
+                                .id("bar-chart-gradient-diagonal")
+                                .name("Desktop")
                                 .band(|d| d.month.clone())
                                 .value(|d| d.desktop)
                                 .label(|d| d.desktop.to_string())
@@ -464,7 +481,7 @@ impl Render for ChartStory {
                         LineChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .label("Desktop")
+                            .name("Desktop")
                             .id("line-chart-tooltip"),
                         false,
                         cx,
@@ -474,7 +491,8 @@ impl Render for ChartStory {
                         LineChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .linear(),
+                            .linear()
+                            .id("line-chart-linear"),
                         false,
                         cx,
                     ))
@@ -483,7 +501,8 @@ impl Render for ChartStory {
                         LineChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .step_after(),
+                            .step_after()
+                            .id("line-chart-step-after"),
                         false,
                         cx,
                     ))
@@ -493,7 +512,8 @@ impl Render for ChartStory {
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
                             .dot()
-                            .stroke(cx.theme().chart_5),
+                            .stroke(cx.theme().chart_5)
+                            .id("line-chart-dots"),
                         false,
                         cx,
                     )),
@@ -507,7 +527,8 @@ impl Render for ChartStory {
                         "Area Chart",
                         AreaChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
-                            .y(|d| d.desktop),
+                            .y(|d| d.desktop)
+                            .id("area-chart"),
                         false,
                         cx,
                     ))
@@ -516,7 +537,8 @@ impl Render for ChartStory {
                         AreaChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .linear(),
+                            .linear()
+                            .id("area-chart-linear"),
                         false,
                         cx,
                     ))
@@ -525,7 +547,8 @@ impl Render for ChartStory {
                         AreaChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
                             .y(|d| d.desktop)
-                            .step_after(),
+                            .step_after()
+                            .id("area-chart-step-after"),
                         false,
                         cx,
                     ))
@@ -538,7 +561,8 @@ impl Render for ChartStory {
                                 0.,
                                 linear_color_stop(cx.theme().chart_1.opacity(0.4), 1.),
                                 linear_color_stop(cx.theme().background.opacity(0.3), 0.),
-                            )),
+                            ))
+                            .id("area-chart-gradient"),
                         false,
                         cx,
                     )),

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -456,10 +456,12 @@ impl Render for ChartStory {
                     .flex_wrap()
                     .gap_4()
                     .child(chart_container(
-                        "Line Chart",
+                        "Line Chart - Tooltip",
                         LineChart::new(self.monthly_devices.clone())
                             .x(|d| d.month.clone())
-                            .y(|d| d.desktop),
+                            .y(|d| d.desktop)
+                            .label("Desktop")
+                            .id("line-chart-tooltip"),
                         false,
                         cx,
                     ))

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -239,7 +239,8 @@ impl Render for ChartStory {
                         "Bar Chart",
                         BarChart::new(self.monthly_devices.clone())
                             .band(|d| d.month.clone())
-                            .value(|d| d.desktop),
+                            .value(|d| d.desktop)
+                            .id("bar-chart-tooltip"),
                         false,
                         cx,
                     ))

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -168,12 +168,23 @@ impl Plot for StackedBarChart {
             ],
         );
 
+        // Highlight the hovered column with a translucent band the width of the bars,
+        // confined to the plot height so it doesn't cover the x-axis labels.
+        let band_width = ScaleBand::new(
+            self.data.iter().map(|v| v.date.clone()).collect(),
+            vec![0., bounds.size.width.as_f32()],
+        )
+        .padding_inner(0.4)
+        .padding_outer(0.2)
+        .band_width();
+
         let mut tooltip = Tooltip::new()
             .anchor(state.cross_line, bounds.size)
             .gap(px(8.))
-            // Confine the crosshair to the plot area so it doesn't cross the x-axis.
             .cross_line(
-                CrossLine::new(state.cross_line).height(bounds.size.height.as_f32() - AXIS_GAP),
+                CrossLine::new(state.cross_line)
+                    .height(bounds.size.height.as_f32() - AXIS_GAP)
+                    .band(px(band_width)),
             )
             .title(d.date.clone());
 

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -9,7 +9,7 @@ use gpui_component::{
         AXIS_GAP, AxisText, Grid, IntoPlot, Plot, PlotAxis,
         scale::{Scale, ScaleBand, ScaleLinear, ScaleOrdinal},
         shape::{Bar, Stack, StackSeries},
-        tooltip::{CrossLine, Tooltip, TooltipPosition, TooltipState},
+        tooltip::{CrossLine, Tooltip, TooltipState},
     },
 };
 
@@ -144,7 +144,6 @@ impl Plot for StackedBarChart {
             index,
             point(px(center_x), position.y),
             vec![],
-            TooltipPosition::for_index(index, self.data.len()),
         ))
     }
 
@@ -178,8 +177,7 @@ impl Plot for StackedBarChart {
         .padding_outer(0.2)
         .band_width();
 
-        let mut tooltip = Tooltip::new()
-            .anchor(state.cross_line, bounds.size)
+        let mut tooltip = Tooltip::new(state.cursor, bounds.size)
             .gap(px(8.))
             .cross_line(
                 CrossLine::new(state.cross_line)

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -171,7 +171,10 @@ impl Plot for StackedBarChart {
         let mut tooltip = Tooltip::new()
             .anchor(state.cross_line, bounds.size)
             .gap(px(8.))
-            .cross_line(CrossLine::new(state.cross_line))
+            // Confine the crosshair to the plot area so it doesn't cross the x-axis.
+            .cross_line(
+                CrossLine::new(state.cross_line).height(bounds.size.height.as_f32() - AXIS_GAP),
+            )
             .title(d.date.clone());
 
         // One row per stacked series (its segment value at this band).

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -136,6 +136,11 @@ impl Plot for StackedBarChart {
         .padding_outer(0.2);
         let band_width = x.band_width();
 
+        // Ignore the x-axis label gutter so hovering the labels doesn't show a tooltip.
+        if position.y.as_f32() > bounds.size.height.as_f32() - AXIS_GAP {
+            return None;
+        }
+
         let index = x.least_index(position.x.as_f32());
         let d = self.data.get(index)?;
         let center_x = x.tick(&d.date.clone())? + band_width / 2.;
@@ -150,6 +155,7 @@ impl Plot for StackedBarChart {
     fn tooltip(
         &self,
         state: &TooltipState,
+        cursor: Point<Pixels>,
         bounds: Bounds<Pixels>,
         _window: &mut Window,
         cx: &mut App,
@@ -177,7 +183,7 @@ impl Plot for StackedBarChart {
         .padding_outer(0.2)
         .band_width();
 
-        let mut tooltip = Tooltip::new(state.cursor, bounds.size)
+        let mut tooltip = Tooltip::new(cursor, bounds.size)
             .gap(px(8.))
             .cross_line(
                 CrossLine::new(state.cross_line)

--- a/crates/story/src/stories/chart_story/stacked_bar_chart.rs
+++ b/crates/story/src/stories/chart_story/stacked_bar_chart.rs
@@ -1,12 +1,15 @@
 // You can draw any chart you want by using the `Plot`.
 
-use gpui::{App, Bounds, Pixels, TextAlign, Window, px};
+use gpui::{
+    AnyElement, App, Bounds, ElementId, IntoElement, Pixels, Point, TextAlign, Window, point, px,
+};
 use gpui_component::{
     ActiveTheme,
     plot::{
         AXIS_GAP, AxisText, Grid, IntoPlot, Plot, PlotAxis,
         scale::{Scale, ScaleBand, ScaleLinear, ScaleOrdinal},
         shape::{Bar, Stack, StackSeries},
+        tooltip::{CrossLine, Tooltip, TooltipPosition, TooltipState},
     },
 };
 
@@ -111,5 +114,77 @@ impl Plot for StackedBarChart {
                 .fill(move |_, _, _| fill)
                 .paint(&bounds, window, cx);
         }
+    }
+
+    fn id(&self) -> Option<ElementId> {
+        // Single demo instance, so a fixed id is fine.
+        Some("stacked-bar-chart".into())
+    }
+
+    fn tooltip_state(
+        &self,
+        position: Point<Pixels>,
+        bounds: Bounds<Pixels>,
+        _cx: &App,
+    ) -> Option<TooltipState> {
+        // Band scale matches `paint`.
+        let x = ScaleBand::new(
+            self.data.iter().map(|v| v.date.clone()).collect(),
+            vec![0., bounds.size.width.as_f32()],
+        )
+        .padding_inner(0.4)
+        .padding_outer(0.2);
+        let band_width = x.band_width();
+
+        let index = x.least_index(position.x.as_f32());
+        let d = self.data.get(index)?;
+        let center_x = x.tick(&d.date.clone())? + band_width / 2.;
+
+        Some(TooltipState::new(
+            index,
+            point(px(center_x), position.y),
+            vec![],
+            TooltipPosition::for_index(index, self.data.len()),
+        ))
+    }
+
+    fn tooltip(
+        &self,
+        state: &TooltipState,
+        bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let d = self.data.get(state.index)?;
+
+        // Same color mapping as `paint`.
+        let ordinal = ScaleOrdinal::new(
+            self.series.iter().map(|s| s.key.clone()).collect(),
+            vec![
+                cx.theme().chart_4,
+                cx.theme().chart_3,
+                cx.theme().chart_2,
+                cx.theme().chart_1,
+            ],
+        );
+
+        let mut tooltip = Tooltip::new()
+            .anchor(state.cross_line, bounds.size)
+            .gap(px(8.))
+            .cross_line(CrossLine::new(state.cross_line))
+            .title(d.date.clone());
+
+        // One row per stacked series (its segment value at this band).
+        for series in self.series.iter() {
+            let color = ordinal.map(&series.key).unwrap_or(cx.theme().chart_4);
+            let value = series
+                .points
+                .get(state.index)
+                .map(|p| p.y1 - p.y0)
+                .unwrap_or(0.);
+            tooltip = tooltip.row(color, series.key.clone(), format!("{}", value));
+        }
+
+        Some(tooltip.into_any_element())
     }
 }

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -243,6 +243,12 @@ where
         let x_fn = self.x.as_ref()?;
         let (x, y) = self.scales(bounds)?;
 
+        // Ignore the x-axis label gutter so hovering the labels doesn't show a tooltip.
+        let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
+        if position.y.as_f32() > bounds.size.height.as_f32() - axis_gap {
+            return None;
+        }
+
         let index = x.least_index(position.x.as_f32());
         let d = self.data.get(index)?;
         let x_tick = x.tick(&x_fn(d))?;
@@ -264,6 +270,7 @@ where
     fn tooltip(
         &self,
         state: &TooltipState,
+        cursor: Point<Pixels>,
         bounds: Bounds<Pixels>,
         _window: &mut Window,
         cx: &mut App,
@@ -277,7 +284,7 @@ where
         let color = |i: usize| *self.strokes.get(i).unwrap_or(&default_color);
 
         // Follow the cursor; the crosshair and dots stay snapped to the data point.
-        let mut tooltip = Tooltip::new(state.cursor, bounds.size)
+        let mut tooltip = Tooltip::new(cursor, bounds.size)
             .gap(px(8.))
             // Confine the crosshair to the plot area so it doesn't cross the x-axis.
             .cross_line(

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -74,7 +74,7 @@ where
 
     /// Set the name of the most recently added series, shown in its tooltip row.
     ///
-    /// Call after the matching [`AreaChart::y`] (e.g. `.y(..).stroke(..).label("Desktop")`).
+    /// Call after the matching [`AreaChart::y`] (e.g. `.y(..).stroke(..).label("Foo")`).
     pub fn label(mut self, label: impl Into<SharedString>) -> Self {
         self.labels.push(label.into());
         self
@@ -135,7 +135,7 @@ where
 
     /// Build the x (point) and y (linear) scales for the given bounds.
     ///
-    /// Shared by `paint` and `hit_test` so the two stay in sync. Returns `None` when there
+    /// Shared by `paint` and `tooltip_state` so the two stay in sync. Returns `None` when there
     /// is no x accessor or no series.
     fn scales(&self, bounds: Bounds<Pixels>) -> Option<(ScalePoint<X>, ScaleLinear<Y>)> {
         let x_fn = self.x.as_ref()?;
@@ -230,11 +230,11 @@ where
         }
     }
 
-    fn plot_id(&self) -> Option<ElementId> {
+    fn id(&self) -> Option<ElementId> {
         self.id.clone()
     }
 
-    fn hit_test(
+    fn tooltip_state(
         &self,
         position: Point<Pixels>,
         bounds: Bounds<Pixels>,
@@ -262,7 +262,7 @@ where
         ))
     }
 
-    fn render_tooltip(
+    fn tooltip(
         &self,
         state: &TooltipState,
         bounds: Bounds<Pixels>,

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -1,6 +1,9 @@
 use std::rc::Rc;
 
-use gpui::{App, Background, Bounds, Hsla, Pixels, SharedString, Window, px};
+use gpui::{
+    AnyElement, App, Background, Bounds, ElementId, Hsla, IntoElement, Pixels, Point, SharedString,
+    Window, point, px,
+};
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive};
 
@@ -10,6 +13,7 @@ use crate::{
         AXIS_GAP, Grid, Plot, PlotAxis, StrokeStyle,
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Area,
+        tooltip::{CrossLine, Dot, Tooltip, TooltipPosition, TooltipState},
     },
 };
 
@@ -28,9 +32,11 @@ where
     strokes: Vec<Hsla>,
     stroke_styles: Vec<StrokeStyle>,
     fills: Vec<Background>,
+    labels: Vec<SharedString>,
     tick_margin: usize,
     x_axis: bool,
     grid: bool,
+    id: Option<ElementId>,
 }
 
 impl<T, X, Y> AreaChart<T, X, Y>
@@ -47,12 +53,31 @@ where
             stroke_styles: vec![],
             strokes: vec![],
             fills: vec![],
+            labels: vec![],
             tick_margin: 1,
             x: None,
             y: vec![],
             x_axis: true,
             grid: true,
+            id: None,
         }
+    }
+
+    /// Enable an interactive hover tooltip (crosshair + a dot and row per series).
+    ///
+    /// The `id` must be unique among sibling elements. Without it, the chart stays a
+    /// non-interactive plot.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Set the name of the most recently added series, shown in its tooltip row.
+    ///
+    /// Call after the matching [`AreaChart::y`] (e.g. `.y(..).stroke(..).label("Desktop")`).
+    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.labels.push(label.into());
+        self
     }
 
     pub fn x(mut self, x: impl Fn(&T) -> X + 'static) -> Self {
@@ -107,6 +132,32 @@ where
         self.grid = grid;
         self
     }
+
+    /// Build the x (point) and y (linear) scales for the given bounds.
+    ///
+    /// Shared by `paint` and `hit_test` so the two stay in sync. Returns `None` when there
+    /// is no x accessor or no series.
+    fn scales(&self, bounds: Bounds<Pixels>) -> Option<(ScalePoint<X>, ScaleLinear<Y>)> {
+        let x_fn = self.x.as_ref()?;
+        if self.y.is_empty() {
+            return None;
+        }
+
+        let width = bounds.size.width.as_f32();
+        let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
+        let height = bounds.size.height.as_f32() - axis_gap;
+
+        let x = ScalePoint::new(self.data.iter().map(|v| x_fn(v)).collect(), vec![0., width]);
+        let domain = self
+            .data
+            .iter()
+            .flat_map(|v| self.y.iter().map(|y_fn| y_fn(v)))
+            .chain(Some(Y::zero()))
+            .collect::<Vec<_>>();
+        let y = ScaleLinear::new(domain, vec![height, 10.]);
+
+        Some((x, y))
+    }
 }
 
 impl<T, X, Y> Plot for AreaChart<T, X, Y>
@@ -118,26 +169,12 @@ where
         let Some(x_fn) = self.x.as_ref() else {
             return;
         };
-
-        if self.y.len() == 0 {
+        let Some((x, y)) = self.scales(bounds) else {
             return;
-        }
+        };
 
-        let width = bounds.size.width.as_f32();
         let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
         let height = bounds.size.height.as_f32() - axis_gap;
-
-        // X scale
-        let x = ScalePoint::new(self.data.iter().map(|v| x_fn(v)).collect(), vec![0., width]);
-
-        // Y scale
-        let domain = self
-            .data
-            .iter()
-            .flat_map(|v| self.y.iter().map(|y_fn| y_fn(v)))
-            .chain(Some(Y::zero()))
-            .collect::<Vec<_>>();
-        let y = ScaleLinear::new(domain, vec![height, 10.]);
 
         // Draw X axis
         let mut axis = PlotAxis::new().stroke(cx.theme().border);
@@ -191,5 +228,76 @@ where
                 .fill(fill)
                 .paint(&bounds, window);
         }
+    }
+
+    fn plot_id(&self) -> Option<ElementId> {
+        self.id.clone()
+    }
+
+    fn hit_test(
+        &self,
+        position: Point<Pixels>,
+        bounds: Bounds<Pixels>,
+        _cx: &App,
+    ) -> Option<TooltipState> {
+        let x_fn = self.x.as_ref()?;
+        let (x, y) = self.scales(bounds)?;
+
+        let index = x.least_index(position.x.as_f32());
+        let d = self.data.get(index)?;
+        let x_tick = x.tick(&x_fn(d))?;
+
+        // One dot per series at the hovered x.
+        let dots = self
+            .y
+            .iter()
+            .filter_map(|y_fn| Some(point(px(x_tick), px(y.tick(&y_fn(d))?))))
+            .collect();
+
+        Some(TooltipState::new(
+            index,
+            point(px(x_tick), position.y),
+            dots,
+            TooltipPosition::for_index(index, self.data.len()),
+        ))
+    }
+
+    fn render_tooltip(
+        &self,
+        state: &TooltipState,
+        bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let x_fn = self.x.as_ref()?;
+        let d = self.data.get(state.index)?;
+        let title: SharedString = x_fn(d).into();
+
+        let default_color = cx.theme().chart_2;
+        let dot_stroke = cx.theme().background;
+        let color = |i: usize| *self.strokes.get(i).unwrap_or(&default_color);
+
+        let mut tooltip = Tooltip::new()
+            // Follow the cursor: hug the crosshair horizontally, track the cursor vertically.
+            .anchor(state.cross_line, bounds.size)
+            .gap(px(8.))
+            .cross_line(CrossLine::new(state.cross_line))
+            .dots(
+                state
+                    .dots
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| Dot::new(*p).stroke(dot_stroke).fill(color(i))),
+            )
+            .title(title);
+
+        // One row per series: swatch + label + value.
+        for (i, y_fn) in self.y.iter().enumerate() {
+            let label = self.labels.get(i).cloned().unwrap_or_default();
+            let value = y_fn(d).to_f64()?;
+            tooltip = tooltip.row(color(i), label, format!("{}", value));
+        }
+
+        Some(tooltip.into_any_element())
     }
 }

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -281,7 +281,11 @@ where
             // Follow the cursor: hug the crosshair horizontally, track the cursor vertically.
             .anchor(state.cross_line, bounds.size)
             .gap(px(8.))
-            .cross_line(CrossLine::new(state.cross_line))
+            // Confine the crosshair to the plot area so it doesn't cross the x-axis.
+            .cross_line(
+                CrossLine::new(state.cross_line)
+                    .height(bounds.size.height.as_f32() - if self.x_axis { AXIS_GAP } else { 0. }),
+            )
             .dots(
                 state
                     .dots

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -13,7 +13,7 @@ use crate::{
         AXIS_GAP, Grid, Plot, PlotAxis, StrokeStyle,
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Area,
-        tooltip::{CrossLine, Dot, Tooltip, TooltipPosition, TooltipState},
+        tooltip::{CrossLine, Dot, Tooltip, TooltipState},
     },
 };
 
@@ -258,7 +258,6 @@ where
             index,
             point(px(x_tick), position.y),
             dots,
-            TooltipPosition::for_index(index, self.data.len()),
         ))
     }
 
@@ -277,9 +276,8 @@ where
         let dot_stroke = cx.theme().background;
         let color = |i: usize| *self.strokes.get(i).unwrap_or(&default_color);
 
-        let mut tooltip = Tooltip::new()
-            // Follow the cursor: hug the crosshair horizontally, track the cursor vertically.
-            .anchor(state.cross_line, bounds.size)
+        // Follow the cursor; the crosshair and dots stay snapped to the data point.
+        let mut tooltip = Tooltip::new(state.cursor, bounds.size)
             .gap(px(8.))
             // Confine the crosshair to the plot area so it doesn't cross the x-axis.
             .cross_line(

--- a/crates/ui/src/chart/area_chart.rs
+++ b/crates/ui/src/chart/area_chart.rs
@@ -32,7 +32,7 @@ where
     strokes: Vec<Hsla>,
     stroke_styles: Vec<StrokeStyle>,
     fills: Vec<Background>,
-    labels: Vec<SharedString>,
+    names: Vec<SharedString>,
     tick_margin: usize,
     x_axis: bool,
     grid: bool,
@@ -53,7 +53,7 @@ where
             stroke_styles: vec![],
             strokes: vec![],
             fills: vec![],
-            labels: vec![],
+            names: vec![],
             tick_margin: 1,
             x: None,
             y: vec![],
@@ -74,9 +74,9 @@ where
 
     /// Set the name of the most recently added series, shown in its tooltip row.
     ///
-    /// Call after the matching [`AreaChart::y`] (e.g. `.y(..).stroke(..).label("Foo")`).
-    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
-        self.labels.push(label.into());
+    /// Call after the matching [`AreaChart::y`] (e.g. `.y(..).stroke(..).name("Desktop")`).
+    pub fn name(mut self, name: impl Into<SharedString>) -> Self {
+        self.names.push(name.into());
         self
     }
 
@@ -293,9 +293,9 @@ where
 
         // One row per series: swatch + label + value.
         for (i, y_fn) in self.y.iter().enumerate() {
-            let label = self.labels.get(i).cloned().unwrap_or_default();
+            let name = self.names.get(i).cloned().unwrap_or_default();
             let value = y_fn(d).to_f64()?;
-            tooltip = tooltip.row(color(i), label, format!("{}", value));
+            tooltip = tooltip.row(color(i), name, format!("{}", value));
         }
 
         Some(tooltip.into_any_element())

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -218,6 +218,25 @@ where
         self
     }
 
+    /// The band scale (matching `paint`): spans the height for horizontal bars, the width
+    /// otherwise. Shared by `tooltip_state` and `tooltip`.
+    fn band_scale(&self, bounds: Bounds<Pixels>) -> Option<ScaleBand<B>> {
+        let band_fn = self.band.as_ref()?;
+        let band_extent = if self.alignment.is_horizontal() {
+            bounds.size.height.as_f32()
+        } else {
+            bounds.size.width.as_f32()
+        };
+        Some(
+            ScaleBand::new(
+                self.data.iter().map(|v| band_fn(v)).collect(),
+                vec![0., band_extent],
+            )
+            .padding_inner(0.4)
+            .padding_outer(0.2),
+        )
+    }
+
     /// Label gaps `(band_side, value_end_side)` reserved along the value axis for
     /// horizontal bars, measured from the actual label text. Shared by `paint` and the
     /// tooltip so the crosshair lines up with the bar region.
@@ -464,21 +483,10 @@ where
         let band_fn = self.band.as_ref()?;
         self.value.as_ref()?;
 
-        // The band axis runs along the height for horizontal bars, the width otherwise.
         // Only the band scale is needed to hit-test which bar is hovered, so no text
         // measurement (and thus no `window`) is required.
         let is_horizontal = self.alignment.is_horizontal();
-        let band_extent = if is_horizontal {
-            bounds.size.height.as_f32()
-        } else {
-            bounds.size.width.as_f32()
-        };
-        let band_scale = ScaleBand::new(
-            self.data.iter().map(|v| band_fn(v)).collect(),
-            vec![0., band_extent],
-        )
-        .padding_inner(0.4)
-        .padding_outer(0.2);
+        let band_scale = self.band_scale(bounds)?;
         let band_width = band_scale.band_width();
 
         let cursor_band = if is_horizontal {
@@ -522,9 +530,9 @@ where
         let value = value_fn(d).to_f64()?;
         let name = self.name.clone().unwrap_or_default();
 
-        // Confine the crosshair to the bar region so it doesn't cross the axis labels.
-        // Horizontal bars get a horizontal line (spanning the value axis between the band
-        // and value-end label gaps); vertical bars a vertical line (spanning the plot height).
+        // Highlight the hovered bar with a translucent band the width of the bar, instead
+        // of a hairline. Confined to the plot area so it doesn't cover the axis labels.
+        let band_width = self.band_scale(bounds)?.band_width();
         let cross_line = if self.alignment.is_horizontal() {
             let (band_gap, value_end_gap) = self.horizontal_gaps(window);
             let length = (bounds.size.width.as_f32() - band_gap - value_end_gap).max(0.);
@@ -536,6 +544,7 @@ where
             CrossLine::new(state.cross_line)
                 .horizontal()
                 .span(start, length)
+                .band(px(band_width))
         } else {
             let axis_gap = if self.label_axis { AXIS_GAP } else { 0. };
             let start = if matches!(self.alignment, BarAlignment::Top) {
@@ -543,7 +552,9 @@ where
             } else {
                 0.
             };
-            CrossLine::new(state.cross_line).span(start, bounds.size.height.as_f32() - axis_gap)
+            CrossLine::new(state.cross_line)
+                .span(start, bounds.size.height.as_f32() - axis_gap)
+                .band(px(band_width))
         };
 
         Some(

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -41,6 +41,7 @@ where
     alignment: BarAlignment,
     corner_radii: Corners<Pixels>,
     id: Option<ElementId>,
+    name: Option<SharedString>,
 }
 
 impl<T, B, V> BarChart<T, B, V>
@@ -65,6 +66,7 @@ where
             alignment: BarAlignment::default(),
             corner_radii: Corners::all(px(0.)),
             id: None,
+            name: None,
         }
     }
 
@@ -75,6 +77,12 @@ where
     /// currently show a tooltip.
     pub fn id(mut self, id: impl Into<ElementId>) -> Self {
         self.id = Some(id.into());
+        self
+    }
+
+    /// Set the series name shown in the hover tooltip row (e.g. "Desktop").
+    pub fn name(mut self, name: impl Into<SharedString>) -> Self {
+        self.name = Some(name.into());
         self
     }
 
@@ -487,6 +495,7 @@ where
         let d = self.data.get(state.index)?;
         let title: SharedString = band_fn(d).into();
         let value = value_fn(d).to_f64()?;
+        let name = self.name.clone().unwrap_or_default();
 
         Some(
             Tooltip::new()
@@ -495,7 +504,7 @@ where
                 .gap(px(8.))
                 .cross_line(CrossLine::new(state.cross_line))
                 .title(title)
-                .row(cx.theme().chart_2, "", format!("{}", value))
+                .row(cx.theme().chart_2, name, format!("{}", value))
                 .into_any_element(),
         )
     }

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -286,18 +286,11 @@ where
         let alignment = self.alignment;
         let is_horizontal = alignment.is_horizontal();
 
-        // Band scale spans the full extent perpendicular to the value axis.
-        let band_extent = if is_horizontal {
-            total_height
-        } else {
-            total_width
+        // Band scale spans the full extent perpendicular to the value axis. Shared with the
+        // tooltip via `band_scale()` so the bars and the hover crosshair stay aligned.
+        let Some(band_scale) = self.band_scale(bounds) else {
+            return;
         };
-        let band_scale = ScaleBand::new(
-            self.data.iter().map(|v| band_fn(v)).collect(),
-            vec![0., band_extent],
-        )
-        .padding_inner(0.4)
-        .padding_outer(0.2);
         let band_width = band_scale.band_width();
 
         let value_dim = if is_horizontal {
@@ -512,6 +505,7 @@ where
     fn tooltip(
         &self,
         state: &TooltipState,
+        cursor: Point<Pixels>,
         bounds: Bounds<Pixels>,
         window: &mut Window,
         cx: &mut App,
@@ -533,25 +527,34 @@ where
             } else {
                 value_end_gap
             };
+            // Skip the tooltip when the cursor is over the value-axis labels, not a bar.
+            if cursor.x.as_f32() < start || cursor.x.as_f32() > start + length {
+                return None;
+            }
             CrossLine::new(state.cross_line)
                 .horizontal()
                 .span(start, length)
                 .band(px(band_width))
         } else {
             let axis_gap = if self.label_axis { AXIS_GAP } else { 0. };
+            let length = bounds.size.height.as_f32() - axis_gap;
             let start = if matches!(self.alignment, BarAlignment::Top) {
                 axis_gap
             } else {
                 0.
             };
+            // Skip the tooltip when the cursor is over the band-axis labels, not a bar.
+            if cursor.y.as_f32() < start || cursor.y.as_f32() > start + length {
+                return None;
+            }
             CrossLine::new(state.cross_line)
-                .span(start, bounds.size.height.as_f32() - axis_gap)
+                .span(start, length)
                 .band(px(band_width))
         };
 
         Some(
             // Follow the cursor; the highlight band stays snapped to the bar.
-            Tooltip::new(state.cursor, bounds.size)
+            Tooltip::new(cursor, bounds.size)
                 .gap(px(8.))
                 .cross_line(cross_line)
                 .title(title)

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -14,7 +14,7 @@ use crate::{
         label::{TEXT_GAP, TEXT_SIZE, Text, measure_text_width},
         scale::{Scale, ScaleBand, ScaleLinear, Sealed},
         shape::{Bar, BarAlignment},
-        tooltip::{CrossLine, Tooltip, TooltipAxis, TooltipPosition, TooltipState},
+        tooltip::{CrossLine, Tooltip, TooltipState},
     },
 };
 
@@ -498,23 +498,15 @@ where
         let d = self.data.get(index)?;
         let center = band_scale.tick(&band_fn(d))? + band_width / 2.;
 
-        // Vertical bars: vertical crosshair at the bar's x, box tracks the cursor y.
-        // Horizontal bars: horizontal crosshair at the bar's y, box tracks the cursor x.
-        let (cross_line, axis) = if is_horizontal {
-            (point(position.x, px(center)), TooltipAxis::Y)
+        // Vertical bars: vertical crosshair at the bar's x. Horizontal bars: horizontal
+        // crosshair at the bar's y. The box tracks the cursor either way.
+        let cross_line = if is_horizontal {
+            point(position.x, px(center))
         } else {
-            (point(px(center), position.y), TooltipAxis::X)
+            point(px(center), position.y)
         };
 
-        Some(
-            TooltipState::new(
-                index,
-                cross_line,
-                vec![],
-                TooltipPosition::for_index(index, self.data.len()),
-            )
-            .axis(axis),
-        )
+        Some(TooltipState::new(index, cross_line, vec![]))
     }
 
     fn tooltip(
@@ -558,9 +550,8 @@ where
         };
 
         Some(
-            Tooltip::new()
-                // Follow the cursor, hugging the bar's center along the band axis.
-                .anchor(state.cross_line, bounds.size)
+            // Follow the cursor; the highlight band stays snapped to the bar.
+            Tooltip::new(state.cursor, bounds.size)
                 .gap(px(8.))
                 .cross_line(cross_line)
                 .title(title)

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -14,7 +14,7 @@ use crate::{
         label::{TEXT_GAP, TEXT_SIZE, Text, measure_text_width},
         scale::{Scale, ScaleBand, ScaleLinear, Sealed},
         shape::{Bar, BarAlignment},
-        tooltip::{CrossLine, Tooltip, TooltipPosition, TooltipState},
+        tooltip::{CrossLine, Tooltip, TooltipAxis, TooltipPosition, TooltipState},
     },
 };
 
@@ -73,8 +73,8 @@ where
     /// Enable an interactive hover tooltip (crosshair + category/value) for this chart.
     ///
     /// The `id` must be unique among sibling elements. Without it, the chart stays a
-    /// non-interactive plot. Only vertical bars ([`BarAlignment::Bottom`] / [`BarAlignment::Top`])
-    /// currently show a tooltip.
+    /// non-interactive plot. Works for every [`BarAlignment`] (vertical bars get a
+    /// vertical crosshair, horizontal bars a horizontal one).
     pub fn id(mut self, id: impl Into<ElementId>) -> Self {
         self.id = Some(id.into());
         self
@@ -457,31 +457,49 @@ where
         let band_fn = self.band.as_ref()?;
         self.value.as_ref()?;
 
-        // Only vertical bars are hit-tested for now (horizontal bars need text
-        // measurement to position the value axis, which isn't available here).
-        if self.alignment.is_horizontal() {
-            return None;
-        }
-
-        // Band scale matches `paint`: spans the full width, same padding.
+        // The band axis runs along the height for horizontal bars, the width otherwise.
+        // Only the band scale is needed to hit-test which bar is hovered, so no text
+        // measurement (and thus no `window`) is required.
+        let is_horizontal = self.alignment.is_horizontal();
+        let band_extent = if is_horizontal {
+            bounds.size.height.as_f32()
+        } else {
+            bounds.size.width.as_f32()
+        };
         let band_scale = ScaleBand::new(
             self.data.iter().map(|v| band_fn(v)).collect(),
-            vec![0., bounds.size.width.as_f32()],
+            vec![0., band_extent],
         )
         .padding_inner(0.4)
         .padding_outer(0.2);
         let band_width = band_scale.band_width();
 
-        let index = band_scale.least_index(position.x.as_f32());
+        let cursor_band = if is_horizontal {
+            position.y
+        } else {
+            position.x
+        };
+        let index = band_scale.least_index(cursor_band.as_f32());
         let d = self.data.get(index)?;
-        let center_x = band_scale.tick(&band_fn(d))? + band_width / 2.;
+        let center = band_scale.tick(&band_fn(d))? + band_width / 2.;
 
-        Some(TooltipState::new(
-            index,
-            point(px(center_x), position.y),
-            vec![],
-            TooltipPosition::for_index(index, self.data.len()),
-        ))
+        // Vertical bars: vertical crosshair at the bar's x, box tracks the cursor y.
+        // Horizontal bars: horizontal crosshair at the bar's y, box tracks the cursor x.
+        let (cross_line, axis) = if is_horizontal {
+            (point(position.x, px(center)), TooltipAxis::Y)
+        } else {
+            (point(px(center), position.y), TooltipAxis::X)
+        };
+
+        Some(
+            TooltipState::new(
+                index,
+                cross_line,
+                vec![],
+                TooltipPosition::for_index(index, self.data.len()),
+            )
+            .axis(axis),
+        )
     }
 
     fn tooltip(
@@ -497,12 +515,20 @@ where
         let value = value_fn(d).to_f64()?;
         let name = self.name.clone().unwrap_or_default();
 
+        // Horizontal bars get a horizontal crosshair; vertical bars a vertical one.
+        let cross_line = CrossLine::new(state.cross_line);
+        let cross_line = if self.alignment.is_horizontal() {
+            cross_line.horizontal()
+        } else {
+            cross_line
+        };
+
         Some(
             Tooltip::new()
-                // Follow the cursor: hug the bar's center, track the cursor vertically.
+                // Follow the cursor, hugging the bar's center along the band axis.
                 .anchor(state.cross_line, bounds.size)
                 .gap(px(8.))
-                .cross_line(CrossLine::new(state.cross_line))
+                .cross_line(cross_line)
                 .title(title)
                 .row(cx.theme().chart_2, name, format!("{}", value))
                 .into_any_element(),

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -217,6 +217,38 @@ where
         self.corner_radii = corner_radii.into();
         self
     }
+
+    /// Label gaps `(band_side, value_end_side)` reserved along the value axis for
+    /// horizontal bars, measured from the actual label text. Shared by `paint` and the
+    /// tooltip so the crosshair lines up with the bar region.
+    fn horizontal_gaps(&self, window: &mut Window) -> (f32, f32) {
+        let Some(band_fn) = self.band.as_ref() else {
+            return (0., 0.);
+        };
+        let font_size = px(TEXT_SIZE);
+        let band_gap = if self.label_axis {
+            self.data
+                .iter()
+                .map(|v| {
+                    let s: SharedString = band_fn(v).into();
+                    measure_text_width(&s, font_size, window)
+                })
+                .fold(0f32, f32::max)
+                + TEXT_GAP * 2.
+        } else {
+            0.
+        };
+        let value_end_gap = if let Some(label_fn) = self.label.as_ref() {
+            self.data
+                .iter()
+                .map(|v| measure_text_width(&label_fn(v), font_size, window))
+                .fold(0f32, f32::max)
+                + TEXT_GAP * 2.
+        } else {
+            TEXT_GAP * 4.
+        };
+        (band_gap, value_end_gap)
+    }
 }
 
 impl<T, B, V> Plot for BarChart<T, B, V>
@@ -260,32 +292,7 @@ where
         // Similarly, value labels (numbers) at the bar ends are measured so the
         // scale range is always shrunk by exactly the right amount.
         let (band_gap, value_end_gap) = if is_horizontal {
-            let font_size = px(TEXT_SIZE);
-            let band_gap = if self.label_axis {
-                let max_w = self
-                    .data
-                    .iter()
-                    .map(|v| {
-                        let s: SharedString = band_fn(v).into();
-                        measure_text_width(&s, font_size, window)
-                    })
-                    .fold(0f32, f32::max);
-                // TEXT_GAP: space between axis line and label start/end.
-                max_w + TEXT_GAP * 2.
-            } else {
-                0.
-            };
-            let value_end_gap = if let Some(label_fn) = self.label.as_ref() {
-                let max_w = self
-                    .data
-                    .iter()
-                    .map(|v| measure_text_width(&label_fn(v), font_size, window))
-                    .fold(0f32, f32::max);
-                max_w + TEXT_GAP * 2.
-            } else {
-                TEXT_GAP * 4.
-            };
-            (band_gap, value_end_gap)
+            self.horizontal_gaps(window)
         } else {
             (axis_gap, 10.)
         };
@@ -506,7 +513,7 @@ where
         &self,
         state: &TooltipState,
         bounds: Bounds<Pixels>,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
         let (band_fn, value_fn) = (self.band.as_ref()?, self.value.as_ref()?);
@@ -515,12 +522,28 @@ where
         let value = value_fn(d).to_f64()?;
         let name = self.name.clone().unwrap_or_default();
 
-        // Horizontal bars get a horizontal crosshair; vertical bars a vertical one.
-        let cross_line = CrossLine::new(state.cross_line);
+        // Confine the crosshair to the bar region so it doesn't cross the axis labels.
+        // Horizontal bars get a horizontal line (spanning the value axis between the band
+        // and value-end label gaps); vertical bars a vertical line (spanning the plot height).
         let cross_line = if self.alignment.is_horizontal() {
-            cross_line.horizontal()
+            let (band_gap, value_end_gap) = self.horizontal_gaps(window);
+            let length = (bounds.size.width.as_f32() - band_gap - value_end_gap).max(0.);
+            let start = if matches!(self.alignment, BarAlignment::Left) {
+                band_gap
+            } else {
+                value_end_gap
+            };
+            CrossLine::new(state.cross_line)
+                .horizontal()
+                .span(start, length)
         } else {
-            cross_line
+            let axis_gap = if self.label_axis { AXIS_GAP } else { 0. };
+            let start = if matches!(self.alignment, BarAlignment::Top) {
+                axis_gap
+            } else {
+                0.
+            };
+            CrossLine::new(state.cross_line).span(start, bounds.size.height.as_f32() - axis_gap)
         };
 
         Some(

--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -1,8 +1,8 @@
 use std::{ops::RangeInclusive, rc::Rc};
 
 use gpui::{
-    App, Background, Bounds, Corners, Hsla, LinearColorStop, Pixels, Point, SharedString, Size,
-    TextAlign, Window, linear_gradient, px,
+    AnyElement, App, Background, Bounds, Corners, ElementId, Hsla, IntoElement, LinearColorStop,
+    Pixels, Point, SharedString, Size, TextAlign, Window, linear_gradient, point, px,
 };
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive};
@@ -14,6 +14,7 @@ use crate::{
         label::{TEXT_GAP, TEXT_SIZE, Text, measure_text_width},
         scale::{Scale, ScaleBand, ScaleLinear, Sealed},
         shape::{Bar, BarAlignment},
+        tooltip::{CrossLine, Tooltip, TooltipPosition, TooltipState},
     },
 };
 
@@ -39,6 +40,7 @@ where
     grid: bool,
     alignment: BarAlignment,
     corner_radii: Corners<Pixels>,
+    id: Option<ElementId>,
 }
 
 impl<T, B, V> BarChart<T, B, V>
@@ -62,7 +64,18 @@ where
             grid: true,
             alignment: BarAlignment::default(),
             corner_radii: Corners::all(px(0.)),
+            id: None,
         }
+    }
+
+    /// Enable an interactive hover tooltip (crosshair + category/value) for this chart.
+    ///
+    /// The `id` must be unique among sibling elements. Without it, the chart stays a
+    /// non-interactive plot. Only vertical bars ([`BarAlignment::Bottom`] / [`BarAlignment::Top`])
+    /// currently show a tooltip.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.id = Some(id.into());
+        self
     }
 
     /// Map each datum to its band-axis value (the categorical/ordinal axis).
@@ -421,6 +434,70 @@ where
         }
 
         bar.paint(&bounds, window, cx);
+    }
+
+    fn id(&self) -> Option<ElementId> {
+        self.id.clone()
+    }
+
+    fn tooltip_state(
+        &self,
+        position: Point<Pixels>,
+        bounds: Bounds<Pixels>,
+        _cx: &App,
+    ) -> Option<TooltipState> {
+        let band_fn = self.band.as_ref()?;
+        self.value.as_ref()?;
+
+        // Only vertical bars are hit-tested for now (horizontal bars need text
+        // measurement to position the value axis, which isn't available here).
+        if self.alignment.is_horizontal() {
+            return None;
+        }
+
+        // Band scale matches `paint`: spans the full width, same padding.
+        let band_scale = ScaleBand::new(
+            self.data.iter().map(|v| band_fn(v)).collect(),
+            vec![0., bounds.size.width.as_f32()],
+        )
+        .padding_inner(0.4)
+        .padding_outer(0.2);
+        let band_width = band_scale.band_width();
+
+        let index = band_scale.least_index(position.x.as_f32());
+        let d = self.data.get(index)?;
+        let center_x = band_scale.tick(&band_fn(d))? + band_width / 2.;
+
+        Some(TooltipState::new(
+            index,
+            point(px(center_x), position.y),
+            vec![],
+            TooltipPosition::for_index(index, self.data.len()),
+        ))
+    }
+
+    fn tooltip(
+        &self,
+        state: &TooltipState,
+        bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let (band_fn, value_fn) = (self.band.as_ref()?, self.value.as_ref()?);
+        let d = self.data.get(state.index)?;
+        let title: SharedString = band_fn(d).into();
+        let value = value_fn(d).to_f64()?;
+
+        Some(
+            Tooltip::new()
+                // Follow the cursor: hug the bar's center, track the cursor vertically.
+                .anchor(state.cross_line, bounds.size)
+                .gap(px(8.))
+                .cross_line(CrossLine::new(state.cross_line))
+                .title(title)
+                .row(cx.theme().chart_2, "", format!("{}", value))
+                .into_any_element(),
+        )
     }
 }
 

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -244,6 +244,7 @@ where
     fn render_tooltip(
         &self,
         state: &TooltipState,
+        bounds: Bounds<Pixels>,
         _window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
@@ -256,7 +257,10 @@ where
 
         Some(
             Tooltip::new()
-                .position(state.position)
+                // Follow the cursor: hug the crosshair (data point x) horizontally and
+                // track the cursor vertically, flipping toward the center near each edge.
+                .anchor(state.cross_line, bounds.size)
+                .gap(px(8.))
                 .cross_line(CrossLine::new(state.cross_line))
                 .dots(
                     state

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -72,7 +72,7 @@ where
         self
     }
 
-    /// Set the series name shown in the hover tooltip row (e.g. "Desktop").
+    /// Set the series name shown in the hover tooltip row (e.g. "Foo").
     pub fn label(mut self, label: impl Into<SharedString>) -> Self {
         self.label = Some(label.into());
         self
@@ -133,7 +133,7 @@ where
 
     /// Build the x (point) and y (linear) scales for the given bounds.
     ///
-    /// Shared by `paint` and `hit_test` so the two stay in sync. Returns `None` when the
+    /// Shared by `paint` and `tooltip_state` so the two stay in sync. Returns `None` when the
     /// x/y accessors have not been set.
     fn scales(&self, bounds: Bounds<Pixels>) -> Option<(ScalePoint<X>, ScaleLinear<Y>)> {
         let (x_fn, y_fn) = (self.x.as_ref()?, self.y.as_ref()?);
@@ -215,11 +215,11 @@ where
         line.paint(&bounds, window);
     }
 
-    fn plot_id(&self) -> Option<ElementId> {
+    fn id(&self) -> Option<ElementId> {
         self.id.clone()
     }
 
-    fn hit_test(
+    fn tooltip_state(
         &self,
         position: Point<Pixels>,
         bounds: Bounds<Pixels>,
@@ -241,7 +241,7 @@ where
         ))
     }
 
-    fn render_tooltip(
+    fn tooltip(
         &self,
         state: &TooltipState,
         bounds: Bounds<Pixels>,

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -261,7 +261,12 @@ where
                 // track the cursor vertically, flipping toward the center near each edge.
                 .anchor(state.cross_line, bounds.size)
                 .gap(px(8.))
-                .cross_line(CrossLine::new(state.cross_line))
+                // Confine the crosshair to the plot area so it doesn't cross the x-axis.
+                .cross_line(
+                    CrossLine::new(state.cross_line).height(
+                        bounds.size.height.as_f32() - if self.x_axis { AXIS_GAP } else { 0. },
+                    ),
+                )
                 .dots(
                     state
                         .dots

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -228,6 +228,12 @@ where
         let (x_fn, y_fn) = (self.x.as_ref()?, self.y.as_ref()?);
         let (x, y) = self.scales(bounds)?;
 
+        // Ignore the x-axis label gutter so hovering the labels doesn't show a tooltip.
+        let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
+        if position.y.as_f32() > bounds.size.height.as_f32() - axis_gap {
+            return None;
+        }
+
         let index = x.least_index(position.x.as_f32());
         let d = self.data.get(index)?;
         let x_tick = x.tick(&x_fn(d))?;
@@ -243,6 +249,7 @@ where
     fn tooltip(
         &self,
         state: &TooltipState,
+        cursor: Point<Pixels>,
         bounds: Bounds<Pixels>,
         _window: &mut Window,
         cx: &mut App,
@@ -256,7 +263,7 @@ where
 
         Some(
             // Follow the cursor; the crosshair and dot stay snapped to the data point.
-            Tooltip::new(state.cursor, bounds.size)
+            Tooltip::new(cursor, bounds.size)
                 .gap(px(8.))
                 // Confine the crosshair to the plot area so it doesn't cross the x-axis.
                 .cross_line(

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -1,6 +1,9 @@
 use std::rc::Rc;
 
-use gpui::{App, Bounds, Hsla, Pixels, SharedString, Window, px};
+use gpui::{
+    AnyElement, App, Bounds, ElementId, Hsla, IntoElement, Pixels, Point, SharedString, Window,
+    point, px,
+};
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive};
 
@@ -10,6 +13,7 @@ use crate::{
         AXIS_GAP, Grid, Plot, PlotAxis, StrokeStyle,
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Line,
+        tooltip::{CrossLine, Dot, Tooltip, TooltipPosition, TooltipState},
     },
 };
 
@@ -31,6 +35,8 @@ where
     tick_margin: usize,
     x_axis: bool,
     grid: bool,
+    id: Option<ElementId>,
+    label: Option<SharedString>,
 }
 
 impl<T, X, Y> LineChart<T, X, Y>
@@ -52,7 +58,24 @@ where
             tick_margin: 1,
             x_axis: true,
             grid: true,
+            id: None,
+            label: None,
         }
+    }
+
+    /// Enable an interactive hover tooltip (with crosshair and a data dot) for this chart.
+    ///
+    /// The `id` must be unique among sibling elements. Without it, the chart stays a
+    /// non-interactive plot.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Set the series name shown in the hover tooltip row (e.g. "Desktop").
+    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.label = Some(label.into());
+        self
     }
 
     pub fn x(mut self, x: impl Fn(&T) -> X + 'static) -> Self {
@@ -107,6 +130,31 @@ where
         self.grid = grid;
         self
     }
+
+    /// Build the x (point) and y (linear) scales for the given bounds.
+    ///
+    /// Shared by `paint` and `hit_test` so the two stay in sync. Returns `None` when the
+    /// x/y accessors have not been set.
+    fn scales(&self, bounds: Bounds<Pixels>) -> Option<(ScalePoint<X>, ScaleLinear<Y>)> {
+        let (x_fn, y_fn) = (self.x.as_ref()?, self.y.as_ref()?);
+
+        let width = bounds.size.width.as_f32();
+        let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
+        let height = bounds.size.height.as_f32() - axis_gap;
+
+        let x = ScalePoint::new(self.data.iter().map(|v| x_fn(v)).collect(), vec![0., width]);
+        // Y scale, ensure start from 0.
+        let y = ScaleLinear::new(
+            self.data
+                .iter()
+                .map(|v| y_fn(v))
+                .chain(Some(Y::zero()))
+                .collect(),
+            vec![height, 10.],
+        );
+
+        Some((x, y))
+    }
 }
 
 impl<T, X, Y> Plot for LineChart<T, X, Y>
@@ -118,23 +166,12 @@ where
         let (Some(x_fn), Some(y_fn)) = (self.x.as_ref(), self.y.as_ref()) else {
             return;
         };
+        let Some((x, y)) = self.scales(bounds) else {
+            return;
+        };
 
-        let width = bounds.size.width.as_f32();
         let axis_gap = if self.x_axis { AXIS_GAP } else { 0. };
         let height = bounds.size.height.as_f32() - axis_gap;
-
-        // X scale
-        let x = ScalePoint::new(self.data.iter().map(|v| x_fn(v)).collect(), vec![0., width]);
-
-        // Y scale, ensure start from 0.
-        let y = ScaleLinear::new(
-            self.data
-                .iter()
-                .map(|v| y_fn(v))
-                .chain(Some(Y::zero()))
-                .collect(),
-            vec![height, 10.],
-        );
 
         // Draw X axis
         let mut axis = PlotAxis::new().stroke(cx.theme().border);
@@ -176,5 +213,60 @@ where
         }
 
         line.paint(&bounds, window);
+    }
+
+    fn plot_id(&self) -> Option<ElementId> {
+        self.id.clone()
+    }
+
+    fn hit_test(
+        &self,
+        position: Point<Pixels>,
+        bounds: Bounds<Pixels>,
+        _cx: &App,
+    ) -> Option<TooltipState> {
+        let (x_fn, y_fn) = (self.x.as_ref()?, self.y.as_ref()?);
+        let (x, y) = self.scales(bounds)?;
+
+        let index = x.least_index(position.x.as_f32());
+        let d = self.data.get(index)?;
+        let x_tick = x.tick(&x_fn(d))?;
+        let y_tick = y.tick(&y_fn(d))?;
+
+        Some(TooltipState::new(
+            index,
+            point(px(x_tick), position.y),
+            vec![point(px(x_tick), px(y_tick))],
+            TooltipPosition::for_index(index, self.data.len()),
+        ))
+    }
+
+    fn render_tooltip(
+        &self,
+        state: &TooltipState,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let (x_fn, y_fn) = (self.x.as_ref()?, self.y.as_ref()?);
+        let d = self.data.get(state.index)?;
+        let title: SharedString = x_fn(d).into();
+        let value = y_fn(d).to_f64()?;
+        let stroke = self.stroke.unwrap_or(cx.theme().chart_2);
+        let label = self.label.clone().unwrap_or_default();
+
+        Some(
+            Tooltip::new()
+                .position(state.position)
+                .cross_line(CrossLine::new(state.cross_line))
+                .dots(
+                    state
+                        .dots
+                        .iter()
+                        .map(|p| Dot::new(*p).stroke(cx.theme().background).fill(stroke)),
+                )
+                .title(title)
+                .row(stroke, label, format!("{}", value))
+                .into_any_element(),
+        )
     }
 }

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -36,7 +36,7 @@ where
     x_axis: bool,
     grid: bool,
     id: Option<ElementId>,
-    label: Option<SharedString>,
+    name: Option<SharedString>,
 }
 
 impl<T, X, Y> LineChart<T, X, Y>
@@ -59,7 +59,7 @@ where
             x_axis: true,
             grid: true,
             id: None,
-            label: None,
+            name: None,
         }
     }
 
@@ -72,9 +72,9 @@ where
         self
     }
 
-    /// Set the series name shown in the hover tooltip row (e.g. "Foo").
-    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
-        self.label = Some(label.into());
+    /// Set the series name shown in the hover tooltip row (e.g. "Desktop").
+    pub fn name(mut self, name: impl Into<SharedString>) -> Self {
+        self.name = Some(name.into());
         self
     }
 
@@ -253,7 +253,7 @@ where
         let title: SharedString = x_fn(d).into();
         let value = y_fn(d).to_f64()?;
         let stroke = self.stroke.unwrap_or(cx.theme().chart_2);
-        let label = self.label.clone().unwrap_or_default();
+        let name = self.name.clone().unwrap_or_default();
 
         Some(
             Tooltip::new()
@@ -269,7 +269,7 @@ where
                         .map(|p| Dot::new(*p).stroke(cx.theme().background).fill(stroke)),
                 )
                 .title(title)
-                .row(stroke, label, format!("{}", value))
+                .row(stroke, name, format!("{}", value))
                 .into_any_element(),
         )
     }

--- a/crates/ui/src/chart/line_chart.rs
+++ b/crates/ui/src/chart/line_chart.rs
@@ -13,7 +13,7 @@ use crate::{
         AXIS_GAP, Grid, Plot, PlotAxis, StrokeStyle,
         scale::{Scale, ScaleLinear, ScalePoint, Sealed},
         shape::Line,
-        tooltip::{CrossLine, Dot, Tooltip, TooltipPosition, TooltipState},
+        tooltip::{CrossLine, Dot, Tooltip, TooltipState},
     },
 };
 
@@ -237,7 +237,6 @@ where
             index,
             point(px(x_tick), position.y),
             vec![point(px(x_tick), px(y_tick))],
-            TooltipPosition::for_index(index, self.data.len()),
         ))
     }
 
@@ -256,10 +255,8 @@ where
         let name = self.name.clone().unwrap_or_default();
 
         Some(
-            Tooltip::new()
-                // Follow the cursor: hug the crosshair (data point x) horizontally and
-                // track the cursor vertically, flipping toward the center near each edge.
-                .anchor(state.cross_line, bounds.size)
+            // Follow the cursor; the crosshair and dot stay snapped to the data point.
+            Tooltip::new(state.cursor, bounds.size)
                 .gap(px(8.))
                 // Confine the crosshair to the plot area so it doesn't cross the x-axis.
                 .cross_line(

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -9,14 +9,58 @@ pub use gpui_component_macros::IntoPlot;
 
 use std::{fmt::Debug, ops::Add};
 
-use gpui::{App, Bounds, IntoElement, Path, PathBuilder, Pixels, Point, Window, point, px};
+use gpui::{
+    AnyElement, App, Bounds, ElementId, IntoElement, Path, PathBuilder, Pixels, Point, Window,
+    point, px,
+};
 
 pub use axis::{AXIS_GAP, AxisLabelSide, AxisText, PlotAxis};
 pub use grid::Grid;
 pub use label::PlotLabel;
 
+use tooltip::TooltipState;
+
 pub trait Plot: IntoElement {
     fn paint(&mut self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut App);
+
+    /// A stable element id that enables interactive tooltip support for this plot.
+    ///
+    /// Return `Some(id)` to opt in to tooltips; the id must be unique among sibling
+    /// elements. Returning `None` (the default) disables all tooltip behavior, leaving
+    /// the plot a pure, non-interactive element identical to the pre-tooltip behavior.
+    fn plot_id(&self) -> Option<ElementId> {
+        None
+    }
+
+    /// Hit-test the cursor against the plot's data.
+    ///
+    /// `position` is the cursor position relative to the plot's top-left origin (already
+    /// origin-subtracted), and `bounds` is the painted area. Return the [`TooltipState`]
+    /// to display (highlighted index, crosshair point, dots, side), or `None` to show
+    /// nothing. Only called while the cursor is inside `bounds`.
+    ///
+    /// The default returns `None`.
+    fn hit_test(
+        &self,
+        _position: Point<Pixels>,
+        _bounds: Bounds<Pixels>,
+        _cx: &App,
+    ) -> Option<TooltipState> {
+        None
+    }
+
+    /// Render the tooltip overlay for the active [`TooltipState`].
+    ///
+    /// Return the overlay element (typically built with [`tooltip::Tooltip::new`]); it is
+    /// painted absolutely positioned above the plot. The default returns `None`.
+    fn render_tooltip(
+        &self,
+        _state: &TooltipState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Option<AnyElement> {
+        None
+    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -51,13 +51,14 @@ pub trait Plot: IntoElement {
 
     /// Render the tooltip overlay for the active [`TooltipState`].
     ///
-    /// `bounds` is the plot's painted area, so the tooltip can position itself relative to
-    /// the cursor (e.g. via [`tooltip::Tooltip::anchor`]). Return the overlay element
-    /// (typically built with [`tooltip::Tooltip::new`]); it is painted absolutely
-    /// positioned above the plot. The default returns `None`.
+    /// `cursor` is the live cursor position (relative to the plot origin) and `bounds` is the
+    /// plot's painted area, so the tooltip box can follow the cursor (pass `cursor` and
+    /// `bounds.size` to [`tooltip::Tooltip::new`]). Return the overlay element; it is painted
+    /// absolutely positioned above the plot. The default returns `None`.
     fn tooltip(
         &self,
         _state: &TooltipState,
+        _cursor: Point<Pixels>,
         _bounds: Bounds<Pixels>,
         _window: &mut Window,
         _cx: &mut App,

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -51,11 +51,14 @@ pub trait Plot: IntoElement {
 
     /// Render the tooltip overlay for the active [`TooltipState`].
     ///
-    /// Return the overlay element (typically built with [`tooltip::Tooltip::new`]); it is
-    /// painted absolutely positioned above the plot. The default returns `None`.
+    /// `bounds` is the plot's painted area, so the tooltip can position itself relative to
+    /// the cursor (e.g. via [`tooltip::Tooltip::anchor`]). Return the overlay element
+    /// (typically built with [`tooltip::Tooltip::new`]); it is painted absolutely
+    /// positioned above the plot. The default returns `None`.
     fn render_tooltip(
         &self,
         _state: &TooltipState,
+        _bounds: Bounds<Pixels>,
         _window: &mut Window,
         _cx: &mut App,
     ) -> Option<AnyElement> {

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -28,11 +28,11 @@ pub trait Plot: IntoElement {
     /// Return `Some(id)` to opt in to tooltips; the id must be unique among sibling
     /// elements. Returning `None` (the default) disables all tooltip behavior, leaving
     /// the plot a pure, non-interactive element identical to the pre-tooltip behavior.
-    fn plot_id(&self) -> Option<ElementId> {
+    fn id(&self) -> Option<ElementId> {
         None
     }
 
-    /// Hit-test the cursor against the plot's data.
+    /// Map the cursor to the tooltip state to display.
     ///
     /// `position` is the cursor position relative to the plot's top-left origin (already
     /// origin-subtracted), and `bounds` is the painted area. Return the [`TooltipState`]
@@ -40,7 +40,7 @@ pub trait Plot: IntoElement {
     /// nothing. Only called while the cursor is inside `bounds`.
     ///
     /// The default returns `None`.
-    fn hit_test(
+    fn tooltip_state(
         &self,
         _position: Point<Pixels>,
         _bounds: Bounds<Pixels>,
@@ -55,7 +55,7 @@ pub trait Plot: IntoElement {
     /// the cursor (e.g. via [`tooltip::Tooltip::anchor`]). Return the overlay element
     /// (typically built with [`tooltip::Tooltip::new`]); it is painted absolutely
     /// positioned above the plot. The default returns `None`.
-    fn render_tooltip(
+    fn tooltip(
         &self,
         _state: &TooltipState,
         _bounds: Bounds<Pixels>,

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -36,9 +36,6 @@ pub struct CrossLine {
     length: Option<f32>,
     /// Band thickness perpendicular to the line (solid band mode only).
     thickness: Pixels,
-    /// Explicit color; when `None`, falls back to a themed default (a subtle `border` for
-    /// the dashed hairline, a translucent highlight for the solid band).
-    color: Option<Hsla>,
     /// `true` (default) draws a dashed hairline; `false` a solid band of `thickness`.
     dashed: bool,
     direction: CrossLineAxis,
@@ -51,25 +48,17 @@ impl CrossLine {
             start: 0.,
             length: None,
             thickness: px(1.),
-            color: None,
             dashed: true,
             direction: Default::default(),
         }
     }
 
-    /// Render a solid highlight band of `thickness` (centered on `point`) instead of the
-    /// default dashed hairline. Use the bar/band width to highlight the hovered column or
-    /// row. The fill defaults to a translucent highlight; use [`CrossLine::color`] to override.
+    /// Render a solid translucent highlight band of `thickness` (centered on `point`)
+    /// instead of the default dashed hairline. Use the bar/band width to highlight the
+    /// hovered column or row.
     pub fn band(mut self, thickness: impl Into<Pixels>) -> Self {
         self.thickness = thickness.into();
         self.dashed = false;
-        self
-    }
-
-    /// Override the line/band color. Defaults: a subtle `border` for the dashed hairline,
-    /// a translucent highlight for the solid band.
-    pub fn color(mut self, color: impl Into<Hsla>) -> Self {
-        self.color = Some(color.into());
         self
     }
 
@@ -111,13 +100,11 @@ impl CrossLine {
     /// `x`; otherwise left→right at its `y`. A dashed hairline draws a 1px dashed border; a
     /// solid band fills a `thickness`-wide strip centered on the data point.
     fn line(&self, vertical: bool, cx: &App) -> Div {
-        let color = self.color.unwrap_or_else(|| {
-            if self.dashed {
-                cx.theme().border
-            } else {
-                cx.theme().foreground.opacity(0.08)
-            }
-        });
+        let color = if self.dashed {
+            cx.theme().border
+        } else {
+            cx.theme().foreground.opacity(0.08)
+        };
         // The dashed hairline is a zero-width strip drawn entirely by its 1px border.
         let thickness = if self.dashed { px(0.) } else { self.thickness };
 
@@ -231,9 +218,6 @@ pub struct TooltipState {
     pub index: usize,
     pub cross_line: Point<Pixels>,
     pub dots: Vec<Point<Pixels>>,
-    /// Live cursor position (relative to the plot origin); the tooltip box hugs it so it
-    /// follows the cursor smoothly. Set by the `IntoPlot` macro; defaults to `cross_line`.
-    pub cursor: Point<Pixels>,
 }
 
 impl TooltipState {
@@ -242,7 +226,6 @@ impl TooltipState {
             index,
             cross_line,
             dots,
-            cursor: cross_line,
         }
     }
 }

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -1,9 +1,9 @@
 use gpui::{
-    AnyElement, App, Div, Half as _, Hsla, IntoElement, ParentElement, Pixels, Point, RenderOnce,
-    StyleRefinement, Styled, Window, div, prelude::FluentBuilder, px,
+    AnyElement, App, Div, Hsla, IntoElement, ParentElement, Pixels, Point, RenderOnce,
+    SharedString, StyleRefinement, Styled, Window, div, prelude::FluentBuilder, px,
 };
 
-use crate::{ActiveTheme, v_flex};
+use crate::{ActiveTheme, StyledExt, h_flex, v_flex};
 
 #[derive(Default)]
 pub enum CrossLineAxis {
@@ -168,6 +168,18 @@ pub enum TooltipPosition {
     Right,
 }
 
+impl TooltipPosition {
+    /// Place the tooltip on the right while the hovered `index` is in the first half of
+    /// `len` items, otherwise on the left, so it stays clear of the screen edge.
+    pub fn for_index(index: usize, len: usize) -> Self {
+        if index < len / 2 {
+            Self::Right
+        } else {
+            Self::Left
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct TooltipState {
     pub index: usize,
@@ -192,6 +204,13 @@ impl TooltipState {
     }
 }
 
+/// A single labelled row in a [`Tooltip`]: a colored swatch, a muted label, and a value.
+struct TooltipRow {
+    color: Hsla,
+    label: SharedString,
+    value: SharedString,
+}
+
 #[derive(IntoElement)]
 pub struct Tooltip {
     base: Div,
@@ -200,6 +219,8 @@ pub struct Tooltip {
     cross_line: Option<CrossLine>,
     dots: Option<Vec<Dot>>,
     appearance: bool,
+    title: Option<SharedString>,
+    rows: Vec<TooltipRow>,
 }
 
 impl Tooltip {
@@ -212,7 +233,30 @@ impl Tooltip {
             cross_line: None,
             dots: None,
             appearance: true,
+            title: None,
+            rows: Vec::new(),
         }
+    }
+
+    /// Set a bold title row shown at the top of the tooltip (e.g. the hovered x value).
+    pub fn title(mut self, title: impl Into<SharedString>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Append a series row: a colored swatch, a muted `label`, and a right-aligned `value`.
+    pub fn row(
+        mut self,
+        color: impl Into<Hsla>,
+        label: impl Into<SharedString>,
+        value: impl Into<SharedString>,
+    ) -> Self {
+        self.rows.push(TooltipRow {
+            color: color.into(),
+            label: label.into(),
+            value: value.into(),
+        });
+        self
     }
 
     /// Set the position of the tooltip.
@@ -260,27 +304,65 @@ impl ParentElement for Tooltip {
 
 impl RenderOnce for Tooltip {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Tooltip {
+            base,
+            position,
+            gap,
+            cross_line,
+            dots,
+            appearance,
+            title,
+            rows,
+        } = self;
+
+        // Structured content (title + rows) takes precedence over freeform `base` children.
+        let content = if title.is_some() || !rows.is_empty() {
+            v_flex()
+                .text_sm()
+                .gap_1()
+                .when_some(title, |this, title| {
+                    this.child(div().font_semibold().child(title))
+                })
+                .children(rows.into_iter().map(|row| {
+                    h_flex()
+                        .items_center()
+                        .justify_between()
+                        .gap_3()
+                        .child(
+                            h_flex()
+                                .items_center()
+                                .gap_1p5()
+                                .child(div().size_2().rounded_sm().bg(row.color))
+                                .child(
+                                    div()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child(row.label),
+                                ),
+                        )
+                        .child(div().child(row.value))
+                }))
+        } else {
+            base
+        };
+
         div()
             .size_full()
             .absolute()
             .top_0()
             .left_0()
-            .when_some(self.cross_line, |this, cross_line| this.child(cross_line))
-            .when_some(self.dots, |this, dots| this.children(dots))
-            .child(self.base.map(|this| {
-                if self.appearance {
+            .when_some(cross_line, |this, cross_line| this.child(cross_line))
+            .when_some(dots, |this, dots| this.children(dots))
+            .child(content.map(|this| {
+                if appearance {
                     this.absolute()
-                        .min_w(px(168.))
+                        .min_w(px(150.))
+                        .popover_style(cx)
                         .p_2()
-                        .border_1()
-                        .border_color(cx.theme().border)
-                        .rounded(cx.theme().radius.half())
-                        .bg(cx.theme().background.opacity(0.9))
-                        .when_some(self.position, |this, position| {
+                        .when_some(position, |this, position| {
                             if position == TooltipPosition::Left {
-                                this.left(self.gap)
+                                this.left(gap)
                             } else {
-                                this.right(self.gap)
+                                this.right(gap)
                             }
                         })
                 } else {

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -30,7 +30,10 @@ impl CrossLineAxis {
 #[derive(IntoElement)]
 pub struct CrossLine {
     point: Point<Pixels>,
-    height: Option<f32>,
+    /// Start offset along the cross axis (vertical line: y; horizontal line: x).
+    start: f32,
+    /// Length along the cross axis; `None` spans the full extent.
+    length: Option<f32>,
     direction: CrossLineAxis,
 }
 
@@ -38,7 +41,8 @@ impl CrossLine {
     pub fn new(point: Point<Pixels>) -> Self {
         Self {
             point,
-            height: None,
+            start: 0.,
+            length: None,
             direction: Default::default(),
         }
     }
@@ -55,9 +59,17 @@ impl CrossLine {
         self
     }
 
-    /// Set the height of the cross line.
+    /// Set the length of the cross line along its axis (from the start edge).
     pub fn height(mut self, height: f32) -> Self {
-        self.height = Some(height);
+        self.length = Some(height);
+        self
+    }
+
+    /// Confine the cross line to `[start, start + length]` along its axis (vertical
+    /// line: y; horizontal line: x), so it stays within the plot area.
+    pub fn span(mut self, start: f32, length: f32) -> Self {
+        self.start = start;
+        self.length = Some(length);
         self
     }
 }
@@ -81,14 +93,11 @@ impl RenderOnce for CrossLine {
                         .absolute()
                         .w(px(1.))
                         .bg(cx.theme().border)
-                        .top_0()
                         .left(self.point.x)
-                        .map(|this| {
-                            if let Some(height) = self.height {
-                                this.h(px(height))
-                            } else {
-                                this.h_full()
-                            }
+                        .top(px(self.start))
+                        .map(|this| match self.length {
+                            Some(length) => this.h(px(length)),
+                            None => this.h_full(),
                         }),
                 )
             })
@@ -96,11 +105,14 @@ impl RenderOnce for CrossLine {
                 this.child(
                     div()
                         .absolute()
-                        .w_full()
                         .h(px(1.))
                         .bg(cx.theme().border)
-                        .left_0()
-                        .top(self.point.y),
+                        .top(self.point.y)
+                        .left(px(self.start))
+                        .map(|this| match self.length {
+                            Some(length) => this.w(px(length)),
+                            None => this.w_full(),
+                        }),
                 )
             })
     }

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -1,6 +1,6 @@
 use gpui::{
     AnyElement, App, Div, Hsla, IntoElement, ParentElement, Pixels, Point, RenderOnce,
-    SharedString, StyleRefinement, Styled, Window, div, prelude::FluentBuilder, px,
+    SharedString, Size, StyleRefinement, Styled, Window, div, prelude::FluentBuilder, px,
 };
 
 use crate::{ActiveTheme, StyledExt, h_flex, v_flex};
@@ -221,6 +221,9 @@ pub struct Tooltip {
     appearance: bool,
     title: Option<SharedString>,
     rows: Vec<TooltipRow>,
+    /// When set, the tooltip follows the cursor: `(anchor point, container size)`.
+    /// The box hugs the anchor and flips toward the center near each edge.
+    anchor: Option<(Point<Pixels>, Size<Pixels>)>,
 }
 
 impl Tooltip {
@@ -235,7 +238,18 @@ impl Tooltip {
             appearance: true,
             title: None,
             rows: Vec::new(),
+            anchor: None,
         }
+    }
+
+    /// Make the tooltip follow the cursor, anchored at `point` within a `within`-sized plot.
+    ///
+    /// The box hugs the anchor and flips toward the center near each edge (so it never
+    /// overflows the near side). Without this, the tooltip is pinned to the plot edge via
+    /// [`Tooltip::position`].
+    pub fn anchor(mut self, point: Point<Pixels>, within: Size<Pixels>) -> Self {
+        self.anchor = Some((point, within));
+        self
     }
 
     /// Set a bold title row shown at the top of the tooltip (e.g. the hovered x value).
@@ -313,6 +327,7 @@ impl RenderOnce for Tooltip {
             appearance,
             title,
             rows,
+            anchor,
         } = self;
 
         // Structured content (title + rows) takes precedence over freeform `base` children.
@@ -353,20 +368,37 @@ impl RenderOnce for Tooltip {
             .when_some(cross_line, |this, cross_line| this.child(cross_line))
             .when_some(dots, |this, dots| this.children(dots))
             .child(content.map(|this| {
-                if appearance {
-                    this.absolute()
-                        .min_w(px(150.))
-                        .popover_style(cx)
-                        .p_2()
-                        .when_some(position, |this, position| {
-                            if position == TooltipPosition::Left {
-                                this.left(gap)
+                if !appearance {
+                    return this.size_full().relative();
+                }
+
+                let card = this.absolute().min_w(px(150.)).popover_style(cx).p_2();
+
+                match anchor {
+                    // Follow mode: hug the anchor, flipping toward the center near each edge.
+                    Some((p, within)) => card
+                        .map(|c| {
+                            if p.x < within.width * 0.5 {
+                                c.left(p.x + gap)
                             } else {
-                                this.right(gap)
+                                c.right(within.width - p.x + gap)
                             }
                         })
-                } else {
-                    this.size_full().relative()
+                        .map(|c| {
+                            if p.y < within.height * 0.5 {
+                                c.top(p.y + gap)
+                            } else {
+                                c.bottom(within.height - p.y + gap)
+                            }
+                        }),
+                    // Edge-pinned mode (backward compatible default).
+                    None => card.when_some(position, |c, position| {
+                        if position == TooltipPosition::Left {
+                            c.left(gap)
+                        } else {
+                            c.right(gap)
+                        }
+                    }),
                 }
             }))
     }

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -226,72 +226,24 @@ impl RenderOnce for Dot {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-pub enum TooltipPosition {
-    #[default]
-    Left,
-    Right,
-}
-
-impl TooltipPosition {
-    /// Place the tooltip on the right while the hovered `index` is in the first half of
-    /// `len` items, otherwise on the left, so it stays clear of the screen edge.
-    pub fn for_index(index: usize, len: usize) -> Self {
-        if index < len / 2 {
-            Self::Right
-        } else {
-            Self::Left
-        }
-    }
-}
-
-/// The axis the data points are laid out along; the follow animation slides along it.
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-pub enum TooltipAxis {
-    /// Data points run along the x-axis (line, area, vertical bars). The default.
-    #[default]
-    X,
-    /// Data points run along the y-axis (horizontal bars).
-    Y,
-}
-
 #[derive(Clone)]
 pub struct TooltipState {
     pub index: usize,
     pub cross_line: Point<Pixels>,
     pub dots: Vec<Point<Pixels>>,
-    pub position: TooltipPosition,
-    /// The axis the data points snap along. Describes how `cross_line` is read: the
-    /// coordinate on this axis is the snapped (data-point) one the follow animation eases,
-    /// while the other tracks the cursor live.
-    pub axis: TooltipAxis,
+    /// Live cursor position (relative to the plot origin); the tooltip box hugs it so it
+    /// follows the cursor smoothly. Set by the `IntoPlot` macro; defaults to `cross_line`.
+    pub cursor: Point<Pixels>,
 }
 
 impl TooltipState {
-    pub fn new(
-        index: usize,
-        cross_line: Point<Pixels>,
-        dots: Vec<Point<Pixels>>,
-        position: TooltipPosition,
-    ) -> Self {
+    pub fn new(index: usize, cross_line: Point<Pixels>, dots: Vec<Point<Pixels>>) -> Self {
         Self {
             index,
             cross_line,
             dots,
-            position,
-            axis: TooltipAxis::X,
+            cursor: cross_line,
         }
-    }
-
-    /// Set the axis the data points snap along (default [`TooltipAxis::X`]).
-    pub fn axis(mut self, axis: TooltipAxis) -> Self {
-        self.axis = axis;
-        self
-    }
-
-    /// Whether the follow animation slides vertically (i.e. the snap axis is y).
-    pub fn slides_vertically(&self) -> bool {
-        matches!(self.axis, TooltipAxis::Y)
     }
 }
 
@@ -305,42 +257,33 @@ struct TooltipRow {
 #[derive(IntoElement)]
 pub struct Tooltip {
     base: Div,
-    position: Option<TooltipPosition>,
     gap: Pixels,
     cross_line: Option<CrossLine>,
     dots: Option<Vec<Dot>>,
     appearance: bool,
     title: Option<SharedString>,
     rows: Vec<TooltipRow>,
-    /// When set, the tooltip follows the cursor: `(anchor point, container size)`.
-    /// The box hugs the anchor and flips toward the center near each edge.
-    anchor: Option<(Point<Pixels>, Size<Pixels>)>,
+    /// Cursor position the box hugs (relative to the plot origin).
+    cursor: Point<Pixels>,
+    /// Plot size, used to flip the box toward the center near each edge so it never
+    /// overflows the near side.
+    within: Size<Pixels>,
 }
 
 impl Tooltip {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    /// Create a tooltip whose box follows the cursor at `cursor` within a `within`-sized plot.
+    pub fn new(cursor: Point<Pixels>, within: Size<Pixels>) -> Self {
         Self {
             base: v_flex().top_0(),
-            position: Default::default(),
             gap: px(0.),
             cross_line: None,
             dots: None,
             appearance: true,
             title: None,
             rows: Vec::new(),
-            anchor: None,
+            cursor,
+            within,
         }
-    }
-
-    /// Make the tooltip follow the cursor, anchored at `point` within a `within`-sized plot.
-    ///
-    /// The box hugs the anchor and flips toward the center near each edge (so it never
-    /// overflows the near side). Without this, the tooltip is pinned to the plot edge via
-    /// [`Tooltip::position`].
-    pub fn anchor(mut self, point: Point<Pixels>, within: Size<Pixels>) -> Self {
-        self.anchor = Some((point, within));
-        self
     }
 
     /// Set a bold title row shown at the top of the tooltip (e.g. the hovered x value).
@@ -361,12 +304,6 @@ impl Tooltip {
             label: label.into(),
             value: value.into(),
         });
-        self
-    }
-
-    /// Set the position of the tooltip.
-    pub fn position(mut self, position: TooltipPosition) -> Self {
-        self.position = Some(position);
         self
     }
 
@@ -411,14 +348,14 @@ impl RenderOnce for Tooltip {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let Tooltip {
             base,
-            position,
             gap,
             cross_line,
             dots,
             appearance,
             title,
             rows,
-            anchor,
+            cursor,
+            within,
         } = self;
 
         // Structured content (title + rows) takes precedence over freeform `base` children.
@@ -463,34 +400,26 @@ impl RenderOnce for Tooltip {
                     return this.size_full().relative();
                 }
 
-                let card = this.absolute().min_w(px(150.)).popover_style(cx).p_2();
-
-                match anchor {
-                    // Follow mode: hug the anchor, flipping toward the center near each edge.
-                    Some((p, within)) => card
-                        .map(|c| {
-                            if p.x < within.width * 0.5 {
-                                c.left(p.x + gap)
-                            } else {
-                                c.right(within.width - p.x + gap)
-                            }
-                        })
-                        .map(|c| {
-                            if p.y < within.height * 0.5 {
-                                c.top(p.y + gap)
-                            } else {
-                                c.bottom(within.height - p.y + gap)
-                            }
-                        }),
-                    // Edge-pinned mode (backward compatible default).
-                    None => card.when_some(position, |c, position| {
-                        if position == TooltipPosition::Left {
-                            c.left(gap)
+                // The box hugs the cursor, flipping toward the center near each edge so it
+                // never overflows the near side.
+                this.absolute()
+                    .min_w(px(150.))
+                    .popover_style(cx)
+                    .p_2()
+                    .map(|c| {
+                        if cursor.x < within.width * 0.5 {
+                            c.left(cursor.x + gap)
                         } else {
-                            c.right(gap)
+                            c.right(within.width - cursor.x + gap)
                         }
-                    }),
-                }
+                    })
+                    .map(|c| {
+                        if cursor.y < within.height * 0.5 {
+                            c.top(cursor.y + gap)
+                        } else {
+                            c.bottom(within.height - cursor.y + gap)
+                        }
+                    })
             }))
     }
 }

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -34,6 +34,13 @@ pub struct CrossLine {
     start: f32,
     /// Length along the cross axis; `None` spans the full extent.
     length: Option<f32>,
+    /// Band thickness perpendicular to the line (solid band mode only).
+    thickness: Pixels,
+    /// Explicit color; when `None`, falls back to a themed default (a subtle `border` for
+    /// the dashed hairline, a translucent highlight for the solid band).
+    color: Option<Hsla>,
+    /// `true` (default) draws a dashed hairline; `false` a solid band of `thickness`.
+    dashed: bool,
     direction: CrossLineAxis,
 }
 
@@ -43,8 +50,27 @@ impl CrossLine {
             point,
             start: 0.,
             length: None,
+            thickness: px(1.),
+            color: None,
+            dashed: true,
             direction: Default::default(),
         }
+    }
+
+    /// Render a solid highlight band of `thickness` (centered on `point`) instead of the
+    /// default dashed hairline. Use the bar/band width to highlight the hovered column or
+    /// row. The fill defaults to a translucent highlight; use [`CrossLine::color`] to override.
+    pub fn band(mut self, thickness: impl Into<Pixels>) -> Self {
+        self.thickness = thickness.into();
+        self.dashed = false;
+        self
+    }
+
+    /// Override the line/band color. Defaults: a subtle `border` for the dashed hairline,
+    /// a translucent highlight for the solid band.
+    pub fn color(mut self, color: impl Into<Hsla>) -> Self {
+        self.color = Some(color.into());
+        self
     }
 
     /// Set the cross line axis to horizontal.
@@ -80,41 +106,68 @@ impl From<Point<Pixels>> for CrossLine {
     }
 }
 
+impl CrossLine {
+    /// Build a single line along one axis: `vertical` runs top→bottom at the data point's
+    /// `x`; otherwise left→right at its `y`. A dashed hairline draws a 1px dashed border; a
+    /// solid band fills a `thickness`-wide strip centered on the data point.
+    fn line(&self, vertical: bool, cx: &App) -> Div {
+        let color = self.color.unwrap_or_else(|| {
+            if self.dashed {
+                cx.theme().border
+            } else {
+                cx.theme().foreground.opacity(0.08)
+            }
+        });
+        // The dashed hairline is a zero-width strip drawn entirely by its 1px border.
+        let thickness = if self.dashed { px(0.) } else { self.thickness };
+
+        let el = div().absolute();
+        let el = if vertical {
+            el.left(self.point.x - thickness * 0.5)
+                .w(thickness)
+                .top(px(self.start))
+                .map(|el| match self.length {
+                    Some(length) => el.h(px(length)),
+                    None => el.h_full(),
+                })
+        } else {
+            el.top(self.point.y - thickness * 0.5)
+                .h(thickness)
+                .left(px(self.start))
+                .map(|el| match self.length {
+                    Some(length) => el.w(px(length)),
+                    None => el.w_full(),
+                })
+        };
+
+        if self.dashed {
+            let el = if vertical {
+                el.border_l_1()
+            } else {
+                el.border_t_1()
+            };
+            el.border_dashed().border_color(color)
+        } else {
+            el.bg(color)
+        }
+    }
+}
+
 impl RenderOnce for CrossLine {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let vertical = self.direction.show_vertical().then(|| self.line(true, cx));
+        let horizontal = self
+            .direction
+            .show_horizontal()
+            .then(|| self.line(false, cx));
+
         div()
             .size_full()
             .absolute()
             .top_0()
             .left_0()
-            .when(self.direction.show_vertical(), |this| {
-                this.child(
-                    div()
-                        .absolute()
-                        .w(px(1.))
-                        .bg(cx.theme().border)
-                        .left(self.point.x)
-                        .top(px(self.start))
-                        .map(|this| match self.length {
-                            Some(length) => this.h(px(length)),
-                            None => this.h_full(),
-                        }),
-                )
-            })
-            .when(self.direction.show_horizontal(), |this| {
-                this.child(
-                    div()
-                        .absolute()
-                        .h(px(1.))
-                        .bg(cx.theme().border)
-                        .top(self.point.y)
-                        .left(px(self.start))
-                        .map(|this| match self.length {
-                            Some(length) => this.w(px(length)),
-                            None => this.w_full(),
-                        }),
-                )
-            })
+            .children(vertical)
+            .children(horizontal)
     }
 }
 

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -180,12 +180,26 @@ impl TooltipPosition {
     }
 }
 
+/// The axis the data points are laid out along; the follow animation slides along it.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub enum TooltipAxis {
+    /// Data points run along the x-axis (line, area, vertical bars). The default.
+    #[default]
+    X,
+    /// Data points run along the y-axis (horizontal bars).
+    Y,
+}
+
 #[derive(Clone)]
 pub struct TooltipState {
     pub index: usize,
     pub cross_line: Point<Pixels>,
     pub dots: Vec<Point<Pixels>>,
     pub position: TooltipPosition,
+    /// The axis the data points snap along. Describes how `cross_line` is read: the
+    /// coordinate on this axis is the snapped (data-point) one the follow animation eases,
+    /// while the other tracks the cursor live.
+    pub axis: TooltipAxis,
 }
 
 impl TooltipState {
@@ -200,7 +214,19 @@ impl TooltipState {
             cross_line,
             dots,
             position,
+            axis: TooltipAxis::X,
         }
+    }
+
+    /// Set the axis the data points snap along (default [`TooltipAxis::X`]).
+    pub fn axis(mut self, axis: TooltipAxis) -> Self {
+        self.axis = axis;
+        self
+    }
+
+    /// Whether the follow animation slides vertically (i.e. the snap axis is y).
+    pub fn slides_vertically(&self) -> bool {
+        matches!(self.axis, TooltipAxis::Y)
     }
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/4a677553-6871-4048-938d-184e0a7e438a

## Breaking Change
Only affects code that builds Tooltip / TooltipState / CrossLine directly. Plain impl Plot charts are unaffected (the new tooltip hooks are additive).

- Tooltip::new() → Tooltip::new(cursor, within) — the box now follows the cursor.
- Removed Tooltip::position() and enum TooltipPosition — no more edge pinning.
- TooltipState::new drops the position arg → TooltipState::new(index, cross_line, dots).
- CrossLine now renders dashed by default (was solid 1px); use CrossLine::band(width) for a solid bar-width band.

```diff
- Tooltip::new().position(TooltipPosition::Left)
+ Tooltip::new(cursor, bounds.size)

- TooltipState::new(index, cross_line, dots, TooltipPosition::Left)
+ TooltipState::new(index, cross_line, dots)
```