### PR TITLE
scroll: Revised `Scrollable` design for better interoperability

### DIFF
--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -9,8 +9,10 @@ use gpui::{
     prelude::FluentBuilder,
 };
 
-/// A trait for elements that can be made scrollable with scrollbars. 
-//  The wrapped element is the scroll area itself, rather than being inserted as a child of a new scroll area.
+/// A trait for elements that can be made scrollable with scrollbars.
+///
+/// The wrapped element is the scroll area itself, rather than being inserted as
+/// a child of a new scroll area.
 pub trait ScrollableElement: InteractiveElement + Styled + ParentElement + Element {
     /// Adds a scrollbar to the element.
     #[track_caller]
@@ -253,6 +255,45 @@ mod tests {
         px,
     };
 
+    fn draw(cx: &mut VisualTestContext) {
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+    }
+
+    fn scroll(cx: &mut VisualTestContext, x: f32, y: f32, dx: f32, dy: f32) {
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(x), px(y)),
+            delta: ScrollDelta::Pixels(point(px(dx), px(dy))),
+            ..Default::default()
+        });
+        draw(cx);
+    }
+
+    fn row(selector: &'static str, height: f32) -> Div {
+        div()
+            .h(px(height))
+            .flex_shrink_0()
+            .debug_selector(move || selector.to_string())
+    }
+
+    fn plain_row(height: f32) -> Div {
+        div().h(px(height)).flex_shrink_0()
+    }
+
+    fn item(selector: &'static str, width: f32) -> Div {
+        div()
+            .w(px(width))
+            .h(px(20.))
+            .flex_shrink_0()
+            .debug_selector(move || selector.to_string())
+    }
+
+    fn plain_item(width: f32) -> Div {
+        div().w(px(width)).h(px(20.)).flex_shrink_0()
+    }
+
     struct SizeFullChildTest;
 
     impl Render for SizeFullChildTest {
@@ -282,18 +323,118 @@ mod tests {
                 .h(px(100.))
                 .gap(px(10.))
                 .overflow_y_scrollbar()
+                .child(row("first-row", 20.))
+                .child(row("second-row", 20.))
+        }
+    }
+
+    struct IssueGapRegressionTest;
+
+    impl Render for IssueGapRegressionTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(100.))
+                .h(px(100.))
+                .child(
+                    crate::v_flex()
+                        .flex_1()
+                        .gap(px(30.))
+                        .overflow_y_scrollbar()
+                        .px(px(12.))
+                        .pb(px(16.))
+                        .children((0..5).map(|ix| {
+                            div()
+                                .h(px(20.))
+                                .flex_shrink_0()
+                                .when(ix == 0, |this| {
+                                    this.debug_selector(|| "issue-first-card".to_string())
+                                })
+                                .when(ix == 1, |this| {
+                                    this.debug_selector(|| "issue-second-card".to_string())
+                                })
+                                .when(ix == 4, |this| {
+                                    this.debug_selector(|| "issue-last-card".to_string())
+                                })
+                        })),
+                )
+        }
+    }
+
+    struct HorizontalGapLayoutTest;
+
+    impl Render for HorizontalGapLayoutTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::h_flex()
+                .w(px(100.))
+                .h(px(40.))
+                .gap(px(10.))
+                .overflow_x_scrollbar()
+                .child(item("horizontal-first-item", 50.))
+                .child(item("horizontal-second-item", 50.))
+                .child(item("horizontal-last-item", 50.))
+        }
+    }
+
+    struct BothAxisScrollTest;
+
+    impl Render for BothAxisScrollTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(100.)).h(px(100.)).overflow_scrollbar().child(
+                div()
+                    .w(px(200.))
+                    .h(px(200.))
+                    .flex_shrink_0()
+                    .debug_selector(|| "both-axis-content".to_string()),
+            )
+        }
+    }
+
+    struct IndependentScrollablesTest;
+
+    impl Render for IndependentScrollablesTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::h_flex()
+                .w(px(220.))
+                .h(px(100.))
+                .gap(px(20.))
                 .child(
                     div()
-                        .h(px(20.))
-                        .flex_shrink_0()
-                        .debug_selector(|| "first-row".to_string()),
+                        .w(px(100.))
+                        .h(px(100.))
+                        .overflow_y_scrollbar()
+                        .child(
+                            crate::v_flex()
+                                .child(plain_row(50.))
+                                .child(plain_row(50.))
+                                .child(row("left-scrollable-last-row", 50.)),
+                        ),
                 )
                 .child(
                     div()
-                        .h(px(20.))
-                        .flex_shrink_0()
-                        .debug_selector(|| "second-row".to_string()),
+                        .w(px(100.))
+                        .h(px(100.))
+                        .overflow_y_scrollbar()
+                        .child(
+                            crate::v_flex()
+                                .child(plain_row(50.))
+                                .child(plain_row(50.))
+                                .child(row("right-scrollable-last-row", 50.)),
+                        ),
                 )
