### PR TITLE
menu: Support async submenu content with rebuild and late parent wiring

### DIFF
--- a/crates/story/src/stories/popover_story.rs
+++ b/crates/story/src/stories/popover_story.rs
@@ -9,11 +9,13 @@ use gpui_component::{
     h_flex,
     input::{Input, InputState},
     list::{List, ListDelegate, ListItem, ListState},
+    menu::{DropdownMenu as _, PopupMenu, PopupMenuItem},
     popover::Popover,
     separator::Separator,
     v_flex,
 };
 use serde::Deserialize;
+use std::time::Duration;
 
 use crate::section;
 
@@ -338,6 +340,46 @@ impl Render for PopoverStory {
                         )
                         .child("This popover is open by default when first rendered."),
                 ),
+            )
+            .child(
+                section("Async Submenu")
+                    .child(
+                        Button::new("async-menu")
+                            .outline()
+                            .label("Async Menu")
+                            .dropdown_menu(|menu, window, cx| {
+                                // The submenu is attached as a plain menu value, its
+                                // content is loaded asynchronously via `rebuild`.
+                                let submenu = PopupMenu::build(window, cx, |menu, _, _| {
+                                    menu.label("Loading...")
+                                });
+
+                                cx.spawn_in(window, {
+                                    let submenu = submenu.clone();
+                                    async move |_, cx| {
+                                        cx.background_executor()
+                                            .timer(Duration::from_secs(1))
+                                            .await;
+                                        _ = submenu.update_in(cx, |menu, window, cx| {
+                                            menu.rebuild(window, cx, |menu, _, _| {
+                                                (1..=3).fold(menu, |menu, ix| {
+                                                    menu.menu(
+                                                        format!("Loaded Item {}", ix),
+                                                        Box::new(Info(ix)),
+                                                    )
+                                                })
+                                            });
+                                        });
+                                    }
+                                })
+                                .detach();
+
+                                menu.menu("Copy", Box::new(Copy))
+                                    .separator()
+                                    .item(PopupMenuItem::submenu("Async Submenu", submenu))
+                            }),
+                    )
+                    .child(self.message.clone()),
             )
             .child(
                 section("Popover Anchor")

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -681,6 +681,38 @@ impl PopupMenu {
         self
     }
 
+    /// Replace all menu items by re-running a builder on this menu, keeping its
+    /// identity (focus, parent menu, layer priority).
+    ///
+    /// For menus whose content arrives asynchronously after the menu is shown,
+    /// e.g. swapping a "loading…" placeholder for the loaded items:
+    ///
+    /// ```ignore
+    /// cx.spawn_in(window, async move |menu, cx| {
+    ///     let items = fetch_items().await;
+    ///     _ = menu.update_in(cx, |menu, window, cx| {
+    ///         menu.rebuild(window, cx, |menu, _, _| {
+    ///             items.into_iter().fold(menu, |menu, item| {
+    ///                 menu.menu(item.label, Box::new(item.action))
+    ///             })
+    ///         });
+    ///     });
+    /// })
+    /// .detach();
+    /// ```
+    pub fn rebuild(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        f: impl FnOnce(Self, &mut Window, &mut Context<Self>) -> Self,
+    ) {
+        let mut menu = std::mem::replace(self, Self::new(cx));
+        menu.menu_items.clear();
+        menu.selected_index = None;
+        *self = f(menu, window, cx);
+        cx.notify();
+    }
+
     fn add_menu_item(
         &mut self,
         label: impl Into<SharedString>,
@@ -1312,6 +1344,24 @@ struct RenderOptions {
 impl Render for PopupMenu {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.update_submenu_menu_anchor(window);
+
+        // Submenus attached via the public `item()` + `PopupMenuItem::submenu()`
+        // path (from contexts that only have the menu value, e.g. a table
+        // delegate's `context_menu`) have no parent wired at construction time.
+        // Wire them here so the dismiss chain, click-outside checks and keyboard
+        // navigation treat them the same as `submenu()`-built children.
+        let parent = cx.entity().downgrade();
+        let parent_priority = self.priority;
+        for item in &self.menu_items {
+            if let PopupMenuItem::Submenu { menu, .. } = item {
+                if menu.read(cx).parent_menu.is_none() {
+                    menu.update(cx, |menu, _| {
+                        menu.parent_menu = Some(parent.clone());
+                        menu.priority = parent_priority + 1;
+                    });
+                }
+            }
+        }
 
         let view = cx.entity().clone();
         let items_count = self.menu_items.len();


### PR DESCRIPTION
## Description

This PR makes `PopupMenu` usable for menus whose content arrives asynchronously after the menu is shown:

- Added `PopupMenu::rebuild` to replace all menu items by re-running a builder on the existing menu entity, keeping its identity (focus, `parent_menu`, layer priority). This allows swapping a "loading…" placeholder for the loaded items once an async fetch completes, without recreating the menu.
- Submenus attached via the public `item()` + `PopupMenuItem::submenu()` path (from contexts that only have the menu value, e.g. a table delegate's `context_menu`) previously had no `parent_menu` or paint priority wired. They are now wired lazily in `render`, so the dismiss chain, click-outside checks, and keyboard navigation treat them the same as `submenu()`-built children.

No breaking changes; both changes are additive.

> Note: Portions of this PR were AI-generated and have been reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)