### PR TITLE
select, combobox: Use popover background for dropdown menus

### DIFF
--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -986,7 +986,7 @@ fn render_popup_shell<D: SearchableListDelegate + 'static>(
                     v_flex()
                         .occlude()
                         .mt_1p5()
-                        .bg(cx.theme().tokens.background)
+                        .bg(cx.theme().tokens.popover)
                         .border_1()
                         .border_color(cx.theme().border)
                         .rounded(popup_radius)

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -558,7 +558,7 @@ where
                                     v_flex()
                                         .occlude()
                                         .mt_1p5()
-                                        .bg(cx.theme().tokens.background)
+                                        .bg(cx.theme().tokens.popover)
                                         .border_1()
                                         .border_color(cx.theme().border)
                                         .rounded(popup_radius)


### PR DESCRIPTION
Select and Combobox paint their dropdown menu panel with `tokens.background`,
while PopupMenu and Popover use `tokens.popover`. With a theme that has a
translucent background color (transparent window setups), open select menus
become see-through and hard to read while every other floating panel stays
opaque.

This paints both menus with `tokens.popover` and its paired
`popover_foreground`, the same pair `popover_style()` uses, so they match the
rest of the popups. In the default themes `popover` falls back to
`background`, so nothing changes visually there. No API changes.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
|   <img width="512" alt="image" src="https://github.com/user-attachments/assets/3492ed62-7f32-4c54-9118-f70ba7c896f7" /> | <img width="512" alt="image" src="https://github.com/user-attachments/assets/58ca615f-0dac-4331-9e54-cabd17804752" /> |

## How to Test

Run `cargo run` and open the Select and Combobox stories, menus should look
unchanged with the default themes (`background` and `popover` are the same
color there). To see the fix, set the theme's `background` to a translucent
color and open a select menu: it stays opaque instead of showing the content
behind it.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
