### PR TITLE
resizable: Avoid NaN panel sizes when total size is zero or non-finite

### DIFF
--- a/crates/ui/src/resizable/mod.rs
+++ b/crates/ui/src/resizable/mod.rs
@@ -310,7 +310,11 @@ impl ResizableState {
         }
 
         let container_size = self.container_size();
-        let total_size = px(self.sizes.iter().map(|s| s.as_f32()).sum::<f32>());
+        let total = self.sizes.iter().map(|s| s.as_f32()).sum::<f32>();
+        if !total.is_finite() || total <= 0. {
+            return;
+        }
+        let total_size = px(total);
 
         for i in 0..self.panels.len() {
             let size = self.sizes[i];


### PR DESCRIPTION
## Description

Fixes a potential `NaN` propagation in `ResizableState::adjust_to_container_size`.

When all panel sizes sum to `0` (e.g. before the first layout pass, or when panels were collapsed to zero), the `size / total_size` ratio becomes `NaN` (`0 / 0`), and every panel size gets poisoned with `NaN` values that then persist in the state and break subsequent resizing.

Now the adjustment is skipped when the total size is not finite or not positive, keeping the previous sizes until valid measurements are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)