+        }
+    }
+
+    struct NoOverflowTest;
+
+    impl Render for NoOverflowTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .gap(px(10.))
+                .overflow_y_scrollbar()
+                .child(row("no-overflow-first-row", 20.))
+                .child(row("no-overflow-second-row", 20.))
         }
     }
 
@@ -302,20 +443,10 @@ mod tests {
         cx.update(crate::init);
         let (_, cx) = cx.add_window_view(|_, _| SizeFullChildTest);
         let cx: &mut VisualTestContext = cx;
-        cx.run_until_parked();
-        cx.update(|window, cx| {
-            _ = window.draw(cx);
-        });
+        draw(cx);
 
         let initial_y = cx.debug_bounds("last-row").unwrap().origin.y;
-        cx.simulate_event(ScrollWheelEvent {
-            position: point(px(10.), px(10.)),
-            delta: ScrollDelta::Pixels(point(px(0.), px(-50.))),
-            ..Default::default()
-        });
-        cx.update(|window, cx| {
-            _ = window.draw(cx);
-        });
+        scroll(cx, 10., 10., 0., -50.);
 
         assert!(cx.debug_bounds("last-row").unwrap().origin.y < initial_y);
     }
@@ -325,13 +456,166 @@ mod tests {
         cx.update(crate::init);
         let (_, cx) = cx.add_window_view(|_, _| GapLayoutTest);
         let cx: &mut VisualTestContext = cx;
-        cx.run_until_parked();
-        cx.update(|window, cx| {
-            _ = window.draw(cx);
-        });
+        draw(cx);
 
         let first = cx.debug_bounds("first-row").unwrap();
         let second = cx.debug_bounds("second-row").unwrap();
         assert_eq!(second.top() - first.bottom(), px(10.));
+    }
+
+    #[gpui::test]
+    fn overflow_y_scrollbar_preserves_gap_for_exact_issue_chain(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| IssueGapRegressionTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let first = cx.debug_bounds("issue-first-card").unwrap();
+        let second = cx.debug_bounds("issue-second-card").unwrap();
+        let last_initial_y = cx.debug_bounds("issue-last-card").unwrap().origin.y;
+
+        assert_eq!(second.top() - first.bottom(), px(30.));
+        assert_eq!(first.left(), px(12.));
+
+        scroll(cx, 10., 10., 0., -50.);
+
+        let first_after_scroll = cx.debug_bounds("issue-first-card").unwrap();
+        let second_after_scroll = cx.debug_bounds("issue-second-card").unwrap();
+        let last_after_scroll_y = cx.debug_bounds("issue-last-card").unwrap().origin.y;
+
+        assert_eq!(
+            second_after_scroll.top() - first_after_scroll.bottom(),
+            px(30.)
+        );
+        assert_eq!(first_after_scroll.left(), px(12.));
+        assert!(last_after_scroll_y < last_initial_y);
+    }
+
+    #[gpui::test]
+    fn horizontal_scrollbar_preserves_source_gap_and_scrolls(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| HorizontalGapLayoutTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let first = cx.debug_bounds("horizontal-first-item").unwrap();
+        let second = cx.debug_bounds("horizontal-second-item").unwrap();
+        let last_initial_x = cx.debug_bounds("horizontal-last-item").unwrap().origin.x;
+
+        assert_eq!(second.left() - first.right(), px(10.));
+
+        scroll(cx, 10., 10., -50., 0.);
+
+        let first_after_scroll = cx.debug_bounds("horizontal-first-item").unwrap();
+        let second_after_scroll = cx.debug_bounds("horizontal-second-item").unwrap();
+        let last_after_scroll_x = cx.debug_bounds("horizontal-last-item").unwrap().origin.x;
+
+        assert_eq!(
+            second_after_scroll.left() - first_after_scroll.right(),
+            px(10.)
+        );
+        assert!(last_after_scroll_x < last_initial_x);
+    }
+
+    #[gpui::test]
+    fn overflow_scrollbar_scrolls_both_axes(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| BothAxisScrollTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let initial = cx.debug_bounds("both-axis-content").unwrap();
+
+        scroll(cx, 10., 10., -40., -50.);
+
+        let after_scroll = cx.debug_bounds("both-axis-content").unwrap();
+        assert!(after_scroll.left() < initial.left());
+        assert!(after_scroll.top() < initial.top());
+    }
+
+    #[gpui::test]
+    fn multiple_scrollables_keep_independent_scroll_state(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| IndependentScrollablesTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let left_initial = cx.debug_bounds("left-scrollable-last-row").unwrap();
+        let right_initial = cx.debug_bounds("right-scrollable-last-row").unwrap();
+
+        scroll(cx, 10., 10., 0., -50.);
+
+        let left_after_scroll = cx.debug_bounds("left-scrollable-last-row").unwrap();
+        let right_after_scroll = cx.debug_bounds("right-scrollable-last-row").unwrap();
+
+        assert!(left_after_scroll.top() < left_initial.top());
+        assert_eq!(right_after_scroll.top(), right_initial.top());
+    }
+
+    #[gpui::test]
+    fn vertical_scrollbar_does_not_scroll_when_content_does_not_overflow(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| NoOverflowTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let first = cx.debug_bounds("no-overflow-first-row").unwrap();
+        let second = cx.debug_bounds("no-overflow-second-row").unwrap();
+
+        assert_eq!(second.top() - first.bottom(), px(10.));
+
+        scroll(cx, 10., 10., 0., -50.);
+
+        let first_after_scroll = cx.debug_bounds("no-overflow-first-row").unwrap();
+        let second_after_scroll = cx.debug_bounds("no-overflow-second-row").unwrap();
+
+        assert_eq!(first_after_scroll.top(), first.top());
+        assert_eq!(second_after_scroll.top(), second.top());
+        assert_eq!(
+            second_after_scroll.top() - first_after_scroll.bottom(),
+            px(10.)
+        );
+    }
+
+    #[gpui::test]
+    fn horizontal_scrollbar_does_not_scroll_when_content_does_not_overflow(
+        cx: &mut TestAppContext,
+    ) {
+        struct HorizontalNoOverflowTest;
+
+        impl Render for HorizontalNoOverflowTest {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                crate::h_flex()
+                    .w(px(100.))
+                    .h(px(40.))
+                    .gap(px(10.))
+                    .overflow_x_scrollbar()
+                    .child(item("no-overflow-first-item", 20.))
+                    .child(item("no-overflow-second-item", 20.))
+                    .child(plain_item(20.))
+            }
+        }
+
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| HorizontalNoOverflowTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let first = cx.debug_bounds("no-overflow-first-item").unwrap();
+        let second = cx.debug_bounds("no-overflow-second-item").unwrap();
+
+        assert_eq!(second.left() - first.right(), px(10.));
+
+        scroll(cx, 10., 10., -50., 0.);
+
+        let first_after_scroll = cx.debug_bounds("no-overflow-first-item").unwrap();
+        let second_after_scroll = cx.debug_bounds("no-overflow-second-item").unwrap();
+
+        assert_eq!(first_after_scroll.left(), first.left());
+        assert_eq!(second_after_scroll.left(), second.left());
+        assert_eq!(
+            second_after_scroll.left() - first_after_scroll.right(),
+            px(10.)
+        );
     }
 }

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -1,6 +1,6 @@
 use std::{panic::Location, rc::Rc};
 
