### PR TITLE
settings: Improves sidebar/resizable behavior in the settings UI.

### DIFF
--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -48,7 +48,7 @@ impl Settings {
             group_variant: GroupBoxVariant::default(),
             size: Size::default(),
             sidebar_width: px(250.0),
-            sidebar_size_range: px(200.0)..px(360.0),
+            sidebar_size_range: px(160.0)..px(360.0),
             sidebar_style: StyleRefinement::default(),
             default_selected_index: SelectIndex::default(),
             header_style: StyleRefinement::default(),
@@ -61,7 +61,7 @@ impl Settings {
         self
     }
 
-    /// Set the resize range of the sidebar, default is `200px..360px`.
+    /// Set the resize range of the sidebar, default is `160px..360px`.
     pub fn sidebar_size_range(mut self, range: impl Into<Range<Pixels>>) -> Self {
         self.sidebar_size_range = range.into();
         self

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use crate::{
     IconName, Sizable, Size, StyledExt,
     group_box::GroupBoxVariant,
@@ -31,6 +33,7 @@ pub struct Settings {
     group_variant: GroupBoxVariant,
     size: Size,
     sidebar_width: Pixels,
+    sidebar_size_range: Range<Pixels>,
     sidebar_style: StyleRefinement,
     default_selected_index: SelectIndex,
     header_style: StyleRefinement,
@@ -45,6 +48,7 @@ impl Settings {
             group_variant: GroupBoxVariant::default(),
             size: Size::default(),
             sidebar_width: px(250.0),
+            sidebar_size_range: px(200.0)..px(360.0),
             sidebar_style: StyleRefinement::default(),
             default_selected_index: SelectIndex::default(),
             header_style: StyleRefinement::default(),
@@ -54,6 +58,12 @@ impl Settings {
     /// Set the width of the sidebar, default is `250px`.
     pub fn sidebar_width(mut self, width: impl Into<Pixels>) -> Self {
         self.sidebar_width = width.into();
+        self
+    }
+
+    /// Set the resize range of the sidebar, default is `200px..360px`.
+    pub fn sidebar_size_range(mut self, range: impl Into<Range<Pixels>>) -> Self {
+        self.sidebar_size_range = range.into();
         self
     }
 
@@ -283,11 +293,13 @@ impl RenderOnce for Settings {
             layout: Axis::Horizontal,
             disabled: false,
         };
+        let sidebar_size_range = self.sidebar_size_range.clone();
 
         h_resizable(self.id.clone())
             .child(
                 resizable_panel()
                     .size(self.sidebar_width)
+                    .size_range(sidebar_size_range)
                     .child(self.render_sidebar(&state, &filtered_pages, window, cx)),
             )
             .child(resizable_panel().child(self.render_active_page(

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -428,6 +428,7 @@ impl<E: SidebarItem> RenderOnce for Sidebar<E> {
                 this.child(
                     h_flex()
                         .id("header")
+                        .min_w_0()
                         .pt_3()
                         .px_3()
                         .gap_2()

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -428,7 +428,6 @@ impl<E: SidebarItem> RenderOnce for Sidebar<E> {
                 this.child(
                     h_flex()
                         .id("header")
-                        .min_w_0()
                         .pt_3()
                         .px_3()
                         .gap_2()


### PR DESCRIPTION
## Description

This PR improves sidebar/resizable behavior in the settings UI and update 'pathfinder_simd' to fix existing compilation errors..

Changes: 
- Added Settings::sidebar_width_range(...) so settings sidebar resize limits can be configured by callers.
- Added a default settings sidebar width range of 200px..360px.
- Applied the width range to the settings sidebar resizable panel.
- Fixed narrow-sidebar layout behavior by allowing sidebar/header/menu/input flex containers to shrink correctly with min_w_0().
- Ensured the settings search input fills the available header width with w_full().
- Update 'pathfinder_simd' to fix existing compilation errors.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="236" height="560" alt="截屏2026-07-06 20 50 58" src="https://github.com/user-attachments/assets/0942dda2-ac7d-4032-b818-58cf41f54867" /> | <img width="416" height="604" alt="截屏2026-07-06 21 09 40" src="https://github.com/user-attachments/assets/e5657035-5bd1-4901-97f2-ba131a9001e0" /> |

## Break Changes

Update 'pathfinder_simd' to fix existing compilation errors.

- Change 1

```
[[package]]
  name = "pathfinder_simd"
- version = "0.5.5"
+ version = "0.5.6"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+ checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
]
```

## How to Test

```
cargo run -r
```

Check the settings page and drag the resizable handle.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
