### PR TITLE
scroll: Fix markdown table horizontal scroll leaking into vertical body scroll

### DIFF
--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -21,14 +21,22 @@ pub(crate) fn horizontal_scroll_area(
     style: &StyleRefinement,
     child: impl IntoElement,
 ) -> impl IntoElement {
+    // The mask must be a sibling of the scrolled element (like in Table), not
+    // a child of it: children are prepainted with the scroll offset applied,
+    // which would slide the mask away from the viewport as the content
+    // scrolls, leaving the uncovered part to the parent scroller.
     div()
-        .id(id)
         .w_full()
         .relative()
-        .refine_style(style)
-        .overflow_hidden()
-        .track_scroll(scroll_handle)
-        .child(child)
+        .child(
+            div()
+                .id(id)
+                .w_full()
+                .refine_style(style)
+                .overflow_hidden()
+                .track_scroll(scroll_handle)
+                .child(child),
+        )
         .child(ScrollableMask::new(Axis::Horizontal, scroll_handle))
 }
 
@@ -37,6 +45,11 @@ pub(crate) fn horizontal_scroll_area(
 /// When the mouse wheel is scrolled, will move the `scroll_handle` scrolling with the `axis` direction.
 /// You can use this `scroll_handle` to control what you want to scroll.
 /// This is only can handle once axis scrolling.
+///
+/// Axis-dominant wheel events are consumed in the capture phase, so the mask
+/// wins over ancestor scrollers (e.g. `gpui::list`) that register their
+/// listeners after their children; events dominated by the other axis keep
+/// propagating. The mask stays inert while occluded.
 pub struct ScrollableMask {
     axis: Axis,
     scroll_handle: ScrollHandle,
@@ -149,9 +162,20 @@ impl Element for ScrollableMask {
             window.on_mouse_event({
                 let view_id = window.current_view();
                 let scroll_handle = self.scroll_handle.clone();
+                let hitbox_id = hitbox.id;
 
-                move |event: &ScrollWheelEvent, phase, _, cx| {
-                    if !(bounds.contains(&event.position) && phase.bubble()) {
+                move |event: &ScrollWheelEvent, phase, window, cx| {
+                    // Handle in the capture phase: ancestor scrollers such as
+                    // `gpui::list` register their wheel listeners after their
+                    // children paint, so in the bubble phase (reverse
+                    // registration order) they run first and would consume the
+                    // vertical component of a trackpad swipe before this mask
+                    // could stop the propagation.
+                    //
+                    // `should_handle_scroll` (instead of a raw bounds check)
+                    // keeps the mask inert when it is occluded, e.g. below an
+                    // open dialog or context menu.
+                    if !(phase.capture() && hitbox_id.should_handle_scroll(window)) {
                         return;
                     }
 
@@ -175,6 +199,10 @@ impl Element for ScrollableMask {
                         offset.y += delta.y;
                     }
 
+                    // NOTE: `set_offset` does not clamp (clamping happens in
+                    // the div's prepaint), so any non-zero axis-dominant delta
+                    // passes this guard — even at the scroll edge the event is
+                    // consumed rather than turned into a parent scroll.
                     if offset != scroll_handle.offset() {
                         scroll_handle.set_offset(offset);
                         cx.notify(view_id);
@@ -190,8 +218,8 @@ impl Element for ScrollableMask {
 mod tests {
     use super::*;
     use gpui::{
-        Context, IntoElement, Render, ScrollDelta, ScrollWheelEvent, TestAppContext,
-        VisualTestContext, Window, div, point, px,
+        Context, IntoElement, ListAlignment, ListState, Render, ScrollDelta, ScrollWheelEvent,
+        TestAppContext, VisualTestContext, Window, div, list, point, px,
     };
 
     struct HorizontalScrollAreaTest {
@@ -230,6 +258,147 @@ mod tests {
             ..Default::default()
         });
 
+        assert_eq!(scroll_handle.offset().x, px(0.));
+    }
+
+    /// Reproduces the markdown table case: the scroll area lives inside a
+    /// `gpui::list` item. The list registers its wheel listener after its
+    /// items paint, so in the bubble phase (reverse registration order) the
+    /// list runs first and consumes `delta.y` of every trackpad swipe.
+    struct ListWithHorizontalAreaTest {
+        scroll_handle: ScrollHandle,
+        list_state: ListState,
+        occluded: bool,
+    }
+
+    impl Render for ListWithHorizontalAreaTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let scroll_handle = self.scroll_handle.clone();
+            let mut root = div().w(px(100.)).h(px(100.)).child(
+                list(self.list_state.clone(), move |ix, _, _| {
+                    if ix == 0 {
+                        horizontal_scroll_area(
+                            "horizontal-scroll-area",
+                            &scroll_handle,
+                            &Default::default(),
+                            div().w(px(300.)).h(px(40.)),
+                        )
+                        .into_any_element()
+                    } else {
+                        div().w(px(100.)).h(px(40.)).into_any_element()
+                    }
+                })
+                .w_full()
+                .h_full(),
+            );
+            if self.occluded {
+                // An overlay above the list, like an open dialog or menu.
+                root = root.child(div().absolute().top_0().left_0().size_full().occlude());
+            }
+            root
+        }
+    }
+
+    fn setup_list_test<'a>(
+        cx: &'a mut TestAppContext,
+        scroll_handle: &ScrollHandle,
+        list_state: &ListState,
+        occluded: bool,
+    ) -> &'a mut VisualTestContext {
+        let (_, cx) = cx.add_window_view({
+            let scroll_handle = scroll_handle.clone();
+            let list_state = list_state.clone();
+            move |_, _| ListWithHorizontalAreaTest {
+                scroll_handle: scroll_handle.clone(),
+                list_state: list_state.clone(),
+                occluded,
+            }
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        cx
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_in_list_keeps_horizontal_dominant_wheel(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let cx = setup_list_test(cx, &scroll_handle, &list_state, false);
+
+        // A trackpad swipe is rarely axis-pure: horizontal dominant with a
+        // small vertical component.
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-40.), px(-10.))),
+            ..Default::default()
+        });
+
+        // The area consumes the horizontal delta...
+        assert_eq!(scroll_handle.offset().x, px(-40.));
+        // ...and the outer list must not scroll vertically.
+        let scroll_top = list_state.logical_scroll_top();
+        assert_eq!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_in_list_bubbles_vertical_dominant_wheel(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let cx = setup_list_test(cx, &scroll_handle, &list_state, false);
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-10.), px(-40.))),
+            ..Default::default()
+        });
+
+        // Vertical dominant: the list scrolls, the area does not.
+        assert_eq!(scroll_handle.offset().x, px(0.));
+        let scroll_top = list_state.logical_scroll_top();
+        assert_ne!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_covers_viewport_after_scrolled(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let cx = setup_list_test(cx, &scroll_handle, &list_state, false);
+
+        // Scroll the area to the middle, then repaint.
+        scroll_handle.set_offset(point(px(-150.), px(0.)));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // Swipe over the right side of the viewport. The mask must still
+        // cover it — it must not slide away with the scrolled content.
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(90.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-40.), px(-10.))),
+            ..Default::default()
+        });
+
+        assert_eq!(scroll_handle.offset().x, px(-190.));
+        let scroll_top = list_state.logical_scroll_top();
+        assert_eq!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));
+    }
+
+    #[gpui::test]
+    fn horizontal_scroll_area_ignores_wheel_when_occluded(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let cx = setup_list_test(cx, &scroll_handle, &list_state, true);
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-40.), px(-10.))),
+            ..Default::default()
+        });
+
+        // An overlay (dialog, context menu) occludes the area: the area
+        // must not scroll underneath it.
         assert_eq!(scroll_handle.offset().x, px(0.));
     }
 

