### PR TITLE
table: Fix vertical wheel scroll leaking into outer scroll container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8032,6 +8032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "table_in_scrollable"
+version = "0.5.1"
+dependencies = [
+ "gpui",
+ "gpui-component",
+ "gpui_platform",
+]
+
+[[package]]
 name = "taffy"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/sidebar",
     "examples/text_selection",
     "examples/root_borderless",
+    "examples/table_in_scrollable",
 ]
 resolver = "2"
 

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -71,14 +71,10 @@ impl ScrollableMask {
     /// Hand wheel events over to the parent scroller at the scroll edges,
     /// like CSS `overscroll-behavior: auto` (scroll chaining).
     ///
-    /// By default the mask consumes every axis-dominant wheel event, even
-    /// when the content is already at its scroll edge (or does not overflow
-    /// at all). That is the right behavior for a horizontal mask: letting a
-    /// horizontal delta bubble would get it mapped onto a vertical-only
-    /// ancestor scroller by gpui's own wheel listener (see #2468). For a
-    /// vertical mask nested in a vertical page, chaining is usually wanted
-    /// instead: consume the event only while the content can still move,
-    /// and let it bubble to the ancestor once the edge is reached.
+    /// By default the mask consumes every axis-dominant wheel event, even at
+    /// the scroll edge. Keep that default for horizontal masks: a bubbled
+    /// horizontal delta would get mapped onto a vertical-only ancestor
+    /// scroller by gpui's own wheel listener (see #2468).
     pub fn chain_at_edge(mut self) -> Self {
         self.chain_at_edge = true;
         self
@@ -213,14 +209,11 @@ impl Element for ScrollableMask {
                     }
 
                     if chain_at_edge {
-                        // Chain mode compares clamped offsets: when an event
-                        // bubbles at the edge, the scrolled element's own
-                        // bubble-phase listener still pushes the shared offset
-                        // beyond the edge unclamped (the div only clamps on
-                        // prepaint). Clamping the current offset too keeps
-                        // that transient overscroll from reading as "room to
-                        // scroll", which would swallow every other event of a
-                        // fling at the edge.
+                        // The current offset must be clamped too: after a
+                        // bubbled event, the scrolled element's own listener
+                        // pushes the shared offset beyond the edge unclamped
+                        // (the div only clamps on prepaint), and that
+                        // transient overscroll would read as "room to scroll".
                         let max_offset = scroll_handle.max_offset();
                         let (current, axis_delta, axis_max) = if is_horizontal {
                             (offset.x, delta.x, max_offset.x)
@@ -231,8 +224,7 @@ impl Element for ScrollableMask {
                         let current = current.clamp(-axis_max, px(0.));
                         let new_offset = (current + axis_delta).clamp(-axis_max, px(0.));
                         if new_offset == current {
-                            // At the edge or no overflow: let the event
-                            // bubble to the parent scroller.
+                            // At the edge or no overflow: bubble to the parent.
                             return;
                         }
 
@@ -480,11 +472,8 @@ mod tests {
         assert_eq!(scroll_handle.offset().x, px(-40.));
     }
 
-    /// Reproduces the DataTable case: a vertically scrollable element with
-    /// its own scrollbar nested inside an outer vertical scroller. Without a
-    /// vertical mask, gpui's wheel listener scrolls the inner element but
-    /// never stops propagation, so the outer scroller moves on the same
-    /// event.
+    /// Reproduces the DataTable case: a vertically scrollable element
+    /// nested inside an outer vertical scroller.
     struct NestedVerticalScrollTest {
         outer_handle: ScrollHandle,
         inner_handle: ScrollHandle,
@@ -647,11 +636,9 @@ mod tests {
             _ = window.draw(cx);
         });
 
-        // Two wheel events at the edge with no redraw in between. The first
-        // one bubbles, and the inner element's own (unclamped) bubble
-        // listener pushes the shared offset beyond the edge. The mask must
-        // compare clamped offsets, or the snap-back would read as "room to
-        // scroll" and swallow the second event.
+        // Two wheel events at the edge with no redraw in between: the first
+        // one leaves the inner offset beyond the edge unclamped, which must
+        // not read as "room to scroll" and swallow the second event.
         for _ in 0..2 {
             cx.simulate_event(ScrollWheelEvent {
                 position: point(px(10.), px(10.)),
@@ -730,8 +717,7 @@ mod tests {
             ..Default::default()
         });
 
-        // The inner scroller consumes the event; the outer list must not
-        // scroll on the same event.
+        // The inner scroller consumes the event; the list must not scroll.
         assert_eq!(scroll_handle.offset().y, px(-40.));
         let scroll_top = list_state.logical_scroll_top();
         assert_eq!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -53,6 +53,7 @@ pub(crate) fn horizontal_scroll_area(
 pub struct ScrollableMask {
     axis: Axis,
     scroll_handle: ScrollHandle,
+    chain_at_edge: bool,
     debug: Option<Hsla>,
 }
 
@@ -62,8 +63,25 @@ impl ScrollableMask {
         Self {
             scroll_handle: scroll_handle.clone(),
             axis,
+            chain_at_edge: false,
             debug: None,
         }
+    }
+
+    /// Hand wheel events over to the parent scroller at the scroll edges,
+    /// like CSS `overscroll-behavior: auto` (scroll chaining).
+    ///
+    /// By default the mask consumes every axis-dominant wheel event, even
+    /// when the content is already at its scroll edge (or does not overflow
+    /// at all). That is the right behavior for a horizontal mask: letting a
+    /// horizontal delta bubble would get it mapped onto a vertical-only
+    /// ancestor scroller by gpui's own wheel listener (see #2468). For a
+    /// vertical mask nested in a vertical page, chaining is usually wanted
+    /// instead: consume the event only while the content can still move,
+    /// and let it bubble to the ancestor once the edge is reached.
+    pub fn chain_at_edge(mut self) -> Self {
+        self.chain_at_edge = true;
+        self
     }
 
     /// Enable the debug border, to show the mask bounds.
@@ -162,6 +180,7 @@ impl Element for ScrollableMask {
             window.on_mouse_event({
                 let view_id = window.current_view();
                 let scroll_handle = self.scroll_handle.clone();
+                let chain_at_edge = self.chain_at_edge;
                 let hitbox_id = hitbox.id;
 
                 move |event: &ScrollWheelEvent, phase, window, cx| {
@@ -191,6 +210,41 @@ impl Element for ScrollableMask {
                         } else {
                             delta.x = px(0.);
                         }
+                    }
+
+                    if chain_at_edge {
+                        // Chain mode compares clamped offsets: when an event
+                        // bubbles at the edge, the scrolled element's own
+                        // bubble-phase listener still pushes the shared offset
+                        // beyond the edge unclamped (the div only clamps on
+                        // prepaint). Clamping the current offset too keeps
+                        // that transient overscroll from reading as "room to
+                        // scroll", which would swallow every other event of a
+                        // fling at the edge.
+                        let max_offset = scroll_handle.max_offset();
+                        let (current, axis_delta, axis_max) = if is_horizontal {
+                            (offset.x, delta.x, max_offset.x)
+                        } else {
+                            (offset.y, delta.y, max_offset.y)
+                        };
+                        let axis_max = axis_max.max(px(0.));
+                        let current = current.clamp(-axis_max, px(0.));
+                        let new_offset = (current + axis_delta).clamp(-axis_max, px(0.));
+                        if new_offset == current {
+                            // At the edge or no overflow: let the event
+                            // bubble to the parent scroller.
+                            return;
+                        }
+
+                        if is_horizontal {
+                            offset.x = new_offset;
+                        } else {
+                            offset.y = new_offset;
+                        }
+                        scroll_handle.set_offset(offset);
+                        cx.notify(view_id);
+                        cx.stop_propagation();
+                        return;
                     }
 
                     if is_horizontal {
@@ -424,5 +478,262 @@ mod tests {
         });
 
         assert_eq!(scroll_handle.offset().x, px(-40.));
+    }
+
+    /// Reproduces the DataTable case: a vertically scrollable element with
+    /// its own scrollbar nested inside an outer vertical scroller. Without a
+    /// vertical mask, gpui's wheel listener scrolls the inner element but
+    /// never stops propagation, so the outer scroller moves on the same
+    /// event.
+    struct NestedVerticalScrollTest {
+        outer_handle: ScrollHandle,
+        inner_handle: ScrollHandle,
+        inner_content_height: Pixels,
+        chain_at_edge: bool,
+    }
+
+    impl Render for NestedVerticalScrollTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("outer")
+                .w(px(100.))
+                .h(px(100.))
+                .overflow_y_scroll()
+                .track_scroll(&self.outer_handle)
+                .child(
+                    div()
+                        .relative()
+                        .w_full()
+                        .h(px(60.))
+                        .child(
+                            div()
+                                .id("inner")
+                                .size_full()
+                                .overflow_y_scroll()
+                                .track_scroll(&self.inner_handle)
+                                .child(div().w_full().h(self.inner_content_height)),
+                        )
+                        .child({
+                            let mask = ScrollableMask::new(Axis::Vertical, &self.inner_handle);
+                            if self.chain_at_edge {
+                                mask.chain_at_edge()
+                            } else {
+                                mask
+                            }
+                        }),
+                )
+                .child(div().w_full().h(px(400.)))
+        }
+    }
+
+    fn setup_nested_vertical_test<'a>(
+        cx: &'a mut TestAppContext,
+        outer_handle: &ScrollHandle,
+        inner_handle: &ScrollHandle,
+        inner_content_height: Pixels,
+        chain_at_edge: bool,
+    ) -> &'a mut VisualTestContext {
+        let (_, cx) = cx.add_window_view({
+            let outer_handle = outer_handle.clone();
+            let inner_handle = inner_handle.clone();
+            move |_, _| NestedVerticalScrollTest {
+                outer_handle: outer_handle.clone(),
+                inner_handle: inner_handle.clone(),
+                inner_content_height,
+                chain_at_edge,
+            }
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        cx
+    }
+
+    #[gpui::test]
+    fn vertical_mask_chain_consumes_wheel_when_scrollable(cx: &mut TestAppContext) {
+        let outer_handle = ScrollHandle::new();
+        let inner_handle = ScrollHandle::new();
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        // The inner scroller consumes the event; the outer one must not move.
+        assert_eq!(inner_handle.offset().y, px(-40.));
+        assert_eq!(outer_handle.offset().y, px(0.));
+    }
+
+    #[gpui::test]
+    fn vertical_mask_chain_hands_off_to_parent_at_edge(cx: &mut TestAppContext) {
+        let outer_handle = ScrollHandle::new();
+        let inner_handle = ScrollHandle::new();
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+
+        // Scroll the inner element to its bottom edge (300 - 60 = 240).
+        inner_handle.set_offset(point(px(0.), px(-240.)));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        // At the edge the event bubbles: the outer scroller takes over.
+        assert_eq!(outer_handle.offset().y, px(-40.));
+        // The inner offset is clamped back to the edge on the next prepaint.
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        assert_eq!(inner_handle.offset().y, px(-240.));
+    }
+
+    #[gpui::test]
+    fn vertical_mask_chain_bubbles_when_no_overflow(cx: &mut TestAppContext) {
+        let outer_handle = ScrollHandle::new();
+        let inner_handle = ScrollHandle::new();
+        // Inner content (40) fits its 60px viewport: nothing to scroll.
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(40.), true);
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        assert_eq!(outer_handle.offset().y, px(-40.));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        assert_eq!(inner_handle.offset().y, px(0.));
+    }
+
+    #[gpui::test]
+    fn vertical_mask_default_traps_at_edge(cx: &mut TestAppContext) {
+        let outer_handle = ScrollHandle::new();
+        let inner_handle = ScrollHandle::new();
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), false);
+
+        inner_handle.set_offset(point(px(0.), px(-240.)));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        // Without `chain_at_edge` the mask consumes the event even at the
+        // edge — pins the existing (horizontal mask) semantics.
+        assert_eq!(outer_handle.offset().y, px(0.));
+    }
+
+    #[gpui::test]
+    fn vertical_mask_chain_ignores_transient_overscroll(cx: &mut TestAppContext) {
+        let outer_handle = ScrollHandle::new();
+        let inner_handle = ScrollHandle::new();
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+
+        inner_handle.set_offset(point(px(0.), px(-240.)));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // Two wheel events at the edge with no redraw in between. The first
+        // one bubbles, and the inner element's own (unclamped) bubble
+        // listener pushes the shared offset beyond the edge. The mask must
+        // compare clamped offsets, or the snap-back would read as "room to
+        // scroll" and swallow the second event.
+        for _ in 0..2 {
+            cx.simulate_event(ScrollWheelEvent {
+                position: point(px(10.), px(10.)),
+                delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+                ..Default::default()
+            });
+        }
+
+        assert_eq!(outer_handle.offset().y, px(-80.));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        assert_eq!(inner_handle.offset().y, px(-240.));
+    }
+
+    /// The vertical mask nested in a `gpui::list` ancestor: the list
+    /// registers its wheel listener after its items paint, so only a
+    /// capture-phase mask can stop it from scrolling on the same event.
+    struct ListWithVerticalAreaTest {
+        scroll_handle: ScrollHandle,
+        list_state: ListState,
+    }
+
+    impl Render for ListWithVerticalAreaTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let scroll_handle = self.scroll_handle.clone();
+            div().w(px(100.)).h(px(100.)).child(
+                list(self.list_state.clone(), move |ix, _, _| {
+                    if ix == 0 {
+                        div()
+                            .relative()
+                            .w_full()
+                            .h(px(60.))
+                            .child(
+                                div()
+                                    .id("inner")
+                                    .size_full()
+                                    .overflow_y_scroll()
+                                    .track_scroll(&scroll_handle)
+                                    .child(div().w_full().h(px(300.))),
+                            )
+                            .child(
+                                ScrollableMask::new(Axis::Vertical, &scroll_handle).chain_at_edge(),
+                            )
+                            .into_any_element()
+                    } else {
+                        div().w(px(100.)).h(px(40.)).into_any_element()
+                    }
+                })
+                .w_full()
+                .h_full(),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn vertical_mask_in_list_consumes_wheel_when_scrollable(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let (_, cx) = cx.add_window_view({
+            let scroll_handle = scroll_handle.clone();
+            let list_state = list_state.clone();
+            move |_, _| ListWithVerticalAreaTest {
+                scroll_handle: scroll_handle.clone(),
+                list_state: list_state.clone(),
+            }
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+            ..Default::default()
+        });
+
+        // The inner scroller consumes the event; the outer list must not
+        // scroll on the same event.
+        assert_eq!(scroll_handle.offset().y, px(-40.));
+        let scroll_top = list_state.logical_scroll_top();
+        assert_eq!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));
     }
 }

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -50,10 +50,15 @@ pub(crate) fn horizontal_scroll_area(
 /// wins over ancestor scrollers (e.g. `gpui::list`) that register their
 /// listeners after their children; events dominated by the other axis keep
 /// propagating. The mask stays inert while occluded.
+///
+/// At the scroll edge the two axes differ, matching platform scrollers:
+/// a vertical mask hands the event over to the ancestor scroller (CSS
+/// `overscroll-behavior: auto` chaining), while a horizontal mask keeps
+/// consuming it — a bubbled horizontal delta would get mapped onto a
+/// vertical-only ancestor by gpui's own wheel listener (see #2468).
 pub struct ScrollableMask {
     axis: Axis,
     scroll_handle: ScrollHandle,
-    chain_at_edge: bool,
     debug: Option<Hsla>,
 }
 
@@ -63,21 +68,8 @@ impl ScrollableMask {
         Self {
             scroll_handle: scroll_handle.clone(),
             axis,
-            chain_at_edge: false,
             debug: None,
         }
-    }
-
-    /// Hand wheel events over to the parent scroller at the scroll edges,
-    /// like CSS `overscroll-behavior: auto` (scroll chaining).
-    ///
-    /// By default the mask consumes every axis-dominant wheel event, even at
-    /// the scroll edge. Keep that default for horizontal masks: a bubbled
-    /// horizontal delta would get mapped onto a vertical-only ancestor
-    /// scroller by gpui's own wheel listener (see #2468).
-    pub fn chain_at_edge(mut self) -> Self {
-        self.chain_at_edge = true;
-        self
     }
 
     /// Enable the debug border, to show the mask bounds.
@@ -176,7 +168,6 @@ impl Element for ScrollableMask {
             window.on_mouse_event({
                 let view_id = window.current_view();
                 let scroll_handle = self.scroll_handle.clone();
-                let chain_at_edge = self.chain_at_edge;
                 let hitbox_id = hitbox.id;
 
                 move |event: &ScrollWheelEvent, phase, window, cx| {
@@ -208,31 +199,21 @@ impl Element for ScrollableMask {
                         }
                     }
 
-                    if chain_at_edge {
+                    if !is_horizontal {
                         // The current offset must be clamped too: after a
                         // bubbled event, the scrolled element's own listener
                         // pushes the shared offset beyond the edge unclamped
                         // (the div only clamps on prepaint), and that
                         // transient overscroll would read as "room to scroll".
-                        let max_offset = scroll_handle.max_offset();
-                        let (current, axis_delta, axis_max) = if is_horizontal {
-                            (offset.x, delta.x, max_offset.x)
-                        } else {
-                            (offset.y, delta.y, max_offset.y)
-                        };
-                        let axis_max = axis_max.max(px(0.));
-                        let current = current.clamp(-axis_max, px(0.));
-                        let new_offset = (current + axis_delta).clamp(-axis_max, px(0.));
+                        let axis_max = scroll_handle.max_offset().y.max(px(0.));
+                        let current = offset.y.clamp(-axis_max, px(0.));
+                        let new_offset = (current + delta.y).clamp(-axis_max, px(0.));
                         if new_offset == current {
                             // At the edge or no overflow: bubble to the parent.
                             return;
                         }
 
-                        if is_horizontal {
-                            offset.x = new_offset;
-                        } else {
-                            offset.y = new_offset;
-                        }
+                        offset.y = new_offset;
                         scroll_handle.set_offset(offset);
                         cx.notify(view_id);
                         cx.stop_propagation();
@@ -432,6 +413,30 @@ mod tests {
     }
 
     #[gpui::test]
+    fn horizontal_scroll_area_traps_wheel_at_edge(cx: &mut TestAppContext) {
+        let scroll_handle = ScrollHandle::new();
+        let list_state = ListState::new(10, ListAlignment::Top, px(0.));
+        let cx = setup_list_test(cx, &scroll_handle, &list_state, false);
+
+        // Scroll the area to its right edge (300 - 100 = 200).
+        scroll_handle.set_offset(point(px(-200.), px(0.)));
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(-40.), px(-10.))),
+            ..Default::default()
+        });
+
+        // A horizontal mask consumes even at the edge: a bubbled horizontal
+        // delta would be axis-mapped onto the vertical list (#2468).
+        let scroll_top = list_state.logical_scroll_top();
+        assert_eq!((scroll_top.item_ix, scroll_top.offset_in_item), (0, px(0.)));
+    }
+
+    #[gpui::test]
     fn horizontal_scroll_area_ignores_wheel_when_occluded(cx: &mut TestAppContext) {
         let scroll_handle = ScrollHandle::new();
         let list_state = ListState::new(10, ListAlignment::Top, px(0.));
@@ -478,7 +483,6 @@ mod tests {
         outer_handle: ScrollHandle,
         inner_handle: ScrollHandle,
         inner_content_height: Pixels,
-        chain_at_edge: bool,
     }
 
     impl Render for NestedVerticalScrollTest {
@@ -502,14 +506,7 @@ mod tests {
                                 .track_scroll(&self.inner_handle)
                                 .child(div().w_full().h(self.inner_content_height)),
                         )
-                        .child({
-                            let mask = ScrollableMask::new(Axis::Vertical, &self.inner_handle);
-                            if self.chain_at_edge {
-                                mask.chain_at_edge()
-                            } else {
-                                mask
-                            }
-                        }),
+                        .child(ScrollableMask::new(Axis::Vertical, &self.inner_handle)),
                 )
                 .child(div().w_full().h(px(400.)))
         }
@@ -520,7 +517,6 @@ mod tests {
         outer_handle: &ScrollHandle,
         inner_handle: &ScrollHandle,
         inner_content_height: Pixels,
-        chain_at_edge: bool,
     ) -> &'a mut VisualTestContext {
         let (_, cx) = cx.add_window_view({
             let outer_handle = outer_handle.clone();
@@ -529,7 +525,6 @@ mod tests {
                 outer_handle: outer_handle.clone(),
                 inner_handle: inner_handle.clone(),
                 inner_content_height,
-                chain_at_edge,
             }
         });
         cx.run_until_parked();
@@ -540,10 +535,10 @@ mod tests {
     }
 
     #[gpui::test]
-    fn vertical_mask_chain_consumes_wheel_when_scrollable(cx: &mut TestAppContext) {
+    fn vertical_mask_consumes_wheel_when_scrollable(cx: &mut TestAppContext) {
         let outer_handle = ScrollHandle::new();
         let inner_handle = ScrollHandle::new();
-        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.));
 
         cx.simulate_event(ScrollWheelEvent {
             position: point(px(10.), px(10.)),
@@ -557,10 +552,10 @@ mod tests {
     }
 
     #[gpui::test]
-    fn vertical_mask_chain_hands_off_to_parent_at_edge(cx: &mut TestAppContext) {
+    fn vertical_mask_hands_off_to_parent_at_edge(cx: &mut TestAppContext) {
         let outer_handle = ScrollHandle::new();
         let inner_handle = ScrollHandle::new();
-        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.));
 
         // Scroll the inner element to its bottom edge (300 - 60 = 240).
         inner_handle.set_offset(point(px(0.), px(-240.)));
@@ -584,11 +579,11 @@ mod tests {
     }
 
     #[gpui::test]
-    fn vertical_mask_chain_bubbles_when_no_overflow(cx: &mut TestAppContext) {
+    fn vertical_mask_bubbles_when_no_overflow(cx: &mut TestAppContext) {
         let outer_handle = ScrollHandle::new();
         let inner_handle = ScrollHandle::new();
         // Inner content (40) fits its 60px viewport: nothing to scroll.
-        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(40.), true);
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(40.));
 
         cx.simulate_event(ScrollWheelEvent {
             position: point(px(10.), px(10.)),
@@ -604,32 +599,10 @@ mod tests {
     }
 
     #[gpui::test]
-    fn vertical_mask_default_traps_at_edge(cx: &mut TestAppContext) {
+    fn vertical_mask_ignores_transient_overscroll(cx: &mut TestAppContext) {
         let outer_handle = ScrollHandle::new();
         let inner_handle = ScrollHandle::new();
-        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), false);
-
-        inner_handle.set_offset(point(px(0.), px(-240.)));
-        cx.update(|window, cx| {
-            _ = window.draw(cx);
-        });
-
-        cx.simulate_event(ScrollWheelEvent {
-            position: point(px(10.), px(10.)),
-            delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
-            ..Default::default()
-        });
-
-        // Without `chain_at_edge` the mask consumes the event even at the
-        // edge — pins the existing (horizontal mask) semantics.
-        assert_eq!(outer_handle.offset().y, px(0.));
-    }
-
-    #[gpui::test]
-    fn vertical_mask_chain_ignores_transient_overscroll(cx: &mut TestAppContext) {
-        let outer_handle = ScrollHandle::new();
-        let inner_handle = ScrollHandle::new();
-        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.), true);
+        let cx = setup_nested_vertical_test(cx, &outer_handle, &inner_handle, px(300.));
 
         inner_handle.set_offset(point(px(0.), px(-240.)));
         cx.update(|window, cx| {
@@ -680,9 +653,7 @@ mod tests {
                                     .track_scroll(&scroll_handle)
                                     .child(div().w_full().h(px(300.))),
                             )
-                            .child(
-                                ScrollableMask::new(Axis::Vertical, &scroll_handle).chain_at_edge(),
-                            )
+                            .child(ScrollableMask::new(Axis::Vertical, &scroll_handle))
                             .into_any_element()
                     } else {
                         div().w(px(100.)).h(px(40.)).into_any_element()

--- a/crates/ui/src/scroll/scrollable_mask.rs
+++ b/crates/ui/src/scroll/scrollable_mask.rs
@@ -220,16 +220,13 @@ impl Element for ScrollableMask {
                         return;
                     }
 
-                    if is_horizontal {
-                        offset.x += delta.x;
-                    } else {
-                        offset.y += delta.y;
-                    }
+                    offset.x += delta.x;
 
                     // NOTE: `set_offset` does not clamp (clamping happens in
-                    // the div's prepaint), so any non-zero axis-dominant delta
-                    // passes this guard — even at the scroll edge the event is
-                    // consumed rather than turned into a parent scroll.
+                    // the div's prepaint), so any non-zero horizontal-dominant
+                    // delta passes this guard — even at the scroll edge the
+                    // event is consumed rather than turned into a parent
+                    // scroll.
                     if offset != scroll_handle.offset() {
                         scroll_handle.set_offset(offset);
                         cx.notify(view_id);

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -2380,12 +2380,10 @@ where
                         Axis::Horizontal,
                         &self.horizontal_scroll_handle,
                     ))
-                    // Keep vertical wheel scrolling from also scrolling an
-                    // ancestor scroll container. `chain_at_edge` hands the
-                    // event back to the ancestor once the table hits its
-                    // top/bottom edge. Skipped when the table is empty: the
-                    // `uniform_list` is not rendered then, so the handle's
-                    // offset and `max_offset` are stale.
+                    // Keep vertical wheel scrolling from leaking into an
+                    // ancestor scroller. Skipped when the table is empty:
+                    // the `uniform_list` is not rendered then, so the
+                    // handle's offset and `max_offset` are stale.
                     .when(rows_count > 0, |this| {
                         this.child(
                             ScrollableMask::new(

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -2380,6 +2380,21 @@ where
                         Axis::Horizontal,
                         &self.horizontal_scroll_handle,
                     ))
+                    // Keep vertical wheel scrolling from also scrolling an
+                    // ancestor scroll container. `chain_at_edge` hands the
+                    // event back to the ancestor once the table hits its
+                    // top/bottom edge. Skipped when the table is empty: the
+                    // `uniform_list` is not rendered then, so the handle's
+                    // offset and `max_offset` are stale.
+                    .when(rows_count > 0, |this| {
+                        this.child(
+                            ScrollableMask::new(
+                                Axis::Vertical,
+                                &self.vertical_scroll_handle.0.borrow().base_handle,
+                            )
+                            .chain_at_edge(),
+                        )
+                    })
                     .when(right_clicked_row.is_some(), |this| {
                         this.on_mouse_down_out(cx.listener(|this, e, window, cx| {
                             this.on_row_right_click(e, None, window, cx);

--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -2385,13 +2385,10 @@ where
                     // the `uniform_list` is not rendered then, so the
                     // handle's offset and `max_offset` are stale.
                     .when(rows_count > 0, |this| {
-                        this.child(
-                            ScrollableMask::new(
-                                Axis::Vertical,
-                                &self.vertical_scroll_handle.0.borrow().base_handle,
-                            )
-                            .chain_at_edge(),
-                        )
+                        this.child(ScrollableMask::new(
+                            Axis::Vertical,
+                            &self.vertical_scroll_handle.0.borrow().base_handle,
+                        ))
                     })
                     .when(right_clicked_row.is_some(), |this| {
                         this.on_mouse_down_out(cx.listener(|this, e, window, cx| {

--- a/examples/table_in_scrollable/Cargo.toml
+++ b/examples/table_in_scrollable/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "table_in_scrollable"
+description = "A DataTable with its own scrollbar nested inside a scrollable page."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+gpui.workspace = true
+gpui_platform.workspace = true
+gpui-component = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/table_in_scrollable/src/main.rs
+++ b/examples/table_in_scrollable/src/main.rs
@@ -36,7 +36,7 @@ impl TableDelegate for MyTable {
     }
 
     fn rows_count(&self, _: &App) -> usize {
-        200
+        30
     }
 
     fn column(&self, col_ix: usize, _: &App) -> Column {

--- a/examples/table_in_scrollable/src/main.rs
+++ b/examples/table_in_scrollable/src/main.rs
@@ -1,0 +1,129 @@
+//! A `DataTable` (which has its own vertical scrollbar) nested inside a
+//! scrollable page.
+//!
+//! Scrolling the mouse wheel over the table should only scroll the table
+//! rows; once the table reaches its top/bottom edge (or when the cursor is
+//! outside the table), the outer page scrolls instead.
+
+use gpui::*;
+use gpui_component::{
+    scroll::ScrollableElement as _,
+    table::{Column, DataTable, TableDelegate, TableState},
+    *,
+};
+
+struct MyTable {
+    columns: Vec<Column>,
+}
+
+impl MyTable {
+    fn new(_: &mut App) -> Self {
+        let columns = vec![
+            Column::new("id", "ID").width(px(50.)),
+            Column::new("name", "Name").width(px(150.)),
+            Column::new("email", "Email").width(px(250.)),
+            Column::new("role", "Role").width(px(150.)),
+            Column::new("status", "Status").width(px(100.)),
+        ];
+
+        Self { columns }
+    }
+}
+
+impl TableDelegate for MyTable {
+    fn columns_count(&self, _: &App) -> usize {
+        self.columns.len()
+    }
+
+    fn rows_count(&self, _: &App) -> usize {
+        200
+    }
+
+    fn column(&self, col_ix: usize, _: &App) -> Column {
+        self.columns[col_ix].clone()
+    }
+
+    fn render_td(
+        &mut self,
+        row_ix: usize,
+        col_ix: usize,
+        _: &mut Window,
+        _: &mut Context<TableState<Self>>,
+    ) -> impl IntoElement {
+        match col_ix {
+            0 => format!("{}", row_ix).into_any_element(),
+            1 => format!("User {}", row_ix).into_any_element(),
+            2 => format!("user-{}@mail.com", row_ix).into_any_element(),
+            3 => "User".into_any_element(),
+            4 => "Active".into_any_element(),
+            _ => panic!("Invalid column index"),
+        }
+    }
+}
+
+pub struct Example {
+    table: Entity<TableState<MyTable>>,
+}
+
+impl Example {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let table = cx.new(|cx| TableState::new(MyTable::new(cx), window, cx));
+
+        Self { table }
+    }
+
+    fn filler(&self, label: &str, height: f32, cx: &App) -> impl IntoElement {
+        div()
+            .h(px(height))
+            .w_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .border_1()
+            .border_dashed()
+            .border_color(cx.theme().border)
+            .text_color(cx.theme().muted_foreground)
+            .child(SharedString::from(label.to_string()))
+    }
+}
+
+impl Render for Example {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div().id("page").size_full().overflow_y_scrollbar().child(
+            v_flex()
+                .p_4()
+                .gap_4()
+                .child(self.filler("Content above the table", 400., cx))
+                .child(
+                    div()
+                        .h(px(300.))
+                        .w_full()
+                        .child(DataTable::new(&self.table).stripe(true).bordered(true)),
+                )
+                .child(self.filler("Content below the table", 800., cx)),
+        )
+    }
+}
+
+fn main() {
+    gpui_platform::application().run(move |cx| {
+        // This must be called before using any GPUI Component features.
+        gpui_component::init(cx);
+
+        let window_options = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(700.), px(700.)), cx)),
+            ..Default::default()
+        };
+
+        cx.spawn(async move |cx| {
+            cx.open_window(window_options, |window, cx| {
+                window.set_window_title("Table in Scrollable");
+                let view = cx.new(|cx| Example::new(window, cx));
+                // This first level on the window, should be a Root.
+                cx.new(|cx| Root::new(view, window, cx).bg(cx.theme().background))
+            })
+            .expect("Failed to open window");
+        })
+        .detach();
+    });
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/71d453a9-e75e-469d-8c14-0d608a060a8d

## Description

When a `DataTable` is nested inside a scrollable ancestor, wheel scrolling over the table scrolled both the table and the ancestor at once: the table body relies on gpui's `uniform_list` wheel listener, which updates the offset but never stops propagation. The horizontal axis was already protected by a `ScrollableMask` (#2608); the vertical axis had no equivalent.

- Add a vertical `ScrollableMask` sibling to the table (skipped when the table is empty, where the handle state is stale).
- `ScrollableMask` edge semantics now differ per axis, matching platform scrollers (macOS responder-chain forwarding, CSS `overscroll-behavior: auto`): a vertical mask consumes axis-dominant wheel events only while the content can still move and hands them back to the ancestor at the edge or when there is no overflow; a horizontal mask keeps consuming even at the edge, since a bubbled horizontal delta would be axis-mapped onto a vertical-only ancestor by gpui's wheel listener (#2468).
- The vertical comparison uses clamped offsets so transient unclamped overscroll from gpui's own listener doesn't swallow events during a fling at the edge.
- Behavior note: a vertical wheel over the table header now scrolls the table body instead of the ancestor, matching browser behavior.
- Add a minimal repro example: `cargo run -p table_in_scrollable`.
