### PR TITLE
text_view: Support selecting text from a TextView in a Dialog

### DIFF
--- a/crates/story/src/stories/dialog_story.rs
+++ b/crates/story/src/stories/dialog_story.rs
@@ -16,7 +16,7 @@ use gpui_component::{
     input::{Input, InputState},
     select::{Select, SelectState},
     table::{Column, DataTable, TableDelegate, TableState},
-    text::markdown,
+    text::{TextView, markdown},
     v_flex,
 };
 
@@ -476,6 +476,59 @@ impl DialogStory {
                 })),
         )
     }
+
+    fn render_textview_dialog(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let dialog_overlay = self.dialog_overlay;
+        let overlay_closable = self.overlay_closable;
+        section("TextView Dialog").child(
+            Dialog::new(cx)
+                .trigger(
+                    Button::new("textview-dialog-btn")
+                        .outline()
+                        .label("TextView Dialog"),
+                )
+                .overlay(dialog_overlay)
+                .keyboard(self.keyboard)
+                .close_button(self.close_button)
+                .overlay_closable(overlay_closable)
+                .p_0()
+                .content({
+                    move |content, _, cx| {
+                        content
+                            .child(
+                                DialogHeader::new()
+                                    .p_4()
+                                    .child(DialogTitle::new().child("TextView Dialog")),
+                            )
+                            .child(
+                                v_flex().px_4().pb_4().gap_3().child(
+                                    TextView::markdown(
+                                        "dialog-textview",
+                                        "This is a dialog with a selectable \
+                                        TextView in it. This text should be \
+                                        selectable.",
+                                    )
+                                    .selectable(true),
+                                ),
+                            )
+                            .child(
+                                DialogFooter::new()
+                                    .p_4()
+                                    .bg(cx.theme().muted)
+                                    .child(
+                                        DialogClose::new()
+                                            .child(Button::new("cancel").label("Cancel").outline()),
+                                    )
+                                    .child(
+                                        DialogAction::new().child(
+                                            Button::new("confirm").primary().label("Confirm"),
+                                        ),
+                                    ),
+                            )
+                    }
+                }),
+        )
+    }
 }
 
 impl Focusable for DialogStory {
@@ -543,7 +596,8 @@ impl Render for DialogStory {
                     .child(self.render_dialog_without_title(cx))
                     .child(self.render_custom_paddings(cx))
                     .child(self.render_custom_style(cx))
-                    .child(self.render_dialog_with_content(cx)),
+                    .child(self.render_dialog_with_content(cx))
+                    .child(self.render_textview_dialog(cx)),
             )
     }
 }

--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -639,11 +639,6 @@ impl RenderOnce for Dialog {
                                         }
                                     })
                             }))
-                            .on_any_mouse_down({
-                                |_, _, cx| {
-                                    cx.stop_propagation();
-                                }
-                            })
                             .with_animation("slide-down", animation.clone(), move |this, delta| {
                                 // This is equivalent to `shadow_xl` with an extra opacity.
                                 let shadow = vec![

--- a/crates/ui/src/sheet.rs
+++ b/crates/ui/src/sheet.rs
@@ -267,11 +267,6 @@ impl RenderOnce for Sheet {
                                         .child(footer),
                                 )
                             })
-                            .on_any_mouse_down({
-                                |_, _, cx| {
-                                    cx.stop_propagation();
-                                }
-                            })
                             .with_animation(
                                 "slide",
                                 Animation::new(Duration::from_secs_f64(0.15)),


### PR DESCRIPTION
## Description

It is currently not possible to select text from a TextView with the mouse if it is in a Dialog. This PR fixes that.

It seems that the changes needed for this undo a revert (#1897). But I've tested this change and it doesn't seem too cause the Dialog (or Sheet which I changed also since they were both a part of that revert PR) to immediately close. AFAICT it works as it should, but maybe it would be good for someone else to test it out to make sure.

## How to Test

I added a Dialog with a TextView as the content in the Dialog story. I added that as the first commit of this PR so you can test how it doesn't work correctly, then apply the second commit to get it to work.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
