### PR TITLE
linux: improve Linux client-side decorations

### DIFF
--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -1,9 +1,9 @@
 // From:
 // https://github.com/zed-industries/zed/blob/56daba28d40301ee4c05546fadb691d070b7b2b6/crates/gpui/examples/window_shadow.rs
 use gpui::{
-    AnyElement, App, CursorStyle, Decorations, Edges, Hsla, InteractiveElement as _,
-    IntoElement, MouseButton, ParentElement, Pixels, Point, RenderOnce, ResizeEdge, Size,
-    Styled as _, Tiling, Window, div, point, prelude::FluentBuilder as _, px,
+    AnyElement, App, CursorStyle, Decorations, Edges, Hsla, InteractiveElement as _, IntoElement,
+    MouseButton, ParentElement, Pixels, Point, RenderOnce, ResizeEdge, Size, Styled as _, Tiling,
+    Window, div, point, prelude::FluentBuilder as _, px,
 };
 
 use crate::ActiveTheme;
@@ -11,10 +11,14 @@ use crate::ActiveTheme;
 #[cfg(not(target_os = "linux"))]
 pub(crate) const SHADOW_SIZE: Pixels = px(0.0);
 #[cfg(target_os = "linux")]
-pub(crate) const SHADOW_SIZE: Pixels = px(12.0);
+pub(crate) const SHADOW_SIZE: Pixels = px(20.0);
 const BORDER_SIZE: Pixels = px(1.0);
 /// Half-width of the resize hit band on each side of the visible frame (inner border).
 const RESIZE_HIT_SIZE: Pixels = px(4.0);
+///
+/// GPUI currently clips overflowing children to a rectangular content mask. A non-zero
+/// radius here would round the frame itself but leave child backgrounds visible in the
+/// corners, so keep the generic window wrapper square until rounded content masks exist.
 pub(crate) const BORDER_RADIUS: Pixels = px(0.0);
 
 /// Create a new window border.
@@ -116,6 +120,12 @@ impl RenderOnce for WindowBorder {
             window.set_client_inset(platform_inset);
         }
         let window_size = window.window_bounds().get_bounds().size;
+        let is_window_active = window.is_window_active();
+        let border_color = if is_window_active {
+            cx.theme().window_border
+        } else {
+            cx.theme().window_border.opacity(0.65)
+        };
 
         div()
             .id("window-backdrop")