-use crate::{StyledExt};
+use crate::StyledExt;
 
 use super::{Scrollbar, ScrollbarAxis, ScrollbarHandle};
 use gpui::{
@@ -122,10 +122,20 @@ where
 
         let root_id = self.id.clone();
         let area_id = (self.id.clone(), "area");
+        let content_id = (self.id.clone(), "content");
         let scrollbar_id = (self.id.clone(), "scrollbar");
 
-        let scroll_area = self
+        let content = self
             .element
+            .id(content_id)
+            .flex_none()
+            .map(|this| match self.axis {
+                ScrollbarAxis::Vertical => this.h_auto().min_h_full(),
+                ScrollbarAxis::Horizontal => this.w_auto().min_w_full(),
+                ScrollbarAxis::Both => this.size_auto().min_size_full(),
+            });
+
+        let scroll_area = div()
             .id(area_id)
             .absolute()
             .top_0()
@@ -133,12 +143,14 @@ where
             .right_0()
             .bottom_0()
             .size_full()
+            .flex()
             .track_scroll(&scroll_handle)
             .map(|this| match self.axis {
-                ScrollbarAxis::Vertical => this.overflow_y_scroll(),
-                ScrollbarAxis::Horizontal => this.overflow_x_scroll(),
+                ScrollbarAxis::Vertical => this.flex_col().overflow_y_scroll(),
+                ScrollbarAxis::Horizontal => this.flex_row().overflow_x_scroll(),
                 ScrollbarAxis::Both => this.overflow_scroll(),
-            });
+            })
+            .child(content);
 
         div()
             .id(root_id)
