### PR TITLE
plot: Don't track hover through occluding overlays for tooltips

### DIFF
--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -35,8 +35,9 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
 
         impl #impl_generics gpui::Element for #type_name #type_generics #where_clause {
             type RequestLayoutState = ();
-            // Carries the prepainted tooltip overlay (if any) from `prepaint` to `paint`.
-            type PrepaintState = Option<gpui::AnyElement>;
+            // Carries the hitbox used for occlusion-aware hover detection and the
+            // prepainted tooltip overlay (if any) from `prepaint` to `paint`.
+            type PrepaintState = (Option<gpui::Hitbox>, Option<gpui::AnyElement>);
 
             fn id(&self) -> Option<gpui::ElementId> {
                 // `Some` opts the plot in to interactive tooltips; `None` (the default)
@@ -73,22 +74,33 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 cx: &mut gpui::App,
             ) -> Self::PrepaintState {
                 // No id => tooltips disabled => behave exactly like a non-interactive plot.
-                let global_id = global_id?;
+                let Some(global_id) = global_id else {
+                    return (None, None);
+                };
 
-                // Read the cursor position recorded by the previous frame's mouse handler.
-                let position = Self::__plot_tooltip_cursor(global_id, window).get()?;
-                let state = <Self as Plot>::tooltip_state(self, position, bounds, cx)?;
+                // The hitbox lets the mouse handler hit-test with occlusion awareness:
+                // `Hitbox::is_hovered` returns false while an occluding hitbox (e.g. an
+                // open popup menu) is above the plot, unlike a plain bounds test.
+                let hitbox = window.insert_hitbox(bounds, gpui::HitboxBehavior::Normal);
 
-                // Pass the live cursor so the tooltip box can follow it; the crosshair and
-                // dots in `state` stay snapped to the data point by `tooltip_state`.
-                //
-                // The overlay paints in the plot's own layer, so the crosshair and dots stay
-                // below content drawn over the plot. The tooltip box defers itself (see
-                // `plot::tooltip::Tooltip`) to paint above sibling content, since it can
-                // extend past the plot bounds.
-                let mut overlay = <Self as Plot>::tooltip(self, &state, position, bounds, window, cx)?;
-                overlay.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);
-                Some(overlay)
+                let overlay = (|| {
+                    // Read the cursor position recorded by the previous frame's mouse handler.
+                    let position = Self::__plot_tooltip_cursor(global_id, window).get()?;
+                    let state = <Self as Plot>::tooltip_state(self, position, bounds, cx)?;
+
+                    // Pass the live cursor so the tooltip box can follow it; the crosshair and
+                    // dots in `state` stay snapped to the data point by `tooltip_state`.
+                    //
+                    // The overlay paints in the plot's own layer, so the crosshair and dots stay
+                    // below content drawn over the plot. The tooltip box defers itself (see
+                    // `plot::tooltip::Tooltip`) to paint above sibling content, since it can
+                    // extend past the plot bounds.
+                    let mut overlay = <Self as Plot>::tooltip(self, &state, position, bounds, window, cx)?;
+                    overlay.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);
+                    Some(overlay)
+                })();
+
+                (Some(hitbox), overlay)
             }
 
             fn paint(
@@ -97,21 +109,28 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 _: Option<&gpui::InspectorElementId>,
                 bounds: gpui::Bounds<gpui::Pixels>,
                 _: &mut Self::RequestLayoutState,
-                overlay: &mut Self::PrepaintState,
+                prepaint: &mut Self::PrepaintState,
                 window: &mut gpui::Window,
                 cx: &mut gpui::App,
             ) {
                 <Self as Plot>::paint(self, bounds, window, cx);
 
-                if let Some(global_id) = global_id {
+                let (hitbox, overlay) = prepaint;
+
+                if let (Some(global_id), Some(hitbox)) = (global_id, hitbox.as_ref()) {
                     // Record the cursor position into element-local state on every move so the
                     // next frame can hit-test it. The handler never touches `self`, satisfying
-                    // the `'static` bound; it only captures the (Copy) bounds and the state cell.
+                    // the `'static` bound; it only captures the (Copy) bounds, the hitbox id
+                    // and the state cell.
                     let cell = Self::__plot_tooltip_cursor(global_id, window);
+                    let hitbox = hitbox.clone();
 
                     window.on_mouse_event(
                         move |e: &gpui::MouseMoveEvent, _, window: &mut gpui::Window, _| {
-                            let next = if bounds.contains(&e.position) {
+                            // `is_hovered` is false when an occluding hitbox (popup menu,
+                            // modal, ...) is above the cursor, so the tooltip clears instead
+                            // of tracking the mouse through the overlay.
+                            let next = if hitbox.is_hovered(window) {
                                 Some(e.position - bounds.origin)
                             } else {
                                 None


### PR DESCRIPTION
## Description

Previously, the `IntoPlot` derive's mouse-move handler used a plain `bounds.contains(&e.position)` test to track the cursor for tooltips. This meant the tooltip (and its crosshair) kept following the mouse even when an occluding overlay — such as an open popup menu or modal — was above the plot.

This PR makes hover detection occlusion-aware:

- `prepaint` now inserts a `Hitbox` (with `HitboxBehavior::Normal`) for the plot bounds and carries it to `paint` via `PrepaintState`.
- The mouse-move handler uses `hitbox.is_hovered(window)` instead of a raw bounds test, so the tooltip clears when another hitbox (popup, modal, etc.) is over the cursor.

Only affects the generated code in `crates/macros`; no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)