### PR TITLE
input: Fix IME composition rendering underline

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1637,39 +1637,71 @@ impl Element for TextElement {
             strikethrough: None,
         };
 
-        let runs = if let Some(highlight_styles) = highlight_styles.filter(|_| !is_empty) {
+        let runs = if let (false, Some(highlight_styles)) = (is_empty, highlight_styles) {
             let mut runs = Vec::with_capacity(highlight_styles.len() + 2);
 
             for (range, style) in &highlight_styles {
-                let mut highlighted_run = text_style.clone().highlight(*style).to_run(range.len());
+                let mut run = text_style.clone().highlight(*style).to_run(range.len());
                 if disabled {
-                    highlighted_run.color = highlighted_run.color.opacity(0.5);
+                    run.color = run.color.opacity(0.5);
                 }
-                extend_runs_with_ime_underline(
-                    &mut runs,
-                    highlighted_run,
-                    range.clone(),
-                    state
-                        .ime_marked_range
-                        .as_ref()
-                        .map(|marked| marked.start..marked.end),
-                    marked_run.underline,
-                );
+
+                if let Some(marked) = &state.ime_marked_range {
+                    let intersection_start = range.start.max(marked.start);
+                    let intersection_end = range.end.min(marked.end);
+                    if intersection_start < intersection_end {
+                        let before_len = intersection_start - range.start;
+                        if before_len > 0 {
+                            runs.push(TextRun {
+                                len: before_len,
+                                ..run.clone()
+                            });
+                        }
+
+                        runs.push(TextRun {
+                            len: intersection_end - intersection_start,
+                            underline: marked_run.underline,
+                            ..run.clone()
+                        });
+
+                        let after_len = range.end - intersection_end;
+                        if after_len > 0 {
+                            runs.push(TextRun {
+                                len: after_len,
+                                ..run
+                            });
+                        }
+                        continue;
+                    }
+                }
+
+                if run.len > 0 {
+                    runs.push(run);
+                }
             }
             runs
+        } else if let Some(ime_marked_range) = &state.ime_marked_range {
+            // IME marked text
+            vec![
+                TextRun {
+                    len: ime_marked_range.start,
+                    ..run.clone()
+                },
+                TextRun {
+                    len: ime_marked_range.end - ime_marked_range.start,
+                    underline: marked_run.underline,
+                    ..run.clone()
+                },
+                TextRun {
+                    len: display_text.len() - ime_marked_range.end,
+                    ..run.clone()
+                },
+            ]
+            .into_iter()
+            .filter(|run| run.len > 0)
+            .collect()
         } else {
-            let mut runs = Vec::with_capacity(3);
-            extend_runs_with_ime_underline(
-                &mut runs,
-                run,
-                0..display_text.len(),
-                state
-                    .ime_marked_range
-                    .as_ref()
-                    .map(|marked| marked.start..marked.end),
-                marked_run.underline,
-            );
-            runs
+            vec![run]
         };
 
         let document_colors = state
@@ -2266,43 +2298,6 @@ pub(super) fn runs_for_range(
     result
 }
 
-fn extend_runs_with_ime_underline(
-    runs: &mut Vec<TextRun>,
-    run: TextRun,
-    run_range: Range<usize>,
-    marked_range: Option<Range<usize>>,
-    marked_underline: Option<UnderlineStyle>,
-) {
-    let Some(marked) = marked_range else {
-        runs.push(run);
-        return;
-    };
-
-    let intersection_start = run_range.start.max(marked.start);
-    let intersection_end = run_range.end.min(marked.end);
-    if intersection_start >= intersection_end {
-        runs.push(run);
-        return;
-    }
-
-    let split_runs = [
-        TextRun {
-            len: intersection_start - run_range.start,
-            ..run.clone()
-        },
-        TextRun {
-            len: intersection_end - intersection_start,
-            underline: marked_underline,
-            ..run.clone()
-        },
-        TextRun {
-            len: run_range.end - intersection_end,
-            ..run
-        },
-    ];
-    runs.extend(split_runs.into_iter().filter(|run| run.len > 0));
-}
-
 fn split_runs_by_bg_segments(
     start_offset: usize,
     runs: &[TextRun],
@@ -2478,67 +2473,6 @@ mod tests {
         assert_runs(runs_for_range(&runs, 3, &(0..3)), &[1, 2]);
         assert_runs(runs_for_range(&runs, 3, &(2..10)), &[4, 1, 3]);
         assert_runs(runs_for_range(&runs, 9, &(0..8)), &[1, 7]);
-    }
-
-    #[test]
-    fn test_highlighted_runs_apply_ime_underline_to_intersection() {
-        let underline = UnderlineStyle {
-            thickness: px(1.),
-            color: Some(gpui::black()),
-            wavy: false,
-        };
-        let text_style = TextStyle::default();
-        let highlight_style = HighlightStyle::default();
-
-        let runs = [0..4, 4..10]
-            .into_iter()
-            .fold(Vec::new(), |mut runs, range| {
-                extend_runs_with_ime_underline(
-                    &mut runs,
-                    text_style
-                        .clone()
-                        .highlight(highlight_style)
-                        .to_run(range.len()),
-                    range,
-                    Some(2..7),
-                    Some(underline),
-                );
-                runs
-            });
-
-        assert_eq!(
-            runs.iter()
-                .map(|run| (run.len, run.underline.is_some()))
-                .collect::<Vec<_>>(),
-            vec![(2, false), (2, true), (3, true), (3, false)]
-        );
-    }
-
-    #[test]
-    fn test_plain_text_runs_apply_ime_underline() {
-        let run = TextRun {
-            len: 10,
-            font: gpui::font(".SystemUIFont"),
-            color: gpui::black(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
-        };
-        let underline = UnderlineStyle {
-            thickness: px(1.),
-            color: Some(gpui::black()),
-            wavy: false,
-        };
-
-        let mut runs = Vec::new();
-        extend_runs_with_ime_underline(&mut runs, run, 0..10, Some(2..7), Some(underline));
-
-        assert_eq!(
-            runs.iter()
-                .map(|run| (run.len, run.underline.is_some()))
-                .collect::<Vec<_>>(),
-            vec![(2, false), (5, true), (3, false)]
-        );
     }
 
     #[test]

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1637,33 +1637,40 @@ impl Element for TextElement {
             strikethrough: None,
         };
 
-        let runs = if !is_empty {
-            if let Some(highlight_styles) = highlight_styles {
-                let mut runs = Vec::with_capacity(highlight_styles.len());
+        let runs = if let Some(highlight_styles) = highlight_styles.filter(|_| !is_empty) {
+            let mut runs = Vec::with_capacity(highlight_styles.len() + 2);
 
-                runs.extend(highlight_styles.iter().map(|(range, style)| {
-                    let mut run = text_style.clone().highlight(*style).to_run(range.len());
-                    if let Some(ime_marked_range) = &state.ime_marked_range {
-                        if range.start >= ime_marked_range.start
-                            && range.end <= ime_marked_range.end
-                        {
-                            run.color = marked_run.color;
-                            run.strikethrough = marked_run.strikethrough;
-                            run.underline = marked_run.underline;
-                        }
+            for (range, style) in highlight_styles {
+                let mut push_run = |range: Range<usize>, marked: bool| {
+                    if range.is_empty() {
+                        return;
                     }
-
+                    let mut run = text_style.clone().highlight(style).to_run(range.len());
+                    if marked {
+                        // Preserve syntax highlighting and add the IME composition underline independently.
+                        run.underline = marked_run.underline;
+                    }
                     if disabled {
-                        run.color = run.color.opacity(0.5)
+                        run.color = run.color.opacity(0.5);
                     }
+                    runs.push(run);
+                };
 
-                    run
-                }));
-
-                runs.into_iter().filter(|run| run.len > 0).collect()
-            } else {
-                vec![run]
+                if let Some(marked) = &state.ime_marked_range {
+                    let intersection_start = range.start.max(marked.start);
+                    let intersection_end = range.end.min(marked.end);
+                    if intersection_start < intersection_end {
+                        push_run(range.start..intersection_start, false);
+                        push_run(intersection_start..intersection_end, true);
+                        push_run(intersection_end..range.end, false);
+                    } else {
+                        push_run(range.clone(), false);
+                    }
+                } else {
+                    push_run(range.clone(), false);
+                }
             }
+            runs
         } else if let Some(ime_marked_range) = &state.ime_marked_range {
             // IME marked text
             vec![

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1646,62 +1646,28 @@ impl Element for TextElement {
                     run.color = run.color.opacity(0.5);
                 }
 
-                if let Some(marked) = &state.ime_marked_range {
-                    let intersection_start = range.start.max(marked.start);
-                    let intersection_end = range.end.min(marked.end);
-                    if intersection_start < intersection_end {
-                        let before_len = intersection_start - range.start;
-                        if before_len > 0 {
-                            runs.push(TextRun {
-                                len: before_len,
-                                ..run.clone()
-                            });
-                        }
-
-                        runs.push(TextRun {
-                            len: intersection_end - intersection_start,
-                            underline: marked_run.underline,
-                            ..run.clone()
-                        });
-
-                        let after_len = range.end - intersection_end;
-                        if after_len > 0 {
-                            runs.push(TextRun {
-                                len: after_len,
-                                ..run
-                            });
-                        }
-                        continue;
-                    }
-                }
-
-                if run.len > 0 {
-                    runs.push(run);
-                }
+                runs.extend(split_run_for_ime_underline(
+                    run,
+                    range.clone(),
+                    state
+                        .ime_marked_range
+                        .as_ref()
+                        .map(|marked| marked.start..marked.end),
+                    marked_run.underline,
+                ));
             }
             runs
-        } else if let Some(ime_marked_range) = &state.ime_marked_range {
-            // IME marked text
-            vec![
-                TextRun {
-                    len: ime_marked_range.start,
-                    ..run.clone()
-                },
-                TextRun {
-                    len: ime_marked_range.end - ime_marked_range.start,
-                    underline: marked_run.underline,
-                    ..run.clone()
-                },
-                TextRun {
-                    len: display_text.len() - ime_marked_range.end,
-                    ..run.clone()
-                },
-            ]
-            .into_iter()
-            .filter(|run| run.len > 0)
-            .collect()
         } else {
-            vec![run]
+            split_run_for_ime_underline(
+                run,
+                0..display_text.len(),
+                state
+                    .ime_marked_range
+                    .as_ref()
+                    .map(|marked| marked.start..marked.end),
+                marked_run.underline,
+            )
+            .into_vec()
         };
 
         let document_colors = state
@@ -2298,6 +2264,46 @@ pub(super) fn runs_for_range(
     result
 }
 
+fn split_run_for_ime_underline(
+    run: TextRun,
+    run_range: Range<usize>,
+    marked_range: Option<Range<usize>>,
+    marked_underline: Option<UnderlineStyle>,
+) -> SmallVec<[TextRun; 3]> {
+    if run.len == 0 {
+        return SmallVec::new();
+    }
+
+    let Some(marked) = marked_range else {
+        return [run].into_iter().collect();
+    };
+
+    let intersection_start = run_range.start.max(marked.start);
+    let intersection_end = run_range.end.min(marked.end);
+    if intersection_start >= intersection_end {
+        return [run].into_iter().collect();
+    }
+
+    [
+        TextRun {
+            len: intersection_start - run_range.start,
+            ..run.clone()
+        },
+        TextRun {
+            len: intersection_end - intersection_start,
+            underline: marked_underline,
+            ..run.clone()
+        },
+        TextRun {
+            len: run_range.end - intersection_end,
+            ..run
+        },
+    ]
+    .into_iter()
+    .filter(|run| run.len > 0)
+    .collect()
+}
+
 fn split_runs_by_bg_segments(
     start_offset: usize,
     runs: &[TextRun],
@@ -2473,6 +2479,61 @@ mod tests {
         assert_runs(runs_for_range(&runs, 3, &(0..3)), &[1, 2]);
         assert_runs(runs_for_range(&runs, 3, &(2..10)), &[4, 1, 3]);
         assert_runs(runs_for_range(&runs, 9, &(0..8)), &[1, 7]);
+    }
+
+    #[test]
+    fn test_split_runs_preserve_ime_underline_across_highlight_boundaries() {
+        let underline = UnderlineStyle {
+            thickness: px(1.),
+            color: Some(gpui::black()),
+            wavy: false,
+        };
+
+        let runs = [0..4, 4..10]
+            .into_iter()
+            .flat_map(|range| {
+                split_run_for_ime_underline(
+                    TextStyle::default().to_run(range.len()),
+                    range,
+                    Some(2..7),
+                    Some(underline),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.len, run.underline.is_some()))
+                .collect::<Vec<_>>(),
+            vec![(2, false), (2, true), (3, true), (3, false)]
+        );
+    }
+
+    #[test]
+    fn test_split_run_applies_ime_underline_without_highlighting() {
+        let underline = UnderlineStyle {
+            thickness: px(1.),
+            color: Some(gpui::black()),
+            wavy: false,
+        };
+
+        let runs = split_run_for_ime_underline(
+            TextStyle::default().to_run(10),
+            0..10,
+            Some(2..7),
+            Some(underline),
+        );
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.len, run.underline.is_some()))
+                .collect::<Vec<_>>(),
+            vec![(2, false), (5, true), (3, false)]
+        );
+        assert!(
+            split_run_for_ime_underline(TextStyle::default().to_run(0), 0..0, None, None)
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1640,59 +1640,36 @@ impl Element for TextElement {
         let runs = if let Some(highlight_styles) = highlight_styles.filter(|_| !is_empty) {
             let mut runs = Vec::with_capacity(highlight_styles.len() + 2);
 
-            for (range, style) in highlight_styles {
-                let mut push_run = |range: Range<usize>, marked: bool| {
-                    if range.is_empty() {
-                        return;
-                    }
-                    let mut run = text_style.clone().highlight(style).to_run(range.len());
-                    if marked {
-                        // Preserve syntax highlighting and add the IME composition underline independently.
-                        run.underline = marked_run.underline;
-                    }
-                    if disabled {
-                        run.color = run.color.opacity(0.5);
-                    }
-                    runs.push(run);
-                };
-
-                if let Some(marked) = &state.ime_marked_range {
-                    let intersection_start = range.start.max(marked.start);
-                    let intersection_end = range.end.min(marked.end);
-                    if intersection_start < intersection_end {
-                        push_run(range.start..intersection_start, false);
-                        push_run(intersection_start..intersection_end, true);
-                        push_run(intersection_end..range.end, false);
-                    } else {
-                        push_run(range.clone(), false);
-                    }
-                } else {
-                    push_run(range.clone(), false);
+            for (range, style) in &highlight_styles {
+                let mut highlighted_run = text_style.clone().highlight(*style).to_run(range.len());
+                if disabled {
+                    highlighted_run.color = highlighted_run.color.opacity(0.5);
                 }
+                extend_runs_with_ime_underline(
+                    &mut runs,
+                    highlighted_run,
+                    range.clone(),
+                    state
+                        .ime_marked_range
+                        .as_ref()
+                        .map(|marked| marked.start..marked.end),
+                    marked_run.underline,
+                );
             }
             runs
-        } else if let Some(ime_marked_range) = &state.ime_marked_range {
-            // IME marked text
-            vec![
-                TextRun {
-                    len: ime_marked_range.start,
-                    ..run.clone()
-                },
-                TextRun {
-                    len: ime_marked_range.end - ime_marked_range.start,
-                    underline: marked_run.underline,
-                    ..run.clone()
-                },
-                TextRun {
-                    len: display_text.len() - ime_marked_range.end,
-                    ..run.clone()
-                },
-            ]
-            .into_iter()
-            .filter(|run| run.len > 0)
-            .collect()
         } else {
-            vec![run]
+            let mut runs = Vec::with_capacity(3);
+            extend_runs_with_ime_underline(
+                &mut runs,
+                run,
+                0..display_text.len(),
+                state
+                    .ime_marked_range
+                    .as_ref()
+                    .map(|marked| marked.start..marked.end),
+                marked_run.underline,
+            );
+            runs
         };
 
         let document_colors = state
@@ -2289,6 +2266,43 @@ pub(super) fn runs_for_range(
     result
 }
 
+fn extend_runs_with_ime_underline(
+    runs: &mut Vec<TextRun>,
+    run: TextRun,
+    run_range: Range<usize>,
+    marked_range: Option<Range<usize>>,
+    marked_underline: Option<UnderlineStyle>,
+) {
+    let Some(marked) = marked_range else {
+        runs.push(run);
+        return;
+    };
+
+    let intersection_start = run_range.start.max(marked.start);
+    let intersection_end = run_range.end.min(marked.end);
+    if intersection_start >= intersection_end {
+        runs.push(run);
+        return;
+    }
+
+    let split_runs = [
+        TextRun {
+            len: intersection_start - run_range.start,
+            ..run.clone()
+        },
+        TextRun {
+            len: intersection_end - intersection_start,
+            underline: marked_underline,
+            ..run.clone()
+        },
+        TextRun {
+            len: run_range.end - intersection_end,
+            ..run
+        },
+    ];
+    runs.extend(split_runs.into_iter().filter(|run| run.len > 0));
+}
+
 fn split_runs_by_bg_segments(
     start_offset: usize,
     runs: &[TextRun],
@@ -2464,6 +2478,67 @@ mod tests {
         assert_runs(runs_for_range(&runs, 3, &(0..3)), &[1, 2]);
         assert_runs(runs_for_range(&runs, 3, &(2..10)), &[4, 1, 3]);
         assert_runs(runs_for_range(&runs, 9, &(0..8)), &[1, 7]);
+    }
+
+    #[test]
+    fn test_highlighted_runs_apply_ime_underline_to_intersection() {
+        let underline = UnderlineStyle {
+            thickness: px(1.),
+            color: Some(gpui::black()),
+            wavy: false,
+        };
+        let text_style = TextStyle::default();
+        let highlight_style = HighlightStyle::default();
+
+        let runs = [0..4, 4..10]
+            .into_iter()
+            .fold(Vec::new(), |mut runs, range| {
+                extend_runs_with_ime_underline(
+                    &mut runs,
+                    text_style
+                        .clone()
+                        .highlight(highlight_style)
+                        .to_run(range.len()),
+                    range,
+                    Some(2..7),
+                    Some(underline),
+                );
+                runs
+            });
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.len, run.underline.is_some()))
+                .collect::<Vec<_>>(),
+            vec![(2, false), (2, true), (3, true), (3, false)]
+        );
+    }
+
+    #[test]
+    fn test_plain_text_runs_apply_ime_underline() {
+        let run = TextRun {
+            len: 10,
+            font: gpui::font(".SystemUIFont"),
+            color: gpui::black(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        let underline = UnderlineStyle {
+            thickness: px(1.),
+            color: Some(gpui::black()),
+            wavy: false,
+        };
+
+        let mut runs = Vec::new();
+        extend_runs_with_ime_underline(&mut runs, run, 0..10, Some(2..7), Some(underline));
+
+        assert_eq!(
+            runs.iter()
+                .map(|run| (run.len, run.underline.is_some()))
+                .collect::<Vec<_>>(),
+            vec![(2, false), (5, true), (3, false)]
+        );
     }
 
     #[test]

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -3037,22 +3037,8 @@ impl EntityInputHandler for InputState {
             self.ime_marked_range = Some((range.start..range.start + new_text.len()).into());
             self.selected_range = new_selected_range_utf16
                 .as_ref()
-                .map(|range_utf16| {
-                    let utf8_offset = |utf16_offset: usize| {
-                        let mut utf8 = 0;
-                        let mut utf16 = 0;
-                        for character in new_text.chars() {
-                            if utf16 >= utf16_offset {
-                                break;
-                            }
-                            utf16 += character.len_utf16();
-                            utf8 += character.len_utf8();
-                        }
-                        utf8
-                    };
-                    range.start + utf8_offset(range_utf16.start)
-                        ..range.start + utf8_offset(range_utf16.end)
-                })
+                .map(|range_utf16| self.range_from_utf16(range_utf16))
+                .map(|new_range| new_range.start + range.start..new_range.end + range.end)
                 .unwrap_or_else(|| range.start + new_text.len()..range.start + new_text.len())
                 .into();
         }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -3037,8 +3037,22 @@ impl EntityInputHandler for InputState {
             self.ime_marked_range = Some((range.start..range.start + new_text.len()).into());
             self.selected_range = new_selected_range_utf16
                 .as_ref()
-                .map(|range_utf16| self.range_from_utf16(range_utf16))
-                .map(|new_range| new_range.start + range.start..new_range.end + range.end)
+                .map(|range_utf16| {
+                    let utf8_offset = |utf16_offset: usize| {
+                        let mut utf8 = 0;
+                        let mut utf16 = 0;
+                        for character in new_text.chars() {
+                            if utf16 >= utf16_offset {
+                                break;
+                            }
+                            utf16 += character.len_utf16();
+                            utf8 += character.len_utf8();
+                        }
+                        utf8
+                    };
+                    range.start + utf8_offset(range_utf16.start)
+                        ..range.start + utf8_offset(range_utf16.end)
+                })
                 .unwrap_or_else(|| range.start + new_text.len()..range.start + new_text.len())
                 .into();
         }


### PR DESCRIPTION
## Description

IME marked text was not underlined when the input already contained text and syntax highlighting was disabled. With syntax highlighting enabled, the underline was only applied when a complete highlight range was contained in the marked range. As a result, the composition underline could disappear or become incomplete when it crossed Markdown or other syntax-highlight boundaries.

This PR fixes the issue mentioned above.

## How to Test

This can be reproduced with the following code.

```rust
use gpui::*;
use gpui_component::{
    input::{Input, InputState},
    *,
};
use gpui_component_assets::Assets;

struct Example {
    editor: Entity<InputState>,
}

impl Example {
    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
        let editor = cx.new(|cx| {
            InputState::new(window, cx)
                .code_editor("markdown")
                .default_value("# Existing Markdown\n\nCompose here: ")
        });
        Self { editor }
    }
}

impl Render for Example {
    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
        v_flex()
            .size_full()
            .p_5()
            .gap_4()
            .child(Input::new(&self.editor).h(px(200.)))
    }
}

fn main() {
    gpui_platform::application()
        .with_assets(Assets)
        .run(|cx| {
            gpui_component::init(cx);
            cx.spawn(async move |cx| {
                cx.open_window(WindowOptions::default(), |window, cx| {
                    let example = cx.new(|cx| Example::new(window, cx));
                    cx.new(|cx| Root::new(example, window, cx))
                })?;
                Ok::<_, anyhow::Error>(())
            })
            .detach();
        });
}
```

**Before**

<img width="232" height="175" alt="スクリーンショット 2026-07-27 1 34 44" src="https://github.com/user-attachments/assets/a1ac1bde-6842-4f67-be78-a8ce2476339a" />

**After**

<img width="312" height="180" alt="スクリーンショット 2026-07-27 1 39 57" src="https://github.com/user-attachments/assets/6a4dc516-44da-47d4-9482-f36d2c81de08" />


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
