### PR TITLE
text: Support HTML `<mark>` tag with highlight color

### DIFF
--- a/crates/story/examples/fixtures/test.html
+++ b/crates/story/examples/fixtures/test.html
@@ -8,7 +8,11 @@
             <a href="https://google.com"
                 >Link with: <b>Bold <i>italic</i></b></a
             >, <strong>bold</strong>, <em>italic</em>, <u>underline</u>, and
-            <code>code</code> text.
+            <code>code</code> text. You can also <mark>highlight</mark> text, or
+            highlight it in <mark color="blue-200">blue</mark>,
+            <mark color="green-200">green</mark>,
+            <mark color="amber/30">amber</mark>, or a custom
+            <mark style="background-color: #fca5a5">hex color</mark>.
         </p>
         <script>
             console.log("Hello, world!");

--- a/crates/ui/src/text/format/html.rs
+++ b/crates/ui/src/text/format/html.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::rc::Rc;
 
-use gpui::{DefiniteLength, SharedString, px, relative};
+use gpui::{DefiniteLength, Hsla, SharedString, px, relative};
 use html5ever::tendril::TendrilSink;
 use html5ever::{LocalName, ParseOpts, local_name, parse_document};
 use markup5ever_rcdom::{Node, NodeData, RcDom};
@@ -99,6 +99,31 @@ fn attr_value(attrs: &RefCell<Vec<html5ever::Attribute>>, name: LocalName) -> Op
             None
         }
     })
+}
+
+/// Get the highlight background color for a `<mark>` element.
+///
+/// Reads the `color` attribute first, then the `background-color` declaration
+/// from the `style` attribute. Color values are parsed by [`crate::try_parse_color`],
+/// supporting hex (`#3366ff`) and Tailwind expressions (`blue`, `blue-200`, `blue/30`).
+fn mark_color(attrs: &RefCell<Vec<html5ever::Attribute>>) -> Option<Hsla> {
+    let color_attr = attrs.borrow().iter().find_map(|attr| {
+        if &*attr.name.local == "color" {
+            Some(attr.value.to_string())
+        } else {
+            None
+        }
+    });
+
+    if let Some(value) = color_attr
+        && let Ok(color) = crate::try_parse_color(value.trim())
+    {
+        return Some(color);
+    }
+
+    style_attrs(attrs)
+        .get("background-color")
+        .and_then(|v| crate::try_parse_color(v.trim()).ok())
 }
 
 /// Get style properties to HashMap
