### PR TITLE
ci: Fix Release Docs wasm build

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -28,7 +28,10 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install -f wasm-bindgen-cli --version 0.2.118
+        # Keep the CLI version in sync with the `wasm-bindgen` crate in Cargo.lock
+        run: |
+          version=$(grep -A 1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | cut -d '"' -f 2)
+          cargo install -f wasm-bindgen-cli --version "$version"
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,6 +3098,7 @@ dependencies = [
  "csv",
  "dirs",
  "fake",
+ "getrandom 0.2.17",
  "gpui",
  "gpui-component",
  "gpui-component-assets",

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -41,6 +41,9 @@ color-lsp = "0.2.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gpui_web.workspace = true
+# `rand 0.8` (via `fake`) does not enable the `js` feature of getrandom,
+# which is required to build for wasm32-unknown-unknown.
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18" }


### PR DESCRIPTION
## Description

The Release Docs workflow has been failing since June. This PR fixes the two build errors in the "Build Story Web (WASM)" step:

1. **`getrandom` 0.2 missing the `js` feature** (current failure): `rand 0.8` (via `fake` in `gpui-component-story`) pulls in `getrandom` 0.2, which hits a `compile_error!` on wasm32-unknown-unknown unless the `js` feature is enabled. The dependency that used to enable it through feature unification was dropped in the GPUI upgrade (#2573). Now the feature is enabled explicitly for wasm targets in `crates/story/Cargo.toml`.

2. **`wasm-bindgen-cli` version mismatch** (failure on the July 13 run): the workflow installed a hardcoded CLI 0.2.118 while Cargo.lock has `wasm-bindgen` 0.2.121. The version is now read from Cargo.lock so they stay in sync.

Verified locally: `cargo check --target wasm32-unknown-unknown` in `crates/story-web` passes.

> This PR is AI-generated (Claude Code) and human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)