### PR TITLE
text_view: Don't allow `TextView` selection behind a `Dialog`/`Sheet`

### DIFF
--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -660,9 +660,6 @@ impl RenderOnce for Dialog {
                                 ];
                                 this.top(y * delta).shadow(shadow)
                             })
-                            // Confine window text selection to this dialog so a
-                            // drag that leaves it (over the overlay) can't select
-                            // content behind.
                             .selection_scope(SelectionScope::Dialog(layer_ix)),
                     )
                     .with_animation("fade-in", animation, move |this, delta| this.opacity(delta)),

--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -15,6 +15,7 @@ use crate::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     dialog::{DialogContent, DialogTitle},
     scroll::ScrollableElement as _,
+    text::{SelectionScope, SelectionScopeElement as _},
     v_flex,
 };
 
@@ -658,7 +659,11 @@ impl RenderOnce for Dialog {
                                     },
                                 ];
                                 this.top(y * delta).shadow(shadow)
-                            }),
+                            })
+                            // Confine window text selection to this dialog so a
+                            // drag that leaves it (over the overlay) can't select
+                            // content behind.
+                            .selection_scope(SelectionScope::Dialog(layer_ix)),
                     )
                     .with_animation("fade-in", animation, move |this, delta| this.opacity(delta)),
             )

--- a/crates/ui/src/global_state.rs
+++ b/crates/ui/src/global_state.rs
@@ -1,7 +1,7 @@
 use gpui::{App, ElementId, Entity, FocusHandle, Global, OwnedMenu};
 use std::collections::HashSet;
 
-use crate::text::TextViewState;
+use crate::text::{SelectionScope, TextViewState};
 
 pub(crate) fn init(cx: &mut App) {
     cx.set_global(GlobalState::new());
@@ -22,6 +22,12 @@ pub struct GlobalState {
     /// interaction (e.g. `Input`, `Button`); reset by the selection
     /// controller in the capture phase of every left mouse down.
     pub(crate) suppress_text_selection: bool,
+    /// Stack of active text-selection scopes, pushed/popped by the
+    /// `SelectionScopeMarker` element that wraps each Dialog/Sheet content
+    /// subtree during paint. Empty means the base window layer. A selectable
+    /// `TextView` reads the top of this stack when it registers, so window
+    /// selection can be confined to the active modal.
+    selection_scope_stack: Vec<SelectionScope>,
 }
 
 impl GlobalState {
@@ -31,6 +37,7 @@ impl GlobalState {
             open_deferred_popovers: HashSet::new(),
             app_menus: Vec::new(),
             suppress_text_selection: false,
+            selection_scope_stack: Vec::new(),
         }
     }
 
@@ -53,6 +60,25 @@ impl GlobalState {
 
     pub(crate) fn text_view_state(&self) -> Option<&Entity<TextViewState>> {
         self.text_view_state_stack.last()
+    }
+
+    /// Push a selection scope while painting a Dialog/Sheet content subtree.
+    pub(crate) fn push_selection_scope(&mut self, scope: SelectionScope) {
+        self.selection_scope_stack.push(scope);
+    }
+
+    /// Pop the selection scope after painting a Dialog/Sheet content subtree.
+    pub(crate) fn pop_selection_scope(&mut self) {
+        self.selection_scope_stack.pop();
+    }
+
+    /// The selection scope currently being painted. `Base` when not inside any
+    /// Dialog/Sheet content subtree.
+    pub(crate) fn current_selection_scope(&self) -> SelectionScope {
+        self.selection_scope_stack
+            .last()
+            .copied()
+            .unwrap_or(SelectionScope::Base)
     }
 
     /// Check if we are currently inside a deferred context (e.g., inside an open Popover).

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -6,7 +6,7 @@ use crate::{
     native_menu::FallbackMenuOverlay,
     notification::{Notification, NotificationList},
     sheet::Sheet,
-    text::{TextSelectionController, TextViewState, WindowTextSelection},
+    text::{SelectionScope, TextSelectionController, TextViewState, WindowTextSelection},
     tooltip::TooltipOverlay,
     window_border,
 };
@@ -54,7 +54,8 @@ pub struct Root {
     /// Window-level text selection state. See `text::window_selection`.
     pub(crate) text_selection: WindowTextSelection,
     /// Selectable TextViews registered this frame, keyed by entity id.
-    pub(crate) selectable_text_views: HashMap<EntityId, (WeakEntity<TextViewState>, Hitbox)>,
+    pub(crate) selectable_text_views:
+        HashMap<EntityId, (WeakEntity<TextViewState>, Hitbox, SelectionScope)>,
     /// Inline text bounds for selectable TextViews, keyed by parent TextView id.
     pub(crate) selectable_text_inlines: HashMap<EntityId, Vec<Bounds<Pixels>>>,
 }
@@ -292,6 +293,9 @@ impl Root {
             previous_focused_handle,
             build,
         ));
+        // Opening a modal confines selection to it; drop any background
+        // selection so it cannot linger (or be copied) under the modal.
+        self.clear_text_selection(cx);
         cx.notify();
     }
 
