### PR TITLE
chore: Provide IBM Plex Sans to fix story app lag to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,12 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
+        uiFont = pkgs.ibm-plex.override {
+          families = [ "sans" ];
+        };
+        fontsConf = pkgs.makeFontsConf {
+          fontDirectories = [ uiFont ];
+        };
         build-dependencies = with pkgs; [
           pkg-config # For dynamically linked libraries
           makeWrapper # To provide LD_LIBRARY_PATH to the final binary
@@ -50,7 +56,8 @@
           buildInputs = dynamic-libraries;
           postFixup = ''
             wrapProgram $out/bin/gpui-component-story \
-            --suffix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath dynamic-libraries}
+            --suffix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath dynamic-libraries} \
+            --set FONTCONFIG_FILE ${fontsConf}
           '';
         });
         devShells.default = with pkgs; mkShell {
@@ -58,6 +65,7 @@
 
           env = {
             RUST_BACKTRACE = "1";
+            FONTCONFIG_FILE = fontsConf;
             LD_LIBRARY_PATH = lib.makeLibraryPath dynamic-libraries;
           };
         };


### PR DESCRIPTION
## Summary

- add IBM Plex Sans to the Nix development environment
- provide a deterministic Fontconfig configuration when running the story app with Cargo
- apply the same font configuration to the packaged executable wrapper

## Why

GPUI resolves the Linux system UI font to IBM Plex Sans. On NixOS, that font was not available inside the development shell, so text rendering repeatedly took the missing-font fallback path. With `RUST_BACKTRACE=1` enabled by the shell, those fallback errors also captured backtraces and caused high single-thread CPU usage during scrolling and other UI interactions.

Providing the expected font removes that hot path. In an 8-second runtime sample, CPU time dropped from approximately 4.05 seconds to 0.97 seconds, and profiling no longer showed unwind/backtrace work.

## Testing

- `nix flake check --no-build`
- `nix develop --command cargo run --release`
- verified `fc-match "IBM Plex Sans"` resolves to `IBMPlexSans-Regular.otf` inside the dev shell
- `nix build .#defaultPackage.x86_64-linux`
- launched the packaged executable through its generated wrapper

Related issue: #1621