@@ -171,24 +181,46 @@ impl RenderOnce for WindowBorder {
                             .when(!(tiling.top || tiling.left), |div| {
                                 div.rounded_tl(BORDER_RADIUS)
                             })
-                            .border_color(cx.theme().window_border)
+                            .border_color(border_color)
                             .when(!tiling.top, |div| div.border_t(BORDER_SIZE))
                             .when(!tiling.bottom, |div| div.border_b(BORDER_SIZE))
                             .when(!tiling.left, |div| div.border_l(BORDER_SIZE))
                             .when(!tiling.right, |div| div.border_r(BORDER_SIZE))
                             .when(!tiling.is_tiled(), |div| {
-                                div.shadow(vec![gpui::BoxShadow {
-                                    color: Hsla {
-                                        h: 0.,
-                                        s: 0.,
-                                        l: 0.,
-                                        a: 0.3,
+                                let opacity = if is_window_active { 1.0 } else { 0.7 };
+                                div.shadow(vec![
+                                    // Keep the effective outer reach below SHADOW_SIZE. GPUI
+                                    // does not grow the paint bounds for blur, so a larger blur
+                                    // or offset would be visibly cut off by the window surface.
+                                    gpui::BoxShadow {
+                                        color: Hsla {
+                                            h: 0.,
+                                            s: 0.,
+                                            l: 0.,
+                                            a: 0.18 * opacity,
+                                        },
+                                        // GNOME-style ambient shadow: horizontally centered
+                                        // with only a slight downward bias.
+                                        blur_radius: px(10.),
+                                        spread_radius: px(-1.),
+                                        offset: point(px(0.0), px(2.0)),
+                                        inset: false,
                                     },
-                                    blur_radius: visual_shadow / 2.,
-                                    spread_radius: px(0.),
-                                    offset: point(px(0.0), px(0.0)),
-                                    inset: false,
-                                }])
+                                    // The contact layer adds definition without increasing the
+                                    // space between the content and the outer window bounds.
+                                    gpui::BoxShadow {
+                                        color: Hsla {
+                                            h: 0.,
+                                            s: 0.,
+                                            l: 0.,
+                                            a: 0.18 * opacity,
+                                        },
+                                        blur_radius: px(3.),
+                                        spread_radius: px(0.),
+                                        offset: point(px(0.0), px(1.0)),
+                                        inset: false,
+                                    },
+                                ])
                             }),
                     })
                     .on_mouse_move(|_e, _, cx| {
@@ -197,25 +229,17 @@ impl RenderOnce for WindowBorder {
                     .bg(gpui::transparent_black())
                     .children(self.children),
             )
-            .when(
-                matches!(decorations, Decorations::Client { .. }),
-                |this| {
-                    let Decorations::Client { tiling, .. } = decorations else {
-                        return this;
-                    };
-                    this.child(
-                        div()
-                            .absolute()
-                            .size_full()
-                            .children(resize_hit_zones(
-                                window_size,
-                                platform_inset,
-                                resize_hit_size,
-                                &tiling,
-                            )),
-                    )
-                },
-            )
+            .when(matches!(decorations, Decorations::Client { .. }), |this| {
+                let Decorations::Client { tiling, .. } = decorations else {
+                    return this;
+                };
+                this.child(div().absolute().size_full().children(resize_hit_zones(
+                    window_size,
+                    platform_inset,
+                    resize_hit_size,
+                    &tiling,
+                )))
+            })
     }
 }
 

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -121,27 +121,21 @@ impl RenderOnce for WindowBorder {
         }
         let window_size = window.window_bounds().get_bounds().size;
         let is_window_active = window.is_window_active();
-        let border_opacity = if is_window_active { 1.0 } else { 0.5 };
-        let border_tint = if cx.theme().is_dark() {
+        let border_color = if cx.theme().is_dark() {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 0.7,
-                a: 0.03 * border_opacity,
+                l: 0.11,
+                a: 1.0,
             }
         } else {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 0.,
-                a: 0.03 * border_opacity,
+                l: 0.96,
+                a: 1.0,
             }
         };
-        // Resolve the tint against the theme's representative background up front.
-        // The painted border is fully opaque and therefore stays consistent over
-        // title bars and content with different backgrounds.
-        let mut border_color = cx.theme().tokens.background.color.blend(border_tint);
-        border_color.a = 1.0;
 
         div()
             .id("window-backdrop")

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -121,20 +121,20 @@ impl RenderOnce for WindowBorder {
         }
         let window_size = window.window_bounds().get_bounds().size;
         let is_window_active = window.is_window_active();
