### PR TITLE
slider: Support `reverse` to fill the track from thumb to max end

### DIFF
--- a/crates/story/src/stories/slider_story.rs
+++ b/crates/story/src/stories/slider_story.rs
@@ -26,6 +26,7 @@ pub struct SliderStory {
     slider_hsl_value: Hsla,
     slider4: Entity<SliderState>,
     slider_logarithmic: Entity<SliderState>,
+    slider_reverse: Entity<SliderState>,
     disabled: bool,
     _subscritions: Vec<Subscription>,
 }
@@ -121,6 +122,14 @@ impl SliderStory {
                 .scale(SliderScale::Logarithmic)
         });
 
+        let slider_reverse = cx.new(|_| {
+            SliderState::new()
+                .min(0.)
+                .max(10.)
+                .step(1.)
+                .default_value(5.)
+        });
+
         let mut _subscritions = vec![
             cx.subscribe(&slider1, |this, _, event: &SliderEvent, cx| match event {
                 SliderEvent::Change(value) => {
@@ -185,6 +194,7 @@ impl SliderStory {
             slider_hsl,
             slider_hsl_value: gpui::red(),
             slider_logarithmic,
+            slider_reverse,
             disabled: false,
             _subscritions,
         }
@@ -242,6 +252,21 @@ impl Render for SliderStory {
                     .child(Slider::new(&self.slider3).disabled(self.disabled))
                     .child(format!("Value: {}", self.slider3.read(cx).value()))
                     .child(format!("Released: {}", self.slider3_released_value)),
+            )
+            .child(
+                section("Reverse Slider (fill thumb..max, e.g. time remaining)")
+                    .max_w_md()
+                    .v_flex()
+                    .child(
+                        Slider::new(&self.slider_reverse)
+                            .horizontal()
+                            .reverse()
+                            .disabled(self.disabled),
+                    )
+                    .child(format!(
+                        "Remaining: {}",
+                        10. - self.slider_reverse.read(cx).value().start()
+                    )),
             )
             .child(
                 section("Vertical with Range")

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -415,6 +415,7 @@ pub struct Slider {
     axis: Axis,
     style: StyleRefinement,
     disabled: bool,
+    reverse: bool,
 }
 
 impl Slider {
@@ -425,6 +426,7 @@ impl Slider {
             state: state.clone(),
             style: StyleRefinement::default(),
             disabled: false,
+            reverse: false,
         }
     }
 
@@ -443,6 +445,20 @@ impl Slider {
     /// Set the disabled state of the slider, default: false
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Reverse the filled (highlighted) side of the track, default: false.
+    ///
+    /// By default the track is filled from the min end to the thumb. With
+    /// `reverse`, the fill goes from the thumb to the max end instead — useful
+    /// when the slider represents a remaining amount (e.g. time left).
+    ///
+    /// This only changes the visual fill; values, events and interactions are
+    /// unaffected. It applies to single-value sliders and is ignored for
+    /// range sliders.
+    pub fn reverse(mut self) -> Self {
+        self.reverse = true;
         self
     }
 
@@ -534,8 +550,12 @@ impl RenderOnce for Slider {
         let state = self.state.read(cx);
         let is_range = state.value().is_range();
         let percentage = state.percentage.clone();
-        let bar_start = relative(percentage.start);
-        let bar_end = relative(1. - percentage.end);
+        let (bar_start, bar_end) = if self.reverse && !is_range {
+            // Fill from the thumb to the max end (remaining side).
+            (relative(percentage.end), relative(0.))
+        } else {
+            (relative(percentage.start), relative(1. - percentage.end))
+        };
         let rem_size = window.rem_size();
 
         let bar_color = self


### PR DESCRIPTION
## Description

Adds a `reverse()` builder method to `Slider`. By default the track is filled from the min end to the thumb; with `reverse`, the fill goes from the thumb to the max end instead — useful when the slider represents a remaining amount (e.g. time left in a media player).

```rust
Slider::new(&state).horizontal().reverse()
```

This only changes the visual fill; values, events and interactions are unaffected. It applies to single-value sliders and is ignored for range sliders (a range slider's fill is already bounded by both thumbs).

Also adds a "Reverse Slider" section to the slider story to showcase the new option.

No breaking changes.

<img width="1642" height="1106" alt="image" src="https://github.com/user-attachments/assets/c107d7e3-9856-4d27-a3c2-360d2d7ac0df" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)