### PR TITLE
field: fix compilation error no method named `into_any` found for struct

### DIFF
--- a/crates/ui/src/form/field.rs
+++ b/crates/ui/src/form/field.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use gpui::{
-    AlignItems, AnyElement, AnyView, App, Axis, Div, Element, ElementId, InteractiveElement as _,
+    AlignItems, AnyElement, AnyView, App, Axis, Div, ElementId, InteractiveElement as _,
     IntoElement, ParentElement, Pixels, Rems, RenderOnce, SharedString, StyleRefinement, Styled,
     Window, div, prelude::FluentBuilder as _, px,
 };
@@ -53,7 +53,7 @@ impl RenderOnce for FieldBuilder {
         match self {
             FieldBuilder::String(value) => value.into_any_element(),
             FieldBuilder::Element(builder) => builder(window, cx),
-            FieldBuilder::View(view) => view.into_any(),
+            FieldBuilder::View(view) => view.into_any_element(),
         }
     }
 }


### PR DESCRIPTION
Closes #2550
## Description

zed [`74b52077`](https://github.com/zed-industries/zed/commit/74b5207744ef95505fd75c56bf2c9d4736e931ee) ("Unify Render and RenderOnce into View", #58087) removed impl Element for AnyView. That impl was where AnyView::into_any() came from, so crates/ui/src/form/field.rs no longer compiles against gpui's main branch:

```
error[E0599]: no method named `into_any` found for struct `AnyView` in the current scope
  --> crates/ui/src/form/field.rs:56:46
```

AnyView still implements IntoElement, which has into_any_element(). This PR moves the one call site over to it and drops the now-unused Element import. The other arms in FieldBuilder::render already call into_any_element().

into_any_element() is on AnyView both before and after #58087. So this compiles whichever commit gpui resolves to.

## How to Test

```sh
# resolve gpui to a commit at/after #58087 (74b52077)
cargo update -p gpui
cargo build -p gpui-component
```

Builds clean on this branch. On zed's current main it fails with the error above. Behavior is unchanged, since into_any_element() returns the same AnyElement the old into_any() did.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
`