### PR TITLE
input: Refactor wrap cache to SumTree and skip foreground parsing on large files

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -470,6 +470,15 @@ impl SyntaxHighlighter {
         self.tree.as_ref()
     }
 
+    /// Apply only the structural `edit` to the existing tree and update the stored text,
+    /// without re-parsing.
+    pub fn edit_tree(&mut self, edit: Option<InputEdit>, text: &Rope) {
+        if let (Some(edit), Some(tree)) = (edit, self.tree.as_mut()) {
+            tree.edit(&edit);
+        }
+        self.text = text.clone();
+    }
+
     /// Returns the language name for this highlighter.
     pub fn language(&self) -> &SharedString {
         &self.language

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -37,6 +37,10 @@ impl SyntaxHighlighter {
         true
     }
 
+    pub fn edit_tree(&mut self, _edit: Option<crate::input::InputEdit>, _text: &ropey::Rope) {
+        // No-op in WASM
+    }
+
     pub fn language(&self) -> &SharedString {
         static EMPTY: SharedString = SharedString::new_static("");
         &EMPTY

--- a/crates/ui/src/input/display_map/display_map.rs
+++ b/crates/ui/src/input/display_map/display_map.rs
@@ -14,9 +14,9 @@ use super::folding::FoldRange;
 use super::text_wrapper::{LineItem, WrapDisplayPoint};
 use super::wrap_map::WrapMap;
 use super::{BufferPoint, DisplayPoint};
+use crate::input::Point as TreeSitterPoint;
 use crate::input::display_map::WrapPoint;
 use crate::input::rope_ext::RopeExt as _;
-use crate::input::Point as TreeSitterPoint;
 
 /// DisplayMap is the main interface for Editor/Input coordinate mapping.
 ///
@@ -113,6 +113,18 @@ impl DisplayMap {
     #[inline]
     pub fn is_buffer_line_hidden(&self, line: usize) -> bool {
         self.buffer_line_to_display_row_range(line).is_none()
+    }
+
+    /// First display row of a buffer line. If the line is fully folded, returns the
+    /// nearest visible display row.
+    pub fn buffer_line_to_display_row(&self, line: usize) -> usize {
+        match self.buffer_line_to_display_row_range(line) {
+            Some(range) => range.start,
+            None => {
+                let wrap_row = self.wrap_map.buffer_line_to_first_wrap_row(line);
+                self.fold_map.nearest_visible_display_row(wrap_row)
+            }
+        }
     }
 
     /// Set fold candidates (from tree-sitter/LSP)
@@ -269,10 +281,7 @@ impl DisplayMap {
 
     /// Convert wrap display point to TreeSitterPoint (buffer line/col).
     #[inline]
-    pub(crate) fn wrap_display_point_to_point(
-        &self,
-        point: WrapDisplayPoint,
-    ) -> TreeSitterPoint {
+    pub(crate) fn wrap_display_point_to_point(&self, point: WrapDisplayPoint) -> TreeSitterPoint {
         self.wrap_map.wrapper().display_point_to_point(point)
     }
 
@@ -298,15 +307,15 @@ impl DisplayMap {
     /// Get the longest row index (by byte length).
     #[inline]
     pub(crate) fn longest_row(&self) -> usize {
-        self.wrap_map.wrapper().longest_row.row
+        self.wrap_map.wrapper().longest_row()
     }
 
     // ==================== Access Methods ====================
 
-    /// Get access to line items (for rendering)
+    /// Get the line item by buffer row index.
     #[inline]
-    pub(crate) fn lines(&self) -> &[LineItem] {
-        self.wrap_map.lines()
+    pub(crate) fn line(&self, row: usize) -> Option<&LineItem> {
+        self.wrap_map.line(row)
     }
 
     /// Get the rope text

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -1,31 +1,31 @@
-use std::ops::Range;
 use gpui::Half;
+use std::ops::Range;
 
 use gpui::{
-    App, Font, LineFragment, Pixels, Point, ShapedLine, Size, TextAlign, Window, point, px,
-    size,
+    App, Font, LineFragment, Pixels, Point, ShapedLine, Size, TextAlign, Window, point, px, size,
 };
 use ropey::Rope;
 use smallvec::SmallVec;
+use sum_tree::{Bias, Dimensions, SumTree};
 
 use crate::input::{LastLayout, Point as TreeSitterPoint, RopeExt, WhitespaceIndicators};
 
 /// A line with soft wrapped lines info.
 #[derive(Debug, Clone)]
 pub(crate) struct LineItem {
-    /// The original line text, without end `\n`.
-    line: Rope,
-    /// The soft wrapped lines relative byte range (0..line.len) of this line (Include first line).
+    /// The byte length of the line, without the end `\n`.
+    len: usize,
+    /// The soft wrapped lines relative byte range (0..len) of this line (Include first line).
     ///
     /// Not contains the line end `\n`.
-    pub(crate) wrapped_lines: Vec<Range<usize>>,
+    pub(crate) wrapped_lines: SmallVec<[Range<usize>; 1]>,
 }
 
 impl LineItem {
     /// Get the bytes length of this line.
     #[inline]
     pub(crate) fn len(&self) -> usize {
-        self.line.len()
+        self.len
     }
 
     /// Get number of soft wrapped lines of this line (include the first line).
@@ -35,12 +35,86 @@ impl LineItem {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct LongestRow {
-    /// The 0-based row index.
-    pub row: usize,
-    /// The bytes length of the longest line.
-    pub len: usize,
+/// Summary of a subtree of [`LineItem`]s, maintained incrementally by the [`SumTree`].
+#[derive(Debug, Clone)]
+pub(crate) struct LineSummary {
+    /// Number of buffer lines.
+    buffer_rows: usize,
+    /// Number of wrap rows (sum of each line's `lines_len()`).
+    wrap_rows: usize,
+    /// Sum of byte lengths of the buffer lines (without the trailing `\n`).
+    bytes: usize,
+    /// Byte length of the longest line in this subtree.
+    max_line_len: usize,
+    /// Buffer row (relative to this subtree) of the first line achieving `max_line_len`.
+    longest_row: usize,
+}
+
+impl sum_tree::Summary for LineSummary {
+    type Context<'a> = &'a ();
+
+    fn zero(_: &()) -> Self {
+        LineSummary {
+            buffer_rows: 0,
+            wrap_rows: 0,
+            bytes: 0,
+            max_line_len: 0,
+            longest_row: 0,
+        }
+    }
+
+    fn add_summary(&mut self, other: &Self, _: &()) {
+        // Keep the leftmost row that achieves a strictly greater length
+        if other.max_line_len > self.max_line_len {
+            self.longest_row = self.buffer_rows + other.longest_row;
+            self.max_line_len = other.max_line_len;
+        }
+        self.buffer_rows += other.buffer_rows;
+        self.wrap_rows += other.wrap_rows;
+        self.bytes += other.bytes;
+    }
+}
+
+impl sum_tree::Item for LineItem {
+    type Summary = LineSummary;
+
+    fn summary(&self, _: &()) -> LineSummary {
+        LineSummary {
+            buffer_rows: 1,
+            wrap_rows: self.lines_len(),
+            bytes: self.len(),
+            max_line_len: self.len(),
+            longest_row: 0,
+        }
+    }
+}
+
+/// Cursor dimension counting buffer rows.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct BufferRows(pub usize);
+
+impl<'a> sum_tree::Dimension<'a, LineSummary> for BufferRows {
+    fn zero(_: &()) -> Self {
+        BufferRows(0)
+    }
+
+    fn add_summary(&mut self, summary: &'a LineSummary, _: &()) {
+        self.0 += summary.buffer_rows;
+    }
+}
+
+/// Cursor dimension counting wrap rows.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct WrapRows(pub usize);
+
+impl<'a> sum_tree::Dimension<'a, LineSummary> for WrapRows {
+    fn zero(_: &()) -> Self {
+        WrapRows(0)
+    }
+
+    fn add_summary(&mut self, summary: &'a LineSummary, _: &()) {
+        self.0 += summary.wrap_rows;
+    }
 }
 
 /// Used to prepare the text with soft wrap to be get lines to displayed in the Editor.
@@ -48,16 +122,12 @@ pub(crate) struct LongestRow {
 /// After use lines to calculate the scroll size of the Editor.
 pub(crate) struct TextWrapper {
     text: Rope,
-    /// Total wrapped lines (Inlucde the first line), value is start and end index of the line.
-    soft_lines: usize,
     font: Font,
     font_size: Pixels,
     /// If is none, it means the text is not wrapped
     wrap_width: Option<Pixels>,
-    /// The longest (row, bytes len) in characters, used to calculate the horizontal scroll width.
-    pub(crate) longest_row: LongestRow,
     /// The lines by split \n
-    pub(crate) lines: Vec<LineItem>,
+    pub(crate) lines: SumTree<LineItem>,
 
     _initialized: bool,
 }
@@ -70,9 +140,7 @@ impl TextWrapper {
             font,
             font_size,
             wrap_width,
-            soft_lines: 0,
-            longest_row: LongestRow::default(),
-            lines: Vec::new(),
+            lines: SumTree::new(&()),
             _initialized: false,
         }
     }
@@ -91,13 +159,60 @@ impl TextWrapper {
     /// Get the total number of lines including wrapped lines.
     #[inline]
     pub(crate) fn len(&self) -> usize {
-        self.soft_lines
+        self.lines.summary().wrap_rows
     }
 
-    /// Get the line item by row index.
+    /// Get the total number of buffer lines.
+    #[inline]
+    pub(crate) fn lines_count(&self) -> usize {
+        self.lines.summary().buffer_rows
+    }
+
+    /// Get the 0-based row index of the longest line (by byte length).
+    #[inline]
+    pub(crate) fn longest_row(&self) -> usize {
+        self.lines.summary().longest_row
+    }
+
+    /// Get the line item by buffer row index.
     #[inline]
     pub(crate) fn line(&self, row: usize) -> Option<&LineItem> {
-        self.lines.iter().skip(row).next()
+        let mut cursor = self.lines.cursor::<BufferRows>(&());
+        cursor.seek(&BufferRows(row), Bias::Right);
+        cursor.item()
+    }
+
+    /// Iterate buffer lines in order.
+    #[inline]
+    pub(crate) fn iter_lines(&self) -> impl Iterator<Item = &LineItem> {
+        self.lines.iter()
+    }
+
+    /// First wrap row of buffer line `row`. Returns the total wrap row count if `row` is
+    /// out of range.
+    pub(crate) fn buffer_line_to_first_wrap_row(&self, row: usize) -> usize {
+        let mut cursor = self.lines.cursor::<Dimensions<BufferRows, WrapRows>>(&());
+        cursor.seek(&BufferRows(row), Bias::Right);
+        cursor.start().1.0
+    }
+
+    /// Wrap row range of buffer line `row`.
+    pub(crate) fn buffer_line_to_wrap_row_range(&self, row: usize) -> Range<usize> {
+        let mut cursor = self.lines.cursor::<Dimensions<BufferRows, WrapRows>>(&());
+        cursor.seek(&BufferRows(row), Bias::Right);
+        let start = cursor.start().1.0;
+        let len = cursor.item().map(|l| l.lines_len()).unwrap_or(0);
+        start..start + len
+    }
+
+    /// Buffer line containing wrap row `wrap_row`, clamped to the last line.
+    pub(crate) fn wrap_row_to_buffer_line(&self, wrap_row: usize) -> usize {
+        let mut cursor = self.lines.cursor::<Dimensions<WrapRows, BufferRows>>(&());
+        cursor.seek(&WrapRows(wrap_row), Bias::Right);
+        match cursor.item() {
+            Some(_) => cursor.start().1.0,
+            None => self.lines_count().saturating_sub(1),
+        }
     }
 
     pub(crate) fn set_wrap_width(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
@@ -169,18 +284,11 @@ impl TextWrapper {
         F: FnMut(&str, Pixels) -> Vec<gpui::Boundary>,
     {
         // Remove the old changed lines.
+        let buffer_line_count = self.lines_count();
         let start_row = self.text.offset_to_point(range.start).row;
-        let start_row = start_row.min(self.lines.len().saturating_sub(1));
+        let start_row = start_row.min(buffer_line_count.saturating_sub(1));
         let end_row = self.text.offset_to_point(range.end).row;
-        let end_row = end_row.min(self.lines.len().saturating_sub(1));
-        let rows_range = start_row..=end_row;
-
-        if rows_range.contains(&self.longest_row.row) {
-            self.longest_row = LongestRow::default();
-        }
-
-        let mut longest_row_ix = self.longest_row.row;
-        let mut longest_row_len = self.longest_row.len;
+        let end_row = end_row.min(buffer_line_count.saturating_sub(1));
 
         // To add the new lines.
         let new_start_row = changed_text.offset_to_point(range.start).row;
@@ -195,18 +303,10 @@ impl TextWrapper {
         let wrap_width = self.wrap_width;
 
         // line not contains `\n`.
-        for (ix, line) in Rope::from(changed_text.slice(new_range))
-            .iter_lines()
-            .enumerate()
-        {
+        for line in Rope::from(changed_text.slice(new_range)).iter_lines() {
             let line_str = line.to_string();
-            let mut wrapped_lines = vec![];
+            let mut wrapped_lines = SmallVec::<[Range<usize>; 1]>::new();
             let mut prev_boundary_ix = 0;
-
-            if line_str.len() > longest_row_len {
-                longest_row_ix = new_start_row + ix;
-                longest_row_len = line_str.len();
-            }
 
             // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
             if let Some(wrap_width) = wrap_width {
@@ -223,23 +323,26 @@ impl TextWrapper {
             }
 
             new_lines.push(LineItem {
-                line: Rope::from(line),
+                len: line.len(),
                 wrapped_lines,
             });
         }
 
-        if self.lines.len() == 0 {
-            self.lines = new_lines;
+        if self.lines.is_empty() {
+            self.lines = SumTree::from_iter(new_lines, &());
         } else {
-            self.lines.splice(rows_range, new_lines);
+            let mut cursor = self.lines.cursor::<BufferRows>(&());
+            let mut new_tree = cursor.slice(&BufferRows(start_row), Bias::Right);
+            // Skip the replaced rows
+            cursor.seek_forward(&BufferRows(end_row + 1), Bias::Right);
+            new_tree.extend(new_lines, &());
+            // Untouched rows after the edit
+            new_tree.append(cursor.suffix(), &());
+            drop(cursor);
+            self.lines = new_tree;
         }
 
         self.text = changed_text.clone();
-        self.soft_lines = self.lines.iter().map(|l| l.lines_len()).sum();
-        self.longest_row = LongestRow {
-            row: longest_row_ix,
-            len: longest_row_len,
-        }
     }
 
     /// Update the text wrapper and recalculate the wrapped lines.
@@ -255,14 +358,14 @@ impl TextWrapper {
     pub(crate) fn offset_to_display_point(&self, offset: usize) -> WrapDisplayPoint {
         let row = self.text.offset_to_point(offset).row;
         let start = self.text.line_start_offset(row);
-        let line = &self.lines[row];
 
-        let mut wrapped_row = self
-            .lines
-            .iter()
-            .take(row)
-            .map(|l| l.lines_len())
-            .sum::<usize>();
+        // Seek to buffer row
+        let mut cursor = self.lines.cursor::<Dimensions<BufferRows, WrapRows>>(&());
+        cursor.seek(&BufferRows(row), Bias::Right);
+        let wrapped_row = cursor.start().1.0;
+        let Some(line) = cursor.item() else {
+            return WrapDisplayPoint::new(wrapped_row, 0, 0);
+        };
 
         let local_offset = offset.saturating_sub(start);
         for (ix, range) in line.wrapped_lines.iter().enumerate() {
@@ -285,23 +388,23 @@ impl TextWrapper {
     ///
     /// Panics if the `point.row` is out of bounds.
     pub(crate) fn display_point_to_offset(&self, point: WrapDisplayPoint) -> usize {
-        let mut wrapped_row = 0;
-        for (row, line) in self.lines.iter().enumerate() {
-            if wrapped_row + line.lines_len() > point.row {
-                let line_start = self.text.line_start_offset(row);
-                let local_row = point.row.saturating_sub(wrapped_row);
-                if let Some(range) = line.wrapped_lines.get(local_row) {
-                    return line_start + (range.start + point.column).min(range.end);
-                } else {
-                    // If not found, return the end of the line.
-                    return line_start + line.len();
-                }
-            }
+        // Seek to wrap row `point.row`
+        let mut cursor = self.lines.cursor::<Dimensions<WrapRows, BufferRows>>(&());
+        cursor.seek(&WrapRows(point.row), Bias::Right);
+        let Some(line) = cursor.item() else {
+            return self.text.len();
+        };
+        let wrapped_row = cursor.start().0.0;
+        let row = cursor.start().1.0;
 
-            wrapped_row += line.lines_len();
+        let line_start = self.text.line_start_offset(row);
+        let local_row = point.row.saturating_sub(wrapped_row);
+        if let Some(range) = line.wrapped_lines.get(local_row) {
+            line_start + (range.start + point.column).min(range.end)
+        } else {
+            // If not found, return the end of the line.
+            line_start + line.len()
         }
-
-        return self.text.len();
     }
 
     pub(crate) fn display_point_to_point(&self, point: WrapDisplayPoint) -> TreeSitterPoint {
@@ -611,7 +714,7 @@ mod tests {
         fn assert_wrapper_lines(text: &Rope, wrapper: &TextWrapper, expected_lines: &[&[&str]]) {
             let mut actual_lines = vec![];
             let mut offset = 0;
-            for line in wrapper.lines.iter() {
+            for line in wrapper.iter_lines() {
                 actual_lines.push(
                     line.wrapped_lines
                         .iter()
@@ -625,7 +728,7 @@ mod tests {
         }
 
         wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
-        assert_eq!(wrapper.lines.len(), 4);
+        assert_eq!(wrapper.lines_count(), 4);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -646,8 +749,8 @@ mod tests {
             text.to_string(),
             "Hello, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
-        assert_eq!(wrapper.lines.len(), 4);
-        assert_eq!(wrapper.lines.len(), 4);
+        assert_eq!(wrapper.lines_count(), 4);
+        assert_eq!(wrapper.lines_count(), 4);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -668,7 +771,7 @@ mod tests {
             text.to_string(),
             "AAA, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。New text"
         );
-        assert_eq!(wrapper.lines.len(), 4);
+        assert_eq!(wrapper.lines_count(), 4);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -690,7 +793,7 @@ mod tests {
             text.to_string(),
             "AAA, 世界!\r\nThis is third line.\n这里是第 4 行。New text"
         );
-        assert_eq!(wrapper.lines.len(), 3);
+        assert_eq!(wrapper.lines_count(), 3);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -710,7 +813,7 @@ mod tests {
             text.to_string(),
             "This is a new line.\nThis is new line 2.\n这里是第 4 行。New text"
         );
-        assert_eq!(wrapper.lines.len(), 3);
+        assert_eq!(wrapper.lines_count(), 3);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -730,7 +833,7 @@ mod tests {
             text.to_string(),
             "This is a new line.\nThis is new line 2.\n这里是第 4 行。New text\nThis is a new line at the end."
         );
-        assert_eq!(wrapper.lines.len(), 4);
+        assert_eq!(wrapper.lines_count(), 4);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -751,7 +854,7 @@ mod tests {
             text.to_string(),
             "This is a new line at the beginning.\nThis is a new line.\nThis is new line 2.\n这里是第 4 行。New text\nThis is a new line at the end."
         );
-        assert_eq!(wrapper.lines.len(), 5);
+        assert_eq!(wrapper.lines_count(), 5);
         assert_wrapper_lines(
             &text,
             &wrapper,
@@ -770,8 +873,8 @@ mod tests {
         text.replace(range.clone(), new_text);
         wrapper._update(&text, &range, &Rope::from(new_text), &mut fake_wrap_line);
         assert_eq!(text.to_string(), "");
-        assert_eq!(wrapper.lines.len(), 1);
-        assert_eq!(wrapper.lines[0].wrapped_lines, vec![0..0]);
+        assert_eq!(wrapper.lines_count(), 1);
+        assert_eq!(wrapper.line(0).unwrap().wrapped_lines.as_slice(), [0..0]);
 
         // Test update_all
         let range = 0..text.len();
@@ -782,7 +885,62 @@ mod tests {
             text.to_string(),
             "This is a full text.\nThis is a second line."
         );
-        assert_eq!(wrapper.lines.len(), 2);
+        assert_eq!(wrapper.lines_count(), 2);
+    }
+
+    fn test_font() -> gpui::Font {
+        gpui::Font {
+            family: "Arial".into(),
+            weight: FontWeight::default(),
+            style: FontStyle::Normal,
+            features: FontFeatures::default(),
+            fallbacks: None,
+        }
+    }
+
+    /// The longest-row summary stays exact when the previously-longest line is shrunk.
+    #[test]
+    fn test_longest_row_after_shrink() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.), None);
+        let mut text = Rope::from("aa\nthis is the longest line\nbb");
+        wrapper._update(&text, &(0..text.len()), &text, &mut |_, _| vec![]);
+        assert_eq!(wrapper.longest_row(), 1);
+
+        // Shrink line 1 so line 2-equivalent isn't longest.
+        // Make line 0 the longest now.
+        let start = text.line_start_offset(0);
+        let end = text.line_end_offset(0);
+        let range = start..end;
+        let new_text = "a very very long first line now";
+        text.replace(range.clone(), new_text);
+        wrapper._update(&text, &range, &Rope::from(new_text), &mut |_, _| vec![]);
+        assert_eq!(wrapper.longest_row(), 0);
+    }
+
+    /// Editing the last line and deleting everything must keep the tree consistent.
+    #[test]
+    fn test_edit_last_line_and_full_delete() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.), None);
+        let mut text = Rope::from("one\ntwo\nthree");
+        wrapper._update(&text, &(0..text.len()), &text, &mut |_, _| vec![]);
+        assert_eq!(wrapper.lines_count(), 3);
+
+        // Replace the last line only.
+        let start = text.line_start_offset(2);
+        let range = start..text.len();
+        let new_text = "THREE EDITED";
+        text.replace(range.clone(), new_text);
+        wrapper._update(&text, &range, &Rope::from(new_text), &mut |_, _| vec![]);
+        assert_eq!(wrapper.lines_count(), 3);
+        assert_eq!(wrapper.line(2).unwrap().len(), "THREE EDITED".len());
+
+        // Delete everything.
+        let range = 0..text.len();
+        text.replace(range.clone(), "");
+        wrapper._update(&text, &range, &Rope::from(""), &mut |_, _| vec![]);
+        assert_eq!(wrapper.lines_count(), 1);
+        assert_eq!(wrapper.len(), 1);
+        assert_eq!(wrapper.line(0).unwrap().wrapped_lines.as_slice(), [0..0]);
     }
 
     #[test]
@@ -841,28 +999,31 @@ mod tests {
         wrapper.text = Rope::from(
             "Hello, 世界!\r\nThis is second line.\nThis is third line.\n这里是第 4 行。",
         );
-        wrapper.lines = vec![
-            // range: 0..15
-            LineItem {
-                line: Rope::from("Hello, 世界!\r"),
-                wrapped_lines: vec![0..15],
-            },
-            // range: 16..36
-            LineItem {
-                line: Rope::from("This is second line."),
-                wrapped_lines: vec![0..10, 10..20],
-            },
-            // range: 37..56
-            LineItem {
-                line: Rope::from("This is third line."),
-                wrapped_lines: vec![0..9, 9..15, 15..20],
-            },
-            // range: 57..79
-            LineItem {
-                line: Rope::from("这里是第 4 行。"),
-                wrapped_lines: vec![0..22],
-            },
-        ];
+        wrapper.lines = SumTree::from_iter(
+            vec![
+                // range: 0..15
+                LineItem {
+                    len: Rope::from("Hello, 世界!\r").len(),
+                    wrapped_lines: smallvec::smallvec![0..15],
+                },
+                // range: 16..36
+                LineItem {
+                    len: Rope::from("This is second line.\n").len(),
+                    wrapped_lines: smallvec::smallvec![0..10, 10..20],
+                },
+                // range: 37..56
+                LineItem {
+                    len: Rope::from("This is third line.\n").len(),
+                    wrapped_lines: smallvec::smallvec![0..9, 9..15, 15..20],
+                },
+                // range: 57..79
+                LineItem {
+                    len: Rope::from("这里是第 4 行。").len(),
+                    wrapped_lines: smallvec::smallvec![0..22],
+                },
+            ],
+            &(),
+        );
 
         assert_eq!(
             wrapper.offset_to_display_point(12),

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -944,6 +944,86 @@ mod tests {
     }
 
     #[test]
+    fn test_wrap_row_buffer_line_boundaries() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.), None);
+        wrapper.text = Rope::from("aa\nbbbb\nc");
+        wrapper.lines = SumTree::from_iter(
+            vec![
+                LineItem {
+                    len: 2,
+                    wrapped_lines: smallvec::smallvec![0..2],
+                },
+                LineItem {
+                    len: 4,
+                    wrapped_lines: smallvec::smallvec![0..2, 2..4],
+                },
+                LineItem {
+                    len: 1,
+                    wrapped_lines: smallvec::smallvec![0..1],
+                },
+            ],
+            &(),
+        );
+
+        assert_eq!(wrapper.lines_count(), 3);
+        assert_eq!(wrapper.len(), 4);
+
+        assert_eq!(wrapper.buffer_line_to_first_wrap_row(0), 0);
+        assert_eq!(wrapper.buffer_line_to_first_wrap_row(1), 1);
+        assert_eq!(wrapper.buffer_line_to_first_wrap_row(2), 3);
+        assert_eq!(wrapper.buffer_line_to_first_wrap_row(3), 4);
+
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(0), 0..1);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(1), 1..3);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(2), 3..4);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(3), 4..4);
+
+        assert_eq!(wrapper.wrap_row_to_buffer_line(0), 0);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(1), 1);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(2), 1);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(3), 2);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(4), 2);
+    }
+
+    #[test]
+    fn test_wrap_row_queries_after_incremental_splice() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.), Some(px(10.)));
+        let mut text = Rope::from("aa\nbbbb\nc");
+        let mut fake_wrap_line = |line: &str, _wrap_width: Pixels| {
+            if line.len() > 2 {
+                vec![Boundary {
+                    ix: 2,
+                    next_indent: 0,
+                }]
+            } else {
+                vec![]
+            }
+        };
+
+        wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(0), 0..1);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(1), 1..3);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(2), 3..4);
+
+        let range = text.line_start_offset(1)..text.line_end_offset(1);
+        let new_text = "dd\neeee";
+        text.replace(range.clone(), new_text);
+        wrapper._update(&text, &range, &Rope::from(new_text), &mut fake_wrap_line);
+
+        assert_eq!(wrapper.lines_count(), 4);
+        assert_eq!(wrapper.len(), 5);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(0), 0..1);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(1), 1..2);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(2), 2..4);
+        assert_eq!(wrapper.buffer_line_to_wrap_row_range(3), 4..5);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(0), 0);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(1), 1);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(2), 2);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(3), 2);
+        assert_eq!(wrapper.wrap_row_to_buffer_line(4), 3);
+    }
+
+    #[test]
     fn test_line_layout() {
         let mut line_layout = LineLayout::new();
 

--- a/crates/ui/src/input/display_map/wrap_map.rs
+++ b/crates/ui/src/input/display_map/wrap_map.rs
@@ -15,31 +15,17 @@ use super::{BufferPoint, WrapPoint};
 use crate::input::rope_ext::RopeExt;
 
 /// WrapMap manages soft-wrapping and provides buffer ↔ wrap coordinate mapping.
+///
+/// Buffer line ↔ wrap row mapping is backed by the [`TextWrapper`]'s `SumTree`.
 pub struct WrapMap {
     /// The underlying text wrapper (reuses existing implementation)
     wrapper: TextWrapper,
-
-    /// Prefix sum cache: buffer_line_starts[line] = first wrap_row for buffer line `line`
-    /// This allows O(1) lookup of buffer_line → wrap_row
-    buffer_line_starts: Vec<usize>,
-
-    /// Cached line count from last rebuild
-    cached_line_count: usize,
-
-    /// Cached total wrap row count from last rebuild.
-    /// Used together with `cached_line_count` to detect if the cache is stale.
-    /// When soft wrap changes a line's wrap count without changing buffer line count,
-    /// this catches the staleness.
-    cached_wrap_row_count: usize,
 }
 
 impl WrapMap {
     pub fn new(font: Font, font_size: Pixels, wrap_width: Option<Pixels>) -> Self {
         Self {
             wrapper: TextWrapper::new(font, font_size, wrap_width),
-            buffer_line_starts: Vec::new(),
-            cached_line_count: 0,
-            cached_wrap_row_count: 0,
         }
     }
 
@@ -52,7 +38,7 @@ impl WrapMap {
     /// Get total number of buffer lines (logical lines)
     #[inline]
     pub fn buffer_line_count(&self) -> usize {
-        self.wrapper.lines.len()
+        self.wrapper.lines_count()
     }
 
     /// Convert buffer position to wrap position
@@ -61,7 +47,7 @@ impl WrapMap {
 
         // Clamp to valid range
         let line = line.min(self.buffer_line_count().saturating_sub(1));
-        let line_item = self.wrapper.lines.get(line);
+        let line_item = self.wrapper.line(line);
 
         let col = if let Some(line_item) = line_item {
             col.min(line_item.len())
@@ -100,34 +86,17 @@ impl WrapMap {
 
     /// Get the buffer line for a given wrap row
     pub fn wrap_row_to_buffer_line(&self, wrap_row: usize) -> usize {
-        if wrap_row >= self.wrap_row_count() {
-            return self.buffer_line_count().saturating_sub(1);
-        }
-
-        // Binary search in prefix sum cache
-        match self.buffer_line_starts.binary_search(&wrap_row) {
-            Ok(line) => line,
-            Err(insert_pos) => insert_pos.saturating_sub(1),
-        }
+        self.wrapper.wrap_row_to_buffer_line(wrap_row)
     }
 
     /// Get the first wrap row for a given buffer line
     pub fn buffer_line_to_first_wrap_row(&self, line: usize) -> usize {
-        if line >= self.buffer_line_starts.len() {
-            return self.wrap_row_count();
-        }
-        self.buffer_line_starts[line]
+        self.wrapper.buffer_line_to_first_wrap_row(line)
     }
 
     /// Get the wrap row range for a buffer line: [start, end)
     pub fn buffer_line_to_wrap_row_range(&self, line: usize) -> Range<usize> {
-        let start = self.buffer_line_to_first_wrap_row(line);
-        let end = if line + 1 < self.buffer_line_starts.len() {
-            self.buffer_line_starts[line + 1]
-        } else {
-            self.wrap_row_count()
-        };
-        start..end
+        self.wrapper.buffer_line_to_wrap_row_range(line)
     }
 
     /// Update text (incremental or full)
@@ -139,62 +108,27 @@ impl WrapMap {
         cx: &mut App,
     ) {
         self.wrapper.update(changed_text, range, new_text, cx);
-        self.rebuild_cache();
     }
 
     /// Update layout parameters (wrap width or font)
     pub fn on_layout_changed(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
         self.wrapper.set_wrap_width(wrap_width, cx);
-        self.rebuild_cache();
     }
 
     /// Set font parameters
     pub fn set_font(&mut self, font: Font, font_size: Pixels, cx: &mut App) {
         self.wrapper.set_font(font, font_size, cx);
-        self.rebuild_cache();
     }
 
     /// Ensure text is prepared (initializes wrapper if needed)
     pub fn ensure_text_prepared(&mut self, text: &Rope, cx: &mut App) -> bool {
-        let did_initialize = self.wrapper.prepare_if_need(text, cx);
-        if did_initialize {
-            self.rebuild_cache();
-        }
-        did_initialize
+        self.wrapper.prepare_if_need(text, cx)
     }
 
     /// Initialize with text
     pub fn set_text(&mut self, text: &Rope, cx: &mut App) {
         self.wrapper.set_default_text(text);
         self.wrapper.prepare_if_need(text, cx);
-        self.rebuild_cache();
-    }
-
-    /// Rebuild the prefix sum cache: buffer_line_starts
-    fn rebuild_cache(&mut self) {
-        let line_count = self.wrapper.lines.len();
-        let wrap_row_count = self.wrapper.len();
-
-        // Skip if nothing changed: both buffer line count and total wrap row count must match.
-        // Checking wrap_row_count is essential because soft-wrap can change the number of
-        // wrap rows per line without changing the buffer line count.
-        if line_count == self.cached_line_count
-            && wrap_row_count == self.cached_wrap_row_count
-            && !self.buffer_line_starts.is_empty()
-        {
-            return;
-        }
-
-        self.buffer_line_starts.clear();
-
-        let mut wrap_row = 0;
-        for line_item in &self.wrapper.lines {
-            self.buffer_line_starts.push(wrap_row);
-            wrap_row += line_item.lines_len();
-        }
-
-        self.cached_line_count = line_count;
-        self.cached_wrap_row_count = wrap_row_count;
     }
 
     /// Get access to the underlying wrapper (for rendering/hit-testing)
@@ -202,9 +136,10 @@ impl WrapMap {
         &self.wrapper
     }
 
-    /// Get access to line items (for rendering)
-    pub(crate) fn lines(&self) -> &[LineItem] {
-        &self.wrapper.lines
+    /// Get the line item by buffer row index.
+    #[inline]
+    pub(crate) fn line(&self, row: usize) -> Option<&LineItem> {
+        self.wrapper.line(row)
     }
 
     /// Get the rope text

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -357,15 +357,17 @@ impl TextElement {
         let is_selected_all = selected_range.len() == state.text.len();
 
         let mut cursor = state.cursor();
+        // Buffer rows from the raw (pre-mask) offsets, used to locate the cursor line.
+        let cursor_row = state.text.offset_to_point(cursor).row;
+        let sel_start_row = state.text.offset_to_point(selected_range.start).row;
+        let sel_end_row = state.text.offset_to_point(selected_range.end).row;
         if state.masked {
             selected_range.start = masked_display_offset(&state.text, selected_range.start);
             selected_range.end = masked_display_offset(&state.text, selected_range.end);
             cursor = masked_display_offset(&state.text, cursor);
         }
 
-        let mut current_row = None;
         let mut scroll_offset = state.scroll_handle.offset();
-        let mut cursor_bounds = None;
 
         // Padding kept between the cursor and the viewport's top/bottom
         // edges, used by the auto-scroll-into-view computation below.
@@ -376,85 +378,30 @@ impl TextElement {
             line_height,
         );
 
-        // The cursor corresponds to the current cursor position in the text no only the line.
-        let mut cursor_pos = None;
-        let mut cursor_start = None;
-        let mut cursor_end = None;
-
-        let mut prev_lines_offset = 0;
-        let mut offset_y = px(0.);
-        let buffer_lines = state.display_map.lines();
+        // Resolve a cursor or selection endpoint to a content-space position.
         let visible_buffer_lines = &last_layout.visible_buffer_lines;
-        let mut vi = 0; // index into visible_buffer_lines / lines
-        for (ix, wrap_line) in buffer_lines.iter().enumerate() {
-            let row = ix;
-            let line_origin = point(px(0.), offset_y);
+        let caret_for = |row: usize, offset: usize, affinity: bool| -> Point<Pixels> {
+            // y of the top of buffer line `row` in content space.
+            let top = line_height * state.display_map.buffer_line_to_display_row(row);
+            let line_origin = point(px(0.), top);
 
-            // break loop if all cursor positions are found
-            if cursor_pos.is_some() && cursor_start.is_some() && cursor_end.is_some() {
-                break;
+            if let Some(vi) = visible_buffer_lines.iter().position(|&bl| bl == row) {
+                let line = &lines[vi];
+                let line_start = last_layout.visible_line_byte_offsets[vi];
+                let local = offset.saturating_sub(line_start);
+                if let Some(pos) = line.position_for_index(local, last_layout, affinity) {
+                    return line_origin + pos;
+                }
             }
+            line_origin
+        };
 
-            // Check if this buffer line has a LineLayout in the compact lines vec
-            let line_layout = if vi < visible_buffer_lines.len() && visible_buffer_lines[vi] == ix {
-                let l = &lines[vi];
-                vi += 1;
-                Some(l)
-            } else {
-                None
-            };
+        let current_row = Some(cursor_row);
+        let cursor_pos = caret_for(cursor_row, cursor, state.cursor_line_end_affinity);
+        let cursor_start = caret_for(sel_start_row, selected_range.start, false);
+        let cursor_end = caret_for(sel_end_row, selected_range.end, false);
 
-            if let Some(line) = line_layout {
-                if cursor_pos.is_none() {
-                    let offset = cursor.saturating_sub(prev_lines_offset);
-                    if let Some(pos) =
-                        line.position_for_index(offset, last_layout, state.cursor_line_end_affinity)
-                    {
-                        current_row = Some(row);
-                        cursor_pos = Some(line_origin + pos);
-                    }
-                }
-                if cursor_start.is_none() {
-                    let offset = selected_range.start.saturating_sub(prev_lines_offset);
-                    if let Some(pos) = line.position_for_index(offset, last_layout, false) {
-                        cursor_start = Some(line_origin + pos);
-                    }
-                }
-                if cursor_end.is_none() {
-                    let offset = selected_range.end.saturating_sub(prev_lines_offset);
-                    if let Some(pos) = line.position_for_index(offset, last_layout, false) {
-                        cursor_end = Some(line_origin + pos);
-                    }
-                }
-
-                offset_y += line.size(line_height).height;
-                // +1 for the last `\n`
-                prev_lines_offset += wrap_line.len() + 1;
-            } else {
-                // Not visible (before visible range or hidden/folded).
-                // Just increase the offset_y and prev_lines_offset for scroll tracking.
-                if prev_lines_offset >= cursor && cursor_pos.is_none() {
-                    current_row = Some(row);
-                    cursor_pos = Some(line_origin);
-                }
-                if prev_lines_offset >= selected_range.start && cursor_start.is_none() {
-                    cursor_start = Some(line_origin);
-                }
-                if prev_lines_offset >= selected_range.end && cursor_end.is_none() {
-                    cursor_end = Some(line_origin);
-                }
-
-                let visible_wrap_rows =
-                    state.display_map.visible_wrap_row_count_for_buffer_line(ix);
-                offset_y += line_height * visible_wrap_rows;
-                // +1 for the last `\n`
-                prev_lines_offset += wrap_line.len() + 1;
-            }
-        }
-
-        if let (Some(cursor_pos), Some(cursor_start), Some(cursor_end)) =
-            (cursor_pos, cursor_start, cursor_end)
-        {
+        let cursor_bounds = {
             let selection_changed = state.last_selected_range != Some(selected_range);
             let auto_scrolling = state.auto_scroll.is_active();
             if selection_changed && !is_selected_all {
@@ -543,14 +490,14 @@ impl TextElement {
             } else {
                 cursor_x
             };
-            cursor_bounds = Some(Bounds::new(
+            Some(Bounds::new(
                 point(
                     cursor_x,
                     bounds.top() + cursor_pos.y + ((line_height - cursor_height) / 2.),
                 ),
                 size(CURSOR_WIDTH, cursor_height),
-            ));
-        }
+            ))
+        };
 
         if let Some(deferred_scroll_offset) = state.deferred_scroll_offset {
             scroll_offset = deferred_scroll_offset;
@@ -829,52 +776,57 @@ impl TextElement {
     ) -> (Range<usize>, Vec<usize>, Pixels) {
         // Add extra rows to avoid showing empty space when scroll to bottom.
         let extra_rows = 1;
-        let mut visible_top = px(0.);
         if state.mode.is_single_line() {
-            return (0..1, vec![0], visible_top);
+            return (0..1, vec![0], px(0.));
         }
 
         let total_lines = state.display_map.wrap_row_count();
+        let display_count = state.display_map.display_row_count();
+        let buffer_line_count = state.display_map.buffer_line_count();
+        if display_count == 0 || buffer_line_count == 0 {
+            return (0..0, Vec::new(), px(0.));
+        }
+
         let mut scroll_top = if let Some(deferred_scroll_offset) = state.deferred_scroll_offset {
             deferred_scroll_offset.y
         } else {
             state.scroll_handle.offset().y
         };
-
-        let mut visible_range = 0..total_lines;
         scroll_top = clamp_auto_grow_vertical_scroll_offset(
             &state.mode,
             scroll_top,
             line_height * total_lines,
             input_height,
         );
-        let mut line_bottom = px(0.);
-        for (ix, _line) in state.display_map.lines().iter().enumerate() {
-            let visible_wrap_rows = state.display_map.visible_wrap_row_count_for_buffer_line(ix);
 
-            if visible_wrap_rows == 0 {
-                continue;
-            }
+        // Display rows are uniformly `line_height` tall, so the visible window maps
+        // directly to a display-row range.
+        let viewport_top = (-scroll_top).max(px(0.));
+        let viewport_bottom = viewport_top + input_height;
+        let line_height_f = f32::from(line_height);
+        let first_display =
+            ((f32::from(viewport_top) / line_height_f).floor() as usize).min(display_count - 1);
+        let last_display =
+            ((f32::from(viewport_bottom) / line_height_f).ceil() as usize).min(display_count - 1);
 
-            let wrapped_height = line_height * visible_wrap_rows;
-            line_bottom += wrapped_height;
+        let start_line = state.display_map.display_row_to_buffer_line(first_display);
+        let end_line = state.display_map.display_row_to_buffer_line(last_display);
 
-            if line_bottom < -scroll_top {
-                visible_top = line_bottom - wrapped_height;
-                visible_range.start = ix;
-            }
+        // y of the top of the first visible buffer line (in content space).
+        let visible_top = match state
+            .display_map
+            .buffer_line_to_display_row_range(start_line)
+        {
+            Some(range) => line_height * range.start,
+            None => line_height * first_display,
+        };
 
-            if line_bottom + scroll_top >= input_height {
-                visible_range.end = (ix + extra_rows).min(total_lines);
-                break;
-            }
-        }
+        let visible_range = start_line..(end_line + 1 + extra_rows).min(buffer_line_count);
 
         // Collect non-hidden buffer lines within the visible range
         let mut visible_buffer_lines = Vec::with_capacity(visible_range.len());
-        for ix in visible_range.start..visible_range.end {
-            let visible_wrap_rows = state.display_map.visible_wrap_row_count_for_buffer_line(ix);
-            if visible_wrap_rows > 0 {
+        for ix in visible_range.clone() {
+            if state.display_map.visible_wrap_row_count_for_buffer_line(ix) > 0 {
                 visible_buffer_lines.push(ix);
             }
         }
@@ -1233,7 +1185,6 @@ impl TextElement {
         window: &mut Window,
     ) -> Vec<LineLayout> {
         let is_single_line = state.mode.is_single_line();
-        let buffer_lines = state.display_map.lines();
 
         if is_single_line {
             let shaped_line = window.text_system().shape_line(
@@ -1279,8 +1230,9 @@ impl TextElement {
 
         for (vi, &buffer_line) in last_layout.visible_buffer_lines.iter().enumerate() {
             let line_text: String = display_text.slice_line(buffer_line).into();
-            let line_item = buffer_lines
-                .get(buffer_line)
+            let line_item = state
+                .display_map
+                .line(buffer_line)
                 .expect("line should exists in wrapper");
 
             debug_assert_eq!(line_item.len(), line_text.len());

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -256,7 +256,14 @@ impl InputMode {
                 let edit = replacement_input_edit(old_text, new_text, selected_range, change_text);
 
                 const SYNC_PARSE_TIMEOUT: Duration = Duration::from_millis(2);
-                let completed = h.update(Some(edit), new_text, Some(SYNC_PARSE_TIMEOUT));
+                // Skip parsing in the foreground above this threshold
+                const SYNC_PARSE_MAX_BYTES: usize = 256 * 1024;
+                let completed = if new_text.len() > SYNC_PARSE_MAX_BYTES {
+                    h.edit_tree(Some(edit), new_text);
+                    false
+                } else {
+                    h.update(Some(edit), new_text, Some(SYNC_PARSE_TIMEOUT))
+                };
                 if completed {
                     // Sync parse succeeded, cancel any pending background parse.
                     parse_task.borrow_mut().take();

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2669,6 +2669,12 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        const PARSE_DEBOUNCE: Duration = Duration::from_millis(150);
+
         let highlighter_rc = pending.highlighter;
         let parse_task_rc = pending.parse_task;
         let language = pending.language;
@@ -2687,8 +2693,22 @@ impl InputState {
             .as_ref()
             .and_then(|h| h.injection_parse_data());
 
+        let cancel = Arc::new(AtomicBool::new(false));
+
         let text_for_apply = text.clone();
         let task = cx.spawn_in(window, async move |entity, cx| {
+            struct CancelOnDrop(Arc<AtomicBool>);
+            impl Drop for CancelOnDrop {
+                fn drop(&mut self) {
+                    self.0.store(true, Ordering::Relaxed);
+                }
+            }
+            let _cancel_guard = CancelOnDrop(cancel.clone());
+
+            // Debounce
+            cx.background_executor().timer(PARSE_DEBOUNCE).await;
+
+            let parse_cancel = cancel.clone();
             let result = cx
                 .background_executor()
                 .spawn(async move {
@@ -2701,6 +2721,15 @@ impl InputState {
                         return None;
                     }
 
+                    let mut progress = |_: &tree_sitter::ParseState| -> std::ops::ControlFlow<()> {
+                        if parse_cancel.load(Ordering::Relaxed) {
+                            std::ops::ControlFlow::Break(())
+                        } else {
+                            std::ops::ControlFlow::Continue(())
+                        }
+                    };
+                    let options = tree_sitter::ParseOptions::new().progress_callback(&mut progress);
+
                     let new_tree = parser.parse_with_options(
                         &mut |offset, _| {
                             if offset >= text.len() {
@@ -2711,8 +2740,13 @@ impl InputState {
                             }
                         },
                         old_tree.as_ref(),
-                        None,
+                        Some(options),
                     )?;
+
+                    // Disrcard the partial result on cancel
+                    if parse_cancel.load(Ordering::Relaxed) {
+                        return None;
+                    }
 
                     // Compute injection layers in the background to avoid blocking the
                     // main thread with combined-injection parsing (e.g. PHP, HTML+JS/CSS).

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1395,7 +1395,7 @@ impl InputState {
 
         if self.soft_wrap && self.mode.is_code_editor() {
             let wrap_point = self.display_map.offset_to_wrap_display_point(self.cursor());
-            if let Some(line) = self.display_map.lines().get(row)
+            if let Some(line) = self.display_map.line(row)
                 && let Some(range) = line.wrapped_lines.get(wrap_point.local_row)
             {
                 let visual_start = logical_start + range.start;
@@ -1423,7 +1423,7 @@ impl InputState {
 
         if self.soft_wrap && self.mode.is_code_editor() {
             let wrap_point = self.display_map.offset_to_wrap_display_point(self.cursor());
-            if let Some(line) = self.display_map.lines().get(row)
+            if let Some(line) = self.display_map.line(row)
                 && let Some(range) = line.wrapped_lines.get(wrap_point.local_row)
             {
                 let visual_end = logical_start + range.end;
@@ -1948,16 +1948,8 @@ impl InputState {
 
         let row = point.row;
 
-        let mut row_offset_y = px(0.);
-        for (ix, _wrap_line) in self.display_map.lines().iter().enumerate() {
-            if ix == row {
-                break;
-            }
-
-            // Only accumulate height for visible (non-folded) wrap rows
-            let visible_wrap_rows = self.display_map.visible_wrap_row_count_for_buffer_line(ix);
-            row_offset_y += line_height * visible_wrap_rows;
-        }
+        // Calculate row offset by multiplying the number of lines before it with the line height
+        let mut row_offset_y = line_height * self.display_map.buffer_line_to_display_row(row);
 
         // For Right alignment use 0 margin: the cursor indicator is clamped inside bounds
         // in layout_cursor, so shifting the text here would cause a first-click visual jump.


### PR DESCRIPTION
## Description

These two changes are related, so I kept them in the same PR but different commits, so it can be reviewed as two.
This is done to improve editing in larger files, but improving this also improves overall editing.
After this change, editing the example json file is faster than Zed (ironically since this uses their sum_tree crate :smile:). Feels on par with Vscode when forcefully enabled highlighting but uses less memory.

### Wrapping refactored to a SumTree

Replaces the `Vec<LineItem>` with a `SumTree<LineItem>`. The vec required O(n) scans for things like row offset, cursor placement or finding the longest line. With SumTree it becomes O(log n) or even O(1) depending on if it's cached. Similar to diagnostics that is already backed by a SumTree. One of the biggest wins is editing though since we no longer need to splice the vec in text_wrapper (`self.lines.splice(rows_range, new_lines);`)

Call sites that previously did `display_map.lines().get(row)` or `.iter().enumerate()` now go through `display_map.line(row)` and `buffer_line_to_display_row(row)`, which resolve via the tree.

### Skip foreground parsing on large files

For large files I've added a threshold for foreground parsing, since we don't even need to attempt it if the file is big enough. It will always time out anyway.. Also attempts to cancel any previous parses, this could be further improved with a parse lock to absolutely prevent parallel parsing.

## Screenshot

### Before

https://github.com/user-attachments/assets/58f94c40-a61c-4c8b-8562-fea428e6f17d

### After

https://github.com/user-attachments/assets/dc3f5ce7-b790-4835-8c49-0b514797b185

### Zed comparison


https://github.com/user-attachments/assets/5b7351fd-9f66-497f-a0d7-93eab827842f



This is with the document color provider and linting disabled in the editor. Also folding is disabled because it still is a bit slow for these huge files.

## How to Test

- Generate test file 
```sh
$ (echo '['; for i in $(seq 1 999999); do echo "{\"id\": $i, \"name\": \"user_$i\"},"; done; echo '{"id": 1000000, "name": "user_1000000"}'; echo ']') > big_test.json
```
- Disable/comment lint_document and document_color_provider in editor.rs
```diff
--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -713,7 +713,7 @@ impl Example {
             editor.lsp.code_action_providers = vec![lsp_store.clone(), Rc::new(TextConvertor)];
             editor.lsp.hover_provider = Some(lsp_store.clone());
             editor.lsp.definition_provider = Some(lsp_store.clone());
-            editor.lsp.document_color_provider = Some(lsp_store.clone());
+            // editor.lsp.document_color_provider = Some(lsp_store.clone());
 
             editor
         });
@@ -731,7 +731,7 @@ impl Example {
         Self::load_files(tree_state.clone(), PathBuf::from("./"), cx);
 
         let _subscriptions = vec![cx.subscribe(&editor, |this, _editor, _: &InputEvent, cx| {
-            this.lint_document(cx);
+            // this.lint_document(cx);
         })];
 
         Self {
```
- Run editor cargo run --release --example editor
- Disable folding (still a bit slow on these large files)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
