### PR TITLE
input: skip notify when hover state unchanged on mouse move

### DIFF
--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -155,13 +155,21 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<InputState>,
     ) {
+        let had_definition = !self.hover_definition.is_empty();
+        let had_popover = self.hover_popover.is_some();
+
         if event.modifiers.secondary() {
             self.handle_hover_definition(offset, window, cx);
         } else {
             self.hover_definition.clear();
             self.handle_hover_popover(offset, window, cx);
         }
-        cx.notify();
+
+        let changed = had_definition != !self.hover_definition.is_empty()
+            || had_popover != self.hover_popover.is_some();
+        if changed {
+            cx.notify();
+        }
     }
 
     pub(crate) fn clear_hover_state(&mut self, cx: &mut Context<InputState>) {

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -165,7 +165,7 @@ impl InputState {
             self.handle_hover_popover(offset, window, cx);
         }
 
-        let changed = had_definition != !self.hover_definition.is_empty()
+        let changed = had_definition == self.hover_definition.is_empty()
             || had_popover != self.hover_popover.is_some();
         if changed {
             cx.notify();


### PR DESCRIPTION
## Description

Problem: gpui-component's InputState::handle_mouse_move calls cx.notify() unconditionally, and GPUI's mark_view_dirty() propagates this up the dispatch tree to MainView.

Cause: InputState::handle_mouse_move in gpui-component calls cx.notify() on every mouse movement pixel, even when no LSP hover state changes. GPUI's mark_view_dirty() walks the dispatch tree upward, marking all ancestors dirty - causing MainView to re-render the entire tree on each mouse move.
Fix: Only cx.notify() when hover_definition or hover_popover actually changed.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
