### PR TITLE
input: Allow to set selection for input

### DIFF
--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1242,24 +1242,6 @@ impl InputState {
         self.focus(window, cx);
     }
 
-    /// Set the selected range using UTF-8 byte offsets.
-    pub fn set_selected_range(
-        &mut self,
-        range: Range<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let len = self.text.len();
-        let start = range.start.min(len);
-        let end = range.end.min(len);
-
-        self.move_to(start, None, cx);
-        self.selection_reversed = false;
-        self.selected_word_range = None;
-        self.select_to(end, cx);
-        self.focus(window, cx);
-    }
-
     /// Focus the input field.
     pub fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         self.focus_handle.focus(window, cx);
@@ -2163,6 +2145,18 @@ impl InputState {
     /// in the underlying rope's byte units.
     pub fn selected_range(&self) -> std::ops::Range<usize> {
         self.selected_range.into()
+    }
+
+    /// Set the selected range using UTF-8 byte offsets.
+    pub fn set_selected_range(&mut self, range: Range<usize>, cx: &mut Context<Self>) {
+        let len = self.text.len();
+        let start = range.start.min(len);
+        let end = range.end.min(len);
+
+        self.move_to(start, None, cx);
+        self.selection_reversed = false;
+        self.selected_word_range = None;
+        self.select_to(end, cx);
     }
 
     pub(crate) fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
@@ -3801,17 +3795,17 @@ ORDER BY id
         let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
         let input = input_view.input;
 
-        cx.update(|window, cx| {
+        cx.update(|_, cx| {
             input.update(cx, |s, cx| {
-                s.set_selected_range(0..5, window, cx);
+                s.set_selected_range(0..5, cx);
                 assert_eq!(s.selected_range(), 0..5);
                 assert_eq!(s.selected_text().to_string(), "hello");
 
-                s.set_selected_range(6..11, window, cx);
+                s.set_selected_range(6..11, cx);
                 assert_eq!(s.selected_text().to_string(), "world");
 
                 // clamped + collapsed
-                s.set_selected_range(100..100, window, cx);
+                s.set_selected_range(100..100, cx);
                 assert_eq!(s.selected_range(), 11..11);
             });
         });

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1242,27 +1242,22 @@ impl InputState {
         self.focus(window, cx);
     }
 
-    /// Set the selection to the given UTF-8 byte range.
-    pub fn set_selection(
+    /// Set the selected range using UTF-8 byte offsets.
+    pub fn set_selected_range(
         &mut self,
-        start: usize,
-        end: usize,
+        range: Range<usize>,
         window: &mut Window,
-        cx: &mut Context<Self>
+        cx: &mut Context<Self>,
     ) {
         let len = self.text.len();
-        let start = start.clamp(0, len);
-        let end: usize = end.clamp(0, len);
+        let start = range.start.min(len);
+        let end = range.end.min(len);
 
         self.move_to(start, None, cx);
         self.selection_reversed = false;
+        self.selected_word_range = None;
         self.select_to(end, cx);
         self.focus(window, cx);
-    }
-
-    /// Return the current selection as a UTF-8 byte range.
-    pub fn selection(&self) -> Range<usize> {
-        self.selected_range.into()
     }
 
     /// Focus the input field.
@@ -3801,23 +3796,23 @@ ORDER BY id
     }
 
     #[gpui::test]
-    fn test_set_selection(cx: &mut TestAppContext) {
+    fn test_set_selected_range(cx: &mut TestAppContext) {
         let input_view = InputView::build(cx, |state| state.default_value("hello world"));
         let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
         let input = input_view.input;
 
         cx.update(|window, cx| {
             input.update(cx, |s, cx| {
-                s.set_selection(0, 5, window, cx);
-                assert_eq!(s.selection(), 0..5);
+                s.set_selected_range(0..5, window, cx);
+                assert_eq!(s.selected_range(), 0..5);
                 assert_eq!(s.selected_text().to_string(), "hello");
 
-                s.set_selection(6, 11, window, cx);
+                s.set_selected_range(6..11, window, cx);
                 assert_eq!(s.selected_text().to_string(), "world");
 
                 // clamped + collapsed
-                s.set_selection(100, 100, window, cx);
-                assert_eq!(s.selection(), 11..11);
+                s.set_selected_range(100..100, window, cx);
+                assert_eq!(s.selected_range(), 11..11);
             });
         });
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1242,6 +1242,29 @@ impl InputState {
         self.focus(window, cx);
     }
 
+    /// Set the selection to the given UTF-8 byte range.
+    pub fn set_selection(
+        &mut self,
+        start: usize,
+        end: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>
+    ) {
+        let len = self.text.len();
+        let start = start.clamp(0, len);
+        let end: usize = end.clamp(0, len);
+
+        self.move_to(start, None, cx);
+        self.selection_reversed = false;
+        self.select_to(end, cx);
+        self.focus(window, cx);
+    }
+
+    /// Return the current selection as a UTF-8 byte range.
+    pub fn selection(&self) -> Range<usize> {
+        self.selected_range.into()
+    }
+
     /// Focus the input field.
     pub fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         self.focus_handle.focus(window, cx);
@@ -3773,6 +3796,28 @@ ORDER BY id
                     state._pending_update,
                     "replace_all on a code editor should request a pending update"
                 );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_selection(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state.default_value("hello world"));
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |s, cx| {
+                s.set_selection(0, 5, window, cx);
+                assert_eq!(s.selection(), 0..5);
+                assert_eq!(s.selected_text().to_string(), "hello");
+
+                s.set_selection(6, 11, window, cx);
+                assert_eq!(s.selected_text().to_string(), "world");
+
+                // clamped + collapsed
+                s.set_selection(100, 100, window, cx);
+                assert_eq!(s.selection(), 11..11);
             });
         });
     }


### PR DESCRIPTION
Closes #2544

## Description

PR to solve selection update on editor component.

## Screenshot


## Break Changes

No breaking changes

## How to Test

Execute test crates/ui/src/input/state.rs - test_set_selection

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] _Tested macOS_ 
- [ ] , Windows and Linux platforms performance (if the change is platform-specific)
