### PR TITLE
highlighter: Preserve text color without syntax highlighting

### DIFF
--- a/crates/ui/src/highlighter/wasm_stub.rs
+++ b/crates/ui/src/highlighter/wasm_stub.rs
@@ -21,10 +21,11 @@ impl SyntaxHighlighter {
 
     pub fn styles(
         &self,
-        _range: &Range<usize>,
+        range: &Range<usize>,
         _theme: &HighlightTheme,
     ) -> Vec<(Range<usize>, HighlightStyle)> {
-        Vec::new()
+        // If the matched styles is empty, return a default range.
+        vec![(range.clone(), HighlightStyle::default())]
     }
 
     pub fn update(


### PR DESCRIPTION
Related to #2325

## Description

When the `tree-sitter` feature is disabled, the stub implementation of `SyntaxHighlighter::styles` returns an empty style list.

The input renderer builds text runs from that list. When the list is empty, no colored text run is created, so GPUI paints the text with its default black instead of preserving the input's text color.

The native highlighter returns the requested range with `HighlightStyle::default()` when no styles match. This change aligns the stub implementation with that behavior so the input text color is preserved when syntax highlighting is disabled.

## How to Test

- Run `cargo check -p gpui-component --target wasm32-unknown-unknown --lib`.
- Build a web application that uses gpui-component with `default-features = false`.
- Enter text in a CodeEditor with a dark theme.
- Verify that existing and newly entered text use the input's text color.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [N/A] Passed `cargo run` for story tests related to the changes.
- [N/A] Tested macOS, Windows and Linux platforms performance (not platform-specific).