-        let border_opacity = if is_window_active { 1.0 } else { 0.65 };
+        let border_opacity = if is_window_active { 1.0 } else { 0.55 };
         let border_color = if cx.theme().is_dark() {
             Hsla {
                 h: 0.,
                 s: 0.,
                 l: 1.,
-                a: 0.18 * border_opacity,
+                a: 0.12 * border_opacity,
             }
         } else {
             Hsla {
                 h: 0.,
                 s: 0.,
                 l: 0.,
-                a: 0.18 * border_opacity,
+                a: 0.1 * border_opacity,
             }
         };
 

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -126,8 +126,8 @@ impl RenderOnce for WindowBorder {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 1.,
-                a: 0.04 * border_opacity,
+                l: 0.,
+                a: 0.12 * border_opacity,
             }
         } else {
             Hsla {

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -127,14 +127,14 @@ impl RenderOnce for WindowBorder {
                 h: 0.,
                 s: 0.,
                 l: 1.,
-                a: 0.12 * border_opacity,
+                a: 0.08 * border_opacity,
             }
         } else {
             Hsla {
                 h: 0.,
                 s: 0.,
                 l: 0.,
-                a: 0.1 * border_opacity,
+                a: 0.06 * border_opacity,
             }
         };
 

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -122,12 +122,12 @@ impl RenderOnce for WindowBorder {
         let window_size = window.window_bounds().get_bounds().size;
         let is_window_active = window.is_window_active();
         let border_opacity = if is_window_active { 1.0 } else { 0.5 };
-        let border_color = if cx.theme().is_dark() {
+        let border_tint = if cx.theme().is_dark() {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 0.,
-                a: 0.12 * border_opacity,
+                l: 0.7,
+                a: 0.03 * border_opacity,
             }
         } else {
             Hsla {
@@ -137,6 +137,11 @@ impl RenderOnce for WindowBorder {
                 a: 0.03 * border_opacity,
             }
         };
+        // Resolve the tint against the theme's representative background up front.
+        // The painted border is fully opaque and therefore stays consistent over
+        // title bars and content with different backgrounds.
+        let mut border_color = cx.theme().tokens.background.color.blend(border_tint);
+        border_color.a = 1.0;
 
         div()
             .id("window-backdrop")

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -125,14 +125,14 @@ impl RenderOnce for WindowBorder {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 0.11,
+                l: 0.2,
                 a: 1.0,
             }
         } else {
             Hsla {
                 h: 0.,
                 s: 0.,
-                l: 0.96,
+                l: 0.8,
                 a: 1.0,
             }
         };

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -121,20 +121,20 @@ impl RenderOnce for WindowBorder {
         }
         let window_size = window.window_bounds().get_bounds().size;
         let is_window_active = window.is_window_active();
-        let border_opacity = if is_window_active { 1.0 } else { 0.55 };
+        let border_opacity = if is_window_active { 1.0 } else { 0.5 };
         let border_color = if cx.theme().is_dark() {
             Hsla {
                 h: 0.,
                 s: 0.,
                 l: 1.,
-                a: 0.08 * border_opacity,
+                a: 0.04 * border_opacity,
             }
         } else {
             Hsla {
                 h: 0.,
                 s: 0.,
                 l: 0.,
-                a: 0.06 * border_opacity,
+                a: 0.03 * border_opacity,
             }
         };
 

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -121,10 +121,21 @@ impl RenderOnce for WindowBorder {
         }
         let window_size = window.window_bounds().get_bounds().size;
         let is_window_active = window.is_window_active();
-        let border_color = if is_window_active {
-            cx.theme().window_border
+        let border_opacity = if is_window_active { 1.0 } else { 0.65 };
+        let border_color = if cx.theme().is_dark() {
+            Hsla {
+                h: 0.,
+                s: 0.,
+                l: 1.,
+                a: 0.18 * border_opacity,
+            }
         } else {
-            cx.theme().window_border.opacity(0.65)
+            Hsla {
+                h: 0.,
+                s: 0.,
+                l: 0.,
+                a: 0.18 * border_opacity,
+            }
         };
 
         div()


### PR DESCRIPTION
## Description

Improve Linux client-side window decorations so application windows have clearer, more native-looking separation from their surroundings.

- Increase the transparent inset available for the drop shadow.
- Replace the hard single-layer shadow with a soft GNOME-style ambient and contact shadow.
- Reduce shadow and border strength for inactive windows.
- Use a subtle dark 1px border in light themes and a subtle light 1px border in dark themes.
- Keep the generic wrapper square because GPUI content masks currently clip children rectangularly; a rounded frame would expose child backgrounds at the corners.

## How to Test

1. Run the story application on Linux with client-side decorations.
2. Check a floating window in both light and dark themes.
3. Verify the shadow fades smoothly without obvious clipping and the 1px edge remains subtle.
4. Focus and unfocus the window and verify inactive decoration contrast is reduced.
5. Maximize or tile the window and verify shadow and borders are removed from tiled edges.

Validation run:

- `cargo check -p gpui-component`
- `git diff --check`

## Checklist

- [x] I have read the CONTRIBUTING document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (Linux-specific visual change).