### PR TITLE
plot: Polish hover crosshair color and fix horizontal bar band

### DIFF
--- a/crates/ui/src/chart/bar_chart.rs
+++ b/crates/ui/src/chart/bar_chart.rs
@@ -533,7 +533,7 @@ where
             }
             CrossLine::new(state.cross_line)
                 .horizontal()
-                .span(start, length)
+                .h_span(start, length)
                 .band(px(band_width))
         } else {
             let axis_gap = if self.label_axis { AXIS_GAP } else { 0. };

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -3,7 +3,7 @@ use gpui::{
     SharedString, Size, StyleRefinement, Styled, Window, div, prelude::FluentBuilder, px,
 };
 
-use crate::{ActiveTheme, StyledExt, h_flex, v_flex};
+use crate::{ActiveTheme, Colorize, StyledExt, h_flex, v_flex};
 
 #[derive(Default)]
 pub enum CrossLineAxis {
@@ -115,7 +115,7 @@ impl CrossLine {
     /// solid band fills a `thickness`-wide strip centered on the data point.
     fn line(&self, vertical: bool, cx: &App) -> Div {
         let color = if self.dashed {
-            cx.theme().border
+            cx.theme().border.mix(cx.theme().foreground, 0.8)
         } else {
             cx.theme().foreground.opacity(0.08)
         };


### PR DESCRIPTION
- Darken the dashed crosshair by blending `border` toward `foreground`, so it reads a touch deeper than the (border-colored) grid lines in both light and dark themes.
- Fix the horizontal bar hover band overflowing the value axis: it called `.span()` (which sets the vertical span) after `.horizontal()`, so the horizontal line fell back to `w_full()`. Use `.h_span()` to confine the band to the bar region.
