### PR TITLE
calendar: added support for custom calendar starting days

### DIFF
--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, rc::Rc};
 
-use chrono::{Datelike, Local, NaiveDate};
+use chrono::{Datelike, Local, NaiveDate, Weekday};
 use gpui::{
     App, ClickEvent, Context, Div, ElementId, Empty, Entity, EventEmitter, FocusHandle,
     InteractiveElement, IntoElement, ParentElement, Render, RenderOnce, SharedString, Stateful,
@@ -266,6 +266,8 @@ pub struct Calendar {
     style: StyleRefinement,
     /// Number of the months view to show.
     number_of_months: usize,
+    /// The first day of the week. Defaults to Sunday.
+    first_day_of_week: Weekday,
 }
 
 /// Use to store the state of the calendar.
@@ -411,10 +413,14 @@ impl CalendarState {
     }
 
     /// Returns the days of the month in a 2D vector to render on calendar.
-    fn days(&self) -> Vec<Vec<NaiveDate>> {
+    fn days(&self, first_day: Weekday) -> Vec<Vec<NaiveDate>> {
         (0..self.number_of_months)
             .flat_map(|offset| {
-                days_in_month(self.current_year, self.current_month as u32 + offset as u32)
+                days_in_month(
+                    self.current_year,
+                    self.current_month as u32 + offset as u32,
+                    first_day,
+                )
             })
             .collect()
     }
@@ -539,12 +545,19 @@ impl Calendar {
             state: state.clone(),
             style: StyleRefinement::default(),
             number_of_months: 1,
+            first_day_of_week: Weekday::Sun,
         }
     }
 
     /// Set number of months to show, default is 1.
     pub fn number_of_months(mut self, number_of_months: usize) -> Self {
         self.number_of_months = number_of_months;
+        self
+    }
+
+    /// Set the first day of the week for the calendar.
+    pub fn first_day_of_week(mut self, day: Weekday) -> Self {
+        self.first_day_of_week = day;
         self
     }
 
@@ -784,7 +797,7 @@ impl Calendar {
 
     fn render_days(&self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let state = self.state.read(cx);
-        let weeks = [
+        let mut weeks = [
             t!("Calendar.week.0"),
             t!("Calendar.week.1"),
             t!("Calendar.week.2"),
@@ -793,6 +806,8 @@ impl Calendar {
             t!("Calendar.week.5"),
             t!("Calendar.week.6"),
         ];
+        // Rotate the header to match the grid's start day.
+        weeks.rotate_left(self.first_day_of_week.num_days_from_sunday() as usize);
 
         h_flex()
             .map(|this| match self.size {
@@ -803,7 +818,7 @@ impl Calendar {
             .justify_between()
             .children(
                 state
-                    .days()
+                    .days(self.first_day_of_week)
                     .chunks(5)
                     .enumerate()
                     .map(|(offset_month, days)| {

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Weekday};
 use gpui::{
     App, AppContext, ClickEvent, Context, ElementId, Empty, Entity, EventEmitter, FocusHandle,
     Focusable, InteractiveElement as _, IntoElement, KeyBinding, MouseButton, ParentElement as _,
@@ -77,6 +77,8 @@ pub struct DatePickerState {
     number_of_months: usize,
     disabled_matcher: Option<Rc<Matcher>>,
     _subscriptions: Vec<Subscription>,
+    /// The first day of the week. Defaults to Sunday.
+    first_day_of_week: Weekday,
 }
 
 impl Focusable for DatePickerState {
@@ -130,6 +132,7 @@ impl DatePickerState {
             number_of_months: 1,
             disabled_matcher: None,
             _subscriptions,
+            first_day_of_week: Weekday::Sun,
         }
     }
 
@@ -142,6 +145,12 @@ impl DatePickerState {
     /// Set the number of months calendar view to display, default is 1.
     pub fn number_of_months(mut self, number_of_months: usize) -> Self {
         self.number_of_months = number_of_months;
+        self
+    }
+
+    /// Set the first day of the week.
+    pub fn first_day_of_week(mut self, day: Weekday) -> Self {
+        self.first_day_of_week = day;
         self
     }
 
@@ -501,6 +510,7 @@ impl RenderOnce for DatePicker {
                                         .child(
                                             Calendar::new(&state.calendar)
                                                 .number_of_months(self.number_of_months)
+                                                .first_day_of_week(state.first_day_of_week)
                                                 .border_0()
                                                 .rounded_none()
                                                 .p_0()

--- a/crates/ui/src/time/utils.rs
+++ b/crates/ui/src/time/utils.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, Duration, NaiveDate};
+use chrono::{Datelike, Duration, NaiveDate, Weekday};
 
 trait NaiveDateExt {
     fn days_in_month(&self) -> i32;
@@ -28,7 +28,7 @@ impl NaiveDateExt for chrono::NaiveDate {
     }
 }
 
-pub(crate) fn days_in_month(year: i32, month: u32) -> Vec<Vec<NaiveDate>> {
+pub(crate) fn days_in_month(year: i32, month: u32, first_day: Weekday) -> Vec<Vec<NaiveDate>> {
     let mut year = year;
     let mut month = month;
     if month > 12 {
@@ -42,7 +42,8 @@ pub(crate) fn days_in_month(year: i32, month: u32) -> Vec<Vec<NaiveDate>> {
 
     let date = NaiveDate::from_ymd_opt(year, month, 1).unwrap();
     let num_days = date.days_in_month();
-    let start_weekday = date.weekday().num_days_from_sunday();
+    let start_weekday =
+        (date.weekday().num_days_from_sunday() + 7 - first_day.num_days_from_sunday()) % 7;
 
     // Get the days in the month, 2023-02 will returns
     // "29|30|31| 1| 2| 3| 4",
@@ -87,7 +88,7 @@ pub(crate) fn days_in_month(year: i32, month: u32) -> Vec<Vec<NaiveDate>> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{Datelike, NaiveDate};
+    use chrono::{Datelike, NaiveDate, Weekday};
 
     use super::{days_in_month, NaiveDateExt};
 
@@ -114,8 +115,8 @@ mod tests {
     #[test]
     fn test_days() {
         #[track_caller]
-        fn assert_case(date: NaiveDate, expected: Vec<&str>) {
-            let out = days_in_month(date.year(), date.month())
+        fn assert_case(date: NaiveDate, first_day: Weekday, expected: Vec<&str>) {
+            let out = days_in_month(date.year(), date.month(), first_day)
                 .iter()
                 .map(|week| {
                     week.iter()
@@ -138,6 +139,7 @@ mod tests {
 
         assert_case(
             NaiveDate::from_ymd_opt(2024, 8, 1).unwrap(),
+            Weekday::Sun,
             vec![
                 "7-28|7-29|7-30|7-31| 1| 2| 3",
                 " 4| 5| 6| 7| 8| 9|10",
@@ -148,6 +150,7 @@ mod tests {
         );
         assert_case(
             NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            Weekday::Sun,
             vec![
                 "2024-12-29|2024-12-30|2024-12-31| 1| 2| 3| 4",
                 " 5| 6| 7| 8| 9|10|11",
@@ -159,6 +162,7 @@ mod tests {
 
         assert_case(
             NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
+            Weekday::Sun,
             vec![
                 "1-28|1-29|1-30|1-31| 1| 2| 3",
                 " 4| 5| 6| 7| 8| 9|10",
@@ -169,12 +173,27 @@ mod tests {
         );
         assert_case(
             NaiveDate::from_ymd_opt(2023, 2, 20).unwrap(),
+            Weekday::Sun,
             vec![
                 "1-29|1-30|1-31| 1| 2| 3| 4",
                 " 5| 6| 7| 8| 9|10|11",
                 "12|13|14|15|16|17|18",
                 "19|20|21|22|23|24|25",
                 "26|27|28|3-1|3-2|3-3|3-4",
+            ],
+        );
+
+        // Monday-first week: Feb 2023 starts on a Wednesday, so the grid
+        // shifts to start on Monday (column 0 = Mon 30 Jan).
+        assert_case(
+            NaiveDate::from_ymd_opt(2023, 2, 1).unwrap(),
+            Weekday::Mon,
+            vec![
+                "1-30|1-31| 1| 2| 3| 4| 5",
+                " 6| 7| 8| 9|10|11|12",
+                "13|14|15|16|17|18|19",
+                "20|21|22|23|24|25|26",
+                "27|28|3-1|3-2|3-3|3-4|3-5",
             ],
         );
     }


### PR DESCRIPTION
Closes #2517 

## Description

Added support for custom starting days for calendar.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="395" height="280" alt="image" src="https://github.com/user-attachments/assets/8926ab0a-d4db-4c50-b100-c5d35c5ffb3c" /> | <img width="375" height="285" alt="image" src="https://github.com/user-attachments/assets/4a9235d2-4d29-42e0-8bc5-04774b7eb0d6" /> |

## How to Test

### First day
                DatePickerState::new(window, cx)
                    .date_format("%Y. %m. %d.")
                    .first_day_of_week(Weekday::Mon)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
