### PR TITLE
input: Add text decoration collections

### DIFF
--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -7,7 +7,7 @@ use crate::section;
 use gpui_component::{button::*, input::*, label::Label, *};
 
 const CODE_EXAMPLE: &str = r#"{"single_line":"code editor"}"#;
-const DECORATIONS_EXAMPLE: &str = "/commit improve decorations with $skill-creator and add tests";
+const DECORATIONS_EXAMPLE: &str = "/review decorations with $code-review before merging";
 
 pub fn init(_: &mut App) {}
 
@@ -146,7 +146,7 @@ impl InputStory {
                             },
                         ),
                         TextDecoration::new(
-                            33..34,
+                            25..26,
                             HighlightStyle {
                                 color: Some(gpui::green()),
                                 ..Default::default()
@@ -169,7 +169,7 @@ impl InputStory {
                             },
                         ),
                         TextDecoration::new(
-                            33..47,
+                            25..37,
                             HighlightStyle {
                                 underline: Some(gpui::UnderlineStyle {
                                     color: Some(gpui::blue()),
@@ -457,7 +457,7 @@ impl InputStory {
                     },
                 ),
                 TextDecoration::new(
-                    33..34,
+                    25..26,
                     HighlightStyle {
                         color: Some(gpui::green()),
                         ..Default::default()
@@ -482,7 +482,7 @@ impl InputStory {
                     },
                 ),
                 TextDecoration::new(
-                    33..47,
+                    25..37,
                     HighlightStyle {
                         underline: Some(gpui::UnderlineStyle {
                             color: Some(gpui::blue()),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -139,14 +139,7 @@ impl InputStory {
                 let color = state.create_decorations_collection(
                     vec![
                         TextDecoration::new(
-                            0..1,
-                            HighlightStyle {
-                                color: Some(cx.theme().red),
-                                ..Default::default()
-                            },
-                        ),
-                        TextDecoration::new(
-                            1..7,
+                            0..7,
                             HighlightStyle {
                                 color: Some(cx.theme().blue),
                                 ..Default::default()
@@ -155,7 +148,7 @@ impl InputStory {
                         TextDecoration::new(
                             25..26,
                             HighlightStyle {
-                                color: Some(cx.theme().green),
+                                color: Some(cx.theme().cyan),
                                 ..Default::default()
                             },
                         ),
@@ -167,7 +160,7 @@ impl InputStory {
                         26..37,
                         HighlightStyle {
                             underline: Some(gpui::UnderlineStyle {
-                                color: Some(cx.theme().green),
+                                color: Some(cx.theme().cyan),
                                 thickness: gpui::px(1.),
                                 wavy: false,
                             }),
@@ -444,14 +437,7 @@ impl InputStory {
         let color_decorations = self.decorations_visible.then(|| {
             vec![
                 TextDecoration::new(
-                    0..1,
-                    HighlightStyle {
-                        color: Some(cx.theme().red),
-                        ..Default::default()
-                    },
-                ),
-                TextDecoration::new(
-                    1..7,
+                    0..7,
                     HighlightStyle {
                         color: Some(cx.theme().blue),
                         ..Default::default()
@@ -460,7 +446,7 @@ impl InputStory {
                 TextDecoration::new(
                     25..26,
                     HighlightStyle {
-                        color: Some(cx.theme().green),
+                        color: Some(cx.theme().cyan),
                         ..Default::default()
                     },
                 ),
@@ -474,7 +460,7 @@ impl InputStory {
                 26..37,
                 HighlightStyle {
                     underline: Some(gpui::UnderlineStyle {
-                        color: Some(cx.theme().green),
+                        color: Some(cx.theme().cyan),
                         thickness: gpui::px(1.),
                         wavy: false,
                     }),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -33,7 +33,8 @@ pub struct InputStory {
     code_input: Entity<InputState>,
     color_input: Entity<InputState>,
     decorations_input: Entity<InputState>,
-    background_decorations: TextDecorationCollection,
+    color_decorations: TextDecorationCollection,
+    underline_decorations: TextDecorationCollection,
     decorations_visible: bool,
     content_type_inputs: Vec<ContentTypeInput>,
 
@@ -134,55 +135,56 @@ impl InputStory {
             InputState::new(window, cx)
                 .default_value("Decorations can style multiple ranges independently")
         });
-        let background_decorations = decorations_input.update(cx, |state, cx| {
-            let background = state.create_decorations_collection(
-                vec![
-                    TextDecoration::new(
-                        0..11,
-                        HighlightStyle {
-                            background_color: Some(gpui::yellow()),
-                            ..Default::default()
-                        },
-                    ),
-                    TextDecoration::new(
-                        22..30,
-                        HighlightStyle {
-                            background_color: Some(gpui::yellow()),
-                            ..Default::default()
-                        },
-                    ),
-                ],
-                cx,
-            );
-            state.create_decorations_collection(
-                vec![
-                    TextDecoration::new(
-                        12..15,
-                        HighlightStyle {
-                            underline: Some(gpui::UnderlineStyle {
-                                color: Some(gpui::blue()),
-                                thickness: gpui::px(1.),
-                                wavy: false,
-                            }),
-                            ..Default::default()
-                        },
-                    ),
-                    TextDecoration::new(
-                        31..37,
-                        HighlightStyle {
-                            underline: Some(gpui::UnderlineStyle {
-                                color: Some(gpui::blue()),
-                                thickness: gpui::px(1.),
-                                wavy: false,
-                            }),
-                            ..Default::default()
-                        },
-                    ),
-                ],
-                cx,
-            );
-            background
-        });
+        let (color_decorations, underline_decorations) =
+            decorations_input.update(cx, |state, cx| {
+                let color = state.create_decorations_collection(
+                    vec![
+                        TextDecoration::new(
+                            0..21,
+                            HighlightStyle {
+                                color: Some(gpui::red()),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDecoration::new(
+                            31..51,
+                            HighlightStyle {
+                                color: Some(gpui::red()),
+                                ..Default::default()
+                            },
+                        ),
+                    ],
+                    cx,
+                );
+                let underline = state.create_decorations_collection(
+                    vec![
+                        TextDecoration::new(
+                            8..16,
+                            HighlightStyle {
+                                underline: Some(gpui::UnderlineStyle {
+                                    color: Some(gpui::blue()),
+                                    thickness: gpui::px(1.),
+                                    wavy: false,
+                                }),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDecoration::new(
+                            26..42,
+                            HighlightStyle {
+                                underline: Some(gpui::UnderlineStyle {
+                                    color: Some(gpui::blue()),
+                                    thickness: gpui::px(1.),
+                                    wavy: false,
+                                }),
+                                ..Default::default()
+                            },
+                        ),
+                    ],
+                    cx,
+                );
+                (color, underline)
+            });
 
         let code_input = cx.new(|cx| {
             InputState::new(window, cx)
@@ -347,7 +349,8 @@ impl InputStory {
             code_input,
             color_input,
             decorations_input,
-            background_decorations,
+            color_decorations,
+            underline_decorations,
             decorations_visible: true,
             input_text_centered,
             input_text_right,
@@ -445,26 +448,55 @@ impl InputStory {
         cx: &mut Context<Self>,
     ) {
         self.decorations_visible = !self.decorations_visible;
-        let decorations = self.decorations_visible.then(|| {
+        let color_decorations = self.decorations_visible.then(|| {
             vec![
                 TextDecoration::new(
-                    0..11,
+                    0..21,
                     HighlightStyle {
-                        background_color: Some(gpui::yellow()),
+                        color: Some(gpui::red()),
                         ..Default::default()
                     },
                 ),
                 TextDecoration::new(
-                    22..30,
+                    31..51,
                     HighlightStyle {
-                        background_color: Some(gpui::yellow()),
+                        color: Some(gpui::red()),
                         ..Default::default()
                     },
                 ),
             ]
         });
-        self.background_decorations
-            .set(decorations.unwrap_or_default(), cx);
+        self.color_decorations
+            .set(color_decorations.unwrap_or_default(), cx);
+
+        let underline_decorations = self.decorations_visible.then(|| {
+            vec![
+                TextDecoration::new(
+                    8..16,
+                    HighlightStyle {
+                        underline: Some(gpui::UnderlineStyle {
+                            color: Some(gpui::blue()),
+                            thickness: gpui::px(1.),
+                            wavy: false,
+                        }),
+                        ..Default::default()
+                    },
+                ),
+                TextDecoration::new(
+                    26..42,
+                    HighlightStyle {
+                        underline: Some(gpui::UnderlineStyle {
+                            color: Some(gpui::blue()),
+                            thickness: gpui::px(1.),
+                            wavy: false,
+                        }),
+                        ..Default::default()
+                    },
+                ),
+            ]
+        });
+        self.underline_decorations
+            .set(underline_decorations.unwrap_or_default(), cx);
         cx.notify();
     }
 }
@@ -647,9 +679,9 @@ impl Render for InputStory {
                         h_flex().gap_2().child(
                             Button::new("toggle-text-decorations")
                                 .label(if self.decorations_visible {
-                                    "Hide backgrounds"
+                                    "Hide decorations"
                                 } else {
-                                    "Show backgrounds"
+                                    "Show decorations"
                                 })
                                 .on_click(cx.listener(Self::on_click_toggle_decorations)),
                         ),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -7,6 +7,7 @@ use crate::section;
 use gpui_component::{button::*, input::*, label::Label, *};
 
 const CODE_EXAMPLE: &str = r#"{"single_line":"code editor"}"#;
+const DECORATIONS_EXAMPLE: &str = "/commit improve decorations with $skill-creator and add tests";
 
 pub fn init(_: &mut App) {}
 
@@ -131,25 +132,23 @@ impl InputStory {
                 .default_value("Custom text color input")
         });
 
-        let decorations_input = cx.new(|cx| {
-            InputState::new(window, cx)
-                .default_value("Decorations can style multiple ranges independently")
-        });
+        let decorations_input =
+            cx.new(|cx| InputState::new(window, cx).default_value(DECORATIONS_EXAMPLE));
         let (color_decorations, underline_decorations) =
             decorations_input.update(cx, |state, cx| {
                 let color = state.create_decorations_collection(
                     vec![
                         TextDecoration::new(
-                            0..21,
+                            0..1,
                             HighlightStyle {
                                 color: Some(gpui::red()),
                                 ..Default::default()
                             },
                         ),
                         TextDecoration::new(
-                            31..51,
+                            33..34,
                             HighlightStyle {
-                                color: Some(gpui::red()),
+                                color: Some(gpui::green()),
                                 ..Default::default()
                             },
                         ),
@@ -159,7 +158,7 @@ impl InputStory {
                 let underline = state.create_decorations_collection(
                     vec![
                         TextDecoration::new(
-                            8..16,
+                            0..7,
                             HighlightStyle {
                                 underline: Some(gpui::UnderlineStyle {
                                     color: Some(gpui::blue()),
@@ -170,7 +169,7 @@ impl InputStory {
                             },
                         ),
                         TextDecoration::new(
-                            26..42,
+                            33..47,
                             HighlightStyle {
                                 underline: Some(gpui::UnderlineStyle {
                                     color: Some(gpui::blue()),
@@ -451,16 +450,16 @@ impl InputStory {
         let color_decorations = self.decorations_visible.then(|| {
             vec![
                 TextDecoration::new(
-                    0..21,
+                    0..1,
                     HighlightStyle {
                         color: Some(gpui::red()),
                         ..Default::default()
                     },
                 ),
                 TextDecoration::new(
-                    31..51,
+                    33..34,
                     HighlightStyle {
-                        color: Some(gpui::red()),
+                        color: Some(gpui::green()),
                         ..Default::default()
                     },
                 ),
@@ -472,7 +471,7 @@ impl InputStory {
         let underline_decorations = self.decorations_visible.then(|| {
             vec![
                 TextDecoration::new(
-                    8..16,
+                    0..7,
                     HighlightStyle {
                         underline: Some(gpui::UnderlineStyle {
                             color: Some(gpui::blue()),
@@ -483,7 +482,7 @@ impl InputStory {
                     },
                 ),
                 TextDecoration::new(
-                    26..42,
+                    33..47,
                     HighlightStyle {
                         underline: Some(gpui::UnderlineStyle {
                             color: Some(gpui::blue()),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -33,7 +33,8 @@ pub struct InputStory {
     code_input: Entity<InputState>,
     color_input: Entity<InputState>,
     decorations_input: Entity<InputState>,
-    background_decorations: TextDecorationCollectionId,
+    background_decorations: TextDecorationCollection,
+    decorations_visible: bool,
     content_type_inputs: Vec<ContentTypeInput>,
 
     _subscriptions: Vec<Subscription>,
@@ -130,31 +131,54 @@ impl InputStory {
         });
 
         let decorations_input = cx.new(|cx| {
-            InputState::new(window, cx).default_value("Independent decoration collections")
+            InputState::new(window, cx)
+                .default_value("Decorations can style multiple ranges independently")
         });
         let background_decorations = decorations_input.update(cx, |state, cx| {
-            let background = state.add_decoration_collection(
-                vec![TextDecoration::new(
-                    0..11,
-                    HighlightStyle {
-                        background_color: Some(gpui::yellow()),
-                        ..Default::default()
-                    },
-                )],
+            let background = state.create_decorations_collection(
+                vec![
+                    TextDecoration::new(
+                        0..11,
+                        HighlightStyle {
+                            background_color: Some(gpui::yellow()),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDecoration::new(
+                        22..30,
+                        HighlightStyle {
+                            background_color: Some(gpui::yellow()),
+                            ..Default::default()
+                        },
+                    ),
+                ],
                 cx,
             );
-            state.add_decoration_collection(
-                vec![TextDecoration::new(
-                    12..22,
-                    HighlightStyle {
-                        underline: Some(gpui::UnderlineStyle {
-                            color: Some(gpui::blue()),
-                            thickness: gpui::px(1.),
-                            wavy: false,
-                        }),
-                        ..Default::default()
-                    },
-                )],
+            state.create_decorations_collection(
+                vec![
+                    TextDecoration::new(
+                        12..15,
+                        HighlightStyle {
+                            underline: Some(gpui::UnderlineStyle {
+                                color: Some(gpui::blue()),
+                                thickness: gpui::px(1.),
+                                wavy: false,
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDecoration::new(
+                        31..37,
+                        HighlightStyle {
+                            underline: Some(gpui::UnderlineStyle {
+                                color: Some(gpui::blue()),
+                                thickness: gpui::px(1.),
+                                wavy: false,
+                            }),
+                            ..Default::default()
+                        },
+                    ),
+                ],
                 cx,
             );
             background
@@ -324,6 +348,7 @@ impl InputStory {
             color_input,
             decorations_input,
             background_decorations,
+            decorations_visible: true,
             input_text_centered,
             input_text_right,
             content_type_inputs,
@@ -411,6 +436,36 @@ impl InputStory {
         self.code_input.update(cx, |input_state, cx| {
             input_state.set_value(CODE_EXAMPLE, window, cx);
         });
+    }
+
+    fn on_click_toggle_decorations(
+        &mut self,
+        _: &ClickEvent,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.decorations_visible = !self.decorations_visible;
+        let decorations = self.decorations_visible.then(|| {
+            vec![
+                TextDecoration::new(
+                    0..11,
+                    HighlightStyle {
+                        background_color: Some(gpui::yellow()),
+                        ..Default::default()
+                    },
+                ),
+                TextDecoration::new(
+                    22..30,
+                    HighlightStyle {
+                        background_color: Some(gpui::yellow()),
+                        ..Default::default()
+                    },
+                ),
+            ]
+        });
+        self.background_decorations
+            .set(decorations.unwrap_or_default(), cx);
+        cx.notify();
     }
 }
 
@@ -589,44 +644,15 @@ impl Render for InputStory {
                     .max_w_md()
                     .child(Input::new(&self.decorations_input))
                     .child(
-                        h_flex()
-                            .gap_2()
-                            .child(
-                                Button::new("clear-text-decoration")
-                                    .label("Clear background")
-                                    .on_click({
-                                        let input = self.decorations_input.clone();
-                                        let collection = self.background_decorations;
-                                        move |_, _, cx| {
-                                            input.update(cx, |state, cx| {
-                                                state.clear_decorations(collection, cx)
-                                            });
-                                        }
-                                    }),
-                            )
-                            .child(
-                                Button::new("restore-text-decoration")
-                                    .label("Restore background")
-                                    .on_click({
-                                        let input = self.decorations_input.clone();
-                                        let collection = self.background_decorations;
-                                        move |_, _, cx| {
-                                            input.update(cx, |state, cx| {
-                                                state.set_decorations(
-                                                    collection,
-                                                    vec![TextDecoration::new(
-                                                        0..11,
-                                                        HighlightStyle {
-                                                            background_color: Some(gpui::yellow()),
-                                                            ..Default::default()
-                                                        },
-                                                    )],
-                                                    cx,
-                                                )
-                                            });
-                                        }
-                                    }),
-                            ),
+                        h_flex().gap_2().child(
+                            Button::new("toggle-text-decorations")
+                                .label(if self.decorations_visible {
+                                    "Hide backgrounds"
+                                } else {
+                                    "Show backgrounds"
+                                })
+                                .on_click(cx.listener(Self::on_click_toggle_decorations)),
+                        ),
                     ),
             )
             .child(

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -659,20 +659,19 @@ impl Render for InputStory {
                     .child(Input::new(&self.color_input).text_color(cx.theme().info)),
             )
             .child(
-                section("Text Decorations")
-                    .max_w_md()
-                    .child(Input::new(&self.decorations_input))
-                    .child(
-                        h_flex().gap_2().child(
-                            Button::new("toggle-text-decorations")
-                                .label(if self.decorations_visible {
-                                    "Hide decorations"
-                                } else {
-                                    "Show decorations"
-                                })
-                                .on_click(cx.listener(Self::on_click_toggle_decorations)),
-                        ),
+                section("Text Decorations").max_w_md().child(
+                    Input::new(&self.decorations_input).suffix(
+                        Button::new("toggle-text-decorations")
+                            .ghost()
+                            .xsmall()
+                            .label(if self.decorations_visible {
+                                "Hide decorations"
+                            } else {
+                                "Show decorations"
+                            })
+                            .on_click(cx.listener(Self::on_click_toggle_decorations)),
                     ),
+                ),
             )
             .child(
                 section("Single line code editor").max_w_md().child(

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -148,6 +148,13 @@ impl InputStory {
                         TextDecoration::new(
                             25..26,
                             HighlightStyle {
+                                color: Some(cx.theme().cyan_light),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDecoration::new(
+                            26..37,
+                            HighlightStyle {
                                 color: Some(cx.theme().cyan),
                                 ..Default::default()
                             },
@@ -445,6 +452,13 @@ impl InputStory {
                 ),
                 TextDecoration::new(
                     25..26,
+                    HighlightStyle {
+                        color: Some(cx.theme().cyan_light),
+                        ..Default::default()
+                    },
+                ),
+                TextDecoration::new(
+                    26..37,
                     HighlightStyle {
                         color: Some(cx.theme().cyan),
                         ..Default::default()

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -141,14 +141,21 @@ impl InputStory {
                         TextDecoration::new(
                             0..1,
                             HighlightStyle {
-                                color: Some(gpui::red()),
+                                color: Some(cx.theme().red),
+                                ..Default::default()
+                            },
+                        ),
+                        TextDecoration::new(
+                            1..7,
+                            HighlightStyle {
+                                color: Some(cx.theme().blue),
                                 ..Default::default()
                             },
                         ),
                         TextDecoration::new(
                             25..26,
                             HighlightStyle {
-                                color: Some(gpui::green()),
+                                color: Some(cx.theme().green),
                                 ..Default::default()
                             },
                         ),
@@ -156,30 +163,17 @@ impl InputStory {
                     cx,
                 );
                 let underline = state.create_decorations_collection(
-                    vec![
-                        TextDecoration::new(
-                            0..7,
-                            HighlightStyle {
-                                underline: Some(gpui::UnderlineStyle {
-                                    color: Some(gpui::blue()),
-                                    thickness: gpui::px(1.),
-                                    wavy: false,
-                                }),
-                                ..Default::default()
-                            },
-                        ),
-                        TextDecoration::new(
-                            25..37,
-                            HighlightStyle {
-                                underline: Some(gpui::UnderlineStyle {
-                                    color: Some(gpui::blue()),
-                                    thickness: gpui::px(1.),
-                                    wavy: false,
-                                }),
-                                ..Default::default()
-                            },
-                        ),
-                    ],
+                    vec![TextDecoration::new(
+                        26..37,
+                        HighlightStyle {
+                            underline: Some(gpui::UnderlineStyle {
+                                color: Some(cx.theme().green),
+                                thickness: gpui::px(1.),
+                                wavy: false,
+                            }),
+                            ..Default::default()
+                        },
+                    )],
                     cx,
                 );
                 (color, underline)
@@ -452,14 +446,21 @@ impl InputStory {
                 TextDecoration::new(
                     0..1,
                     HighlightStyle {
-                        color: Some(gpui::red()),
+                        color: Some(cx.theme().red),
+                        ..Default::default()
+                    },
+                ),
+                TextDecoration::new(
+                    1..7,
+                    HighlightStyle {
+                        color: Some(cx.theme().blue),
                         ..Default::default()
                     },
                 ),
                 TextDecoration::new(
                     25..26,
                     HighlightStyle {
-                        color: Some(gpui::green()),
+                        color: Some(cx.theme().green),
                         ..Default::default()
                     },
                 ),
@@ -469,30 +470,17 @@ impl InputStory {
             .set(color_decorations.unwrap_or_default(), cx);
 
         let underline_decorations = self.decorations_visible.then(|| {
-            vec![
-                TextDecoration::new(
-                    0..7,
-                    HighlightStyle {
-                        underline: Some(gpui::UnderlineStyle {
-                            color: Some(gpui::blue()),
-                            thickness: gpui::px(1.),
-                            wavy: false,
-                        }),
-                        ..Default::default()
-                    },
-                ),
-                TextDecoration::new(
-                    25..37,
-                    HighlightStyle {
-                        underline: Some(gpui::UnderlineStyle {
-                            color: Some(gpui::blue()),
-                            thickness: gpui::px(1.),
-                            wavy: false,
-                        }),
-                        ..Default::default()
-                    },
-                ),
-            ]
+            vec![TextDecoration::new(
+                26..37,
+                HighlightStyle {
+                    underline: Some(gpui::UnderlineStyle {
+                        color: Some(cx.theme().green),
+                        thickness: gpui::px(1.),
+                        wavy: false,
+                    }),
+                    ..Default::default()
+                },
+            )]
         });
         self.underline_decorations
             .set(underline_decorations.unwrap_or_default(), cx);

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -141,21 +141,14 @@ impl InputStory {
                         TextDecoration::new(
                             0..7,
                             HighlightStyle {
-                                color: Some(cx.theme().blue),
+                                color: Some(cx.theme().muted_foreground),
                                 ..Default::default()
                             },
                         ),
                         TextDecoration::new(
-                            25..26,
+                            25..37,
                             HighlightStyle {
-                                color: Some(cx.theme().cyan_light),
-                                ..Default::default()
-                            },
-                        ),
-                        TextDecoration::new(
-                            26..37,
-                            HighlightStyle {
-                                color: Some(cx.theme().cyan),
+                                color: Some(cx.theme().primary),
                                 ..Default::default()
                             },
                         ),
@@ -167,7 +160,7 @@ impl InputStory {
                         26..37,
                         HighlightStyle {
                             underline: Some(gpui::UnderlineStyle {
-                                color: Some(cx.theme().cyan),
+                                color: Some(cx.theme().primary),
                                 thickness: gpui::px(1.),
                                 wavy: false,
                             }),
@@ -446,21 +439,14 @@ impl InputStory {
                 TextDecoration::new(
                     0..7,
                     HighlightStyle {
-                        color: Some(cx.theme().blue),
+                        color: Some(cx.theme().muted_foreground),
                         ..Default::default()
                     },
                 ),
                 TextDecoration::new(
-                    25..26,
+                    25..37,
                     HighlightStyle {
-                        color: Some(cx.theme().cyan_light),
-                        ..Default::default()
-                    },
-                ),
-                TextDecoration::new(
-                    26..37,
-                    HighlightStyle {
-                        color: Some(cx.theme().cyan),
+                        color: Some(cx.theme().primary),
                         ..Default::default()
                     },
                 ),
@@ -474,7 +460,7 @@ impl InputStory {
                 26..37,
                 HighlightStyle {
                     underline: Some(gpui::UnderlineStyle {
-                        color: Some(cx.theme().cyan),
+                        color: Some(cx.theme().primary),
                         thickness: gpui::px(1.),
                         wavy: false,
                     }),

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    App, AppContext as _, ClickEvent, Context, Entity, InteractiveElement, IntoElement,
-    ParentElement as _, Render, Role, Styled, Subscription, Window, div,
+    App, AppContext as _, ClickEvent, Context, Entity, HighlightStyle, InteractiveElement,
+    IntoElement, ParentElement as _, Render, Role, Styled, Subscription, Window, div,
 };
 
 use crate::section;
@@ -32,6 +32,8 @@ pub struct InputStory {
     custom_menu_input: Entity<InputState>,
     code_input: Entity<InputState>,
     color_input: Entity<InputState>,
+    decorations_input: Entity<InputState>,
+    background_decorations: TextDecorationCollectionId,
     content_type_inputs: Vec<ContentTypeInput>,
 
     _subscriptions: Vec<Subscription>,
@@ -125,6 +127,37 @@ impl InputStory {
             InputState::new(window, cx)
                 .placeholder("Type something...")
                 .default_value("Custom text color input")
+        });
+
+        let decorations_input = cx.new(|cx| {
+            InputState::new(window, cx).default_value("Independent decoration collections")
+        });
+        let background_decorations = decorations_input.update(cx, |state, cx| {
+            let background = state.add_decoration_collection(
+                vec![TextDecoration::new(
+                    0..11,
+                    HighlightStyle {
+                        background_color: Some(gpui::yellow()),
+                        ..Default::default()
+                    },
+                )],
+                cx,
+            );
+            state.add_decoration_collection(
+                vec![TextDecoration::new(
+                    12..22,
+                    HighlightStyle {
+                        underline: Some(gpui::UnderlineStyle {
+                            color: Some(gpui::blue()),
+                            thickness: gpui::px(1.),
+                            wavy: false,
+                        }),
+                        ..Default::default()
+                    },
+                )],
+                cx,
+            );
+            background
         });
 
         let code_input = cx.new(|cx| {
@@ -289,6 +322,8 @@ impl InputStory {
             custom_menu_input,
             code_input,
             color_input,
+            decorations_input,
+            background_decorations,
             input_text_centered,
             input_text_right,
             content_type_inputs,
@@ -548,6 +583,51 @@ impl Render for InputStory {
                 section("Custom Text Color")
                     .max_w_md()
                     .child(Input::new(&self.color_input).text_color(cx.theme().info)),
+            )
+            .child(
+                section("Text Decorations")
+                    .max_w_md()
+                    .child(Input::new(&self.decorations_input))
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("clear-text-decoration")
+                                    .label("Clear background")
+                                    .on_click({
+                                        let input = self.decorations_input.clone();
+                                        let collection = self.background_decorations;
+                                        move |_, _, cx| {
+                                            input.update(cx, |state, cx| {
+                                                state.clear_decorations(collection, cx)
+                                            });
+                                        }
+                                    }),
+                            )
+                            .child(
+                                Button::new("restore-text-decoration")
+                                    .label("Restore background")
+                                    .on_click({
+                                        let input = self.decorations_input.clone();
+                                        let collection = self.background_decorations;
+                                        move |_, _, cx| {
+                                            input.update(cx, |state, cx| {
+                                                state.set_decorations(
+                                                    collection,
+                                                    vec![TextDecoration::new(
+                                                        0..11,
+                                                        HighlightStyle {
+                                                            background_color: Some(gpui::yellow()),
+                                                            ..Default::default()
+                                                        },
+                                                    )],
+                                                    cx,
+                                                )
+                                            });
+                                        }
+                                    }),
+                            ),
+                    ),
             )
             .child(
                 section("Single line code editor").max_w_md().child(

--- a/crates/ui/src/input/decorations.rs
+++ b/crates/ui/src/input/decorations.rs
@@ -32,7 +32,7 @@ struct TextDecorationCollectionId(usize);
 /// [`IEditorDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html).
 #[derive(Clone, Debug)]
 pub struct TextDecorationCollection {
-    input: WeakEntity<InputState>,
+    state: WeakEntity<InputState>,
     id: TextDecorationCollectionId,
 }
 
@@ -42,7 +42,7 @@ impl TextDecorationCollection {
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
     pub fn set(&self, decorations: Vec<TextDecoration>, cx: &mut App) {
-        let _ = self.input.update(cx, |state, cx| {
+        let _ = self.state.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.set(self.id, decorations) {
                 cx.notify();
@@ -55,7 +55,7 @@ impl TextDecorationCollection {
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.append`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#append).
     pub fn append(&self, decorations: Vec<TextDecoration>, cx: &mut App) {
-        let _ = self.input.update(cx, |state, cx| {
+        let _ = self.state.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.append(self.id, decorations) {
                 cx.notify();
@@ -76,7 +76,7 @@ impl TextDecorationCollection {
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges).
     pub fn get_ranges(&self, cx: &App) -> Vec<Range<usize>> {
-        self.input
+        self.state
             .read_with(cx, |state, _| {
                 state
                     .decorations
@@ -185,7 +185,7 @@ impl InputState {
         let id = self.decorations.create(decorations);
         cx.notify();
         TextDecorationCollection {
-            input: cx.entity().downgrade(),
+            state: cx.entity().downgrade(),
             id,
         }
     }

--- a/crates/ui/src/input/decorations.rs
+++ b/crates/ui/src/input/decorations.rs
@@ -133,6 +133,16 @@ impl DecorationCollections {
             .map(|(_, decorations)| decorations.as_slice())
     }
 
+    pub(super) fn adjust_for_edit(&mut self, edited_range: &Range<usize>, inserted_len: usize) {
+        for (_, decorations) in &mut self.entries {
+            decorations.retain_mut(|decoration| {
+                decoration.range =
+                    adjust_range_for_edit(&decoration.range, edited_range, inserted_len);
+                !decoration.range.is_empty()
+            });
+        }
+    }
+
     pub(super) fn clear(&mut self) {
         for (_, decorations) in &mut self.entries {
             decorations.clear();
@@ -144,6 +154,52 @@ impl DecorationCollections {
             .iter()
             .map(|(_, decorations)| decorations.as_slice())
     }
+}
+
+fn adjust_range_for_edit(
+    range: &Range<usize>,
+    edited_range: &Range<usize>,
+    inserted_len: usize,
+) -> Range<usize> {
+    let removed_len = edited_range.end.saturating_sub(edited_range.start);
+    let shift = |offset: usize| {
+        if inserted_len >= removed_len {
+            offset.saturating_add(inserted_len - removed_len)
+        } else {
+            offset.saturating_sub(removed_len - inserted_len)
+        }
+    };
+
+    if edited_range.is_empty() {
+        let start = if range.start < edited_range.start {
+            range.start
+        } else {
+            shift(range.start)
+        };
+        let end = if range.end <= edited_range.start {
+            range.end
+        } else {
+            shift(range.end)
+        };
+        return start..end;
+    }
+
+    let inserted_end = edited_range.start + inserted_len;
+    let start = if range.start <= edited_range.start {
+        range.start
+    } else if range.start >= edited_range.end {
+        shift(range.start)
+    } else {
+        edited_range.start
+    };
+    let end = if range.end <= edited_range.start {
+        range.end
+    } else if range.end >= edited_range.end {
+        shift(range.end)
+    } else {
+        inserted_end
+    };
+    start..end
 }
 
 fn normalize(text: &Rope, decorations: Vec<TextDecoration>) -> Vec<TextDecoration> {
@@ -167,11 +223,12 @@ impl InputState {
     /// [`createDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ICodeEditor.html#createDecorationsCollection)
     /// ownership model. Ranges use UTF-8 byte offsets into [`Self::value`].
     ///
-    /// Decorations are presentation state, so their ranges are cleared when
-    /// the input value changes. The collection remains valid and can be
-    /// populated again with [`TextDecorationCollection::set`]. Decorations are not
-    /// rendered while the input is masked. Collections live until their
-    /// [`InputState`] is dropped.
+    /// Decoration ranges follow text edits and do not need to be set again
+    /// after each change. Insertions at a range boundary do not expand the
+    /// range, matching Monaco's
+    /// [`NeverGrowsWhenTypingAtEdges`](https://microsoft.github.io/monaco-editor/typedoc/enums/editor_editor_api.editor.TrackedRangeStickiness.html#NeverGrowsWhenTypingAtEdges)
+    /// behavior. Decorations are not rendered while the input is masked.
+    /// Collections live until their [`InputState`] is dropped.
     ///
     /// Collections are layered in insertion order; the first collection wins
     /// when overlapping decorations set the same [`HighlightStyle`] property.
@@ -244,5 +301,34 @@ mod tests {
             collections.get(second),
             Some(&[TextDecoration::new(5..6, second_style)][..])
         );
+    }
+
+    #[test]
+    fn decoration_ranges_follow_text_edits() {
+        let style = HighlightStyle::default();
+        let mut collections = DecorationCollections::default();
+        let collection = collections.create(vec![TextDecoration::new(2..6, style)]);
+
+        collections.adjust_for_edit(&(0..0), 2);
+        assert_eq!(
+            collections.get(collection),
+            Some(&[TextDecoration::new(4..8, style)][..])
+        );
+
+        collections.adjust_for_edit(&(6..6), 2);
+        assert_eq!(
+            collections.get(collection),
+            Some(&[TextDecoration::new(4..10, style)][..])
+        );
+
+        collections.adjust_for_edit(&(4..10), 3);
+        assert_eq!(
+            collections.get(collection),
+            Some(&[TextDecoration::new(4..7, style)][..])
+        );
+
+        assert_eq!(adjust_range_for_edit(&(2..6), &(2..2), 2), 4..8);
+        assert_eq!(adjust_range_for_edit(&(2..6), &(6..6), 2), 2..6);
+        assert_eq!(adjust_range_for_edit(&(2..6), &(2..6), 3), 2..5);
     }
 }

--- a/crates/ui/src/input/decorations.rs
+++ b/crates/ui/src/input/decorations.rs
@@ -1,0 +1,248 @@
+use std::ops::Range;
+
+use gpui::{AppContext, Context, HighlightStyle, WeakEntity};
+use ropey::Rope;
+use sum_tree::Bias;
+
+use super::{InputState, RopeExt as _};
+
+/// A presentation style applied to a UTF-8 byte range in an input.
+///
+/// This is the GPUI [`HighlightStyle`] counterpart of Monaco's
+/// [`IModelDeltaDecoration`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IModelDeltaDecoration.html).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextDecoration {
+    pub range: Range<usize>,
+    pub style: HighlightStyle,
+}
+
+impl TextDecoration {
+    /// Create a text decoration from a UTF-8 byte range and a GPUI style.
+    pub fn new(range: Range<usize>, style: HighlightStyle) -> Self {
+        Self { range, style }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct TextDecorationCollectionId(usize);
+
+/// An independently managed collection of [`TextDecoration`]s.
+///
+/// This is the GPUI Component counterpart of Monaco's
+/// [`IEditorDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html).
+#[derive(Clone, Debug)]
+pub struct TextDecorationCollection {
+    input: WeakEntity<InputState>,
+    id: TextDecorationCollectionId,
+}
+
+impl TextDecorationCollection {
+    /// Replace all decorations in this collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
+    pub fn set<C: AppContext>(&self, decorations: Vec<TextDecoration>, cx: &mut C) {
+        let _ = self.input.update(cx, |state, cx| {
+            let decorations = normalize(&state.text, decorations);
+            if state.decorations.set(self.id, decorations) {
+                cx.notify();
+            }
+        });
+    }
+
+    /// Add decorations to this collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.append`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#append).
+    pub fn append<C: AppContext>(&self, decorations: Vec<TextDecoration>, cx: &mut C) {
+        let _ = self.input.update(cx, |state, cx| {
+            let decorations = normalize(&state.text, decorations);
+            if state.decorations.append(self.id, decorations) {
+                cx.notify();
+            }
+        });
+    }
+
+    /// Remove all decorations from this collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.clear`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#clear).
+    pub fn clear<C: AppContext>(&self, cx: &mut C) {
+        self.set(Vec::new(), cx);
+    }
+
+    /// Return the UTF-8 byte ranges in this collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges).
+    pub fn get_ranges<C: AppContext>(&self, cx: &C) -> Vec<Range<usize>> {
+        self.input
+            .read_with(cx, |state, _| {
+                state
+                    .decorations
+                    .get(self.id)
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|decoration| decoration.range.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Default)]
+pub(super) struct DecorationCollections {
+    entries: Vec<(TextDecorationCollectionId, Vec<TextDecoration>)>,
+}
+
+impl DecorationCollections {
+    fn create(&mut self, decorations: Vec<TextDecoration>) -> TextDecorationCollectionId {
+        let id = TextDecorationCollectionId(self.entries.len());
+        self.entries.push((id, decorations));
+        id
+    }
+
+    fn set(&mut self, id: TextDecorationCollectionId, decorations: Vec<TextDecoration>) -> bool {
+        let Some((_, current)) = self
+            .entries
+            .iter_mut()
+            .find(|(entry_id, _)| *entry_id == id)
+        else {
+            return false;
+        };
+        *current = decorations;
+        true
+    }
+
+    fn append(&mut self, id: TextDecorationCollectionId, decorations: Vec<TextDecoration>) -> bool {
+        let Some((_, current)) = self
+            .entries
+            .iter_mut()
+            .find(|(entry_id, _)| *entry_id == id)
+        else {
+            return false;
+        };
+        current.extend(decorations);
+        true
+    }
+
+    fn get(&self, id: TextDecorationCollectionId) -> Option<&[TextDecoration]> {
+        self.entries
+            .iter()
+            .find(|(entry_id, _)| *entry_id == id)
+            .map(|(_, decorations)| decorations.as_slice())
+    }
+
+    pub(super) fn clear(&mut self) {
+        for (_, decorations) in &mut self.entries {
+            decorations.clear();
+        }
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = &[TextDecoration]> {
+        self.entries
+            .iter()
+            .map(|(_, decorations)| decorations.as_slice())
+    }
+}
+
+fn normalize(text: &Rope, decorations: Vec<TextDecoration>) -> Vec<TextDecoration> {
+    decorations
+        .into_iter()
+        .filter_map(|decoration| {
+            let range = text.clip_offset(decoration.range.start, Bias::Left)
+                ..text.clip_offset(decoration.range.end, Bias::Right);
+            (!range.is_empty()).then_some(TextDecoration {
+                range,
+                style: decoration.style,
+            })
+        })
+        .collect()
+}
+
+impl InputState {
+    /// Create an independently managed collection of text decorations.
+    ///
+    /// This follows Monaco's
+    /// [`createDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ICodeEditor.html#createDecorationsCollection)
+    /// ownership model. Ranges use UTF-8 byte offsets into [`Self::value`].
+    ///
+    /// Decorations are presentation state, so their ranges are cleared when
+    /// the input value changes. The collection remains valid and can be
+    /// populated again with [`TextDecorationCollection::set`]. Decorations are not
+    /// rendered while the input is masked. Collections live until their
+    /// [`InputState`] is dropped.
+    ///
+    /// Collections are layered in insertion order; the first collection wins
+    /// when overlapping decorations set the same [`HighlightStyle`] property.
+    /// Callers should avoid conflicting overlaps within one collection.
+    pub fn create_decorations_collection(
+        &mut self,
+        decorations: Vec<TextDecoration>,
+        cx: &mut Context<Self>,
+    ) -> TextDecorationCollection {
+        let decorations = normalize(&self.text, decorations);
+        let id = self.decorations.create(decorations);
+        cx.notify();
+        TextDecorationCollection {
+            input: cx.entity().downgrade(),
+            id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collections_are_independent_and_ranges_are_clipped() {
+        let text = Rope::from("héllo");
+        let first_style = HighlightStyle {
+            font_weight: Some(gpui::FontWeight::BOLD),
+            ..Default::default()
+        };
+        let second_style = HighlightStyle {
+            background_color: Some(gpui::red()),
+            ..Default::default()
+        };
+        let mut collections = DecorationCollections::default();
+
+        let first = collections.create(normalize(
+            &text,
+            vec![TextDecoration::new(2..4, first_style)],
+        ));
+        let second = collections.create(normalize(
+            &text,
+            vec![TextDecoration::new(5..100, second_style)],
+        ));
+
+        assert_ne!(first, second);
+        assert_eq!(
+            collections.get(first),
+            Some(&[TextDecoration::new(1..4, first_style)][..])
+        );
+        assert_eq!(
+            collections.get(second),
+            Some(&[TextDecoration::new(5..6, second_style)][..])
+        );
+
+        assert!(collections.append(first, vec![TextDecoration::new(4..5, second_style)]));
+        assert_eq!(
+            collections.get(first),
+            Some(
+                &[
+                    TextDecoration::new(1..4, first_style),
+                    TextDecoration::new(4..5, second_style),
+                ][..]
+            )
+        );
+
+        assert!(collections.set(first, Vec::new()));
+        assert_eq!(collections.get(first), Some(&[][..]));
+        assert_eq!(
+            collections.get(second),
+            Some(&[TextDecoration::new(5..6, second_style)][..])
+        );
+    }
+}

--- a/crates/ui/src/input/decorations.rs
+++ b/crates/ui/src/input/decorations.rs
@@ -41,7 +41,11 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
-    pub fn set<C: AppContext>(&self, decorations: Vec<TextDecoration>, cx: &mut C) {
+    pub fn set<AppContextType: AppContext>(
+        &self,
+        decorations: Vec<TextDecoration>,
+        cx: &mut AppContext,
+    ) {
         let _ = self.input.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.set(self.id, decorations) {
@@ -54,7 +58,11 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.append`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#append).
-    pub fn append<C: AppContext>(&self, decorations: Vec<TextDecoration>, cx: &mut C) {
+    pub fn append<AppContextType: AppContext>(
+        &self,
+        decorations: Vec<TextDecoration>,
+        cx: &mut AppContextType,
+    ) {
         let _ = self.input.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.append(self.id, decorations) {
@@ -67,7 +75,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.clear`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#clear).
-    pub fn clear<C: AppContext>(&self, cx: &mut C) {
+    pub fn clear<AppContextType: AppContext>(&self, cx: &mut AppContextType) {
         self.set(Vec::new(), cx);
     }
 
@@ -75,7 +83,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges).
-    pub fn get_ranges<C: AppContext>(&self, cx: &C) -> Vec<Range<usize>> {
+    pub fn get_ranges<AppContextType: AppContext>(&self, cx: &AppContextType) -> Vec<Range<usize>> {
         self.input
             .read_with(cx, |state, _| {
                 state

--- a/crates/ui/src/input/decorations.rs
+++ b/crates/ui/src/input/decorations.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use gpui::{AppContext, Context, HighlightStyle, WeakEntity};
+use gpui::{App, Context, HighlightStyle, WeakEntity};
 use ropey::Rope;
 use sum_tree::Bias;
 
@@ -41,11 +41,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
-    pub fn set<AppContextType: AppContext>(
-        &self,
-        decorations: Vec<TextDecoration>,
-        cx: &mut AppContext,
-    ) {
+    pub fn set(&self, decorations: Vec<TextDecoration>, cx: &mut App) {
         let _ = self.input.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.set(self.id, decorations) {
@@ -58,11 +54,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.append`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#append).
-    pub fn append<AppContextType: AppContext>(
-        &self,
-        decorations: Vec<TextDecoration>,
-        cx: &mut AppContextType,
-    ) {
+    pub fn append(&self, decorations: Vec<TextDecoration>, cx: &mut App) {
         let _ = self.input.update(cx, |state, cx| {
             let decorations = normalize(&state.text, decorations);
             if state.decorations.append(self.id, decorations) {
@@ -75,7 +67,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.clear`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#clear).
-    pub fn clear<AppContextType: AppContext>(&self, cx: &mut AppContextType) {
+    pub fn clear(&self, cx: &mut App) {
         self.set(Vec::new(), cx);
     }
 
@@ -83,7 +75,7 @@ impl TextDecorationCollection {
     ///
     /// This corresponds to Monaco's
     /// [`IEditorDecorationsCollection.getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges).
-    pub fn get_ranges<AppContextType: AppContext>(&self, cx: &AppContextType) -> Vec<Range<usize>> {
+    pub fn get_ranges(&self, cx: &App) -> Vec<Range<usize>> {
         self.input
             .read_with(cx, |state, _| {
                 state

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -21,7 +21,7 @@ use crate::{
     scroll::Scrollbar,
 };
 
-use super::{InputState, LastLayout, WhitespaceIndicators, mode::InputMode};
+use super::{InputState, LastLayout, TextDecoration, WhitespaceIndicators, mode::InputMode};
 
 const BOTTOM_MARGIN_ROWS: usize = 3;
 pub(super) const RIGHT_MARGIN: Pixels = px(10.);
@@ -29,6 +29,49 @@ pub(super) const LINE_NUMBER_RIGHT_MARGIN: Pixels = px(10.);
 const FOLD_ICON_WIDTH: Pixels = px(14.);
 const FOLD_ICON_HITBOX_WIDTH: Pixels = px(18.);
 const MAX_HIGHLIGHT_LINE_LENGTH: usize = 10_000;
+
+fn compose_decorations(
+    mut styles: Vec<(Range<usize>, HighlightStyle)>,
+    decorations: impl IntoIterator<Item = (Range<usize>, HighlightStyle)>,
+    visible_byte_range: Range<usize>,
+) -> Option<Vec<(Range<usize>, HighlightStyle)>> {
+    let mut visible_decorations = decorations
+        .into_iter()
+        .filter_map(|(range, style)| {
+            let range =
+                range.start.max(visible_byte_range.start)..range.end.min(visible_byte_range.end);
+            (!range.is_empty()).then_some((range, style))
+        })
+        .peekable();
+
+    if visible_decorations.peek().is_none() {
+        return (!styles.is_empty()).then_some(styles);
+    }
+    if styles.is_empty() {
+        styles.push((visible_byte_range.clone(), HighlightStyle::default()));
+    }
+
+    Some(gpui::combine_highlights(visible_decorations, styles).collect())
+}
+
+fn compose_decoration_collections<'a>(
+    mut styles: Vec<(Range<usize>, HighlightStyle)>,
+    collections: impl IntoIterator<Item = &'a [TextDecoration]>,
+    visible_byte_range: Range<usize>,
+) -> Option<Vec<(Range<usize>, HighlightStyle)>> {
+    for decorations in collections {
+        styles = compose_decorations(
+            styles,
+            decorations
+                .iter()
+                .map(|decoration| (decoration.range.clone(), decoration.style)),
+            visible_byte_range.clone(),
+        )
+        .unwrap_or_default();
+    }
+
+    (!styles.is_empty()).then_some(styles)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct EditorScrollbarLayout {
@@ -1289,9 +1332,29 @@ impl TextElement {
                 diagnostics,
                 ..
             } => (highlighter.borrow_mut(), diagnostics),
-            _ => return None,
+            _ => {
+                return (!state.masked)
+                    .then(|| {
+                        compose_decoration_collections(
+                            Vec::new(),
+                            state.decoration_collections(),
+                            visible_byte_range,
+                        )
+                    })
+                    .flatten();
+            }
         };
-        let highlighter = highlighter.as_mut()?;
+        let Some(highlighter) = highlighter.as_mut() else {
+            return (!state.masked)
+                .then(|| {
+                    compose_decoration_collections(
+                        Vec::new(),
+                        state.decoration_collections(),
+                        visible_byte_range,
+                    )
+                })
+                .flatten();
+        };
 
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
 
@@ -1364,10 +1427,16 @@ impl TextElement {
             styles.push(hover_style);
         }
 
-        // Compose order: tree-sitter (base) -> custom (overlay) -> diagnostics (top).
-        // Diagnostics keep highest priority so errors remain visible regardless
-        // of language coloring.
+        // Compose tree-sitter, semantic, application, then diagnostic styles.
         styles = gpui::combine_highlights(custom_styles, styles).collect();
+        if !state.masked {
+            styles = compose_decoration_collections(
+                styles,
+                state.decoration_collections(),
+                visible_byte_range.clone(),
+            )
+            .unwrap_or_default();
+        }
         styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
 
         Some(styles)
@@ -2369,6 +2438,50 @@ fn split_runs_by_bg_segments(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_plain_text_decorations_include_unstyled_gaps() {
+        let decoration = HighlightStyle {
+            background_color: Some(gpui::red()),
+            ..Default::default()
+        };
+        let styles = compose_decorations(Vec::new(), [(2..5, decoration)], 0..10).unwrap();
+
+        assert_eq!(
+            styles
+                .iter()
+                .map(|(range, _)| range.clone())
+                .collect::<Vec<_>>(),
+            vec![0..2, 2..5, 5..10]
+        );
+        assert_eq!(styles[0].1, HighlightStyle::default());
+        assert_eq!(styles[1].1.background_color, Some(gpui::red()));
+        assert_eq!(styles[2].1, HighlightStyle::default());
+    }
+
+    #[test]
+    fn test_first_decoration_collection_has_precedence() {
+        let first = [TextDecoration::new(
+            0..4,
+            HighlightStyle {
+                background_color: Some(gpui::red()),
+                ..Default::default()
+            },
+        )];
+        let second = [TextDecoration::new(
+            0..4,
+            HighlightStyle {
+                background_color: Some(gpui::blue()),
+                ..Default::default()
+            },
+        )];
+
+        let styles =
+            compose_decoration_collections(Vec::new(), [&first[..], &second[..]], 0..4).unwrap();
+
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0].1.background_color, Some(gpui::red()));
+    }
 
     #[test]
     fn test_editor_scrollbar_layout_uses_current_scroll_size() {

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1337,7 +1337,7 @@ impl TextElement {
                     .then(|| {
                         compose_decoration_collections(
                             Vec::new(),
-                            state.decoration_collections(),
+                            state.decorations.iter(),
                             visible_byte_range,
                         )
                     })
@@ -1349,7 +1349,7 @@ impl TextElement {
                 .then(|| {
                     compose_decoration_collections(
                         Vec::new(),
-                        state.decoration_collections(),
+                        state.decorations.iter(),
                         visible_byte_range,
                     )
                 })
@@ -1432,7 +1432,7 @@ impl TextElement {
         if !state.masked {
             styles = compose_decoration_collections(
                 styles,
-                state.decoration_collections(),
+                state.decorations.iter(),
                 visible_byte_range.clone(),
             )
             .unwrap_or_default();

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -6,6 +6,7 @@ mod change;
 mod clear_button;
 mod content_type;
 mod cursor;
+mod decorations;
 mod display_map;
 mod element;
 mod indent;
@@ -27,6 +28,7 @@ mod state;
 pub(crate) use clear_button::*;
 pub use content_type::*;
 pub use cursor::*;
+pub use decorations::*;
 #[cfg(not(feature = "tree-sitter"))]
 pub use display_map::Tree;
 pub use display_map::{BufferPoint, DisplayMap, DisplayPoint, FoldRange};

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -5,11 +5,11 @@
 use anyhow::Result;
 use gpui::{
     Action, App, AppContext, Bounds, ClipboardItem, Context, Edges, Entity, EntityInputHandler,
-    EventEmitter, FocusHandle, Focusable, HighlightStyle, InteractiveElement as _, IntoElement,
-    KeyBinding, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    ParentElement as _, Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine,
-    SharedString, Styled as _, Subscription, Task, UTF16Selection, Window, actions, div, point,
-    prelude::FluentBuilder as _, px,
+    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
+    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Styled as _,
+    Subscription, Task, UTF16Selection, Window, actions, div, point, prelude::FluentBuilder as _,
+    px,
 };
 use gpui::{Half, TextAlign};
 use ropey::{Rope, RopeSlice};
@@ -18,7 +18,6 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::ops::Range;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use sum_tree::Bias;
 use unicode_segmentation::*;
 
@@ -26,6 +25,7 @@ use super::{
     DisplayMap, MASK_CHAR,
     blink_cursor::BlinkCursor,
     change::Change,
+    decorations::DecorationCollections,
     element::{EditorScrollbarSnapshot, TextElement},
     mask_pattern::{MaskPattern, normalize_number_input},
     mode::InputMode,
@@ -72,29 +72,6 @@ impl Enter {
         })
     }
 }
-
-/// A presentation style applied to a UTF-8 byte range in an input.
-///
-/// This is the GPUI `HighlightStyle` counterpart of Monaco's
-/// [`IModelDeltaDecoration`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IModelDeltaDecoration.html).
-#[derive(Clone, Debug, PartialEq)]
-pub struct TextDecoration {
-    pub range: Range<usize>,
-    pub style: HighlightStyle,
-}
-
-impl TextDecoration {
-    /// Create an input decoration from a UTF-8 byte range and a GPUI style.
-    pub fn new(range: Range<usize>, style: HighlightStyle) -> Self {
-        Self { range, style }
-    }
-}
-
-/// Identifies an independently managed collection of [`TextDecoration`]s.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct TextDecorationCollectionId(u64);
-
-static NEXT_DECORATION_COLLECTION_ID: AtomicU64 = AtomicU64::new(1);
 
 actions!(
     input,
@@ -420,7 +397,7 @@ pub struct InputState {
     pub(super) editor_scrollbar_paddings: Cell<Edges<Pixels>>,
     pub(super) editor_scrollbar_snapshot: Cell<Option<EditorScrollbarSnapshot>>,
     pub(super) text_align: TextAlign,
-    pub(super) decoration_collections: Vec<(TextDecorationCollectionId, Vec<TextDecoration>)>,
+    pub(super) decorations: DecorationCollections,
 
     /// The mask pattern for formatting the input text
     pub(crate) mask_pattern: MaskPattern,
@@ -557,7 +534,7 @@ impl InputState {
             mask_pattern: MaskPattern::default(),
             mask_pattern_set: false,
             text_align: TextAlign::Left,
-            decoration_collections: Vec::new(),
+            decorations: DecorationCollections::default(),
             lsp: Lsp::default(),
             diagnostic_popover: None,
             context_menu_content: None,
@@ -1294,106 +1271,6 @@ impl InputState {
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
         self._pending_update = true;
         cx.notify();
-    }
-
-    /// Add an independently managed collection of text decorations.
-    ///
-    /// This follows Monaco's
-    /// [`createDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ICodeEditor.html#createDecorationsCollection)
-    /// ownership model. Ranges use UTF-8 byte offsets into [`Self::value`].
-    ///
-    /// Decorations are presentation state, so their ranges are cleared when
-    /// the input value changes. The collection remains valid and can be
-    /// populated again with [`Self::set_decorations`]. Decorations are not
-    /// rendered while the input is masked. Collections live until their
-    /// [`InputState`] is dropped.
-    ///
-    /// Collections are layered in insertion order; the first collection wins
-    /// when overlapping decorations set the same [`HighlightStyle`] property.
-    /// Callers should avoid conflicting overlaps within one collection.
-    pub fn add_decoration_collection(
-        &mut self,
-        decorations: Vec<TextDecoration>,
-        cx: &mut Context<Self>,
-    ) -> TextDecorationCollectionId {
-        let id = TextDecorationCollectionId(
-            NEXT_DECORATION_COLLECTION_ID.fetch_add(1, Ordering::Relaxed),
-        );
-        self.decoration_collections
-            .push((id, self.normalize_decorations(decorations)));
-        cx.notify();
-        id
-    }
-
-    /// Replace all decorations in a collection.
-    ///
-    /// This corresponds to Monaco's
-    /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
-    pub fn set_decorations(
-        &mut self,
-        collection: TextDecorationCollectionId,
-        decorations: Vec<TextDecoration>,
-        cx: &mut Context<Self>,
-    ) {
-        let decorations = self.normalize_decorations(decorations);
-        if let Some((_, current)) = self
-            .decoration_collections
-            .iter_mut()
-            .find(|(id, _)| *id == collection)
-        {
-            *current = decorations;
-            cx.notify();
-        }
-    }
-
-    /// Remove all decorations without removing the collection.
-    ///
-    /// This corresponds to Monaco's
-    /// [`IEditorDecorationsCollection.clear`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#clear).
-    pub fn clear_decorations(
-        &mut self,
-        collection: TextDecorationCollectionId,
-        cx: &mut Context<Self>,
-    ) {
-        self.set_decorations(collection, Vec::new(), cx);
-    }
-
-    /// Return the decorations in a collection.
-    ///
-    /// Unlike Monaco's range-only
-    /// [`getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges),
-    /// this returns each range together with its GPUI [`HighlightStyle`].
-    pub fn decorations(&self, collection: TextDecorationCollectionId) -> Option<&[TextDecoration]> {
-        self.decoration_collections
-            .iter()
-            .find(|(id, _)| *id == collection)
-            .map(|(_, decorations)| decorations.as_slice())
-    }
-
-    fn normalize_decorations(&self, decorations: Vec<TextDecoration>) -> Vec<TextDecoration> {
-        decorations
-            .into_iter()
-            .filter_map(|decoration| {
-                let range = self.text.clip_offset(decoration.range.start, Bias::Left)
-                    ..self.text.clip_offset(decoration.range.end, Bias::Right);
-                (!range.is_empty()).then_some(TextDecoration {
-                    range,
-                    style: decoration.style,
-                })
-            })
-            .collect()
-    }
-
-    fn clear_decorations_after_edit(&mut self) {
-        for (_, decorations) in &mut self.decoration_collections {
-            decorations.clear();
-        }
-    }
-
-    pub(super) fn decoration_collections(&self) -> impl Iterator<Item = &[TextDecoration]> {
-        self.decoration_collections
-            .iter()
-            .map(|(_, decorations)| decorations.as_slice())
     }
 
     pub(super) fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -3054,7 +2931,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
-        self.clear_decorations_after_edit();
+        self.decorations.clear();
         if mask_changed {
             // A segment-based history entry no longer matches the masked
             // document, record a whole-document change instead, so that
@@ -3138,7 +3015,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
-        self.clear_decorations_after_edit();
+        self.decorations.clear();
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
@@ -3974,50 +3851,6 @@ ORDER BY id
                 // clamped + collapsed
                 s.set_selected_range(100..100, cx);
                 assert_eq!(s.selected_range(), 11..11);
-            });
-        });
-    }
-
-    #[gpui::test]
-    fn test_decorations_collections_are_independent(cx: &mut TestAppContext) {
-        let input_view = InputView::build(cx, |state| state.default_value("héllo"));
-        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
-        let input = input_view.input;
-        let first_style = HighlightStyle {
-            font_weight: Some(gpui::FontWeight::BOLD),
-            ..Default::default()
-        };
-        let second_style = HighlightStyle {
-            background_color: Some(gpui::red()),
-            ..Default::default()
-        };
-
-        cx.update(|window, cx| {
-            input.update(cx, |state, cx| {
-                let first = state
-                    .add_decoration_collection(vec![TextDecoration::new(2..4, first_style)], cx);
-                let second = state
-                    .add_decoration_collection(vec![TextDecoration::new(5..100, second_style)], cx);
-                assert_ne!(first, second);
-
-                assert_eq!(
-                    state.decorations(first),
-                    Some(&[TextDecoration::new(1..4, first_style)][..])
-                );
-                assert_eq!(
-                    state.decorations(second),
-                    Some(&[TextDecoration::new(5..6, second_style)][..])
-                );
-
-                state.clear_decorations(first, cx);
-                assert_eq!(state.decorations(first), Some(&[][..]));
-                assert_eq!(
-                    state.decorations(second),
-                    Some(&[TextDecoration::new(5..6, second_style)][..])
-                );
-
-                state.set_value("world", window, cx);
-                assert_eq!(state.decorations(second), Some(&[][..]));
             });
         });
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -5,11 +5,11 @@
 use anyhow::Result;
 use gpui::{
     Action, App, AppContext, Bounds, ClipboardItem, Context, Edges, Entity, EntityInputHandler,
-    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
-    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Styled as _,
-    Subscription, Task, UTF16Selection, Window, actions, div, point, prelude::FluentBuilder as _,
-    px,
+    EventEmitter, FocusHandle, Focusable, HighlightStyle, InteractiveElement as _, IntoElement,
+    KeyBinding, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ParentElement as _, Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, ShapedLine,
+    SharedString, Styled as _, Subscription, Task, UTF16Selection, Window, actions, div, point,
+    prelude::FluentBuilder as _, px,
 };
 use gpui::{Half, TextAlign};
 use ropey::{Rope, RopeSlice};
@@ -18,6 +18,7 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::ops::Range;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use sum_tree::Bias;
 use unicode_segmentation::*;
 
@@ -71,6 +72,29 @@ impl Enter {
         })
     }
 }
+
+/// A presentation style applied to a UTF-8 byte range in an input.
+///
+/// This is the GPUI `HighlightStyle` counterpart of Monaco's
+/// [`IModelDeltaDecoration`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IModelDeltaDecoration.html).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextDecoration {
+    pub range: Range<usize>,
+    pub style: HighlightStyle,
+}
+
+impl TextDecoration {
+    /// Create an input decoration from a UTF-8 byte range and a GPUI style.
+    pub fn new(range: Range<usize>, style: HighlightStyle) -> Self {
+        Self { range, style }
+    }
+}
+
+/// Identifies an independently managed collection of [`TextDecoration`]s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextDecorationCollectionId(u64);
+
+static NEXT_DECORATION_COLLECTION_ID: AtomicU64 = AtomicU64::new(1);
 
 actions!(
     input,
@@ -396,6 +420,7 @@ pub struct InputState {
     pub(super) editor_scrollbar_paddings: Cell<Edges<Pixels>>,
     pub(super) editor_scrollbar_snapshot: Cell<Option<EditorScrollbarSnapshot>>,
     pub(super) text_align: TextAlign,
+    pub(super) decoration_collections: Vec<(TextDecorationCollectionId, Vec<TextDecoration>)>,
 
     /// The mask pattern for formatting the input text
     pub(crate) mask_pattern: MaskPattern,
@@ -532,6 +557,7 @@ impl InputState {
             mask_pattern: MaskPattern::default(),
             mask_pattern_set: false,
             text_align: TextAlign::Left,
+            decoration_collections: Vec::new(),
             lsp: Lsp::default(),
             diagnostic_popover: None,
             context_menu_content: None,
@@ -1268,6 +1294,106 @@ impl InputState {
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
         self._pending_update = true;
         cx.notify();
+    }
+
+    /// Add an independently managed collection of text decorations.
+    ///
+    /// This follows Monaco's
+    /// [`createDecorationsCollection`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ICodeEditor.html#createDecorationsCollection)
+    /// ownership model. Ranges use UTF-8 byte offsets into [`Self::value`].
+    ///
+    /// Decorations are presentation state, so their ranges are cleared when
+    /// the input value changes. The collection remains valid and can be
+    /// populated again with [`Self::set_decorations`]. Decorations are not
+    /// rendered while the input is masked. Collections live until their
+    /// [`InputState`] is dropped.
+    ///
+    /// Collections are layered in insertion order; the first collection wins
+    /// when overlapping decorations set the same [`HighlightStyle`] property.
+    /// Callers should avoid conflicting overlaps within one collection.
+    pub fn add_decoration_collection(
+        &mut self,
+        decorations: Vec<TextDecoration>,
+        cx: &mut Context<Self>,
+    ) -> TextDecorationCollectionId {
+        let id = TextDecorationCollectionId(
+            NEXT_DECORATION_COLLECTION_ID.fetch_add(1, Ordering::Relaxed),
+        );
+        self.decoration_collections
+            .push((id, self.normalize_decorations(decorations)));
+        cx.notify();
+        id
+    }
+
+    /// Replace all decorations in a collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.set`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#set).
+    pub fn set_decorations(
+        &mut self,
+        collection: TextDecorationCollectionId,
+        decorations: Vec<TextDecoration>,
+        cx: &mut Context<Self>,
+    ) {
+        let decorations = self.normalize_decorations(decorations);
+        if let Some((_, current)) = self
+            .decoration_collections
+            .iter_mut()
+            .find(|(id, _)| *id == collection)
+        {
+            *current = decorations;
+            cx.notify();
+        }
+    }
+
+    /// Remove all decorations without removing the collection.
+    ///
+    /// This corresponds to Monaco's
+    /// [`IEditorDecorationsCollection.clear`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#clear).
+    pub fn clear_decorations(
+        &mut self,
+        collection: TextDecorationCollectionId,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_decorations(collection, Vec::new(), cx);
+    }
+
+    /// Return the decorations in a collection.
+    ///
+    /// Unlike Monaco's range-only
+    /// [`getRanges`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IEditorDecorationsCollection.html#getRanges),
+    /// this returns each range together with its GPUI [`HighlightStyle`].
+    pub fn decorations(&self, collection: TextDecorationCollectionId) -> Option<&[TextDecoration]> {
+        self.decoration_collections
+            .iter()
+            .find(|(id, _)| *id == collection)
+            .map(|(_, decorations)| decorations.as_slice())
+    }
+
+    fn normalize_decorations(&self, decorations: Vec<TextDecoration>) -> Vec<TextDecoration> {
+        decorations
+            .into_iter()
+            .filter_map(|decoration| {
+                let range = self.text.clip_offset(decoration.range.start, Bias::Left)
+                    ..self.text.clip_offset(decoration.range.end, Bias::Right);
+                (!range.is_empty()).then_some(TextDecoration {
+                    range,
+                    style: decoration.style,
+                })
+            })
+            .collect()
+    }
+
+    fn clear_decorations_after_edit(&mut self) {
+        for (_, decorations) in &mut self.decoration_collections {
+            decorations.clear();
+        }
+    }
+
+    pub(super) fn decoration_collections(&self) -> impl Iterator<Item = &[TextDecoration]> {
+        self.decoration_collections
+            .iter()
+            .map(|(_, decorations)| decorations.as_slice())
     }
 
     pub(super) fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -2928,6 +3054,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
+        self.clear_decorations_after_edit();
         if mask_changed {
             // A segment-based history entry no longer matches the masked
             // document, record a whole-document change instead, so that
@@ -3011,6 +3138,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
+        self.clear_decorations_after_edit();
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
@@ -3846,6 +3974,50 @@ ORDER BY id
                 // clamped + collapsed
                 s.set_selected_range(100..100, cx);
                 assert_eq!(s.selected_range(), 11..11);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_decorations_collections_are_independent(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state.default_value("héllo"));
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+        let first_style = HighlightStyle {
+            font_weight: Some(gpui::FontWeight::BOLD),
+            ..Default::default()
+        };
+        let second_style = HighlightStyle {
+            background_color: Some(gpui::red()),
+            ..Default::default()
+        };
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                let first = state
+                    .add_decoration_collection(vec![TextDecoration::new(2..4, first_style)], cx);
+                let second = state
+                    .add_decoration_collection(vec![TextDecoration::new(5..100, second_style)], cx);
+                assert_ne!(first, second);
+
+                assert_eq!(
+                    state.decorations(first),
+                    Some(&[TextDecoration::new(1..4, first_style)][..])
+                );
+                assert_eq!(
+                    state.decorations(second),
+                    Some(&[TextDecoration::new(5..6, second_style)][..])
+                );
+
+                state.clear_decorations(first, cx);
+                assert_eq!(state.decorations(first), Some(&[][..]));
+                assert_eq!(
+                    state.decorations(second),
+                    Some(&[TextDecoration::new(5..6, second_style)][..])
+                );
+
+                state.set_value("world", window, cx);
+                assert_eq!(state.decorations(second), Some(&[][..]));
             });
         });
     }

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -2931,7 +2931,11 @@ impl EntityInputHandler for InputState {
             }
         }
 
-        self.decorations.clear();
+        if mask_changed {
+            self.decorations.clear();
+        } else {
+            self.decorations.adjust_for_edit(&range, new_text.len());
+        }
         if mask_changed {
             // A segment-based history entry no longer matches the masked
             // document, record a whole-document change instead, so that
@@ -3015,7 +3019,7 @@ impl EntityInputHandler for InputState {
             }
         }
 
-        self.decorations.clear();
+        self.decorations.adjust_for_edit(&range, new_text.len());
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }


### PR DESCRIPTION
## Summary

- add `TextDecoration` and `TextDecorationCollection` as a small, presentation-only API for input decorations
- expose Rust-style `create_decorations_collection`, returning a collection handle with `set`, `append`, `clear`, and `get_ranges`
- keep collection identity internal instead of exposing opaque IDs; the handle uses a weak reference to its owning `InputState`
- use GPUI `HighlightStyle` and UTF-8 byte ranges, with Monaco Decorations API links on the corresponding public APIs
- keep decoration storage outside `state.rs` and compose it into the existing rendering paths
- include an interactive Input Story example with multiple background and underline ranges

<img width="982" height="757" alt="image" src="https://github.com/user-attachments/assets/694c95ab-a7a0-4208-8c42-8a2973b9e30b" />

This supersedes #2599. The earlier approach touched more input and UTF-16 conversion logic than the underline/highlight requirement needed. This PR intentionally keeps the implementation localized and preserves the existing input/highlighter behavior.

For follow-up changes, please modify only what the concrete requirement needs and keep diffs narrowly scoped; avoid changing unrelated core input behavior.

Monaco is used as a reference for the ownership model and API capabilities, while naming, types, and return values follow Rust and GPUI conventions rather than copying the TypeScript API literally.

## Test Plan

- `cargo test -p gpui-component --lib` (325 passed)
- `cargo test -p gpui-component decoration --lib` (3 passed)
- `cargo check -p gpui-component-story`
- `git diff --check`