### PR TITLE
input: Skip highlighting for plain text and unregistered languages

### DIFF
--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -341,6 +341,29 @@ impl SyntaxHighlighter {
         }
     }
 
+    /// Build an inert highlighter that never parses and creates no styles,
+    /// for languages without a grammar.
+    fn build_inert(language: SharedString) -> Self {
+        Self {
+            language,
+            query: None,
+            injections_query: None,
+            locals_pattern_index: 0,
+            highlights_pattern_index: 0,
+            non_local_variable_patterns: Vec::new(),
+            injection_content_capture_index: None,
+            injection_language_capture_index: None,
+            local_scope_capture_index: None,
+            local_def_capture_index: None,
+            local_def_value_capture_index: None,
+            local_ref_capture_index: None,
+            text: Rope::new(),
+            parser: Parser::new(),
+            tree: None,
+            injection_layers: Vec::new(),
+        }
+    }
+
     /// Build the highlighter for the given language.
     ///
     /// https://github.com/tree-sitter/tree-sitter/blob/v0.26.8/crates/highlight/src/highlight.rs#L339
@@ -352,10 +375,14 @@ impl SyntaxHighlighter {
             ));
         };
 
+        // Languages without grammar default to a highlighter that never
+        // parses and creates no styles.
+        let Some(grammar) = config.language.as_ref() else {
+            return Ok(Self::build_inert(config.name.clone()));
+        };
+
         let mut parser = Parser::new();
-        parser
-            .set_language(&config.language)
-            .context("parse set_language")?;
+        parser.set_language(grammar).context("parse set_language")?;
 
         // Concatenate the query strings, keeping track of the start offset of each section.
         let mut query_source = String::new();