@@ -321,6 +346,14 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &Rc<Node>) {
             }
             local_name!("code") => {
                 merge_children_with_mark(node, paragraph, Some(TextMark::default().code()));
+            }
+            local_name!("mark") => {
+                let color = mark_color(&attrs).unwrap_or_else(|| crate::yellow(200));
+                merge_children_with_mark(
+                    node,
+                    paragraph,
+                    Some(TextMark::default().highlight(color)),
+                );
             }
             local_name!("a") => {
                 let link_mark = LinkMark {
@@ -661,6 +694,20 @@ mod tests {
     #[test]
     fn test_trim_text() {
         assert_eq!(trim_text("  \n\tHello world \t\r "), " Hello world ",);
+    }
+
+    #[test]
+    fn test_mark() {
+        let mut cx = NodeContext::default();
+
+        // `<mark>` is rendered as a highlight, kept as `==...==` in markdown.
+        let html = r#"<p>Hello <mark>world</mark></p>"#;
+        let node = super::parse(html, &mut cx).unwrap();
+        assert_eq!(node.to_markdown(), "Hello ==world==");
+
+        let html = r#"<p><mark color="blue">blue</mark> and <mark style="background-color: #336699">hex</mark></p>"#;
+        let node = super::parse(html, &mut cx).unwrap();
+        assert_eq!(node.to_markdown(), "==blue== and ==hex==");
     }
 
     #[test]

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -7,9 +7,9 @@ use std::{
 
 use gpui::{
     AnyElement, App, DefiniteLength, Div, ElementId, FontStyle, FontWeight, Half, HighlightStyle,
-    InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement, ScrollHandle,
-    SharedString, SharedUri, StatefulInteractiveElement, Styled, StyledImage as _, Window, div,
-    img, prelude::FluentBuilder as _, px, relative, rems,
+    Hsla, InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement,
+    ScrollHandle, SharedString, SharedUri, StatefulInteractiveElement, Styled, StyledImage as _,
+    Window, div, img, prelude::FluentBuilder as _, px, relative, rems,
 };
 use markdown::mdast;
 use ropey::Rope;
@@ -282,6 +282,10 @@ pub struct TextMark {
     pub strikethrough: bool,
     pub underline: bool,
     pub code: bool,
+    /// Highlight (`<mark>`) the text with this background color.
+    ///
+    /// `None` means the text is not highlighted.
+    pub highlight: Option<Hsla>,
     pub link: Option<LinkMark>,
 }
 
@@ -311,6 +315,12 @@ impl TextMark {
         self
     }
 
+    /// Mark the text as highlighted (`<mark>`) with the given background color.
+    pub fn highlight(mut self, color: Hsla) -> Self {
+        self.highlight = Some(color);
+        self
+    }
+
     pub fn link(mut self, link: impl Into<LinkMark>) -> Self {
         self.link = Some(link.into());
         self
@@ -322,6 +332,9 @@ impl TextMark {
         self.strikethrough |= other.strikethrough;
         self.underline |= other.underline;
         self.code |= other.code;
+        if other.highlight.is_some() {
+            self.highlight = other.highlight;
+        }
         if let Some(link) = other.link {
             self.link = Some(link);
         }
@@ -872,6 +885,9 @@ impl Paragraph {
                     if style.code {
                         highlight.background_color = Some(cx.theme().accent);
                     }
+                    if let Some(color) = style.highlight {
+                        highlight.background_color = Some(color);
+                    }
 
                     if let Some(mut link_mark) = style.link.clone() {
                         highlight.color = Some(cx.theme().link);
@@ -983,6 +999,9 @@ impl Paragraph {
                     if style.code {
                         highlight.background_color = Some(cx.theme().accent);
                     }
+                    if let Some(color) = style.highlight {
+                        highlight.background_color = Some(color);
+                    }
 
                     if let Some(mut link_mark) = style.link.clone() {
                         highlight.color = Some(cx.theme().link);
@@ -1043,6 +1062,9 @@ impl Paragraph {
                     }
                     if style.code {
                         text = format!("`{}`", &text_node.text[range.clone()]);
+                    }
+                    if style.highlight.is_some() {
+                        text = format!("=={}==", &text_node.text[range.clone()]);
                     }
                     if let Some(link) = &style.link {
                         text = format!("[{}]({})", &text_node.text[range.clone()], link.url);


### PR DESCRIPTION
## Description

Adds support for the HTML `<mark>` tag in the text/HTML renderer, rendering marked text with a background highlight.

The highlight color is customizable via the `color` attribute or the `background-color` style declaration, parsed by the existing `try_parse_color` helper:

```html
<mark>highlighted</mark>                                   <!-- default light yellow -->
<mark color="blue-200">blue tint</mark>                   <!-- Tailwind scale -->
<mark color="amber/30">amber, 30% opacity</mark>          <!-- opacity modifier -->
<mark style="background-color: #fca5a5">custom hex</mark>  <!-- hex -->
```

- Accepts hex (`#3366ff`), named colors (`blue`), Tailwind scales (`blue-200`), and opacity (`amber/30`).
- Defaults to a light yellow highlight when no color is given.

`TextMark` gains an additive `highlight: Option<Hsla>` field (private module, not part of the public API). The `<mark>` demos were added to the HTML example fixture, with a unit test covering the tag.

> Note: AI-generated code, refactored to match project style.