### PR TITLE
input: add Lsp::show_document hook following LSP window/showDocument

### DIFF
--- a/crates/ui/src/input/lsp/definitions.rs
+++ b/crates/ui/src/input/lsp/definitions.rs
@@ -160,24 +160,31 @@ impl InputState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Give the host a chance to handle the location first, e.g. to open
-        // virtual/external documents (stdlib docs) in an app window.
-        if let Some(handler) = self.lsp.on_open_location.clone() {
-            if handler(location, window, cx) {
+        let external = location
+            .target_uri
+            .scheme()
+            .map(|s| s.as_str() == "https" || s.as_str() == "http")
+            == Some(true);
+
+        // Give the host a chance to show the document first (window/showDocument),
+        // e.g. to open virtual/external documents (stdlib docs) in an app window.
+        if let Some(handler) = self.lsp.show_document.clone() {
+            let params = lsp_types::ShowDocumentParams {
+                uri: location.target_uri.clone(),
+                external: Some(external),
+                take_focus: Some(true),
+                selection: Some(location.target_selection_range),
+            };
+            if handler(&params, window, cx) {
                 return;
             }
         }
 
-        if location
-            .target_uri
-            .scheme()
-            .map(|s| s.as_str() == "https" || s.as_str() == "http")
-            == Some(true)
-        {
+        if external {
             cx.open_url(&location.target_uri.to_string());
         } else {
             // Move to the location.
-            let target_range = location.target_range;
+            let target_range = location.target_selection_range;
             let start = self.text.position_to_offset(&target_range.start);
             let end = self.text.position_to_offset(&target_range.end);
 

--- a/crates/ui/src/input/lsp/definitions.rs
+++ b/crates/ui/src/input/lsp/definitions.rs
@@ -111,7 +111,7 @@ impl InputState {
     pub(crate) fn on_action_go_to_definition(
         &mut self,
         _: &GoToDefinition,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let offset = self.cursor();
@@ -121,7 +121,7 @@ impl InputState {
             }
 
             if let Some(location) = locations.first().cloned() {
-                self.go_to_definition(&location, cx);
+                self.go_to_definition(&location, window, cx);
             }
         }
     }
@@ -131,7 +131,7 @@ impl InputState {
         &mut self,
         event: &MouseDownEvent,
         offset: usize,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<InputState>,
     ) -> bool {
         if !event.modifiers.secondary() {
@@ -149,7 +149,7 @@ impl InputState {
             return false;
         };
 
-        self.go_to_definition(&location, cx);
+        self.go_to_definition(&location, window, cx);
 
         true
     }
@@ -157,8 +157,17 @@ impl InputState {
     pub(crate) fn go_to_definition(
         &mut self,
         location: &lsp_types::LocationLink,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Give the host a chance to handle the location first, e.g. to open
+        // virtual/external documents (stdlib docs) in an app window.
+        if let Some(handler) = self.lsp.on_open_location.clone() {
+            if handler(location, window, cx) {
+                return;
+            }
+        }
+
         if location
             .target_uri
             .scheme()

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -19,6 +19,14 @@ pub use document_colors::*;
 pub use hover::*;
 pub use semantic_tokens::*;
 
+/// Host hook to intercept opening an LSP location (Go to Definition).
+///
+/// Called before the built-in behavior. Return `true` if the host handled
+/// the location (e.g. opened a docs window for a virtual/external URI);
+/// return `false` to fall through to the default handling (http(s) URIs
+/// open in the browser, anything else jumps within the current document).
+pub type OpenLocationHandler = Rc<dyn Fn(&lsp_types::LocationLink, &mut Window, &mut App) -> bool>;
+
 /// LSP ServerCapabilities
 ///
 /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities
@@ -35,6 +43,9 @@ pub struct Lsp {
     pub document_color_provider: Option<Rc<dyn DocumentColorProvider>>,
     /// The range semantic tokens provider.
     pub semantic_tokens_provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
+    /// Optional host hook to intercept Go to Definition locations
+    /// (see [`OpenLocationHandler`]).
+    pub on_open_location: Option<OpenLocationHandler>,
 
     document_colors: Vec<(lsp_types::Range, Hsla)>,
     /// Cached semantic tokens as absolute position ranges + theme token-type
@@ -55,6 +66,7 @@ impl Default for Lsp {
             definition_provider: None,
             document_color_provider: None,
             semantic_tokens_provider: None,
+            on_open_location: None,
             document_colors: vec![],
             semantic_tokens: vec![],
             _hover_task: Task::ready(Ok(())),

--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -19,13 +19,17 @@ pub use document_colors::*;
 pub use hover::*;
 pub use semantic_tokens::*;
 
-/// Host hook to intercept opening an LSP location (Go to Definition).
+/// Host hook to show a document when following an LSP location
+/// (Go to Definition), modeled after the `window/showDocument` request.
 ///
-/// Called before the built-in behavior. Return `true` if the host handled
-/// the location (e.g. opened a docs window for a virtual/external URI);
-/// return `false` to fall through to the default handling (http(s) URIs
+/// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument
+///
+/// Called before the built-in behavior. Return `true` if the host has shown
+/// the document (e.g. opened a docs window for a virtual/external URI);
+/// return `false` to fall through to the default handling (`external` URIs
 /// open in the browser, anything else jumps within the current document).
-pub type OpenLocationHandler = Rc<dyn Fn(&lsp_types::LocationLink, &mut Window, &mut App) -> bool>;
+pub type ShowDocumentHandler =
+    Rc<dyn Fn(&lsp_types::ShowDocumentParams, &mut Window, &mut App) -> bool>;
 
 /// LSP ServerCapabilities
 ///
@@ -43,9 +47,11 @@ pub struct Lsp {
     pub document_color_provider: Option<Rc<dyn DocumentColorProvider>>,
     /// The range semantic tokens provider.
     pub semantic_tokens_provider: Option<Rc<dyn DocumentRangeSemanticTokensProvider>>,
-    /// Optional host hook to intercept Go to Definition locations
-    /// (see [`OpenLocationHandler`]).
-    pub on_open_location: Option<OpenLocationHandler>,
+    /// Optional host hook to show documents for Go to Definition locations,
+    /// following the `window/showDocument` request (see [`ShowDocumentHandler`]).
+    ///
+    /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument
+    pub show_document: Option<ShowDocumentHandler>,
 
     document_colors: Vec<(lsp_types::Range, Hsla)>,
     /// Cached semantic tokens as absolute position ranges + theme token-type
@@ -66,7 +72,7 @@ impl Default for Lsp {
             definition_provider: None,
             document_color_provider: None,
             semantic_tokens_provider: None,
-            on_open_location: None,
+            show_document: None,
             document_colors: vec![],
             semantic_tokens: vec![],
             _hover_task: Task::ready(Ok(())),


### PR DESCRIPTION
## What

Adds an optional `Lsp::on_show_document` host hook on `InputState`, called at the start of `go_to_definition` before the built-in handling. The hook is modeled after the LSP [`window/showDocument`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument) request:

```rust
pub type ShowDocumentHandler =
    Rc<dyn Fn(&lsp_types::ShowDocumentParams, &mut Window, &mut App) -> bool>;
```

The component builds `ShowDocumentParams` from the resolved `LocationLink` (`uri`, `external` for http(s) targets, `take_focus`, `selection` from `targetSelectionRange`).

- Return `true`: the host has shown the document; the component does nothing further.
- Return `false` (or hook unset): falls through to the existing behavior — `external` URIs open in the browser, anything else jumps within the current document.

The default in-document jump now selects `targetSelectionRange` (the range the spec says should be selected and revealed when following a link) instead of `targetRange`.

## Why

The built-in Go to Definition can only jump within the current document or open a browser URL. Language providers that resolve symbols into virtual/external documents (e.g. NaviScript stdlib symbols resolving to `navi-doc://module/name`) need a way to route Cmd+Click to an in-app docs window. Without a hook, non-http cross-file locations would be misinterpreted as same-document ranges and jump to a wrong position.

`window/showDocument` is the spec's standard "client, show this document" abstraction, so the hook reuses its params shape rather than inventing a new one.

## Notes

- Branch is based on `d1c48828` (the rev currently pinned by longbridge-gpui's Cargo.lock) so it can be consumed immediately; happy to rebase onto `main` if preferred.
- `go_to_definition` (crate-private) gains a `&mut Window` parameter; both internal call sites already had a window in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