@@ -307,6 +311,7 @@ impl Root {
         if let Some(handle) = self.close_dialog_internal() {
             window.focus(&handle, cx);
         }
+        self.clear_text_selection(cx);
         cx.notify();
     }
 
@@ -330,6 +335,7 @@ impl Root {
             })
             .detach();
         }
+        self.clear_text_selection(cx);
         cx.notify();
     }
 
@@ -343,6 +349,7 @@ impl Root {
         if let Some(handle) = previous_focused_handle.and_then(|h| h.upgrade()) {
             window.focus(&handle, cx);
         }
+        self.clear_text_selection(cx);
         cx.notify();
     }
 
@@ -369,6 +376,9 @@ impl Root {
             placement,
             builder: Rc::new(build),
         });
+        // Opening a modal confines selection to it; drop any background
+        // selection so it cannot linger (or be copied) under the modal.
+        self.clear_text_selection(cx);
         cx.notify();
     }
 
@@ -383,6 +393,7 @@ impl Root {
             window.focus(&previous_handle, cx);
         }
         self.active_sheet = None;
+        self.clear_text_selection(cx);
         cx.notify();
     }
 

--- a/crates/ui/src/sheet.rs
+++ b/crates/ui/src/sheet.rs
@@ -281,9 +281,6 @@ impl RenderOnce for Sheet {
                                     })
                                 },
                             )
-                            // Confine window text selection to this sheet so a
-                            // drag that leaves it (over the overlay) can't select
-                            // content behind.
                             .selection_scope(SelectionScope::Sheet),
                     ),
             )

--- a/crates/ui/src/sheet.rs
+++ b/crates/ui/src/sheet.rs
@@ -17,6 +17,7 @@ use crate::{
     dialog::overlay_color,
     h_flex,
     scroll::ScrollableElement as _,
+    text::{SelectionScope, SelectionScopeElement as _},
     title_bar::TITLE_BAR_HEIGHT,
     v_flex,
 };
@@ -279,7 +280,11 @@ impl RenderOnce for Sheet {
                                         Placement::Left => this.left(y),
                                     })
                                 },
-                            ),
+                            )
+                            // Confine window text selection to this sheet so a
+                            // drag that leaves it (over the overlay) can't select
+                            // content behind.
+                            .selection_scope(SelectionScope::Sheet),
                     ),
             )
     }

--- a/crates/ui/src/text/mod.rs
+++ b/crates/ui/src/text/mod.rs
@@ -18,6 +18,7 @@ pub use style::*;
 pub use text_view::*;
 pub(crate) use window_selection::TextSelectionController;
 pub(crate) use window_selection::WindowTextSelection;