@@ -231,4 +243,95 @@ fn render_scrollbar<H: ScrollbarHandle + Clone>(
         .right_0()
         .bottom_0()
         .child(Scrollbar::new(scroll_handle).id(id).axis(axis))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{
+        Context, Render, ScrollDelta, ScrollWheelEvent, TestAppContext, VisualTestContext, point,
+        px,
+    };
+
+    struct SizeFullChildTest;
+
+    impl Render for SizeFullChildTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(100.))
+                .h(px(100.))
+                .overflow_y_scrollbar()
+                .child(
+                    div()
+                        .size_full()
+                        .child(crate::v_flex().children((0..4).map(|ix| {
+                            div().h(px(50.)).flex_shrink_0().when(ix == 3, |this| {
+                                this.debug_selector(|| "last-row".to_string())
+                            })
+                        }))),
+                )
+        }
+    }
+
+    struct GapLayoutTest;
+
+    impl Render for GapLayoutTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .gap(px(10.))
+                .overflow_y_scrollbar()
+                .child(
+                    div()
+                        .h(px(20.))
+                        .flex_shrink_0()
+                        .debug_selector(|| "first-row".to_string()),
+                )
+                .child(
+                    div()
+                        .h(px(20.))
+                        .flex_shrink_0()
+                        .debug_selector(|| "second-row".to_string()),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn vertical_scrollbar_scrolls_past_a_size_full_child(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| SizeFullChildTest);
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        let initial_y = cx.debug_bounds("last-row").unwrap().origin.y;
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-50.))),
+            ..Default::default()
+        });
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        assert!(cx.debug_bounds("last-row").unwrap().origin.y < initial_y);
+    }
+
+    #[gpui::test]
+    fn vertical_scrollbar_preserves_source_gap(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| GapLayoutTest);
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        let first = cx.debug_bounds("first-row").unwrap();
+        let second = cx.debug_bounds("second-row").unwrap();
+        assert_eq!(second.top() - first.bottom(), px(10.));
+    }
 }

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -1,15 +1,16 @@
 use std::{panic::Location, rc::Rc};
 
-use crate::{StyledExt, scroll::ScrollbarHandle};
+use crate::{StyledExt};
 
-use super::{Scrollbar, ScrollbarAxis};
+use super::{Scrollbar, ScrollbarAxis, ScrollbarHandle};
 use gpui::{
     App, Div, Element, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce,
     ScrollHandle, Stateful, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
     prelude::FluentBuilder,
 };
 
