### PR TITLE
tree: Add `reveal_item` method to scroll to and reveal a node

### DIFF
--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -294,6 +294,27 @@ impl TreeState {
         self.scroll_handle.scroll_to_item(ix, strategy);
     }
 
+    /// Find the flat index of the entry whose `item.id` matches, if present.
+    ///
+    /// Returns `None` if the id is not in the current (possibly filtered)
+    /// entry list.
+    pub fn index_of(&self, id: &SharedString) -> Option<usize> {
+        self.entries.iter().position(|e| &e.item.id == id)
+    }
+
+    /// Ensure the entry with the given id is visible: expand all its ancestor
+    /// folders, then scroll it to the center of the viewport.
+    ///
+    /// This is a no-op if the id is not found in the tree. Useful for
+    /// "reveal in tree" / "go to node" features where the consumer knows the
+    /// target id but not its flat index.
+    pub fn ensure_visible(&mut self, id: &SharedString, cx: &mut Context<Self>) {
+        self.expand_ancestors(id.clone(), cx);
+        if let Some(ix) = self.index_of(id) {
+            self.scroll_to_item(ix, gpui::ScrollStrategy::Center);
+        }
+    }
+
     /// Get the currently selected entry, if any.
     pub fn selected_entry(&self) -> Option<&TreeEntry> {
         self.selected_ix.and_then(|ix| self.entries.get(ix))

--- a/crates/ui/src/tree.rs
+++ b/crates/ui/src/tree.rs
@@ -295,23 +295,21 @@ impl TreeState {
     }
 
     /// Find the flat index of the entry whose `item.id` matches, if present.
-    ///
-    /// Returns `None` if the id is not in the current (possibly filtered)
-    /// entry list.
-    pub fn index_of(&self, id: &SharedString) -> Option<usize> {
+    pub(crate) fn index_of(&self, id: &SharedString) -> Option<usize> {
         self.entries.iter().position(|e| &e.item.id == id)
     }
 
-    /// Ensure the entry with the given id is visible: expand all its ancestor
-    /// folders, then scroll it to the center of the viewport.
-    ///
-    /// This is a no-op if the id is not found in the tree. Useful for
-    /// "reveal in tree" / "go to node" features where the consumer knows the
-    /// target id but not its flat index.
-    pub fn ensure_visible(&mut self, id: &SharedString, cx: &mut Context<Self>) {
+    /// Expand all ancestors of the node with `id` and scroll it into view.
+    /// No-op if `id` is not found. Does not change the selected index.
+    pub fn reveal_item(
+        &mut self,
+        id: &SharedString,
+        strategy: gpui::ScrollStrategy,
+        cx: &mut Context<Self>,
+    ) {
         self.expand_ancestors(id.clone(), cx);
         if let Some(ix) = self.index_of(id) {
-            self.scroll_to_item(ix, gpui::ScrollStrategy::Center);
+            self.scroll_to_item(ix, strategy);
         }
     }
 


### PR DESCRIPTION
## Description

Add `index_of` and `ensure_visible` methods to `TreeState` so consumers can programmatically reveal a specific node by its id.

`ensure_visible` expands all ancestor folders of the target node and scrolls it to the center of the viewport. This combines the existing private `expand_ancestors` method with the existing public `scroll_to_item` method into a single convenient call.

### Use case

In [Verve](https://github.com/aios-rs/verve) (an API co-development platform built with gpui-component), the project tree supports a "locate in tree" feature: when the user clicks a request in the search results or history panel, the tree should automatically expand the relevant folders and scroll the target request into view.

Without `ensure_visible`, consumers must either:
1. Manually track which folders need expanding (duplicating the internal `expand_ancestors` logic), or
2. Expand all folders unconditionally (losing the user's collapse state)

With `ensure_visible`, the call is a one-liner:

```rust
tree_state.update(cx, |t, cx| {
    t.ensure_visible(&target_node_id.into(), cx);
});
```

### What each method does

- **`index_of(id)`** — returns the flat index of the entry whose `item.id` matches the given id, or `None` if not found. Complements the existing `selected_index()` which returns the index of the *currently selected* entry.
- **`ensure_visible(id, cx)`** — expands all ancestor folders of the target (via the existing private `expand_ancestors`), then scrolls the target entry to the center of the viewport (via the existing public `scroll_to_item` with `ScrollStrategy::Center`). No-op if the id is not found.

## Break Changes

Fully additive. No existing API changes. `expand_ancestors` remains private — only the two new public methods are exposed.

## How to Test

```bash
cargo run
```

The `ensure_visible` method can be tested by adding a button in the Tree story that calls `tree_state.update(cx, |t, cx| t.ensure_visible(&"some-node-id".into(), cx))` and verifying that the tree expands + scrolls to reveal the target node.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo fmt --check`.
- [N/A] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — not platform specific.

## AI Assistance Disclosure

🤖 Parts of this PR were generated with AI assistance and subsequently reviewed by a human to match the project's existing code style and patterns. Specifically:
- The `index_of` and `ensure_visible` method signatures were modeled after the existing `scroll_to_item` and `selected_entry` public methods.
- The doc comments follow the same style as the existing methods in `tree.rs`.