### PR TITLE
story: Align combobox custom trigger carets

### DIFF
--- a/crates/story/src/stories/combobox_story.rs
+++ b/crates/story/src/stories/combobox_story.rs
@@ -592,8 +592,7 @@ impl Render for ComboboxStory {
                                         }),
                                 )
                                 .child(
-                                    Icon::new(IconName::ChevronDown)
-                                        .size_4()
+                                    Caret::new(ctx.size)
                                         .text_color(cx.theme().muted_foreground),
                                 )
                                 .into_any_element()
@@ -677,8 +676,7 @@ impl Render for ComboboxStory {
                                         }),
                                 )
                                 .child(
-                                    Icon::new(IconName::ChevronDown)
-                                        .size_4()
+                                    Caret::new(ctx.size)
                                         .text_color(cx.theme().muted_foreground),
                                 )
                                 .into_any_element()

--- a/crates/story/src/stories/combobox_story.rs
+++ b/crates/story/src/stories/combobox_story.rs
@@ -593,7 +593,7 @@ impl Render for ComboboxStory {
                                 )
                                 .child(
                                     Icon::new(IconName::ChevronDown)
-                                        .xsmall()
+                                        .size_4()
                                         .text_color(cx.theme().muted_foreground),
                                 )
                                 .into_any_element()
@@ -678,7 +678,7 @@ impl Render for ComboboxStory {
                                 )
                                 .child(
                                     Icon::new(IconName::ChevronDown)
-                                        .xsmall()
+                                        .size_4()
                                         .text_color(cx.theme().muted_foreground),
                                 )
                                 .into_any_element()

--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -8,6 +8,8 @@ use gpui::{
 
 use rust_i18n::t;
 
+pub use crate::select::Caret;
+
 use crate::{
     ActiveTheme, Disableable, ElementExt as _, Icon, IconName, IndexPath, Sizable, Size,
     StyleSized, StyledExt,
@@ -20,7 +22,6 @@ use crate::{
         SearchableListAdapter, SearchableListChange, SearchableListDelegate, SearchableListItem,
         SearchableListState,
     },
-    select::Caret,
     v_flex,
 };
 

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -34,17 +34,19 @@ pub use crate::searchable_list::SearchableListItemElement as SelectListItem;
 pub use crate::searchable_list::SearchableVec;
 
 #[derive(IntoElement)]
-pub(crate) struct Caret {
+pub struct Caret {
     size: Size,
     color: Option<Hsla>,
 }
 
 impl Caret {
-    pub(crate) fn new(size: Size) -> Self {
+    /// Create a select caret sized for its trigger.
+    pub fn new(size: Size) -> Self {
         Self { size, color: None }
     }
 
-    pub(crate) fn text_color(mut self, color: Hsla) -> Self {
+    /// Set the caret color.
+    pub fn text_color(mut self, color: Hsla) -> Self {
         self.color = Some(color);
         self
     }


### PR DESCRIPTION
## Summary

- expose and re-export the shared `Caret` component for custom Combobox triggers
- use `Caret::new(ctx.size)` in the Item with Icon and Custom Trigger examples
- keep custom trigger caret sizing consistent with the Combobox size mapping

## Test Plan

- `cargo check -p gpui-component-story`
- `git diff --check`