### PR TITLE
feat(resizable): support dynamic panel state

### DIFF
--- a/crates/ui/src/resizable/mod.rs
+++ b/crates/ui/src/resizable/mod.rs
@@ -86,7 +86,13 @@ impl ResizableState {
         self.done_resizing(cx);
     }
 
-    pub(crate) fn insert_panel(
+    /// Insert a panel into the state used by a dynamic [`ResizablePanelGroup`].
+    ///
+    /// Call this when the rendered panel collection changes outside of the
+    /// group's normal render-time synchronization and existing panel sizes
+    /// should stay associated with their current indices. An index past the
+    /// end of the collection appends the panel.
+    pub fn insert_panel(
         &mut self,
         size: Option<Pixels>,
         ix: Option<usize>,
@@ -110,7 +116,7 @@ impl ResizableState {
             panel.size = Some(self.sizes[i]);
         }
 
-        if let Some(ix) = ix {
+        if let Some(ix) = ix.map(|ix| ix.min(self.panels.len())) {
             self.panels.insert(ix, panel_state);
             self.sizes.insert(ix, size);
         } else {
@@ -170,7 +176,15 @@ impl ResizableState {
         cx.notify();
     }
 
-    pub(crate) fn remove_panel(&mut self, panel_ix: usize, cx: &mut Context<Self>) {
+    /// Remove a panel from the state used by a dynamic
+    /// [`ResizablePanelGroup`].
+    ///
+    /// Out-of-range indices are ignored.
+    pub fn remove_panel(&mut self, panel_ix: usize, cx: &mut Context<Self>) {
+        if panel_ix >= self.panels.len() {
+            return;
+        }
+
         self.panels.remove(panel_ix);
         self.sizes.remove(panel_ix);
         if let Some(resizing_panel_ix) = self.resizing_panel_ix {
@@ -179,6 +193,33 @@ impl ResizableState {
             }
         }
         self.adjust_to_container_size(cx);
+    }
+
+    /// Reset every panel to an equal share of the current container.
+    ///
+    /// This is useful for dynamic split layouts that expose a "reset sizes"
+    /// command. A [`ResizablePanelEvent::Resized`] event is emitted, matching a
+    /// completed pointer or programmatic resize.
+    pub fn reset_panel_sizes(&mut self, cx: &mut Context<Self>) {
+        if self.panels.is_empty() {
+            return;
+        }
+
+        let container_size = self.container_size();
+        if container_size.is_zero() {
+            for (panel, panel_size) in self.panels.iter_mut().zip(self.sizes.iter_mut()) {
+                panel.size = None;
+                *panel_size = PANEL_MIN_SIZE;
+            }
+        } else {
+            let size = container_size / self.panels.len() as f32;
+            for (panel, panel_size) in self.panels.iter_mut().zip(self.sizes.iter_mut()) {
+                panel.size = Some(size);
+                *panel_size = size;
+            }
+        }
+        self.done_resizing(cx);
+        cx.notify();
     }
 
     pub(crate) fn replace_panel(
@@ -335,4 +376,52 @@ pub(crate) struct ResizablePanelState {
     pub size: Option<Pixels>,
     pub size_range: Range<Pixels>,
     bounds: Bounds<Pixels>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{AppContext as _, TestAppContext, size};
+
+    #[gpui::test]
+    fn reset_panel_sizes_distributes_the_container_equally(cx: &mut TestAppContext) {
+        let state = cx.new(|_| ResizableState {
+            axis: Axis::Horizontal,
+            panels: vec![ResizablePanelState::default(); 3],
+            sizes: vec![px(100.), px(200.), px(300.)],
+            resizing_panel_ix: Some(1),
+            bounds: Bounds {
+                size: size(px(600.), px(400.)),
+                ..Default::default()
+            },
+        });
+
+        state.update(cx, |state, cx| state.reset_panel_sizes(cx));
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.sizes(), &vec![px(200.); 3]);
+            assert_eq!(state.resizing_panel_ix, None);
+            assert!(
+                state
+                    .panels
+                    .iter()
+                    .all(|panel| panel.size == Some(px(200.)))
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn removing_an_unknown_panel_is_a_noop(cx: &mut TestAppContext) {
+        let state = cx.new(|_| ResizableState {
+            panels: vec![ResizablePanelState::default()],
+            sizes: vec![px(100.)],
+            ..Default::default()
+        });
+
+        state.update(cx, |state, cx| state.remove_panel(9, cx));
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.sizes(), &vec![px(100.)]);
+        });
+    }
 }

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -332,17 +332,23 @@ impl RenderOnce for ResizablePanel {
             .children(self.children)
             .when(self.panel_ix > 0, |this| {
                 let ix = self.panel_ix - 1;
-                this.child(resize_handle(("resizable-handle", ix), self.axis).on_drag(
-                    DragPanel,
-                    move |drag_panel, _, _, cx| {
-                        cx.stop_propagation();
-                        // Set current resizing panel ix
-                        state.update(cx, |state, _| {
-                            state.resizing_panel_ix = Some(ix);
-                        });
-                        cx.new(|_| drag_panel.deref().clone())
-                    },
-                ))
+                let reset_state = state.clone();
+                this.child(
+                    resize_handle(("resizable-handle", ix), self.axis)
+                        .on_drag(DragPanel, move |drag_panel, _, _, cx| {
+                            cx.stop_propagation();
+                            // Set current resizing panel ix
+                            state.update(cx, |state, _| {
+                                state.resizing_panel_ix = Some(ix);
+                            });
+                            cx.new(|_| drag_panel.deref().clone())
+                        })
+                        .on_double_click(move |_, cx| {
+                            reset_state.update(cx, |state, cx| {
+                                state.reset_panel_sizes(cx);
+                            });
+                        }),
+                )
             })
     }
 }

--- a/crates/ui/src/resizable/resize_handle.rs
+++ b/crates/ui/src/resizable/resize_handle.rs
@@ -1,12 +1,12 @@
 use std::{cell::Cell, rc::Rc};
 
 use gpui::{
-    div, prelude::FluentBuilder as _, px, AnyElement, App, Axis, Element, ElementId, Entity,
-    GlobalElementId, InteractiveElement, IntoElement, MouseDownEvent, MouseUpEvent,
-    ParentElement as _, Pixels, Point, Render, StatefulInteractiveElement, Styled as _, Window,
+    AnyElement, App, Axis, Element, ElementId, Entity, GlobalElementId, InteractiveElement,
+    IntoElement, MouseDownEvent, MouseUpEvent, ParentElement as _, Pixels, Point, Render,
+    StatefulInteractiveElement, Styled as _, Window, div, prelude::FluentBuilder as _, px,
 };
 
-use crate::{dock::DockPlacement, ActiveTheme as _, AxisExt as _};
+use crate::{ActiveTheme as _, AxisExt as _, dock::DockPlacement};
 
 pub(crate) const HANDLE_PADDING: Pixels = px(4.);
 pub(crate) const HANDLE_SIZE: Pixels = px(1.);
@@ -25,6 +25,7 @@ pub(crate) struct ResizeHandle<T: 'static, E: 'static + Render> {
     drag_value: Option<Rc<T>>,
     placement: Option<DockPlacement>,
     on_drag: Option<Rc<dyn Fn(&Point<Pixels>, &mut Window, &mut App) -> Entity<E>>>,
+    on_double_click: Option<Rc<dyn Fn(&mut Window, &mut App)>>,
 }
 
 impl<T: 'static, E: 'static + Render> ResizeHandle<T, E> {
@@ -36,6 +37,7 @@ impl<T: 'static, E: 'static + Render> ResizeHandle<T, E> {
             drag_value: None,
             placement: None,
             axis,
+            on_double_click: None,
         }
     }
 
@@ -54,6 +56,14 @@ impl<T: 'static, E: 'static + Render> ResizeHandle<T, E> {
 
     pub(crate) fn placement(mut self, placement: DockPlacement) -> Self {
         self.placement = Some(placement);
+        self
+    }
+
+    pub(crate) fn on_double_click(
+        mut self,
+        handler: impl Fn(&mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_double_click = Some(Rc::new(handler));
         self
     }
 }
@@ -196,9 +206,17 @@ impl<T: 'static, E: 'static + Render> Element for ResizeHandle<T, E> {
 
             window.on_mouse_event({
                 let state = state.clone();
-                move |ev: &MouseDownEvent, phase, window, _| {
+                let on_double_click = self.on_double_click.clone();
+                move |ev: &MouseDownEvent, phase, window, cx| {
                     if bounds.contains(&ev.position) && phase.bubble() {
-                        state.set_active(true);
+                        if ev.click_count >= 2 {
+                            state.set_active(false);
+                            if let Some(on_double_click) = &on_double_click {
+                                on_double_click(window, cx);
+                            }
+                        } else {
+                            state.set_active(true);
+                        }
                         window.refresh();
                     }
                 }


### PR DESCRIPTION
Expose safe insert and remove operations for externally managed ResizablePanelGroup collections, and add reset_panel_sizes for equal-size reset commands. Out-of-range insertion appends and out-of-range removal is a no-op.

The new reset API emits the same Resized event as pointer and programmatic resizing.

Tested with:
- cargo test -p gpui-component resizable:: --lib