### PR TITLE
feat(input): support application text highlights

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -35,20 +35,24 @@ fn compose_text_highlights(
     text_highlights: &[(Range<usize>, HighlightStyle)],
     visible_byte_range: Range<usize>,
 ) -> Option<Vec<(Range<usize>, HighlightStyle)>> {
-    let text_highlights = text_highlights.iter().filter_map(|(range, style)| {
+    let has_visible_highlight = text_highlights.iter().any(|(range, _)| {
+        range.start < visible_byte_range.end && range.end > visible_byte_range.start
+    });
+    if !has_visible_highlight {
+        return (!styles.is_empty()).then_some(styles);
+    }
+
+    if styles.is_empty() {
+        styles.push((visible_byte_range.clone(), HighlightStyle::default()));
+    }
+    let visible_highlights = text_highlights.iter().filter_map(|(range, style)| {
         let range =
             range.start.max(visible_byte_range.start)..range.end.min(visible_byte_range.end);
         (!range.is_empty()).then_some((range, *style))
     });
-    let text_highlights = text_highlights.collect::<Vec<_>>();
-    if !text_highlights.is_empty() {
-        if styles.is_empty() {
-            styles.push((visible_byte_range, HighlightStyle::default()));
-        }
-        styles = gpui::combine_highlights(text_highlights, styles).collect();
-    }
+    styles = gpui::combine_highlights(visible_highlights, styles).collect();
 
-    (!styles.is_empty()).then_some(styles)
+    Some(styles)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1303,81 +1307,105 @@ impl TextElement {
         let state = self.state.read(cx);
         let text = &state.text;
         let is_multi_line = state.mode.is_multi_line();
+        let text_highlights = if state.masked {
+            &[][..]
+        } else {
+            &state.text_highlights
+        };
+
+        let (mut highlighter, diagnostics) = match &state.mode {
+            InputMode::CodeEditor {
+                highlighter,
+                diagnostics,
+                ..
+            } => (highlighter.borrow_mut(), diagnostics),
+            _ => {
+                return compose_text_highlights(Vec::new(), text_highlights, visible_byte_range);
+            }
+        };
+        let Some(highlighter) = highlighter.as_mut() else {
+            return compose_text_highlights(Vec::new(), text_highlights, visible_byte_range);
+        };
+
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
 
-        if let InputMode::CodeEditor {
-            highlighter,
-            diagnostics,
-            ..
-        } = &state.mode
-            && let Some(highlighter) = highlighter.borrow_mut().as_mut()
-        {
-            // Helper to flush a contiguous range of lines. These ranges are
-            // disjoint, so appending avoids repeatedly cloning and recombining
-            // prior styles.
-            let flush_range =
-                |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
-                    let byte_start = text.line_start_offset(start_line);
-                    let byte_end = if is_multi_line {
-                        // +1 for `\n`
-                        text.line_start_offset(end_line + 1)
-                    } else {
-                        text.line_end_offset(end_line)
-                    };
-                    let range_styles = if skip {
-                        vec![(byte_start..byte_end, HighlightStyle::default())]
-                    } else {
-                        highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme)
-                    };
+        // Helper to flush a contiguous range of lines. These ranges are disjoint,
+        // so appending avoids repeatedly cloning and recombining prior styles.
+        let flush_range = |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
+            let byte_start = text.line_start_offset(start_line);
+            let byte_end = if is_multi_line {
+                // +1 for `\n`
+                text.line_start_offset(end_line + 1)
+            } else {
+                text.line_end_offset(end_line)
+            };
+            let range_styles = if skip {
+                vec![(byte_start..byte_end, HighlightStyle::default())]
+            } else {
+                highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme)
+            };
 
-                    styles.extend(range_styles);
-                };
+            styles.extend(range_styles);
+        };
 
-            // Group contiguous visible lines into ranges and call styles() once
-            // per range.
-            let mut visible_iter = visible_buffer_lines.iter().peekable();
-            let mut range_start: Option<usize> = None;
+        // Group contiguous visible lines into ranges and call styles() once per range
+        let mut visible_iter = visible_buffer_lines.iter().peekable();
+        let mut range_start: Option<usize> = None;
 
-            while let Some(&line) = visible_iter.next() {
-                let line_len = text.slice_line(line).len();
-                if line_len > MAX_HIGHLIGHT_LINE_LENGTH {
-                    if let Some(start) = range_start.take() {
-                        flush_range(start, line - 1, false, &mut styles);
-                    }
-
-                    flush_range(line, line, true, &mut styles);
-                    continue;
+        while let Some(&line) = visible_iter.next() {
+            // Check if this line is too long for highlighting
+            let line_len = text.slice_line(line).len();
+            if line_len > MAX_HIGHLIGHT_LINE_LENGTH {
+                // Flush any accumulated range first
+                if let Some(start) = range_start.take() {
+                    flush_range(start, line - 1, false, &mut styles);
                 }
 
-                range_start.get_or_insert(line);
-                if visible_iter
-                    .peek()
-                    .map(|&&next| next == line + 1)
-                    .unwrap_or(false)
-                {
-                    continue;
-                }
-
-                let start_line = range_start.take().unwrap();
-                flush_range(start_line, line, false, &mut styles);
+                flush_range(line, line, true, &mut styles);
+                continue;
             }
 
-            let diagnostic_styles = diagnostics.styles_for_range(&visible_byte_range, cx);
-            let semantic_styles = state.lsp.semantic_tokens_for_range(
-                text,
-                &visible_byte_range,
-                &cx.theme().highlight_theme,
-            );
+            range_start.get_or_insert(line);
 
-            if let Some(hover_style) = self.layout_hover_definition(cx) {
-                styles.push(hover_style);
+            // Check if next line is contiguous, if so keep accumulating
+            if visible_iter
+                .peek()
+                .map(|&&next| next == line + 1)
+                .unwrap_or(false)
+            {
+                continue;
             }
 
-            styles = gpui::combine_highlights(semantic_styles, styles).collect();
-            styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
+            // Flush the contiguous range
+            let start_line = range_start.take().unwrap();
+            flush_range(start_line, line, false, &mut styles);
         }
 
-        compose_text_highlights(styles, &state.text_highlights, visible_byte_range)
+        let diagnostic_styles = diagnostics.styles_for_range(&visible_byte_range, cx);
+
+        // Range semantic tokens, resolved from the LSP provider's cached
+        // result through the active highlight theme so it shares the same
+        // colour vocabulary as the tree-sitter path. Empty Vec when no
+        // provider is set, so `combine_highlights` short-circuits.
+        let custom_styles = state.lsp.semantic_tokens_for_range(
+            text,
+            &visible_byte_range,
+            &cx.theme().highlight_theme,
+        );
+
+        // hover definition style
+        if let Some(hover_style) = self.layout_hover_definition(cx) {
+            styles.push(hover_style);
+        }
+
+        // Compose order: tree-sitter (base) -> custom (overlay) -> application
+        // highlights -> diagnostics (top).
+        styles = gpui::combine_highlights(custom_styles, styles).collect();
+        styles = compose_text_highlights(styles, text_highlights, visible_byte_range.clone())
+            .unwrap_or_default();
+        styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
+
+        Some(styles)
     }
 }
 

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1398,8 +1398,7 @@ impl TextElement {
             styles.push(hover_style);
         }
 
-        // Compose order: tree-sitter (base) -> custom (overlay) -> application
-        // highlights -> diagnostics (top).
+        // Compose tree-sitter, custom, application, then diagnostic highlights.
         styles = gpui::combine_highlights(custom_styles, styles).collect();
         styles = compose_text_highlights(styles, text_highlights, visible_byte_range.clone())
             .unwrap_or_default();

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -30,6 +30,27 @@ const FOLD_ICON_WIDTH: Pixels = px(14.);
 const FOLD_ICON_HITBOX_WIDTH: Pixels = px(18.);
 const MAX_HIGHLIGHT_LINE_LENGTH: usize = 10_000;
 
+fn compose_text_highlights(
+    mut styles: Vec<(Range<usize>, HighlightStyle)>,
+    text_highlights: &[(Range<usize>, HighlightStyle)],
+    visible_byte_range: Range<usize>,
+) -> Option<Vec<(Range<usize>, HighlightStyle)>> {
+    let text_highlights = text_highlights.iter().filter_map(|(range, style)| {
+        let range =
+            range.start.max(visible_byte_range.start)..range.end.min(visible_byte_range.end);
+        (!range.is_empty()).then_some((range, *style))
+    });
+    let text_highlights = text_highlights.collect::<Vec<_>>();
+    if !text_highlights.is_empty() {
+        if styles.is_empty() {
+            styles.push((visible_byte_range, HighlightStyle::default()));
+        }
+        styles = gpui::combine_highlights(text_highlights, styles).collect();
+    }
+
+    (!styles.is_empty()).then_some(styles)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct EditorScrollbarLayout {
     bounds: Bounds<Pixels>,
@@ -1282,95 +1303,81 @@ impl TextElement {
         let state = self.state.read(cx);
         let text = &state.text;
         let is_multi_line = state.mode.is_multi_line();
-
-        let (mut highlighter, diagnostics) = match &state.mode {
-            InputMode::CodeEditor {
-                highlighter,
-                diagnostics,
-                ..
-            } => (highlighter.borrow_mut(), diagnostics),
-            _ => return None,
-        };
-        let highlighter = highlighter.as_mut()?;
-
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
 
-        // Helper to flush a contiguous range of lines. These ranges are disjoint,
-        // so appending avoids repeatedly cloning and recombining prior styles.
-        let flush_range = |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
-            let byte_start = text.line_start_offset(start_line);
-            let byte_end = if is_multi_line {
-                // +1 for `\n`
-                text.line_start_offset(end_line + 1)
-            } else {
-                text.line_end_offset(end_line)
-            };
-            let range_styles = if skip {
-                vec![(byte_start..byte_end, HighlightStyle::default())]
-            } else {
-                highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme)
-            };
+        if let InputMode::CodeEditor {
+            highlighter,
+            diagnostics,
+            ..
+        } = &state.mode
+            && let Some(highlighter) = highlighter.borrow_mut().as_mut()
+        {
+            // Helper to flush a contiguous range of lines. These ranges are
+            // disjoint, so appending avoids repeatedly cloning and recombining
+            // prior styles.
+            let flush_range =
+                |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
+                    let byte_start = text.line_start_offset(start_line);
+                    let byte_end = if is_multi_line {
+                        // +1 for `\n`
+                        text.line_start_offset(end_line + 1)
+                    } else {
+                        text.line_end_offset(end_line)
+                    };
+                    let range_styles = if skip {
+                        vec![(byte_start..byte_end, HighlightStyle::default())]
+                    } else {
+                        highlighter.styles(&(byte_start..byte_end), &cx.theme().highlight_theme)
+                    };
 
-            styles.extend(range_styles);
-        };
+                    styles.extend(range_styles);
+                };
 
-        // Group contiguous visible lines into ranges and call styles() once per range
-        let mut visible_iter = visible_buffer_lines.iter().peekable();
-        let mut range_start: Option<usize> = None;
+            // Group contiguous visible lines into ranges and call styles() once
+            // per range.
+            let mut visible_iter = visible_buffer_lines.iter().peekable();
+            let mut range_start: Option<usize> = None;
 
-        while let Some(&line) = visible_iter.next() {
-            // Check if this line is too long for highlighting
-            let line_len = text.slice_line(line).len();
-            if line_len > MAX_HIGHLIGHT_LINE_LENGTH {
-                // Flush any accumulated range first
-                if let Some(start) = range_start.take() {
-                    flush_range(start, line - 1, false, &mut styles);
+            while let Some(&line) = visible_iter.next() {
+                let line_len = text.slice_line(line).len();
+                if line_len > MAX_HIGHLIGHT_LINE_LENGTH {
+                    if let Some(start) = range_start.take() {
+                        flush_range(start, line - 1, false, &mut styles);
+                    }
+
+                    flush_range(line, line, true, &mut styles);
+                    continue;
                 }
 
-                flush_range(line, line, true, &mut styles);
-                continue;
+                range_start.get_or_insert(line);
+                if visible_iter
+                    .peek()
+                    .map(|&&next| next == line + 1)
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                let start_line = range_start.take().unwrap();
+                flush_range(start_line, line, false, &mut styles);
             }
 
-            range_start.get_or_insert(line);
+            let diagnostic_styles = diagnostics.styles_for_range(&visible_byte_range, cx);
+            let semantic_styles = state.lsp.semantic_tokens_for_range(
+                text,
+                &visible_byte_range,
+                &cx.theme().highlight_theme,
+            );
 
-            // Check if next line is contiguous, if so keep accumulating
-            if visible_iter
-                .peek()
-                .map(|&&next| next == line + 1)
-                .unwrap_or(false)
-            {
-                continue;
+            if let Some(hover_style) = self.layout_hover_definition(cx) {
+                styles.push(hover_style);
             }
 
-            // Flush the contiguous range
-            let start_line = range_start.take().unwrap();
-            flush_range(start_line, line, false, &mut styles);
+            styles = gpui::combine_highlights(semantic_styles, styles).collect();
+            styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
         }
 
-        let diagnostic_styles = diagnostics.styles_for_range(&visible_byte_range, cx);
-
-        // Range semantic tokens, resolved from the LSP provider's cached
-        // result through the active highlight theme so it shares the same
-        // colour vocabulary as the tree-sitter path. Empty Vec when no
-        // provider is set, so `combine_highlights` short-circuits.
-        let custom_styles = state.lsp.semantic_tokens_for_range(
-            text,
-            &visible_byte_range,
-            &cx.theme().highlight_theme,
-        );
-
-        // hover definition style
-        if let Some(hover_style) = self.layout_hover_definition(cx) {
-            styles.push(hover_style);
-        }
-
-        // Compose order: tree-sitter (base) -> custom (overlay) -> diagnostics (top).
-        // Diagnostics keep highest priority so errors remain visible regardless
-        // of language coloring.
-        styles = gpui::combine_highlights(custom_styles, styles).collect();
-        styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
-
-        Some(styles)
+        compose_text_highlights(styles, &state.text_highlights, visible_byte_range)
     }
 }
 
@@ -2347,6 +2354,26 @@ fn split_runs_by_bg_segments(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_plain_text_highlights_include_unstyled_gaps() {
+        let highlight = HighlightStyle {
+            background_color: Some(gpui::red()),
+            ..Default::default()
+        };
+        let styles = compose_text_highlights(Vec::new(), &[(2..5, highlight)], 0..10).unwrap();
+
+        assert_eq!(
+            styles
+                .iter()
+                .map(|(range, _)| range.clone())
+                .collect::<Vec<_>>(),
+            vec![0..2, 2..5, 5..10]
+        );
+        assert_eq!(styles[0].1, HighlightStyle::default());
+        assert_eq!(styles[1].1.background_color, Some(gpui::red()));
+        assert_eq!(styles[2].1, HighlightStyle::default());
+    }
 
     #[test]
     fn test_editor_scrollbar_layout_uses_current_scroll_size() {

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1284,11 +1284,11 @@ impl InputState {
         highlights: Vec<(Range<usize>, HighlightStyle)>,
         cx: &mut Context<Self>,
     ) {
-        let text_len = self.text.len();
         self.text_highlights = highlights
             .into_iter()
             .filter_map(|(range, style)| {
-                let range = range.start.min(text_len)..range.end.min(text_len);
+                let range = self.text.clip_offset(range.start, Bias::Left)
+                    ..self.text.clip_offset(range.end, Bias::Right);
                 (!range.is_empty()).then_some((range, style))
             })
             .collect();
@@ -2958,6 +2958,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
+        self.text_highlights.clear();
         if mask_changed {
             // A segment-based history entry no longer matches the masked
             // document, record a whole-document change instead, so that
@@ -3041,6 +3042,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
+        self.text_highlights.clear();
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
@@ -3882,16 +3884,21 @@ ORDER BY id
 
     #[gpui::test]
     fn test_set_text_highlights_clamps_ranges(cx: &mut TestAppContext) {
-        let input = InputView::build(cx, |state| state.default_value("hello")).input;
+        let input_view = InputView::build(cx, |state| state.default_value("héllo"));
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
         let style = HighlightStyle {
             font_weight: Some(gpui::FontWeight::BOLD),
             ..Default::default()
         };
 
-        cx.update(|cx| {
+        cx.update(|window, cx| {
             input.update(cx, |state, cx| {
-                state.set_text_highlights(vec![(1..4, style), (4..100, style), (8..9, style)], cx);
-                assert_eq!(state.text_highlights(), &[(1..4, style), (4..5, style)]);
+                state.set_text_highlights(vec![(2..4, style), (5..100, style), (8..9, style)], cx);
+                assert_eq!(state.text_highlights(), &[(1..4, style), (5..6, style)]);
+
+                state.set_value("world", window, cx);
+                assert!(state.text_highlights().is_empty());
             });
         });
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -5,11 +5,11 @@
 use anyhow::Result;
 use gpui::{
     Action, App, AppContext, Bounds, ClipboardItem, Context, Edges, Entity, EntityInputHandler,
-    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
-    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Styled as _,
-    Subscription, Task, UTF16Selection, Window, actions, div, point, prelude::FluentBuilder as _,
-    px,
+    EventEmitter, FocusHandle, Focusable, HighlightStyle, InteractiveElement as _, IntoElement,
+    KeyBinding, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ParentElement as _, Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine,
+    SharedString, Styled as _, Subscription, Task, UTF16Selection, Window, actions, div, point,
+    prelude::FluentBuilder as _, px,
 };
 use gpui::{Half, TextAlign};
 use ropey::{Rope, RopeSlice};
@@ -396,6 +396,8 @@ pub struct InputState {
     pub(super) editor_scrollbar_paddings: Cell<Edges<Pixels>>,
     pub(super) editor_scrollbar_snapshot: Cell<Option<EditorScrollbarSnapshot>>,
     pub(super) text_align: TextAlign,
+    /// Application-provided presentation highlights in UTF-8 byte ranges.
+    pub(super) text_highlights: Vec<(Range<usize>, HighlightStyle)>,
 
     /// The mask pattern for formatting the input text
     pub(crate) mask_pattern: MaskPattern,
@@ -532,6 +534,7 @@ impl InputState {
             mask_pattern: MaskPattern::default(),
             mask_pattern_set: false,
             text_align: TextAlign::Left,
+            text_highlights: Vec::new(),
             lsp: Lsp::default(),
             diagnostic_popover: None,
             context_menu_content: None,
@@ -1268,6 +1271,33 @@ impl InputState {
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
         self._pending_update = true;
         cx.notify();
+    }
+
+    /// Set application-provided presentation highlights.
+    ///
+    /// Ranges use UTF-8 byte offsets into [`Self::value`]. Empty ranges are
+    /// discarded and ranges beyond the current value are clamped. These
+    /// highlights work in plain, auto-growing, and code-editor inputs and are
+    /// composed with syntax, semantic-token, and diagnostic highlighting.
+    pub fn set_text_highlights(
+        &mut self,
+        highlights: Vec<(Range<usize>, HighlightStyle)>,
+        cx: &mut Context<Self>,
+    ) {
+        let text_len = self.text.len();
+        self.text_highlights = highlights
+            .into_iter()
+            .filter_map(|(range, style)| {
+                let range = range.start.min(text_len)..range.end.min(text_len);
+                (!range.is_empty()).then_some((range, style))
+            })
+            .collect();
+        cx.notify();
+    }
+
+    /// Return the application-provided presentation highlights.
+    pub fn text_highlights(&self) -> &[(Range<usize>, HighlightStyle)] {
+        &self.text_highlights
     }
 
     pub(super) fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -3846,6 +3876,22 @@ ORDER BY id
                 // clamped + collapsed
                 s.set_selected_range(100..100, cx);
                 assert_eq!(s.selected_range(), 11..11);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_text_highlights_clamps_ranges(cx: &mut TestAppContext) {
+        let input = InputView::build(cx, |state| state.default_value("hello")).input;
+        let style = HighlightStyle {
+            font_weight: Some(gpui::FontWeight::BOLD),
+            ..Default::default()
+        };
+
+        cx.update(|cx| {
+            input.update(cx, |state, cx| {
+                state.set_text_highlights(vec![(1..4, style), (4..100, style), (8..9, style)], cx);
+                assert_eq!(state.text_highlights(), &[(1..4, style), (4..5, style)]);
             });
         });
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1278,7 +1278,8 @@ impl InputState {
     /// Ranges use UTF-8 byte offsets into [`Self::value`]. Empty ranges are
     /// discarded and ranges beyond the current value are clamped. These
     /// highlights work in plain, auto-growing, and code-editor inputs and are
-    /// composed with syntax, semantic-token, and diagnostic highlighting.
+    /// composed with syntax, semantic-token, and diagnostic highlighting. They
+    /// are cleared when the value changes and are not rendered for masked input.
     pub fn set_text_highlights(
         &mut self,
         highlights: Vec<(Range<usize>, HighlightStyle)>,


### PR DESCRIPTION
Add InputState set_text_highlights and text_highlights APIs for application-owned UTF-8 byte ranges. Presentation highlights now work in plain, auto-growing, and code-editor inputs and compose with existing syntax, semantic-token, hover, and diagnostic styles.

Ranges are clamped on assignment, visible-range clipping is handled during layout, and plain inputs receive default runs for unstyled gaps.

Tested with:
- cargo test -p gpui-component --lib (320 passed)