### PR TITLE
tab_bar: Match segmented tab shadow to shadcn

### DIFF
--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -779,7 +779,7 @@ impl RenderOnce for Tab {
                                 .h(inner_height)
                                 .bg(inline_inner_bg)
                                 .rounded(inner_radius)
-                                .when(tab_style.shadow, |this| this.shadow_xs()),
+                                .when(tab_style.shadow, |this| this.shadow_sm()),
                         ),
                 )
             })

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -224,7 +224,7 @@ impl TabBar {
                         .h(inner_height)
                         .bg(cx.theme().tokens.background)
                         .rounded(inner_radius)
-                        .shadow_xs(),
+                        .shadow_sm(),
                 ),
                 TabVariant::Pill => el.flex().items_center().child(
                     div()


### PR DESCRIPTION
## Summary

- use `shadow_sm()` for the animated Segmented tab indicator
- keep the first-layout fallback shadow consistent with the indicator
- preserve the existing Segmented sliding transition

### Before

<img width="632" height="111" alt="image" src="https://github.com/user-attachments/assets/50aa96c3-2cb6-47b1-9c66-98d1d6a8bc3a" />

### After

<img width="1588" height="217" alt="image" src="https://github.com/user-attachments/assets/dd272cec-021d-4f50-b998-b20697255e45" />


## Test Plan

- `cargo test -p gpui-component --lib` (320 passed)
- `cargo run -p gpui-component-story -- Tabs`