### PR TITLE
table: Skip header column virtualization below a column-count threshold

### DIFF
--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -1473,6 +1473,15 @@ where
     ) -> (Range<usize>, Pixels) {
         let total_cols = self.col_groups.len();
 
+        // Virtualization pays off at very large column counts; below this
+        // threshold rendering every header cell is cheap, and skipping
+        // virtualization avoids scroll-time flicker from spacer/offset
+        // mismatches while panning horizontally.
+        const VIRTUALIZE_MIN_COLS: usize = 200;
+        if total_cols - left_columns_count <= VIRTUALIZE_MIN_COLS {
+            return (left_columns_count..total_cols, px(0.));
+        }
+
         if self.bounds.size.width == px(0.) {
             return (left_columns_count..total_cols, px(0.));
         }


### PR DESCRIPTION
## Problem

Since #2282, the table header virtualizes its leaf columns: off-screen header cells are replaced by spacer divs whose widths are recomputed from the horizontal scroll offset on each frame. While panning horizontally in a continuous gesture, the spacer widths and the scroll container's applied offset can briefly disagree, and the left-most rendered header cells visibly flicker in and out (the body rows, which use the virtual-list path, stay stable). Reproduced with a ~40-column `DataTable` on macOS, both native and gpui_web.

## Fix

Only virtualize the header when a table has more than 200 leaf columns. Below that, rendering every header cell is cheap (the virtualization was introduced for 1000+-column tables where `render_th`'s interactive elements drop FPS), and the non-virtualized path has no flicker.

This keeps the FPS win for very wide tables while removing the artifact for typical ones. A follow-up could fix the spacer/offset synchronization itself, at which point the threshold can go away — related history: #2030 attempted a header/scroll sync fix that was later reverted.

## Testing

- Verified the flicker reproduces on a 40-column table at the parent rev and disappears with this change (macOS, native + wasm).
- `cargo check -p gpui-component` passes; behavior above the threshold is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)