--- a/crates/ui/src/text/style.rs
+++ b/crates/ui/src/text/style.rs
@@ -20,7 +20,8 @@ pub struct TextViewStyle {
     pub highlight_theme: Arc<HighlightTheme>,
     /// The style refinement for code blocks.
     pub code_block: StyleRefinement,
-    /// Style refinement applied to the table container (the bordered wrapper).
+    /// Style refinement applied to the table container (the bordered wrapper
+    /// in wrap mode, the scroll viewport in horizontal-scroll mode).
     ///
     /// Set `overflow_x: scroll` here to keep table cells on a single line and
     /// scroll the table horizontally instead of wrapping cell content, e.g.


### PR DESCRIPTION
## Description

With a trackpad, horizontal swipes over a horizontally scrollable markdown table (`TextViewStyle.table` with `overflow_x: scroll`) scrolled the whole markdown body vertically instead, making the table nearly impossible to scroll. Two causes:

1. With `scrollable(true)` the body is a `gpui::list`, which registers its wheel listener after its items paint, so in the bubble phase (reverse registration order) it consumed `delta.y` before `ScrollableMask` could stop the propagation. The mask now consumes axis-dominant wheel events in the capture phase; vertical-dominant events keep bubbling to the body (preserves #2468).

2. The mask was a child of the scrolled element and slid away from the viewport as the table scrolled, leaving the uncovered part leaking to the parent scroller. It is now a sibling of the scrolled element, same as `Table`.

The mask also checks `HitboxId::should_handle_scroll` now, staying inert when occluded (dialogs, context menus). Since capture runs in registration order, nested masks resolve innermost-first.

Added 4 tests reproducing the `gpui::list` structure.