### PR TITLE
input: Avoid painting unset gutter background

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -2122,25 +2122,18 @@ impl Element for TextElement {
         if let Some(line_numbers) = prepaint.line_numbers.as_ref() {
             offset_y += invisible_top_padding;
 
-            // Gutter background: prefer the dedicated `editor.gutter.background`
-            // theme key, falling back to the editor background so existing
-            // themes render unchanged.
-            let gutter_bg = cx
-                .theme()
-                .highlight_theme
-                .style
-                .editor_gutter_background
-                .unwrap_or_else(|| cx.theme().editor_background());
-            window.paint_quad(fill(
-                Bounds {
-                    origin: input_bounds.origin,
-                    size: size(
-                        prepaint.last_layout.line_number_width - LINE_NUMBER_RIGHT_MARGIN,
-                        input_bounds.size.height + prepaint.ghost_lines_height,
-                    ),
-                },
-                gutter_bg,
-            ));
+            if let Some(gutter_bg) = cx.theme().highlight_theme.style.editor_gutter_background {
+                window.paint_quad(fill(
+                    Bounds {
+                        origin: input_bounds.origin,
+                        size: size(
+                            prepaint.last_layout.line_number_width - LINE_NUMBER_RIGHT_MARGIN,
+                            input_bounds.size.height + prepaint.ghost_lines_height,
+                        ),
+                    },
+                    gutter_bg,
+                ));
+            }
 
             // Each item is the normal lines.
             for (lines, &buffer_line) in line_numbers


### PR DESCRIPTION
Related to #2411

## Description

The line-number gutter is painted as a separate quad on top of the editor background.

When `editor.gutter.background` is unset, the current implementation falls back to `editor_background()`. Since the editor already paints that background, translucent colors are composited twice in the gutter and make it appear darker than the text area.

The fallback can also conflict with a background applied through the editor's `Styled` implementation because the gutter still paints the theme's editor background separately.

This change paints the gutter background only when `editor.gutter.background` is explicitly configured. When it is unset, the editor background remains visible without an additional paint layer. Themes that define a dedicated gutter background continue to render it as before.

## Screenshots
Before:
<img width="739" height="891" alt="editor-gutter-before" src="https://github.com/user-attachments/assets/4be62f5a-32dc-49fc-ad9a-cb6d5f46ae04" />

After:
<img width="370" height="393" alt="editor-gutter-after" src="https://github.com/user-attachments/assets/3eda8ce4-0baa-4251-8bc7-898e22c5d59f" />

## How to Test

- Run `cargo check -p gpui-component`.
- Run `cargo run` and open the Editor story.
- Use a theme with a translucent `editor.background` and no `editor.gutter.background`.
- Verify that the gutter and text area have the same visual background.
- Set `editor.gutter.background` and verify that the explicit gutter background is still rendered.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [N/A] Tested macOS, Windows and Linux platforms performance (not platform-specific).