+pub(crate) use window_selection::{SelectionScope, SelectionScopeElement};
 
 pub(crate) fn init(cx: &mut App) {
     state::init(cx);

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -6,6 +6,127 @@ use gpui::{
 
 use crate::{Root, global_state::GlobalState, scroll::AutoScroll, text::TextViewState};
 
+/// The modal layer a selectable [`TextView`](crate::text::TextView) belongs to.
+///
+/// Window text selection is global, but when a modal (Dialog/Sheet) is open the
+/// selection must be confined to that modal so a drag that leaves the modal
+/// (e.g. over the overlay) cannot select TextViews behind it. Each selectable
+/// view is tagged with the scope it painted under (see [`SelectionScopeMarker`]),
+/// and selection only considers views whose scope matches the active layer (see
+/// [`Root::active_selection_scope`]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SelectionScope {
+    /// The base window content, outside any Dialog/Sheet.
+    Base,
+    /// A Dialog at the given layer index (matches `Dialog::layer_ix`, i.e. the
+    /// position in `Root::active_dialogs`).
+    Dialog(usize),
+    /// The active Sheet.
+    Sheet,
+}
+
+/// Extension trait that confines window text selection started inside an
+/// element's subtree to a modal [`SelectionScope`]. Chains like `Styled` /
+/// `focus_trap`, so a Dialog/Sheet wraps its content with a single call:
+///
+/// ```ignore
+/// v_flex().child(content).selection_scope(SelectionScope::Dialog(layer_ix))
+/// ```
+pub(crate) trait SelectionScopeElement: IntoElement + Sized {
+    fn selection_scope(self, scope: SelectionScope) -> SelectionScopeMarker<Self::Element> {
+        SelectionScopeMarker {
+            scope,
+            element: self.into_element(),
+        }
+    }
+}
+
+impl<E: IntoElement> SelectionScopeElement for E {}
+
+/// A layout-transparent wrapper element (created by
+/// [`SelectionScopeElement::selection_scope`]) that marks its subtree with a
+/// [`SelectionScope`] during paint, so selectable
+/// [`TextView`](crate::text::TextView)s painted inside it register under that
+/// scope. It delegates every [`Element`] method to the wrapped element and only
+/// brackets `paint` with a scope push/pop — mirroring the `text_view_state_stack`
+/// idiom in `TextView::paint`.
+pub(crate) struct SelectionScopeMarker<E> {
+    scope: SelectionScope,
+    element: E,
+}
+
+impl<E: Element> IntoElement for SelectionScopeMarker<E> {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl<E: Element> Element for SelectionScopeMarker<E> {
+    type RequestLayoutState = E::RequestLayoutState;
+    type PrepaintState = E::PrepaintState;
+
+    fn id(&self) -> Option<ElementId> {
+        self.element.id()
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        self.element.source_location()
+    }
+
+    fn request_layout(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        self.element.request_layout(id, inspector_id, window, cx)
+    }
+
+    fn prepaint(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        self.element
+            .prepaint(id, inspector_id, bounds, request_layout, window, cx)
+    }
+
+    fn paint(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        request_layout: &mut Self::RequestLayoutState,
+        prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        // Mark the subtree so selectable TextViews register under this scope.
+        // Registration happens during the child's paint (see `TextView::paint`),
+        // so bracketing the child paint is sufficient. Paint is depth-first and
+        // single-threaded, so the bracket is exact even if the dialog layer is
+        // later wrapped in a deferred draw.
+        GlobalState::global_mut(cx).push_selection_scope(self.scope);
+        self.element.paint(
+            id,
+            inspector_id,
+            bounds,
+            request_layout,
+            prepaint,
+            window,
+            cx,
+        );
+        GlobalState::global_mut(cx).pop_selection_scope();
+    }
+}
+
 /// Window-level text selection state, owned by [`Root`].
 ///
 /// All text selection (including within a single TextView) is driven by this
@@ -121,13 +242,16 @@ impl Root {
         let id = state.entity_id();
         let weak = state.downgrade();
         let hitbox = hitbox.clone();
+        // Capture the modal scope this view is painting under (set by the
+        // `SelectionScopeMarker` wrapping a Dialog/Sheet content subtree).
+        let scope = GlobalState::global(cx).current_selection_scope();
         root.update(cx, |root, _| {
             // Prune dead views on each registration. This is O(N) per call (O(N²)
             // per frame across N selectable views), acceptable for typical view
             // counts; revisit if a window ever hosts hundreds of selectable views.
             root.selectable_text_views
-                .retain(|_, (view, _)| view.upgrade().is_some());
-            root.selectable_text_views.insert(id, (weak, hitbox));
+                .retain(|_, (view, _, _)| view.upgrade().is_some());
+            root.selectable_text_views.insert(id, (weak, hitbox, scope));
             root.selectable_text_inlines.remove(&id);
         });
     }
@@ -160,7 +284,7 @@ impl Root {
         if self.text_selection.resolved_points(cx).is_some() {
             return true;
         }
-        self.selectable_text_views.values().any(|(view, _)| {
+        self.selectable_text_views.values().any(|(view, _, _)| {
             view.upgrade()
                 .is_some_and(|view| view.read(cx).has_view_selection())
         })
@@ -177,13 +301,19 @@ impl Root {
     pub(crate) fn window_selected_text(&self, cx: &App) -> String {
         let resolved = self.text_selection.resolved_points(cx);
         let single_view = self.text_selection.single_view();
+        // A window selection lives in exactly one scope (its endpoints are
+        // confined to the active modal by `text_selection_endpoint`, and the
+        // selection is cleared when a modal opens/closes). Only views in that
+        // scope contribute, so copying never mixes text across layers.
+        let anchor_scope = self.active_selection_scope();
 
         let mut items: Vec<(Point<Pixels>, String)> = Vec::new();
-        for (id, (view, _)) in self.selectable_text_views.iter() {
+        for (id, (view, _, scope)) in self.selectable_text_views.iter() {
             let Some(view) = view.upgrade() else { continue };
             let state = view.read(cx);
             let in_window_selection = resolved.is_some()
                 && state.is_selectable()
+                && *scope == anchor_scope
                 && single_view.map_or(true, |v| v == *id);
             if !state.has_view_selection() && !in_window_selection {
                 continue;
@@ -220,7 +350,7 @@ impl Root {
         self.text_selection.cursor = None;
         self.text_selection.is_selecting = false;
         self.text_selection.did_hit_text = false;
-        self.selectable_text_views.retain(|_, (view, _)| {
+        self.selectable_text_views.retain(|_, (view, _, _)| {
             let Some(view) = view.upgrade() else {
                 return false;
             };
@@ -378,6 +508,21 @@ impl Root {
         self.notify_selectable_text_views(cx);
     }
 
+    /// The scope window text selection is confined to right now. When any
+    /// Dialog is open, selection is limited to the topmost dialog (highest
+    /// `layer_ix`); otherwise to the active Sheet if one is open; otherwise the
+    /// base window. Views registered under a different scope are excluded from
+    /// selection (see [`Root::text_selection_endpoint`]).
+    fn active_selection_scope(&self) -> SelectionScope {
+        if !self.active_dialogs.is_empty() {
+            SelectionScope::Dialog(self.active_dialogs.len() - 1)
+        } else if self.active_sheet.is_some() {
+            SelectionScope::Sheet
+        } else {
+            SelectionScope::Base
+        }
+    }
+
     /// Resolve a window position to a selection endpoint. Uses hitbox hover
     /// testing so clipped or occluded TextViews are correctly excluded.
     ///
@@ -393,12 +538,22 @@ impl Root {
         window: &Window,
         cx: &App,
     ) -> SelectionEndpoint {
+        // Confine selection to the active modal layer: when a Dialog/Sheet is
+        // open, views behind it must not participate. The overlay's `.occlude()`
+        // already keeps the true-hit path below from hovering behind-views, but
+        // the proxy-anchor fallback ignores occlusion, so both loops filter by
+        // scope (the true-hit filter is cheap defense-in-depth).
+        let scope = self.active_selection_scope();
+
         let mut best: Option<(WeakEntity<TextViewState>, f32)> = None;
         // `is_hovered` reflects the hitbox state as of the last prepaint frame —
         // a one-frame lag that is negligible for mouse-driven selection.
         // Smallest-area wins as a proxy for the innermost (topmost) view when
         // TextViews overlap.
-        for (view, hitbox) in self.selectable_text_views.values() {
+        for (view, hitbox, view_scope) in self.selectable_text_views.values() {
+            if *view_scope != scope {
+                continue;
+            }
             if view.upgrade().is_none() {
                 continue;
             }
@@ -437,7 +592,10 @@ impl Root {
         // it is a pure relative offset.
         let mut predecessor: Option<(WeakEntity<TextViewState>, Pixels)> = None;
         let mut first: Option<(WeakEntity<TextViewState>, Pixels)> = None;
-        for (view, _) in self.selectable_text_views.values() {
+        for (view, _, view_scope) in self.selectable_text_views.values() {
+            if *view_scope != scope {
+                continue;
+            }
             let Some(entity) = view.upgrade() else {
                 continue;
             };
@@ -485,7 +643,7 @@ impl Root {
     }
 
     fn notify_selectable_text_views(&mut self, cx: &mut Context<Self>) {
-        self.selectable_text_views.retain(|_, (view, _)| {
+        self.selectable_text_views.retain(|_, (view, _, _)| {
             let Some(view) = view.upgrade() else {
                 return false;
             };
@@ -518,7 +676,7 @@ impl Root {
         // view too.
         if old_points.is_none() {
             if let Some(id) = self.text_selection.single_view() {
-                if let Some((view, _)) = self.selectable_text_views.get(&id) {
+                if let Some((view, _, _)) = self.selectable_text_views.get(&id) {
                     if let Some(view) = view.upgrade() {
                         view.update(cx, |_, cx| cx.notify());
                     }
@@ -543,7 +701,7 @@ impl Root {
             (None, None) => return,
         };
 
-        self.selectable_text_views.retain(|_, (view, _)| {
+        self.selectable_text_views.retain(|_, (view, _, _)| {
             let Some(view) = view.upgrade() else {
                 return false;
             };
@@ -688,9 +846,10 @@ impl Element for TextSelectionController {
 
 #[cfg(test)]
 mod tests {
+    use super::{SelectionScope, SelectionScopeElement};
     use crate::global_state::GlobalState;
     use crate::{
-        Root,
+        Placement, Root,
         text::{TextView, TextViewState},
     };
     use gpui::{
@@ -700,6 +859,7 @@ mod tests {
     };
     use std::cell::Cell;
     use std::rc::Rc;
+    use std::time::Duration;
 
     struct ChatTestView {
         focus_handle: FocusHandle,
@@ -1089,6 +1249,308 @@ mod tests {
             b_notified.get(),
             "view B was not notified when the drag returned to the anchor view, \
              so its stale highlight would never be repainted away",
+        );
+    }
+
+    /// A view with a selectable TextView in the base window that also mounts the
+    /// Dialog/Sheet layers (which `Root::render` does not mount itself), so a
+    /// real modal can be opened on top of the base content.
+    struct ModalScopeTestView {
+        focus_handle: FocusHandle,
+        base: Entity<TextViewState>,
+    }
+
+    impl ModalScopeTestView {
+        fn new(cx: &mut Context<Self>) -> Self {
+            Self {
+                focus_handle: cx.focus_handle(),
+                base: cx.new(|cx| TextViewState::markdown("Hello world", cx)),
+            }
+        }
+    }
+
+    impl Render for ModalScopeTestView {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let sheet_layer = Root::render_sheet_layer(window, cx);
+            let dialog_layer = Root::render_dialog_layer(window, cx);
+            div()
+                .track_focus(&self.focus_handle)
+                .size_full()
+                .child(
+                    div()
+                        .h(px(40.))
+                        .child(TextView::new(&self.base).selectable(true)),
+                )
+                .children(sheet_layer)
+                .children(dialog_layer)
+        }
+    }
+
+    fn setup_modal(
+        cx: &mut TestAppContext,
+    ) -> (Entity<ModalScopeTestView>, &mut VisualTestContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(ModalScopeTestView::new);
+            Root::new(view, window, cx)
+        });
+        let view = root.read_with(cx, |root, _| {
+            root.view()
+                .clone()
+                .downcast::<ModalScopeTestView>()
+                .unwrap()
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        (view, cx)
+    }
+
+    /// Advance past the modal open animation so it reaches its resting position,
+    /// then redraw so its TextViews register and their bounds are stable for the
+    /// subsequent drag.
+    fn settle(cx: &mut VisualTestContext) {
+        cx.executor().advance_clock(Duration::from_millis(500));
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    fn open_dialog_with_text(
+        cx: &mut VisualTestContext,
+        text: &'static str,
+    ) -> Entity<TextViewState> {
+        let state = cx.update(|_, cx| cx.new(|cx| TextViewState::markdown(text, cx)));
+        let state_for_builder = state.clone();
+        cx.update(|window, cx| {
+            Root::update(window, cx, |root, window, cx| {
+                root.open_dialog(
+                    move |dialog, _, _| {
+                        dialog.child(TextView::new(&state_for_builder).selectable(true))
+                    },
+                    window,
+                    cx,
+                );
+            });
+        });
+        settle(cx);
+        state
+    }
+
+    #[gpui::test]
+    fn drag_inside_dialog_still_selects_its_text(cx: &mut TestAppContext) {
+        let (_, cx) = setup_modal(cx);
+        let dialog_state = open_dialog_with_text(cx, "Dialog text");
+
+        // A drag entirely within the dialog's TextView must still select (the
+        // scope filter must not break in-dialog selection — see #2501).
+        let b = dialog_state.read_with(cx, |s, _| s.bounds());
+        drag(
+            cx,
+            point(b.origin.x + px(1.), b.center().y),
+            point(b.origin.x + b.size.width + px(80.), b.center().y),
+        );
+
+        let text = window_selected_text(cx);
+        assert!(
+            text.contains("Dialog text"),
+            "dialog text was not selectable: {text:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn opening_dialog_clears_base_selection(cx: &mut TestAppContext) {
+        let (view, cx) = setup_modal(cx);
+
+        let b = view.read_with(cx, |v, cx| v.base.read(cx).bounds());
+        drag(
+            cx,
+            point(b.origin.x + px(1.), b.center().y),
+            point(b.origin.x + b.size.width + px(80.), b.center().y),
+        );
+        assert!(window_selected_text(cx).contains("Hello world"));
+
+        let _dialog = open_dialog_with_text(cx, "Dialog text");
+
+        let text = window_selected_text(cx);
+        assert!(
+            !text.contains("Hello world"),
+            "base selection was not cleared when the dialog opened: {text:?}"
+        );
+    }
+
+    /// A behind-the-modal selectable TextView covered by a full-window
+    /// occluding overlay (mirroring a Dialog/Sheet overlay), plus a `front`
+    /// TextView marked with a modal [`SelectionScope`] and painted on top of the
+    /// overlay. This reproduces the modal stacking at fixed coordinates without a
+    /// real modal's open animation (which cannot be settled under the test
+    /// clock).
+    struct SyntheticModalView {
+        focus_handle: FocusHandle,
+        behind: Entity<TextViewState>,
+        front: Entity<TextViewState>,
+        front_scope: SelectionScope,
+    }
+
+    impl SyntheticModalView {
+        fn new(front_scope: SelectionScope, cx: &mut Context<Self>) -> Self {
+            Self {
+                focus_handle: cx.focus_handle(),
+                behind: cx.new(|cx| TextViewState::markdown("Behind text", cx)),
+                front: cx.new(|cx| TextViewState::markdown("Front text", cx)),
+                front_scope,
+            }
+        }
+    }
+
+    impl Render for SyntheticModalView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .track_focus(&self.focus_handle)
+                .size_full()
+                // Behind the modal, at the top. Occluded by the overlay below.
+                .child(
+                    div()
+                        .h(px(40.))
+                        .child(TextView::new(&self.behind).selectable(true)),
+                )
+                // A full-window occluding overlay (mirrors the modal overlay)
+                // with modal-scoped content painted on top of it.
+                .child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .size_full()
+                        .occlude()
+                        .child(
+                            div()
+                                .absolute()
+                                .top(px(100.))
+                                .left_0()
+                                .h(px(40.))
+                                .child(TextView::new(&self.front).selectable(true))
+                                .selection_scope(self.front_scope),
+                        ),
+                )
+        }
+    }
+
+    fn setup_synthetic(
+        front_scope: SelectionScope,
+        cx: &mut TestAppContext,
+    ) -> (Entity<SyntheticModalView>, &mut VisualTestContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| SyntheticModalView::new(front_scope, cx));
+            Root::new(view, window, cx)
+        });
+        let view = root.read_with(cx, |root, _| {
+            root.view()
+                .clone()
+                .downcast::<SyntheticModalView>()
+                .unwrap()
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        (view, cx)
+    }
+
+    /// Open an empty dialog (its layer is not mounted, so nothing renders) purely
+    /// to make `active_selection_scope()` return `Dialog(0)`.
+    fn activate_dialog_scope(cx: &mut VisualTestContext) {
+        cx.update(|window, cx| {
+            Root::update(window, cx, |root, window, cx| {
+                root.open_dialog(|dialog, _, _| dialog, window, cx);
+            });
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    /// Open an empty sheet purely to make `active_selection_scope()` return
+    /// `Sheet`.
+    fn activate_sheet_scope(cx: &mut VisualTestContext) {
+        cx.update(|window, cx| {
+            Root::update(window, cx, |root, window, cx| {
+                root.open_sheet_at(Placement::Right, |sheet, _, _| sheet, window, cx);
+            });
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    /// Regression guard: with a dialog active, a drag that starts in
+    /// the dialog-scoped content and leaves it over the overlay must not select
+    /// the TextView behind the overlay.
+    #[gpui::test]
+    fn selection_behind_active_dialog_is_excluded(cx: &mut TestAppContext) {
+        let (view, cx) = setup_synthetic(SelectionScope::Dialog(0), cx);
+        activate_dialog_scope(cx);
+
+        // Anchor inside the modal-scoped content, then drag up onto the behind
+        // view's glyphs (left side; the behind view spans the full window width,
+        // so its center is far from its text).
+        let from = view.read_with(cx, |v, cx| v.front.read(cx).bounds().center());
+        let to = view.read_with(cx, |v, cx| {
+            let b = v.behind.read(cx).bounds();
+            point(b.origin.x + px(4.), b.center().y)
+        });
+        drag(cx, from, to);
+
+        let behind = view.read_with(cx, |v, cx| v.behind.read(cx).selected_text());
+        assert!(
+            behind.trim().is_empty(),
+            "view behind the dialog overlay was selected: {behind:?}"
+        );
+    }
+
+    /// The same guard for a Sheet (#2501 de-guarded both Dialog and Sheet).
+    #[gpui::test]
+    fn selection_behind_active_sheet_is_excluded(cx: &mut TestAppContext) {
+        let (view, cx) = setup_synthetic(SelectionScope::Sheet, cx);
+        activate_sheet_scope(cx);
+
+        let from = view.read_with(cx, |v, cx| v.front.read(cx).bounds().center());
+        let to = view.read_with(cx, |v, cx| {
+            let b = v.behind.read(cx).bounds();
+            point(b.origin.x + px(4.), b.center().y)
+        });
+        drag(cx, from, to);
+
+        let behind = view.read_with(cx, |v, cx| v.behind.read(cx).selected_text());
+        assert!(
+            behind.trim().is_empty(),
+            "view behind the sheet overlay was selected: {behind:?}"
+        );
+    }
+
+    /// The scope filter must not over-exclude: content in the active modal scope
+    /// stays selectable.
+    #[gpui::test]
+    fn front_view_in_active_scope_is_selectable(cx: &mut TestAppContext) {
+        let (view, cx) = setup_synthetic(SelectionScope::Dialog(0), cx);
+        activate_dialog_scope(cx);
+
+        let b = view.read_with(cx, |v, cx| v.front.read(cx).bounds());
+        drag(
+            cx,
+            point(b.origin.x + px(1.), b.center().y),
+            point(b.origin.x + b.size.width + px(80.), b.center().y),
+        );
+
+        let front = view.read_with(cx, |v, cx| v.front.read(cx).selected_text());
+        assert!(
+            front.contains("Front"),
+            "active-scope content was not selectable: {front:?}"
         );
     }
 }

--- a/examples/dialog_overlay/src/main.rs
+++ b/examples/dialog_overlay/src/main.rs
@@ -20,12 +20,12 @@ impl HelloWorld {
         });
     }
 
-    fn show_drawer(&mut self, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
-        window.open_sheet(cx, move |drawer, _, _| {
-            drawer.title("Selectable Drawer").child(
+    fn show_sheet(&mut self, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
+        window.open_sheet(cx, move |sheet, _, _| {
+            sheet.title("Selectable Sheet").child(
                 TextView::markdown(
-                    "drawer-text",
-                    "Select **this** text, then drag the mouse *out of the drawer* over \
+                    "sheet-text",
+                    "Select **this** text, then drag the mouse *out of the sheet* over \
                      the paragraph behind it. The text behind must NOT get selected",
                 )
                 .selectable(true),
@@ -39,7 +39,7 @@ impl Render for HelloWorld {
         div()
             .bg(gpui::white())
             .size_full()
-            .child(TitleBar::new().child("dialog & Drawer"))
+            .child(TitleBar::new().child("Dialog & Sheet"))
             .child(
                 div()
                     .p_8()
@@ -58,18 +58,18 @@ impl Render for HelloWorld {
                             .child(
                                 Button::new("btn2")
                                     .outline()
-                                    .label("Open Drawer")
-                                    .on_click(cx.listener(Self::show_drawer)),
+                                    .label("Open Sheet")
+                                    .on_click(cx.listener(Self::show_sheet)),
                             ),
                     )
-                    // Selectable text behind the modals. Open a dialog/drawer,
+                    // Selectable text behind the modals. Open a dialog/sheet,
                     // select its text, drag the mouse out over this paragraph,
                     // and confirm this text is NOT selected.
                     .child(
                         TextView::markdown(
                             "behind-text",
                             "**Background text** behind the modals. While a dialog or \
-                             drawer is open, a selection started inside it must not \
+                             sheet is open, a selection started inside it must not \
                              extend onto this paragraph.",
                         )
                         .selectable(true),

--- a/examples/dialog_overlay/src/main.rs
+++ b/examples/dialog_overlay/src/main.rs
@@ -1,5 +1,5 @@
 use gpui::*;
-use gpui_component::{button::*, menu::ContextMenuExt, *};
+use gpui_component::{button::*, menu::ContextMenuExt, text::TextView, *};
 use gpui_component_assets::Assets;
 
 actions!(class_menu, [Open, Delete, Export, Info]);
@@ -9,13 +9,27 @@ pub struct HelloWorld;
 impl HelloWorld {
     fn show_dialog(&mut self, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
         window.open_dialog(cx, move |dialog, _, _| {
-            dialog.title("Test dialog").child("Hello from dialog!")
+            dialog.title("Selectable dialog").child(
+                TextView::markdown(
+                    "dialog-text",
+                    "Select **this** text, then drag the mouse *out of the dialog* over \
+                     the paragraph behind it. The text behind must NOT get selected",
+                )
+                .selectable(true),
+            )
         });
     }
 
     fn show_drawer(&mut self, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
         window.open_sheet(cx, move |drawer, _, _| {
-            drawer.title("Test Drawer").child("Hello from Drawer!")
+            drawer.title("Selectable Drawer").child(
+                TextView::markdown(
+                    "drawer-text",
+                    "Select **this** text, then drag the mouse *out of the drawer* over \
+                     the paragraph behind it. The text behind must NOT get selected",
+                )
+                .selectable(true),
+            )
         });
     }
 }
@@ -47,6 +61,18 @@ impl Render for HelloWorld {
                                     .label("Open Drawer")
                                     .on_click(cx.listener(Self::show_drawer)),
                             ),
+                    )
+                    // Selectable text behind the modals. Open a dialog/drawer,
+                    // select its text, drag the mouse out over this paragraph,
+                    // and confirm this text is NOT selected.
+                    .child(
+                        TextView::markdown(
+                            "behind-text",
+                            "**Background text** behind the modals. While a dialog or \
+                             drawer is open, a selection started inside it must not \
+                             extend onto this paragraph.",
+                        )
+                        .selectable(true),
                     )
                     .child(
                         div()


### PR DESCRIPTION
Closes #2518.

Each selectable `TextView` is now tagged with the modal layer it paints under, via a new `.selection_scope(scope)` element modifier that pushes/pops a scope during paint (mirroring the existing `text_view_state_stack` idiom). Window selection only considers views in the active layer — the topmost dialog, else the active sheet, else the base window — and is cleared when a modal opens/closes. Covers both `Dialog` and `Sheet`. 

| Before | After |
| - | - |
|  <img width="960" height="828" alt="Dialog1" src="https://github.com/user-attachments/assets/2e91c56b-558a-4e55-a05c-7a1bda241a77" /> | <img width="962" height="827" alt="Dialog2" src="https://github.com/user-attachments/assets/29b472fa-1ed8-4088-b300-4643bde88afa" /> |
| <img width="960" height="828" alt="Sheet1" src="https://github.com/user-attachments/assets/e59b5b6a-ddd8-42b9-a844-f316cb8f1dec" /> | <img width="962" height="827" alt="Sheet2" src="https://github.com/user-attachments/assets/b822fa9e-4042-479e-82a6-7d1fd857dc8f" /> |