-/// A trait for elements that can be made scrollable with scrollbars.
+/// A trait for elements that can be made scrollable with scrollbars. 
+//  The wrapped element is the scroll area itself, rather than being inserted as a child of a new scroll area.
 pub trait ScrollableElement: InteractiveElement + Styled + ParentElement + Element {
     /// Adds a scrollbar to the element.
     #[track_caller]
@@ -19,7 +20,7 @@ pub trait ScrollableElement: InteractiveElement + Styled + ParentElement + Eleme
         axis: impl Into<ScrollbarAxis>,
     ) -> Self {
         self.child(ScrollbarLayer {
-            id: "scrollbar_layer".into(),
+            id: caller_id(),
             axis: axis.into(),
             scroll_handle: Rc::new(scroll_handle.clone()),
         })
@@ -30,6 +31,7 @@ pub trait ScrollableElement: InteractiveElement + Styled + ParentElement + Eleme
     fn vertical_scrollbar<H: ScrollbarHandle + Clone>(self, scroll_handle: &H) -> Self {
         self.scrollbar(scroll_handle, ScrollbarAxis::Vertical)
     }
+
     /// Adds a horizontal scrollbar to the element.
     #[track_caller]
     fn horizontal_scrollbar<H: ScrollbarHandle + Clone>(self, scroll_handle: &H) -> Self {
@@ -37,25 +39,28 @@ pub trait ScrollableElement: InteractiveElement + Styled + ParentElement + Eleme
     }
 
     /// Almost equivalent to [`StatefulInteractiveElement::overflow_scroll`], but adds scrollbars.
+    /// Preserves the source element as the scrollable container.
     #[track_caller]
     fn overflow_scrollbar(self) -> Scrollable<Self> {
         Scrollable::new(self, ScrollbarAxis::Both)
     }
 
     /// Almost equivalent to [`StatefulInteractiveElement::overflow_x_scroll`], but adds Horizontal scrollbar.
+    /// Preserves the source element as the scrollable container.
     #[track_caller]
     fn overflow_x_scrollbar(self) -> Scrollable<Self> {
         Scrollable::new(self, ScrollbarAxis::Horizontal)
     }
 
     /// Almost equivalent to [`StatefulInteractiveElement::overflow_y_scroll`], but adds Vertical scrollbar.
+    /// Preserves the source element as the scrollable container.
     #[track_caller]
     fn overflow_y_scrollbar(self) -> Scrollable<Self> {
         Scrollable::new(self, ScrollbarAxis::Vertical)
     }
 }
 
