### PR TITLE
markdown: Fix render list item blocks

### DIFF
--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -153,6 +153,31 @@ See the way the text is aligned, depending on the position of `':'`
 - [ ] Task 2, going to do something if there is a long text that needs to be wrapped to the next line.
 - [ ] Task 3
 
+### Block content in list items
+
+1. A fenced code block:
+
+   ```rust
+   fn main() {
+       println!("Nested code block");
+   }
+   ```
+
+2. A blockquote:
+
+   > Blockquotes inside list items should remain visible.
+
+3. A table:
+
+   | Name  | Value |
+   | ----- | ----- |
+   | Alpha | 1     |
+   | Beta  | 2     |
+
+4. A heading:
+
+   #### Heading inside a list item
+
 ## Heading
 
 Add `##` at the beginning of a line to set as Heading.

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -1231,6 +1231,46 @@ impl BlockNode {
 }
 
 impl BlockNode {
+    fn render_list_item_row(
+        content: AnyElement,
+        ix: usize,
+        options: NodeRenderOptions,
+        checked: Option<bool>,
+        cx: &mut App,
+    ) -> Div {
+        h_flex()
+            .w_full()
+            .flex_1()
+            .min_w_0()
+            .relative()
+            .items_start()
+            .content_start()
+            .when(!options.todo && checked.is_none(), |this| {
+                this.child(list_item_prefix(ix, options.ordered, options.depth))
+            })
+            .when_some(checked, |this, checked| {
+                // Todo list checkbox
+                this.child(
+                    div()
+                        .flex()
+                        .mt(rems(0.4))
+                        .mr_1p5()
+                        .size(rems(0.875))
+                        .items_center()
+                        .justify_center()
+                        .rounded(cx.theme().radius.half())
+                        .border_1()
+                        .border_color(cx.theme().primary)
+                        .text_color(cx.theme().primary_foreground)
+                        .when(checked, |this| {
+                            this.bg(cx.theme().tokens.primary)
+                                .child(Icon::new(IconName::Check).size_2().text_xs())
+                        }),
+                )
+            })
+            .child(div().flex_1().min_w_0().overflow_hidden().child(content))
+    }
+
     fn render_list_item(
         item: &BlockNode,
         ix: usize,
@@ -1289,48 +1329,9 @@ impl BlockNode {
                                     }
                                 }
 
-                                items.push(
-                                    h_flex()
-                                        .w_full()
-                                        .flex_1()
-                                        .min_w_0()
-                                        .relative()
-                                        .items_start()
-                                        .content_start()
-                                        .when(!options.todo && checked.is_none(), |this| {
-                                            this.child(list_item_prefix(
-                                                ix,
-                                                options.ordered,
-                                                options.depth,
-                                            ))
-                                        })
-                                        .when_some(*checked, |this, checked| {
-                                            // Todo list checkbox
-                                            this.child(
-                                                div()
-                                                    .flex()
-                                                    .mt(rems(0.4))
-                                                    .mr_1p5()
-                                                    .size(rems(0.875))
-                                                    .items_center()
-                                                    .justify_center()
-                                                    .rounded(cx.theme().radius.half())
-                                                    .border_1()
-                                                    .border_color(cx.theme().primary)
-                                                    .text_color(cx.theme().primary_foreground)
-                                                    .when(checked, |this| {
-                                                        this.bg(cx.theme().tokens.primary).child(
-                                                            Icon::new(IconName::Check)
-                                                                .size_2()
-                                                                .text_xs(),
-                                                        )
-                                                    }),
-                                            )
-                                        })
-                                        .child(
-                                            div().flex_1().min_w_0().overflow_hidden().child(text),
-                                        ),
-                                );
+                                items.push(Self::render_list_item_row(
+                                    text, ix, options, *checked, cx,
+                                ));
                             }
                             BlockNode::List { .. } => {
                                 items.push(div().ml(rems(1.)).child(child.render_block(
@@ -1345,7 +1346,43 @@ impl BlockNode {
                                     cx,
                                 )));
                             }
-                            _ => {}
+                            BlockNode::Root { .. }
+                            | BlockNode::Heading { .. }
+                            | BlockNode::Blockquote { .. }
+                            | BlockNode::CodeBlock(_)
+                            | BlockNode::Custom(_)
+                            | BlockNode::Table(_)
+                            | BlockNode::HorizontalRule { .. } => {
+                                let block = child.render_block(
+                                    NodeRenderOptions {
+                                        depth: options.depth + 1,
+                                        todo: checked.is_some(),
+                                        is_last: true,
+                                        ..options
+                                    },
+                                    node_cx,
+                                    window,
+                                    cx,
+                                );
+
+                                if child_ix == 0 {
+                                    items.push(Self::render_list_item_row(
+                                        block, ix, options, *checked, cx,
+                                    ));
+                                } else {
+                                    items.push(
+                                        div()
+                                            .w_full()
+                                            .pl(rems(0.75))
+                                            .overflow_hidden()
+                                            .child(block),
+                                    );
+                                }
+                            }
+                            BlockNode::ListItem { .. }
+                            | BlockNode::Break { .. }
+                            | BlockNode::Definition { .. }
+                            | BlockNode::Unknown => {}
                         }
                     }
                     items

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -733,10 +733,14 @@ impl CodeBlock {
         let style = &node_cx.style;
 
         div()
+            .w_full()
+            .min_w_0()
             .when(!options.is_last, |this| this.pb(style.paragraph_gap))
             .child(
                 div()
                     .id(("codeblock", options.ix))
+                    .w_full()
+                    .min_w_0()
                     .p_3()
                     .rounded(cx.theme().radius)
                     .bg(cx.theme().tokens.muted)
@@ -1373,6 +1377,7 @@ impl BlockNode {
                                     items.push(
                                         div()
                                             .w_full()
+                                            .min_w_0()
                                             .pl(rems(0.75))
                                             .overflow_hidden()
                                             .child(block),
@@ -1718,6 +1723,8 @@ impl BlockNode {
                 children, ordered, ..
             } => v_flex()
                 .id((if *ordered { "ol" } else { "ul" }, ix))
+                .w_full()
+                .min_w_0()
                 .pb(mb)
                 .children({
                     let mut items = Vec::with_capacity(children.len());

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -1324,7 +1324,7 @@ impl BlockNode {
                                             v_flex().child(preceding_row).child(
                                                 div()
                                                     .w_full()
-                                                    .pl(rems(0.75))
+                                                    .pl(rems(1.))
                                                     .overflow_hidden()
                                                     .child(text),
                                             ),
@@ -1374,11 +1374,14 @@ impl BlockNode {
                                         block, ix, options, *checked, cx,
                                     ));
                                 } else {
+                                    // Indent continuation blocks to align with a
+                                    // nested sub-list (`ml(rems(1.))`) and with
+                                    // continuation paragraphs.
                                     items.push(
                                         div()
                                             .w_full()
                                             .min_w_0()
-                                            .pl(rems(0.75))
+                                            .pl(rems(1.))
                                             .overflow_hidden()
                                             .child(block),
                                     );

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -462,7 +462,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn list_item_renders_fenced_code_block(cx: &mut TestAppContext) {
+    fn list_item_renders_fenced_code_block_at_document_width(cx: &mut TestAppContext) {
         struct ListItemBlockRoot;
 
         impl Render for ListItemBlockRoot {
@@ -471,19 +471,29 @@ mod tests {
                 _window: &mut Window,
                 _cx: &mut Context<Self>,
             ) -> impl IntoElement {
-                div()
-                    .w(px(420.))
-                    .child(
-                        div()
-                            .debug_selector(|| "plain-list-item".into())
-                            .child(TextView::markdown("plain-list", "1. List item")),
-                    )
-                    .child(div().debug_selector(|| "list-item-with-code".into()).child(
-                        TextView::markdown(
-                            "list-with-code",
-                            "1. List item\n   ```rust\n   fn main() {}\n   ```",
-                        ),
-                    ))
+                div().w(px(840.)).h(px(400.)).child(
+                    crate::resizable::h_resizable("markdown-width-test")
+                        .child(crate::resizable::resizable_panel().child(div()))
+                        .child(crate::resizable::resizable_panel().child(
+                            TextView::markdown(
+                                "list-with-code",
+                                "1. List item\n   ```rust\n   nested code\n   ```\n\n```rust\ntop-level code\n```",
+                            )
+                            .code_block_actions(|code_block, _, _| {
+                                let selector = if code_block.code().contains("nested") {
+                                    "nested-code-action"
+                                } else {
+                                    "top-level-code-action"
+                                };
+                                div()
+                                    .debug_selector(move || selector.into())
+                                    .child("Copy")
+                            })
+                            .scrollable(true)
+                            .p_5()
+                            .flex_none(),
+                        )),
+                )
             }
         }
 
@@ -496,11 +506,11 @@ mod tests {
             let _ = window.draw(cx);
         });
 
-        let plain = cx.debug_bounds("plain-list-item").unwrap();
-        let with_code = cx.debug_bounds("list-item-with-code").unwrap();
+        let nested_action = cx.debug_bounds("nested-code-action").unwrap();
+        let top_level_action = cx.debug_bounds("top-level-code-action").unwrap();
         assert!(
-            with_code.size.height > plain.size.height + px(20.),
-            "nested code block should increase the list item's rendered height"
+            top_level_action.right() - nested_action.right() < px(32.),
+            "nested code block should fill the list item's available width"
         );
     }
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -358,9 +358,9 @@ mod tests {
     use super::{TextView, TextViewPlugin};
     use crate::text::TextViewState;
     use gpui::{
-        AppContext as _, Context, Entity, IntoElement, Modifiers, MouseButton, MouseDownEvent,
-        MouseUpEvent, ParentElement as _, Render, Styled as _, TestAppContext, VisualTestContext,
-        Window, div, point, px,
+        AppContext as _, Context, Entity, InteractiveElement as _, IntoElement, Modifiers,
+        MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render, Styled as _,
+        TestAppContext, VisualTestContext, Window, div, point, px,
     };
 
     struct TextViewTestRoot {
@@ -460,7 +460,50 @@ mod tests {
             "unloaded inline image fallback should stay generic and compact"
         );
     }
-  
+
+    #[gpui::test]
+    fn list_item_renders_fenced_code_block(cx: &mut TestAppContext) {
+        struct ListItemBlockRoot;
+
+        impl Render for ListItemBlockRoot {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                div()
+                    .w(px(420.))
+                    .child(
+                        div()
+                            .debug_selector(|| "plain-list-item".into())
+                            .child(TextView::markdown("plain-list", "1. List item")),
+                    )
+                    .child(div().debug_selector(|| "list-item-with-code".into()).child(
+                        TextView::markdown(
+                            "list-with-code",
+                            "1. List item\n   ```rust\n   fn main() {}\n   ```",
+                        ),
+                    ))
+            }
+        }
+
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| ListItemBlockRoot);
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let plain = cx.debug_bounds("plain-list-item").unwrap();
+        let with_code = cx.debug_bounds("list-item-with-code").unwrap();
+        assert!(
+            with_code.size.height > plain.size.height + px(20.),
+            "nested code block should increase the list item's rendered height"
+        );
+    }
+
     #[test]
     fn plugin_accepts_text_view_plugins_beyond_markdown() {
         let view = TextView::markdown("plugin-test", "").plugin(DummyTextViewPlugin);


### PR DESCRIPTION
Closes #[issue number]

## Description

Markdown block elements such as fenced code blocks, tables, blockquotes, and headings were being dropped when nested inside list items. These blocks now render at the full available list width, with regression coverage for visibility and code-block action alignment.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
|<img width="1594" height="533" alt="Screenshot 2026-07-22 at 3 10 36 pm" src="https://github.com/user-attachments/assets/68558d68-a152-42c1-80a6-fa9e50b7ac59" /> | <img width="1242" height="511" alt="Screenshot 2026-07-22 at 3 05 54 pm" src="https://github.com/user-attachments/assets/61023976-bf05-4206-ae10-d5fa74f73641" /> |




## How to Test

Run `cargo run --example markdown` with this fix applied:
````markdown
# Hello, **World**!
  
1. This is the first list item Hello!
    ```text
    a nested block
    ```
2. second list item
  
```text
non-nested block
```
````
## Checklist

- [ X ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ X ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ X ] Passed `cargo run` for story tests related to the changes.
