### PR TITLE
chore: Replace tokio sleep with background executor timer

### DIFF
--- a/skills/gpui/references/async.md
+++ b/skills/gpui/references/async.md
@@ -97,7 +97,8 @@ impl MyView {
         let _task = cx.spawn(async move |this, cx: &mut AsyncApp| {
             // Task automatically cancelled when dropped
             loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                cx.background_executor().timer(Duration::from_secs(1)).await;
+
                 this.update(cx, |state, cx| {
                     state.tick();
                     cx.notify();
@@ -145,7 +146,8 @@ cx.background_spawn(async move {
 ```rust
 cx.spawn(async move |this, cx: &mut AsyncApp| {
     loop {
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        cx.background_executor().timer(Duration::from_secs(5)).await;
+
         this.update(cx, |state, cx| {
             state.tick();
             cx.notify();


### PR DESCRIPTION
# Fix Async Patterns in GPUI Documentation


## Description

This PR fixes the async spawn examples in `skills/gpui/references/async.md` that contained incorrect patterns leading to runtime panics. The examples were using tokio's sleep functions (`tokio::time::sleep`) within GPUI's async context, which is incorrect. The correct pattern is to use GPUI's built-in timer functionality via `cx.background_executor().timer()`.

**Problem Solved:**
- Removed dependency on tokio for sleep functionality in GPUI async examples

**Benefits:**
- Example will run without panics
- Demonstrates the correct GPUI async pattern

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Runtime panic on async spawn] | [Successfully runs and updates UI] |

## Break Changes

None. This is purely a documentation fix that corrects the example code.


---

**Correct Async Pattern Example:**
```diff
- // ❌ Incorrect: Uses tokio sleep and wrong spawn signature
- cx.spawn(...{
-     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-     cx.update(|cx| {
...
-     }).ok();
- });

+ // ✅ Correct: Uses GPUI's timer and proper spawn signature
+ cx.spawn(async move |this, cx| {
+     cx.background_executor()
+         .timer(std::time::Duration::from_secs(2))
+         .await;
+     
+     this.update(cx, |this, cx| {
...
+     }).ok();
+ });
```