### PR TITLE
editor: Fix completion menu intrinsic width measurement

### DIFF
--- a/crates/ui/src/list/cache.rs
+++ b/crates/ui/src/list/cache.rs
@@ -95,6 +95,12 @@ impl RowsCache {
             .position(|p| p.is_entry() && p.eq_index_path(path))
     }
 
+    /// Returns the flattened position of the first item row, skipping section
+    /// headers and footers.
+    pub(crate) fn first_entry_position(&self) -> Option<usize> {
+        self.entities.iter().position(RowEntry::is_entry)
+    }
+
     /// Return prev row, if the row is the first in the first section, goes to the last row.
     ///
     /// Empty rows section are skipped.
@@ -251,6 +257,14 @@ mod tests {
                 children
             })
             .collect()
+    }
+
+    #[test]
+    fn first_entry_position_skips_section_headers() {
+        let mut row_cache = RowsCache::default();
+        row_cache.entities = Rc::new(build_entities(&[2]));
+
+        assert_eq!(row_cache.first_entry_position(), Some(1));
     }
 
     #[test]

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -510,6 +510,9 @@ where
         let rows_cache = self.rows_cache.clone();
         let scrollbar_visible = self.options.scrollbar_visible;
         let scroll_handle = self.scroll_handle.clone();
+        let item_to_measure_index = rows_cache
+            .position_of(&self.item_to_measure_index)
+            .unwrap_or(0);
 
         v_flex()
             .flex_grow_1()
@@ -563,6 +566,7 @@ where
                                     .collect::<Vec<_>>()
                             },
                         )
+                        .with_item_to_measure_index(item_to_measure_index)
                         .paddings(self.options.paddings.clone())
                         .when(self.options.max_height.is_some(), |this| {
                             this.with_sizing_behavior(ListSizingBehavior::Infer)

--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -512,6 +512,7 @@ where
         let scroll_handle = self.scroll_handle.clone();
         let item_to_measure_index = rows_cache
             .position_of(&self.item_to_measure_index)
+            .or_else(|| rows_cache.first_entry_position())
             .unwrap_or(0);
 
         v_flex()

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -124,8 +124,9 @@ impl VirtualListScrollHandle {
 ///
 /// This is like `uniform_list` in GPUI, but support two axis.
 ///
-/// The `item_sizes` is the size of each column,
-/// only the `height` is used, `width` is ignored and VirtualList will measure the first item width.
+/// The `item_sizes` is the size of each row. Only the `height` is used; `width` is inferred
+/// by measuring the item selected with [`VirtualList::with_item_to_measure_index`], defaulting
+/// to the first item.
 ///
 /// See also [`h_virtual_list`]
 #[inline]
@@ -197,6 +198,7 @@ where
         item_sizes,
         render_items: Box::new(render_range),
         sizing_behavior: ListSizingBehavior::default(),
+        item_to_measure_index: 0,
     }
 }
 
@@ -212,6 +214,7 @@ pub struct VirtualList {
         dyn for<'a> Fn(Range<usize>, &'a mut Window, &'a mut App) -> SmallVec<[AnyElement; 64]>,
     >,
     sizing_behavior: ListSizingBehavior,
+    item_to_measure_index: usize,
 }
 
 impl Styled for VirtualList {
@@ -230,6 +233,12 @@ impl VirtualList {
     /// Set the sizing behavior for the list.
     pub fn with_sizing_behavior(mut self, behavior: ListSizingBehavior) -> Self {
         self.sizing_behavior = behavior;
+        self
+    }
+
+    /// Set the item index used to infer the list's cross-axis size.
+    pub fn with_item_to_measure_index(mut self, index: usize) -> Self {
+        self.item_to_measure_index = index;
         self
     }
 
@@ -301,7 +310,7 @@ impl VirtualList {
             return Size::default();
         }
 
-        let item_ix = 0;
+        let item_ix = self.item_to_measure_index.min(self.items_count - 1);
         let mut items = (self.render_items)(item_ix..item_ix + 1, window, cx);
         let Some(mut item_to_measure) = items.pop() else {
             return Size::default();

--- a/crates/ui/src/virtual_list.rs
+++ b/crates/ui/src/virtual_list.rs
@@ -145,8 +145,9 @@ where
 
 /// Create a [`VirtualList`] in horizontal direction.
 ///
-/// The `item_sizes` is the size of each column,
-/// only the `width` is used, `height` is ignored and VirtualList will measure the first item height.
+/// The `item_sizes` is the size of each column. Only the `width` is used; `height` is inferred
+/// by measuring the item selected with [`VirtualList::with_item_to_measure_index`], defaulting
+/// to the first item.
 ///
 /// See also [`v_virtual_list`]
 #[inline]
@@ -425,25 +426,19 @@ impl Element for VirtualList {
                                 })
                                 .collect::<Vec<_>>();
 
-                            state.content_size = if self.axis.is_horizontal() {
-                                Size {
-                                    width: px(state
-                                        .sizes
-                                        .iter()
-                                        .map(|size| size.as_f32())
-                                        .sum::<f32>()),
-                                    height: longest_item_size.height,
-                                }
+                            if self.axis.is_horizontal() {
+                                state.content_size.width =
+                                    px(state.sizes.iter().map(|size| size.as_f32()).sum::<f32>());
                             } else {
-                                Size {
-                                    width: longest_item_size.width,
-                                    height: px(state
-                                        .sizes
-                                        .iter()
-                                        .map(|size| size.as_f32())
-                                        .sum::<f32>()),
-                                }
-                            };
+                                state.content_size.height =
+                                    px(state.sizes.iter().map(|size| size.as_f32()).sum::<f32>());
+                            }
+                        }
+
+                        if self.axis.is_horizontal() {
+                            state.content_size.height = longest_item_size.height;
+                        } else {
+                            state.content_size.width = longest_item_size.width;
                         }
 
                         (state.clone(), state)


### PR DESCRIPTION
## Description

Completion menus already select their longest label/detail row with `ListState::set_item_to_measure_index`, but that representative row was not reaching `VirtualList`'s cross-axis measurement. `VirtualList` always measured flattened item `0`, which is commonly an empty section-header entry, so the popover collapsed to its 120px minimum.

This change passes the selected row's flattened index through `ListState` to `VirtualList` and uses that item when inferring content width. The existing completion popover constraints remain unchanged: short lists stay compact, longer lists expand to content, and width remains capped by the existing 320px/available-space maximum.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="518" height="312" alt="Screenshot 2026-07-15 at 5 12 26 pm" src="https://github.com/user-attachments/assets/a037f58a-4b1f-4cf7-ad75-330b99b22d6e" /> | <img width="726" height="326" alt="Screenshot 2026-07-15 at 5 14 10 pm" src="https://github.com/user-attachments/assets/9cfd24b0-d63d-4250-a4da-303c7cc25a47" /> |

## How to Test

1. Use an LSP server such as `rust-analyzer` and trigger a completion list with short items; confirm the popup remains compact.
2. Trigger a list containing longer labels/details; confirm the popup expands beyond 120px.
3. Confirm very long items remain capped at the existing maximum and documentation stays adjacent to the actual completion width.
4. Run `cargo check -p gpui-component` and `cargo test -p gpui-component`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.