@@ -367,7 +394,7 @@ impl SyntaxHighlighter {
 
         // Construct a single query by concatenating the three query strings, but record the
         // range of pattern indices that belong to each individual string.
-        let mut query = Query::new(&config.language, &query_source).context("new query")?;
+        let mut query = Query::new(grammar, &query_source).context("new query")?;
 
         let mut locals_pattern_index = 0;
         let mut highlights_pattern_index = 0;
@@ -384,9 +411,7 @@ impl SyntaxHighlighter {
         }
 
         let injections_query = if !config.injections.is_empty() {
-            Query::new(&config.language, &config.injections)
-                .ok()
-                .map(Arc::new)
+            Query::new(grammar, &config.injections).ok().map(Arc::new)
         } else {
             None
         };
@@ -502,6 +527,12 @@ impl SyntaxHighlighter {
         timeout: Option<Duration>,
     ) -> bool {
         if self.text.eq(text) {
+            return true;
+        }
+
+        // If there's no grammar for the language, just update the text.
+        if self.parser.language().is_none() {
+            self.text = text.clone();
             return true;
         }
 
@@ -638,7 +669,7 @@ impl SyntaxHighlighter {
                 return Some((config.name, query.clone()));
             }
 
-            let query = match Query::new(&config.language, &config.highlights) {
+            let query = match Query::new(config.language.as_ref()?, &config.highlights) {
                 Ok(query) => Arc::new(query),
                 Err(error) => {
                     tracing::error!(
@@ -808,7 +839,7 @@ impl SyntaxHighlighter {
         }
         let config = LanguageRegistry::singleton().language(language_name)?;
         let mut parser = Parser::new();
-        parser.set_language(&config.language).ok()?;
+        parser.set_language(config.language.as_ref()?).ok()?;
         parser.set_included_ranges(&ranges).ok()?;
         let parse_start = Instant::now();
         let mut timed_out = false;
@@ -1248,6 +1279,24 @@ mod tests {
         let mut style = HighlightStyle::default();
         style.color = Some(color);
         style
+    }
+
+    #[test]
+    fn test_plain_text_never_parses() {
+        // "text" has no grammar, the highlighter shouldn't parse.
+        let mut highlighter = SyntaxHighlighter::new("text");
+        let rope = Rope::from("hello {\"a\": 1}\nworld");
+        assert!(highlighter.update(None, &rope, None));
+        assert!(highlighter.tree().is_none());
+        assert_eq!(highlighter.text().to_string(), rope.to_string());
+
+        let styles = highlighter.styles(&(0..rope.len()), &HighlightTheme::default_dark());
+        assert_eq!(styles, vec![(0..rope.len(), HighlightStyle::default())]);
+
+        // Unregistered languages fall back to plain text.
+        let mut highlighter = SyntaxHighlighter::new("no-such-language");
+        assert!(highlighter.update(None, &rope, None));
+        assert!(highlighter.tree().is_none());
     }
 
     #[cfg(feature = "tree-sitter-languages")]

--- a/crates/ui/src/highlighter/languages.rs
+++ b/crates/ui/src/highlighter/languages.rs
@@ -369,8 +369,13 @@ impl Language {
     ///
     /// (language, query, injection, locals)
     pub(super) fn config(&self) -> LanguageConfig {
+        // Plain text has no grammar, it should never be parsed.
+        if matches!(self, Self::Plain) {
+            return LanguageConfig::plain(self.name());
+        }
+
         let (language, query, injection, locals) = match self {
-            Self::Plain => (tree_sitter_json::LANGUAGE, "", "", ""),
+            Self::Plain => unreachable!(),
             Self::Json => (
                 tree_sitter_json::LANGUAGE,
                 include_str!("languages/json/highlights.scm"),

--- a/crates/ui/src/highlighter/languages.rs
+++ b/crates/ui/src/highlighter/languages.rs
@@ -369,16 +369,8 @@ impl Language {
     ///
     /// (language, query, injection, locals)
     pub(super) fn config(&self) -> LanguageConfig {
-        // Plain text has no grammar, it should never be parsed.
-        if matches!(self, Self::Plain) {
-            return LanguageConfig::plain(self.name());
-        }
-
         let (language, query, injection, locals) = match self {
-            Self::Plain => {
-                debug_assert!(false, "Plain language has no grammar to configure");
-                return LanguageConfig::plain(self.name());
-            }
+            Self::Plain => return LanguageConfig::plain(self.name()),
             Self::Json => (
                 tree_sitter_json::LANGUAGE,
                 include_str!("languages/json/highlights.scm"),

--- a/crates/ui/src/highlighter/languages.rs
+++ b/crates/ui/src/highlighter/languages.rs
@@ -375,7 +375,10 @@ impl Language {
         }
 
         let (language, query, injection, locals) = match self {
-            Self::Plain => unreachable!(),
+            Self::Plain => {
+                debug_assert!(false, "Plain language has no grammar to configure");
+                return LanguageConfig::plain(self.name());
+            }
             Self::Json => (
                 tree_sitter_json::LANGUAGE,
                 include_str!("languages/json/highlights.scm"),

--- a/crates/ui/src/highlighter/registry.rs
+++ b/crates/ui/src/highlighter/registry.rs
@@ -60,7 +60,7 @@ pub(super) const HIGHLIGHT_NAMES: [&str; 41] = [
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageConfig {
     pub name: SharedString,
-    pub language: tree_sitter::Language,
+    pub language: Option<tree_sitter::Language>,
     pub injection_languages: Vec<SharedString>,
     pub highlights: SharedString,
     pub injections: SharedString,
@@ -78,12 +78,29 @@ impl LanguageConfig {
     ) -> Self {
         Self {
             name: name.into(),
-            language,
+            language: Some(language),
             injection_languages,
             highlights: SharedString::from(highlights.to_string()),
             injections: SharedString::from(injections.to_string()),
             locals: SharedString::from(locals.to_string()),
         }
+    }
+
+    /// A plain text language without a grammar, it will never be parsed.
+    pub fn plain(name: impl Into<SharedString>) -> Self {
+        Self {
+            name: name.into(),
+            language: None,
+            injection_languages: vec![],
+            highlights: SharedString::default(),
+            injections: SharedString::default(),
+            locals: SharedString::default(),
+        }
+    }
+
+    /// Whether this language has a grammar to parse with.
+    pub fn has_grammar(&self) -> bool {
+        self.language.is_some()
     }
 }
 

--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -88,6 +88,12 @@ pub struct LanguageConfig {
     pub name: SharedString,
 }
 
+impl LanguageConfig {
+    pub fn has_grammar(&self) -> bool {
+        false
+    }
+}
+
 // Re-export theme types from registry module (which will be conditionally compiled)
 // For WASM, we create minimal stubs here
 use schemars::JsonSchema;

--- a/crates/ui/src/input/mode.rs
+++ b/crates/ui/src/input/mode.rs
@@ -7,6 +7,7 @@ use ropey::Rope;
 
 use super::display_map::DisplayMap;
 use crate::highlighter::DiagnosticSet;
+use crate::highlighter::LanguageRegistry;
 use crate::highlighter::SyntaxHighlighter;
 use crate::input::{InputEdit, RopeExt as _, TabSize};
 
@@ -245,6 +246,14 @@ impl InputMode {
 
                 let mut highlighter_ref = highlighter.borrow_mut();
                 if highlighter_ref.is_none() {
+                    // Do not create a highlighter if the language has no grammar.
+                    let has_grammar = LanguageRegistry::singleton()
+                        .language(language)
+                        .is_some_and(|config| config.has_grammar());
+                    if !has_grammar {
+                        return None;
+                    }
+
                     let new_highlighter = SyntaxHighlighter::new(language);
                     highlighter_ref.replace(new_highlighter);
                 }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2727,9 +2727,12 @@ impl InputState {
                     let Some(config) = LanguageRegistry::singleton().language(&language) else {
                         return None;
                     };
+                    let Some(grammar) = config.language.as_ref() else {
+                        return None;
+                    };
 
                     let mut parser = tree_sitter::Parser::new();
-                    if parser.set_language(&config.language).is_err() {
+                    if parser.set_language(grammar).is_err() {
                         return None;
                     }
 


### PR DESCRIPTION
Closes #2566

## Description

Plain text and other unregistered languages, like a code fence in markdown, falls back to JSON currently. Which is a lot of unnecessary parsing, and also causes quite a big memory overhead.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1793" height="724" alt="Before" src="https://github.com/user-attachments/assets/48c77797-0a25-4e8c-ad55-63ac7fed226d" /> | <img width="1793" height="724" alt="After" src="https://github.com/user-attachments/assets/28fdc9bf-7596-42e3-8ec0-062c279e8d44" /> |

## How to Test

- Generate a big text file
```sh
(for i in $(seq 1 999999); do echo 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'; done) > big_lorem.txt
```
- Disable linter and color provider in the editor
```diff
--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -713,7 +713,7 @@ impl Example {
             editor.lsp.code_action_providers = vec![lsp_store.clone(), Rc::new(TextConvertor)];
             editor.lsp.hover_provider = Some(lsp_store.clone());
             editor.lsp.definition_provider = Some(lsp_store.clone());
-            editor.lsp.document_color_provider = Some(lsp_store.clone());
+            // editor.lsp.document_color_provider = Some(lsp_store.clone());
 
             editor
         });
@@ -731,7 +731,7 @@ impl Example {
         Self::load_files(tree_state.clone(), PathBuf::from("./"), cx);
 
         let _subscriptions = vec![cx.subscribe(&editor, |this, _editor, _: &InputEvent, cx| {
-            this.lint_document(cx);
+            // this.lint_document(cx);
         })];
 
         Self {
```
- Run the editor example, open the big text file and compare memory usage

I've also checked various other files in the editor example

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
