### PR TITLE
refactor(input): move LSP provider setters onto Lsp and privatize fields

### DIFF
--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -709,11 +709,19 @@ impl Example {
                 .placeholder("Enter your code here...");
 
             let lsp_store = Rc::new(lsp_store.clone());
-            editor.lsp.completion_provider = Some(lsp_store.clone());
-            editor.lsp.code_action_providers = vec![lsp_store.clone(), Rc::new(TextConvertor)];
-            editor.lsp.hover_provider = Some(lsp_store.clone());
-            editor.lsp.definition_provider = Some(lsp_store.clone());
-            editor.lsp.document_color_provider = Some(lsp_store.clone());
+            editor
+                .lsp
+                .set_completion_provider(Some(lsp_store.clone()), cx);
+            editor
+                .lsp
+                .set_code_action_providers(vec![lsp_store.clone(), Rc::new(TextConvertor)], cx);
+            editor.lsp.set_hover_provider(Some(lsp_store.clone()), cx);
+            editor
+                .lsp
+                .set_definition_provider(Some(lsp_store.clone()), cx);
+            editor
+                .lsp
+                .set_document_color_provider(Some(lsp_store.clone()), cx);
 
             editor
         });

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -137,7 +137,9 @@ impl Example {
 
             // Install the example range semantic tokens provider, alongside
             // the other LSP providers. It highlights TODO/FIXME/… markers.
-            input_state.lsp.semantic_tokens_provider = Some(Rc::new(MarkerHighlighter));
+            input_state
+                .lsp
+                .set_semantic_tokens_provider(Some(Rc::new(MarkerHighlighter)), cx);
 
             input_state
         });

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -87,6 +87,90 @@ impl Lsp {
 }
 
 impl InputState {
+    /// Set the LSP completion provider.
+    pub fn set_lsp_completion_provider(
+        &mut self,
+        provider: Option<Rc<dyn CompletionProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.completion_provider = provider;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the LSP hover provider.
+    pub fn set_lsp_hover_provider(
+        &mut self,
+        provider: Option<Rc<dyn HoverProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.hover_provider = provider;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the LSP definition provider.
+    pub fn set_lsp_definition_provider(
+        &mut self,
+        provider: Option<Rc<dyn DefinitionProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.definition_provider = provider;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the LSP document color provider.
+    pub fn set_lsp_document_color_provider(
+        &mut self,
+        provider: Option<Rc<dyn DocumentColorProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.document_color_provider = provider;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the LSP semantic tokens provider.
+    pub fn set_lsp_semantic_tokens_provider(
+        &mut self,
+        provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.semantic_tokens_provider = provider;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Replace all LSP code action providers.
+    pub fn set_lsp_code_action_providers(
+        &mut self,
+        providers: Vec<Rc<dyn CodeActionProvider>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.code_action_providers = providers;
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Clear all LSP code action providers.
+    pub fn clear_lsp_code_action_providers(&mut self, cx: &mut Context<Self>) {
+        self.lsp.code_action_providers.clear();
+        self._pending_update = true;
+        cx.notify();
+    }
+
+    /// Append an LSP code action provider.
+    pub fn push_lsp_code_action_provider(
+        &mut self,
+        provider: Rc<dyn CodeActionProvider>,
+        cx: &mut Context<Self>,
+    ) {
+        self.lsp.code_action_providers.push(provider);
+        self._pending_update = true;
+        cx.notify();
+    }
+
     pub(crate) fn hide_context_menu(&mut self, cx: &mut Context<Self>) {
         self.context_menu_content = None;
         self._context_menu_task = Task::ready(Ok(()));

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -24,23 +24,24 @@ pub use semantic_tokens::*;
 /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities
 pub struct Lsp {
     /// The completion provider.
-    pub completion_provider: Option<Rc<dyn CompletionProvider>>,
+    completion_provider: Option<Rc<dyn CompletionProvider>>,
     /// The code action providers.
-    pub code_action_providers: Vec<Rc<dyn CodeActionProvider>>,
+    code_action_providers: Vec<Rc<dyn CodeActionProvider>>,
     /// The hover provider.
-    pub hover_provider: Option<Rc<dyn HoverProvider>>,
+    hover_provider: Option<Rc<dyn HoverProvider>>,
     /// The definition provider.
-    pub definition_provider: Option<Rc<dyn DefinitionProvider>>,
+    definition_provider: Option<Rc<dyn DefinitionProvider>>,
     /// The document color provider.
-    pub document_color_provider: Option<Rc<dyn DocumentColorProvider>>,
+    document_color_provider: Option<Rc<dyn DocumentColorProvider>>,
     /// The range semantic tokens provider.
-    pub semantic_tokens_provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
+    semantic_tokens_provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
 
     document_colors: Vec<(lsp_types::Range, Hsla)>,
     /// Cached semantic tokens as absolute position ranges + theme token-type
     /// names. Color is resolved from the name at paint time so theme switches
     /// take effect without a refetch.
     semantic_tokens: Vec<(lsp_types::Range, SharedString)>,
+    pub(crate) pending_update: bool,
     _hover_task: Task<Result<()>>,
     _document_color_task: Task<()>,
     _semantic_tokens_task: Task<()>,
@@ -57,6 +58,7 @@ impl Default for Lsp {
             semantic_tokens_provider: None,
             document_colors: vec![],
             semantic_tokens: vec![],
+            pending_update: false,
             _hover_task: Task::ready(Ok(())),
             _document_color_task: Task::ready(()),
             _semantic_tokens_task: Task::ready(()),
@@ -84,93 +86,103 @@ impl Lsp {
         self._document_color_task = Task::ready(());
         self._semantic_tokens_task = Task::ready(());
     }
+
+    /// Whether a definition provider is set.
+    pub(crate) fn has_definition_provider(&self) -> bool {
+        self.definition_provider.is_some()
+    }
+
+    /// Whether any code action provider is set.
+    pub(crate) fn has_code_action_providers(&self) -> bool {
+        !self.code_action_providers.is_empty()
+    }
+
+    /// Set the completion provider.
+    pub fn set_completion_provider(
+        &mut self,
+        provider: Option<Rc<dyn CompletionProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.completion_provider = provider;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the hover provider.
+    pub fn set_hover_provider(
+        &mut self,
+        provider: Option<Rc<dyn HoverProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.hover_provider = provider;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the definition provider.
+    pub fn set_definition_provider(
+        &mut self,
+        provider: Option<Rc<dyn DefinitionProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.definition_provider = provider;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the document color provider.
+    pub fn set_document_color_provider(
+        &mut self,
+        provider: Option<Rc<dyn DocumentColorProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.document_color_provider = provider;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Set the semantic tokens provider.
+    pub fn set_semantic_tokens_provider(
+        &mut self,
+        provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.semantic_tokens_provider = provider;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Replace all code action providers.
+    pub fn set_code_action_providers(
+        &mut self,
+        providers: Vec<Rc<dyn CodeActionProvider>>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.code_action_providers = providers;
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Clear all code action providers.
+    pub fn clear_code_action_providers(&mut self, cx: &mut Context<InputState>) {
+        self.code_action_providers.clear();
+        self.pending_update = true;
+        cx.notify();
+    }
+
+    /// Append a code action provider.
+    pub fn push_code_action_provider(
+        &mut self,
+        provider: Rc<dyn CodeActionProvider>,
+        cx: &mut Context<InputState>,
+    ) {
+        self.code_action_providers.push(provider);
+        self.pending_update = true;
+        cx.notify();
+    }
 }
 
 impl InputState {
-    /// Set the LSP completion provider.
-    pub fn set_lsp_completion_provider(
-        &mut self,
-        provider: Option<Rc<dyn CompletionProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.completion_provider = provider;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Set the LSP hover provider.
-    pub fn set_lsp_hover_provider(
-        &mut self,
-        provider: Option<Rc<dyn HoverProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.hover_provider = provider;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Set the LSP definition provider.
-    pub fn set_lsp_definition_provider(
-        &mut self,
-        provider: Option<Rc<dyn DefinitionProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.definition_provider = provider;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Set the LSP document color provider.
-    pub fn set_lsp_document_color_provider(
-        &mut self,
-        provider: Option<Rc<dyn DocumentColorProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.document_color_provider = provider;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Set the LSP semantic tokens provider.
-    pub fn set_lsp_semantic_tokens_provider(
-        &mut self,
-        provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.semantic_tokens_provider = provider;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Replace all LSP code action providers.
-    pub fn set_lsp_code_action_providers(
-        &mut self,
-        providers: Vec<Rc<dyn CodeActionProvider>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.code_action_providers = providers;
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Clear all LSP code action providers.
-    pub fn clear_lsp_code_action_providers(&mut self, cx: &mut Context<Self>) {
-        self.lsp.code_action_providers.clear();
-        self._pending_update = true;
-        cx.notify();
-    }
-
-    /// Append an LSP code action provider.
-    pub fn push_lsp_code_action_provider(
-        &mut self,
-        provider: Rc<dyn CodeActionProvider>,
-        cx: &mut Context<Self>,
-    ) {
-        self.lsp.code_action_providers.push(provider);
-        self._pending_update = true;
-        cx.notify();
-    }
-
     pub(crate) fn hide_context_menu(&mut self, cx: &mut Context<Self>) {
         self.context_menu_content = None;
         self._context_menu_task = Task::ready(Ok(()));

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -432,7 +432,7 @@ pub struct InputState {
     /// A flag to indicate if we have a pending update to the text.
     ///
     /// If true, will call some update (for example LSP, Syntax Highlight) before render.
-    _pending_update: bool,
+    pub(super) _pending_update: bool,
     /// A flag to indicate if we should ignore the next completion event.
     pub(super) silent_replace_text: bool,
     /// A flag to indicate if we should emit InputEvents.

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -432,7 +432,7 @@ pub struct InputState {
     /// A flag to indicate if we have a pending update to the text.
     ///
     /// If true, will call some update (for example LSP, Syntax Highlight) before render.
-    pub(super) _pending_update: bool,
+    _pending_update: bool,
     /// A flag to indicate if we should ignore the next completion event.
     pub(super) silent_replace_text: bool,
     /// A flag to indicate if we should emit InputEvents.
@@ -1644,8 +1644,8 @@ impl InputState {
             }
 
             let is_enable = !self.disabled;
-            let has_goto_definition = is_enable && self.lsp.definition_provider.is_some();
-            let has_code_action = is_enable && !self.lsp.code_action_providers.is_empty();
+            let has_goto_definition = is_enable && self.lsp.has_definition_provider();
+            let has_code_action = is_enable && self.lsp.has_code_action_providers();
             let is_selected = !self.selected_range.is_empty();
             let has_paste = is_enable && cx.read_from_clipboard().is_some();
 
@@ -2708,6 +2708,12 @@ impl InputState {
     ) {
         // No-op
     }
+
+    /// Whether there is a pending update to the text or the LSP providers,
+    /// that should be applied before the next render.
+    fn has_pending_update(&self) -> bool {
+        self._pending_update || self.lsp.pending_update
+    }
 }
 
 impl EntityInputHandler for InputState {
@@ -3023,17 +3029,21 @@ impl Focusable for InputState {
 
 impl Render for InputState {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if self._pending_update {
-            let bg = self
-                .mode
-                .update_highlighter(&(0..0), &self.text, &self.text, "", false, cx);
-            if let Some(bg) = bg {
-                Self::dispatch_background_parse(bg, window, cx);
+        if self.has_pending_update() {
+            if self._pending_update {
+                let bg =
+                    self.mode
+                        .update_highlighter(&(0..0), &self.text, &self.text, "", false, cx);
+                if let Some(bg) = bg {
+                    Self::dispatch_background_parse(bg, window, cx);
+                }
+
+                self.update_fold_candidates();
             }
 
-            self.update_fold_candidates();
             self.lsp.update(&self.text, window, cx);
             self._pending_update = false;
+            self.lsp.pending_update = false;
         }
 
         div()

--- a/crates/ui/src/inspector.rs
+++ b/crates/ui/src/inspector.rs
@@ -99,7 +99,9 @@ impl DivInspector {
                     hard_tabs: false,
                 });
 
-            editor.lsp.completion_provider = Some(lsp_provider.clone());
+            editor
+                .lsp
+                .set_completion_provider(Some(lsp_provider.clone()), cx);
             editor
         });
 


### PR DESCRIPTION
## Summary

Privatize the provider fields on `Lsp` and expose them through setters on `Lsp` itself, so runtime provider changes reliably trigger an LSP refresh.

- Move the `set_lsp_*` methods off `InputState` and onto `Lsp`, renamed to `set_completion_provider`, `set_hover_provider`, `set_definition_provider`, `set_document_color_provider`, `set_semantic_tokens_provider`, `set_code_action_providers`, `clear_code_action_providers`, `push_code_action_provider`.
- Make the provider fields private and add a `pending_update` flag on `Lsp`. Each setter sets it and calls `cx.notify()`.
- `InputState::render` now checks a single `has_pending_update()` (text or LSP) and refreshes the LSP when a provider changed, then clears both flags.
- Add `has_definition_provider()` / `has_code_action_providers()` helpers for the private fields.
- Migrate `inspector.rs` and the `editor` / `markdown` story examples to the setters.

## Breaking Changes

The provider fields on `Lsp` are now private. You can no longer assign them directly. Use the setters on `input_state.lsp` instead, which also mark the state dirty so the LSP refreshes on the next render.

Before:

```rust
input_state.lsp.completion_provider = Some(provider);
input_state.lsp.code_action_providers = vec![provider];
input_state.lsp.semantic_tokens_provider = Some(provider);
```

After:

```rust
input_state.lsp.set_completion_provider(Some(provider), cx);
input_state.lsp.set_code_action_providers(vec![provider], cx);
input_state.lsp.set_semantic_tokens_provider(Some(provider), cx);
```

Setters: `set_completion_provider`, `set_hover_provider`, `set_definition_provider`, `set_document_color_provider`, `set_semantic_tokens_provider`, `set_code_action_providers`, `clear_code_action_providers`, `push_code_action_provider`.

## Notes

AI-assisted refactor, reviewed and adjusted to match project style.