-/// A scrollable element wrapper that adds scrollbars to an interactive element.
+/// A scrollable element wrapper that renders the original element as the scroll area and overlays scrollbars.
 #[derive(IntoElement)]
 pub struct Scrollable<E: InteractiveElement + Styled + ParentElement + Element> {
     id: ElementId,
@@ -69,9 +74,8 @@ where
 {
     #[track_caller]
     fn new(element: E, axis: impl Into<ScrollbarAxis>) -> Self {
-        let caller = Location::caller();
         Self {
-            id: ElementId::CodeLocation(*caller),
+            id: caller_id(),
             element,
             axis: axis.into(),
         }
@@ -96,13 +100,10 @@ where
     }
 }
 
-impl InteractiveElement for Scrollable<Div> {
-    fn interactivity(&mut self) -> &mut gpui::Interactivity {
-        self.element.interactivity()
-    }
-}
-
-impl InteractiveElement for Scrollable<Stateful<Div>> {
+impl<E> InteractiveElement for Scrollable<E>
+where
+    E: InteractiveElement + Styled + ParentElement + Element,
+{
     fn interactivity(&mut self) -> &mut gpui::Interactivity {
         self.element.interactivity()
     }
@@ -113,42 +114,44 @@ where
     E: InteractiveElement + Styled + ParentElement + Element + 'static,
 {
     fn render(mut self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let scroll_handle = window
-            .use_keyed_state(self.id.clone(), cx, |_, _| ScrollHandle::default())
-            .read(cx)
-            .clone();
+        let scroll_handle = scroll_handle_for(&self.id, window, cx);
 
-        // Inherit the size from the element style.
-        let style = StyleRefinement {
-            size: self.element.style().size.clone(),
-            ..Default::default()
-        };
+        // Preserve the caller-requested size on the wrapper, while keeping the
+        // caller's element as the actual scroll-tracked layout container.
+        let root_style = root_style_from(&mut self.element);
+
+        let root_id = self.id.clone();
+        let area_id = (self.id.clone(), "area");
+        let scrollbar_id = (self.id.clone(), "scrollbar");
+
+        let scroll_area = self
+            .element
+            .id(area_id)
+            .absolute()
+            .top_0()
+            .left_0()
+            .right_0()
+            .bottom_0()
+            .size_full()
+            .track_scroll(&scroll_handle)
+            .map(|this| match self.axis {
+                ScrollbarAxis::Vertical => this.overflow_y_scroll(),
+                ScrollbarAxis::Horizontal => this.overflow_x_scroll(),
+                ScrollbarAxis::Both => this.overflow_scroll(),
+            });
 
         div()
-            .id(self.id)
+            .id(root_id)
             .size_full()
-            .refine_style(&style)
+            .flex_1()
+            .min_w_0()
+            .min_h_0()
+            .refine_style(&root_style)
             .relative()
-            .child(
-                div()
-                    .id("scroll-area")
-                    .flex()
-                    .size_full()
-                    .track_scroll(&scroll_handle)
-                    .map(|this| match self.axis {
-                        ScrollbarAxis::Vertical => this.flex_col().overflow_y_scroll(),
-                        ScrollbarAxis::Horizontal => this.flex_row().overflow_x_scroll(),
-                        ScrollbarAxis::Both => this.overflow_scroll(),
-                    })
-                    .child(
-                        self.element
-                            // Refine element size to `flex_1`.
-                            .size_auto()
-                            .flex_1(),
-                    ),
-            )
+            .overflow_hidden()
+            .child(scroll_area)
             .child(render_scrollbar(
-                "scrollbar",
+                scrollbar_id,
                 &scroll_handle,
                 self.axis,
                 window,
@@ -183,6 +186,30 @@ where
 
 #[inline]
 #[track_caller]
+fn caller_id() -> ElementId {
+    ElementId::CodeLocation(*Location::caller())
+}
+
+#[inline]
+fn scroll_handle_for(id: &ElementId, window: &mut Window, cx: &mut App) -> ScrollHandle {
+    window
+        .use_keyed_state(id.clone(), cx, |_, _| ScrollHandle::default())
+        .read(cx)
+        .clone()
+}
+
+#[inline]
+fn root_style_from<E>(element: &mut E) -> StyleRefinement
+where
+    E: Styled,
+{
+    StyleRefinement {
+        size: element.style().size.clone(),
+        ..Default::default()
+    }
+}
+
+#[inline]
 fn render_scrollbar<H: ScrollbarHandle + Clone>(
     id: impl Into<ElementId>,
     scroll_handle: &H,

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -375,17 +375,33 @@ mod tests {
         }
     }
 
-    struct BothAxisScrollTest;
+    struct OverflowScrollbarVerticalTest;
 
-    impl Render for BothAxisScrollTest {
+    impl Render for OverflowScrollbarVerticalTest {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-            div().w(px(100.)).h(px(100.)).overflow_scrollbar().child(
-                div()
-                    .w(px(200.))
-                    .h(px(200.))
-                    .flex_shrink_0()
-                    .debug_selector(|| "both-axis-content".to_string()),
-            )
+            crate::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .gap(px(10.))
+                .overflow_scrollbar()
+                .child(row("both-axis-vertical-first-row", 50.))
+                .child(row("both-axis-vertical-second-row", 50.))
+                .child(row("both-axis-vertical-last-row", 50.))
+        }
+    }
+
+    struct OverflowScrollbarHorizontalTest;
+
+    impl Render for OverflowScrollbarHorizontalTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::h_flex()
+                .w(px(100.))
+                .h(px(40.))
+                .gap(px(10.))
+                .overflow_scrollbar()
+                .child(item("both-axis-horizontal-first-item", 50.))
+                .child(item("both-axis-horizontal-second-item", 50.))
+                .child(item("both-axis-horizontal-last-item", 50.))
         }
     }
 
@@ -518,19 +534,50 @@ mod tests {
     }
 
     #[gpui::test]
-    fn overflow_scrollbar_scrolls_both_axes(cx: &mut TestAppContext) {
+    fn overflow_scrollbar_preserves_vertical_source_gap(cx: &mut TestAppContext) {
         cx.update(crate::init);
-        let (_, cx) = cx.add_window_view(|_, _| BothAxisScrollTest);
+        let (_, cx) = cx.add_window_view(|_, _| OverflowScrollbarVerticalTest);
         let cx: &mut VisualTestContext = cx;
         draw(cx);
 
-        let initial = cx.debug_bounds("both-axis-content").unwrap();
+        let first = cx.debug_bounds("both-axis-vertical-first-row").unwrap();
+        let second = cx.debug_bounds("both-axis-vertical-second-row").unwrap();
 
-        scroll(cx, 10., 10., -40., -50.);
+        assert_eq!(second.top() - first.bottom(), px(10.));
+    }
 
-        let after_scroll = cx.debug_bounds("both-axis-content").unwrap();
-        assert!(after_scroll.left() < initial.left());
-        assert!(after_scroll.top() < initial.top());
+    #[gpui::test]
+    fn overflow_scrollbar_preserves_gap_and_scrolls_horizontally(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| OverflowScrollbarHorizontalTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        let first = cx.debug_bounds("both-axis-horizontal-first-item").unwrap();
+        let second = cx.debug_bounds("both-axis-horizontal-second-item").unwrap();
+        let last_initial_x = cx
+            .debug_bounds("both-axis-horizontal-last-item")
+            .unwrap()
+            .origin
+            .x;
+
+        assert_eq!(second.left() - first.right(), px(10.));
+
+        scroll(cx, 10., 10., -50., 0.);
+
+        let first_after_scroll = cx.debug_bounds("both-axis-horizontal-first-item").unwrap();
+        let second_after_scroll = cx.debug_bounds("both-axis-horizontal-second-item").unwrap();
+        let last_after_scroll_x = cx
+            .debug_bounds("both-axis-horizontal-last-item")
+            .unwrap()
+            .origin
+            .x;
+
+        assert_eq!(
+            second_after_scroll.left() - first_after_scroll.right(),
+            px(10.)
+        );
+        assert!(last_after_scroll_x < last_initial_x);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #2508

## Description

Fix `.overflow_y_scrollbar()` / `.overflow_scrollbar()` layout behavior when used with layout styles such as `.gap()`.

Previously, `Scrollable` rendered an additional internal scroll-area `div` and inserted the caller's element as a child of that wrapper. This changed the layout structure and could cause styles applied to the original element, such as flex gap, to no longer behave as expected.

This PR changes `Scrollable` so the original element itself becomes the scroll-tracked container. The outer wrapper is only used to preserve sizing and overlay the scrollbar. This keeps the caller's layout styles intact while still rendering the scrollbar.

Main changes:

* Preserve the source element as the actual scroll area.
* Move scroll tracking and overflow behavior directly onto the source element.
* Keep the outer wrapper responsible for sizing, positioning, and scrollbar overlay.
* Use generated element IDs instead of fixed string IDs for scrollable parts.
* Generalize the `InteractiveElement` implementation for `Scrollable<E>`.

## Screenshot

| Before                        | After                           |
| ----------------------------- | ------------------------------- |
| See issue #2508 actual result | See issue #2508 expected result |

## How to Test

1. Run a story or example that uses `.overflow_y_scrollbar()` with a flex layout and `.gap()`, for example:

```rust
v_flex()
    .flex_1()
    .gap(px(30.))
    .overflow_y_scrollbar()
    .px(px(12.))
    .pb(px(16.))
    .children(cards)
```

2. Confirm that the gap between children is preserved.
3. Confirm that the vertical scrollbar still appears and scrolls correctly.
4. Confirm that existing `.overflow_scrollbar()`, `.overflow_x_scrollbar()`, and `.overflow_y_scrollbar()` usages still work.

## Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
* [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
* [x] Passed `cargo run` for story tests related to the changes.
* [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
