### PR TITLE
highlighter: Fix markdown inline highlighting across list items

### DIFF
--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -4,7 +4,7 @@ Build Status [![Build Status](https://github.com/longbridge/gpui-component/actio
 
 Inline image mix: larger PNG avatars <img src="https://avatars.githubusercontent.com/u/5518" alt="Jason Lee avatar" width="32" height="32" /> and <img src="https://avatars.githubusercontent.com/u/28998859" alt="GitHub avatar" width="32" height="32" /> stay inside the same text flow, and another SVG badge ![Rust](https://rust-lang.org/static/images/rust-logo-blk.svg) should wrap with nearby text when the window is resized.
 
-This is first paragraph, there have **BOLD**, _italic_, and ~strikethrough~, `code` text [^1] [^2].
+This is first paragraph, there have **BOLD**, _italic_, and ~~strikethrough~~, `code` text [^1] [^2].
 
 This is an additional demonstration paragraph in English demonstrating more content for [Markdown GFM]. It includes various stylistic elements and plain text.
 
@@ -125,11 +125,11 @@ See the way the text is aligned, depending on the position of `':'`
 
 ### Bulleted List
 
-- Bullet 1, this is very long and needs to be wrapped to the next line, display should be wrapped to the next line as well.
+- Bullet 1, this is **very long** and needs to be wrapped to the next line, display should be wrapped to the next line as well.
   Continuation paragraph that should appear below.
-- Bullet 2, the second bullet item is also long and needs to be wrapped to the next line.
+- Bullet 2, the `second` bullet item is also long and needs to be wrapped to the next line.
   - Bullet 2.1
-    This is a deepth continuation paragraph.
+    This is a `deepth continuation` paragraph.
     - Bullet 2.1.1
       - Bullet 2.1.1.1
     - Bullet 2.1.2
@@ -138,7 +138,7 @@ See the way the text is aligned, depending on the position of `':'`
 
 - Bullet 3 `https://deepwiki.com/longbridge/gpui-component`
 - Bullet 4
-- `https://github.com/longbridge/gpui-component` Bullet 5 
+- `https://github.com/longbridge/gpui-component` Bullet 5
 - Bullet 6
 
 ### Numbered List

--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -136,10 +136,7 @@ See the way the text is aligned, depending on the position of `':'`
 
   - Bullet 2.2
 
-- Bullet 3 `https://deepwiki.com/longbridge/gpui-component`
-- Bullet 4
-- `https://github.com/longbridge/gpui-component` Bullet 5
-- Bullet 6
+- Bullet 3
 
 ### Numbered List
 

--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -136,7 +136,10 @@ See the way the text is aligned, depending on the position of `':'`
 
   - Bullet 2.2
 
-- Bullet 3
+- Bullet 3 `https://deepwiki.com/longbridge/gpui-component`
+- Bullet 4
+- `https://github.com/longbridge/gpui-component` Bullet 5 
+- Bullet 6
 
 ### Numbered List
 

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -1384,38 +1384,21 @@ $x = 1;
     #[test]
     #[cfg(feature = "tree-sitter-languages")]
     fn test_markdown_inline_code_spans_in_list_items() {
-        let markdown = r#"Implemented and committed in three groups:
-
-- `965e8f56 Track document render dirtiness`
-- `4040a99d Record document render dirty reasons`
-- `b0f607ab Detect EGL damage support`
-
-What changed:
-- Added per-document render dirty tracking while preserving current full-context rendering.
-- Added coarse dirty reasons: visual, layout, position, stacking, full.
-- Added tests for document-scoped dirty behavior and reason clearing.
-- Added EGL damage capability detection for buffer age and swap-with-damage function loading.
-- Started querying buffer age during present, but still uses plain `eglSwapBuffers`.
-"#;
+        let markdown = "- `one`\n- `two`\n- `three`\n\nLater `four`\n";
         let rope = Rope::from_str(markdown);
         let mut highlighter = SyntaxHighlighter::new("markdown");
         highlighter.update(None, &rope, None);
 
         let highlights = highlighter.match_styles(0..markdown.len());
-        for text in [
-            "965e8f56 Track document render dirtiness",
-            "4040a99d Record document render dirty reasons",
-            "b0f607ab Detect EGL damage support",
-            "eglSwapBuffers",
-        ] {
+        for text in ["one", "two", "three", "four"] {
             assert!(
                 has_highlight_covering(&highlights, markdown, text, "text.code.span"),
                 "{text:?} should be highlighted as a code span"
             );
         }
 
-        let prose_start = markdown.find("What changed:").unwrap();
-        let prose_end = prose_start + "What changed:".len();
+        let prose_start = markdown.find("Later").unwrap();
+        let prose_end = prose_start + "Later".len();
         assert!(
             !highlights.iter().any(|item| {
                 item.name.as_ref() == "text.code.span"

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -156,6 +156,12 @@ fn normalize_combined_injection_ranges(
     include_markdown_inline_separator_ranges(ranges)
 }
 
+/// Combined markdown inline injections are parsed as one tree with
+/// `set_included_ranges`. If we include only the inline nodes that contain
+/// trigger bytes, the parser sees those ranges as adjacent and can merge a
+/// closing backtick from one list item with an opening backtick from the next.
+/// Keeping the separator bytes between retained inline ranges preserves the
+/// original boundaries.
 fn include_markdown_inline_separator_ranges(
     ranges: Vec<tree_sitter::Range>,
 ) -> Vec<tree_sitter::Range> {

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -145,6 +145,56 @@ fn injection_ranges_within_limits(ranges: &[tree_sitter::Range]) -> bool {
         && injection_ranges_byte_count(ranges) <= MAX_INJECTION_BYTES
 }
 
+fn normalize_combined_injection_ranges(
+    language_name: &SharedString,
+    ranges: Vec<tree_sitter::Range>,
+) -> Vec<tree_sitter::Range> {
+    if language_name.as_ref() != "markdown_inline" || ranges.len() <= 1 {
+        return ranges;
+    }
+
+    include_markdown_inline_separator_ranges(ranges)
+}
+
+fn include_markdown_inline_separator_ranges(
+    ranges: Vec<tree_sitter::Range>,
+) -> Vec<tree_sitter::Range> {
+    let mut normalized = Vec::with_capacity(ranges.len().min(MAX_INJECTION_RANGES));
+    let mut byte_count = 0usize;
+    let mut previous_range: Option<tree_sitter::Range> = None;
+
+    for range in ranges {
+        let mut pending_ranges = Vec::with_capacity(2);
+        if let Some(previous) = previous_range {
+            if previous.end_byte < range.start_byte {
+                pending_ranges.push(tree_sitter::Range {
+                    start_byte: previous.end_byte,
+                    end_byte: range.start_byte,
+                    start_point: previous.end_point,
+                    end_point: range.start_point,
+                });
+            }
+        }
+        pending_ranges.push(range);
+
+        let pending_len = pending_ranges
+            .iter()
+            .map(injection_range_len)
+            .sum::<usize>();
+        if normalized.len().saturating_add(pending_ranges.len()) > MAX_INJECTION_RANGES
+            || byte_count.saturating_add(pending_len) > MAX_INJECTION_BYTES
+        {
+            break;
+        }
+
+        byte_count += pending_len;
+        normalized.extend(pending_ranges);
+        previous_range = Some(range);
+    }
+
+    normalized
+}
+
 fn should_include_injection_range(
     language_name: &SharedString,
     range: &tree_sitter::Range,
@@ -665,6 +715,10 @@ impl SyntaxHighlighter {
                 continue;
             }
             sort_ranges(&mut ranges);
+            ranges = normalize_combined_injection_ranges(&language_name, ranges);
+            if ranges.is_empty() {
+                continue;
+            }
             let old_tree = old_layer_trees
                 .get(&(language_name.clone(), ranges_cache_key(&ranges)))
                 .copied();
@@ -1324,6 +1378,51 @@ $x = 1;
                 .iter()
                 .all(|layer| layer.language_name.as_ref() != "markdown_inline"),
             "plain inline ranges should not create markdown_inline injection layers"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-languages")]
+    fn test_markdown_inline_code_spans_in_list_items() {
+        let markdown = r#"Implemented and committed in three groups:
+
+- `965e8f56 Track document render dirtiness`
+- `4040a99d Record document render dirty reasons`
+- `b0f607ab Detect EGL damage support`
+
+What changed:
+- Added per-document render dirty tracking while preserving current full-context rendering.
+- Added coarse dirty reasons: visual, layout, position, stacking, full.
+- Added tests for document-scoped dirty behavior and reason clearing.
+- Added EGL damage capability detection for buffer age and swap-with-damage function loading.
+- Started querying buffer age during present, but still uses plain `eglSwapBuffers`.
+"#;
+        let rope = Rope::from_str(markdown);
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        highlighter.update(None, &rope, None);
+
+        let highlights = highlighter.match_styles(0..markdown.len());
+        for text in [
+            "965e8f56 Track document render dirtiness",
+            "4040a99d Record document render dirty reasons",
+            "b0f607ab Detect EGL damage support",
+            "eglSwapBuffers",
+        ] {
+            assert!(
+                has_highlight_covering(&highlights, markdown, text, "text.code.span"),
+                "{text:?} should be highlighted as a code span"
+            );
+        }
+
+        let prose_start = markdown.find("What changed:").unwrap();
+        let prose_end = prose_start + "What changed:".len();
+        assert!(
+            !highlights.iter().any(|item| {
+                item.name.as_ref() == "text.code.span"
+                    && item.range.start <= prose_start
+                    && item.range.end >= prose_end
+            }),
+            "plain prose after the list should not be highlighted as a code span"
         );
     }
 

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -145,6 +145,17 @@ fn injection_ranges_within_limits(ranges: &[tree_sitter::Range]) -> bool {
         && injection_ranges_byte_count(ranges) <= MAX_INJECTION_BYTES
 }
 
+/// Combined markdown inline injections are parsed as one tree with
+/// `set_included_ranges`. If we include only the inline nodes that contain
+/// trigger bytes, the parser sees those ranges as adjacent and can merge a
+/// closing backtick from one list item with an opening backtick from the next.
+/// Re-inserting the separator bytes between retained inline ranges preserves
+/// the original boundaries.
+///
+/// The separator bytes count against the same `MAX_INJECTION_RANGES` /
+/// `MAX_INJECTION_BYTES` budget as the content ranges, so on a very large
+/// document the tail ranges may be dropped here even though `push_limited`
+/// already admitted them.
 fn normalize_combined_injection_ranges(
     language_name: &SharedString,
     ranges: Vec<tree_sitter::Range>,
@@ -153,18 +164,6 @@ fn normalize_combined_injection_ranges(
         return ranges;
     }
 
-    include_markdown_inline_separator_ranges(ranges)
-}
-
-/// Combined markdown inline injections are parsed as one tree with
-/// `set_included_ranges`. If we include only the inline nodes that contain
-/// trigger bytes, the parser sees those ranges as adjacent and can merge a
-/// closing backtick from one list item with an opening backtick from the next.
-/// Keeping the separator bytes between retained inline ranges preserves the
-/// original boundaries.
-fn include_markdown_inline_separator_ranges(
-    ranges: Vec<tree_sitter::Range>,
-) -> Vec<tree_sitter::Range> {
     let mut normalized = Vec::with_capacity(ranges.len().min(MAX_INJECTION_RANGES));
     let mut byte_count = 0usize;
     let mut previous_range: Option<tree_sitter::Range> = None;


### PR DESCRIPTION
### Problem

Markdown inline highlighting could break across list items. Code span highlighting could stop after the first list item, then apply to later plain text until another code span appeared.

### Solution

Preserve the separator text between combined markdown inline ranges before parsing them. This keeps each list item separated during highlighting. Added a regression test for code spans in markdown list items.

### Testing

- All highlighter tests (including a new one)
- Manual testing via `cargo run -p gpui-component-story --example markdown`

---

Implemented-by: Codex 5.5
Reviewed-by: Claude Opus 4.8