### PR TITLE
sidebar: Revert #2540 added min_w_0 to sidebar.

### DIFF
--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -426,9 +426,9 @@ impl<E: SidebarItem> RenderOnce for Sidebar<E> {
             })
             .when_some(self.header.take(), |this, header| {
                 this.child(
-                    h_flex()
+                    div()
                         .id("header")
-                        .min_w_0()
+                        .w_full()
                         .pt_3()
                         .px_3()
                         .gap_2()

--- a/crates/ui/src/sidebar/mod.rs
+++ b/crates/ui/src/sidebar/mod.rs
@@ -426,9 +426,8 @@ impl<E: SidebarItem> RenderOnce for Sidebar<E> {
             })
             .when_some(self.header.take(), |this, header| {
                 this.child(
-                    div()
+                    h_flex()
                         .id("header")
-                        .w_full()
                         .pt_3()
                         .px_3()
                         .gap_2()


### PR DESCRIPTION
Revert #2540 changes, this will broken the sidebar input width.

<img width="660" height="462" alt="image" src="https://github.com/user-attachments/assets/a7b3f874-d7e9-4830-8dbe-dfde886966d1" />