### PR TITLE
chart: Support element labels in `RadarChart`

### DIFF
--- a/crates/macros/src/derive_into_plot.rs
+++ b/crates/macros/src/derive_into_plot.rs
@@ -35,9 +35,14 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
 
         impl #impl_generics gpui::Element for #type_name #type_generics #where_clause {
             type RequestLayoutState = ();
-            // Carries the hitbox used for occlusion-aware hover detection and the
-            // prepainted tooltip overlay (if any) from `prepaint` to `paint`.
-            type PrepaintState = (Option<gpui::Hitbox>, Option<gpui::AnyElement>);
+            // Carries the hitbox used for occlusion-aware hover detection, the plot's
+            // prepainted child elements and the prepainted tooltip overlay (if any)
+            // from `prepaint` to `paint`.
+            type PrepaintState = (
+                Option<gpui::Hitbox>,
+                Vec<gpui::AnyElement>,
+                Option<gpui::AnyElement>,
+            );
 
             fn id(&self) -> Option<gpui::ElementId> {
                 // `Some` opts the plot in to interactive tooltips; `None` (the default)
@@ -73,9 +78,14 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                 window: &mut gpui::Window,
                 cx: &mut gpui::App,
             ) -> Self::PrepaintState {
+                // Child elements must be laid out here: `layout_as_root` / `prepaint_at`
+                // are prepaint-only. Above the early return below, so plots without an
+                // id still get their children.
+                let children = <Self as Plot>::prepaint(self, bounds, window, cx);
+
                 // No id => tooltips disabled => behave exactly like a non-interactive plot.
                 let Some(global_id) = global_id else {
-                    return (None, None);
+                    return (None, children, None);
                 };
 
                 // The hitbox lets the mouse handler hit-test with occlusion awareness:
@@ -109,7 +119,7 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
                     Some(overlay)
                 })();
 
-                (Some(hitbox), overlay)
+                (Some(hitbox), children, overlay)
             }
 
             fn paint(
@@ -124,7 +134,12 @@ pub fn derive_into_plot(input: TokenStream) -> TokenStream {
             ) {
                 <Self as Plot>::paint(self, bounds, window, cx);
 
-                let (hitbox, overlay) = prepaint;
+                let (hitbox, children, overlay) = prepaint;
+
+                // Child elements (e.g. element labels) paint above the plot graphics.
+                for child in children.iter_mut() {
+                    child.paint(window, cx);
+                }
 
                 if let (Some(global_id), Some(hitbox)) = (global_id, hitbox.as_ref()) {
                     // Record the cursor position into element-local state on every move so the

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    App, AppContext, Context, Entity, FocusHandle, Focusable, Hsla, IntoElement, ParentElement,
-    Render, Rgba, SharedString, Styled, Window, div, linear_color_stop, linear_gradient,
-    prelude::FluentBuilder, px,
+    App, AppContext, Context, Entity, FocusHandle, Focusable, FontWeight, Hsla, IntoElement,
+    ParentElement, Render, Rgba, SharedString, Styled, Window, div, linear_color_stop,
+    linear_gradient, prelude::FluentBuilder, px,
 };
 use gpui_component::{
     ActiveTheme, StyledExt,
@@ -361,11 +361,48 @@ impl Render for ChartStory {
                     .child(chart_container(
                         "Radar Chart - Dots",
                         RadarChart::new(self.radar_devices.clone())
-                            .label(|d| d.month.clone())
+                            // An element label: the dimension name over a grade badge.
+                            .label({
+                                let muted_foreground = cx.theme().muted_foreground;
+                                let accent = cx.theme().chart_2;
+
+                                move |d: &RadarDevice| {
+                                    let grade = match d.desktop {
+                                        v if v >= 250. => "A",
+                                        v if v >= 200. => "B",
+                                        _ => "C",
+                                    };
+
+                                    v_flex()
+                                        .items_center()
+                                        .gap_1()
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(muted_foreground)
+                                                .child(d.month.clone()),
+                                        )
+                                        .child(
+                                            h_flex()
+                                                .justify_center()
+                                                .size_6()
+                                                .rounded_full()
+                                                .bg(accent.opacity(0.1))
+                                                .text_sm()
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                                .text_color(accent)
+                                                .child(grade),
+                                        )
+                                        .into_any_element()
+                                }
+                            })
                             .value(|d| d.desktop)
                             .name("Desktop")
                             .stroke(cx.theme().chart_2)
                             .dot()
+                            // A badge label is far taller than a line of text, so
+                            // pull the ring in to leave it room.
+                            .outer_radius(64.)
                             .id("radar-chart-dots"),
                         true,
                         cx,

--- a/crates/ui/src/chart/mod.rs
+++ b/crates/ui/src/chart/mod.rs
@@ -11,7 +11,7 @@ pub use bar_chart::BarChart;
 pub use candlestick_chart::CandlestickChart;
 pub use line_chart::LineChart;
 pub use pie_chart::PieChart;
-pub use radar_chart::RadarChart;
+pub use radar_chart::{RadarChart, RadarLabel};
 pub use sankey_chart::{SankeyChart, SankeyLabel};
 
 use gpui::{Hsla, SharedString, TextAlign};

--- a/crates/ui/src/chart/radar_chart.rs
+++ b/crates/ui/src/chart/radar_chart.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use gpui::{
-    AnyElement, App, Background, Bounds, ElementId, Hsla, IntoElement, Pixels, Point, SharedString,
-    TextAlign, Window, point, px,
+    AnyElement, App, AvailableSpace, Background, Bounds, ElementId, Hsla, IntoElement, Pixels,
+    Point, SharedString, TextAlign, Window, point, px,
 };
 use gpui_component_macros::IntoPlot;
 use num_traits::{Num, ToPrimitive, Zero};
@@ -30,6 +30,41 @@ const DEFAULT_LABEL_GAP: f32 = 10.;
 /// The default number of concentric grid rings.
 const DEFAULT_GRID_LEVELS: usize = 4;
 
+/// The label of one radar dimension, returned by [`RadarChart::label`].
+pub enum RadarLabel {
+    /// Plain text, drawn by the plot's own text layer: honors
+    /// [`RadarChart::label_color`] and supplies the tooltip title.
+    Text(SharedString),
+    /// A custom element, measured at its natural size and anchored like a text
+    /// label. [`RadarChart::label_color`] does not apply, and it supplies no
+    /// tooltip title.
+    Element(AnyElement),
+}
+
+impl From<&'static str> for RadarLabel {
+    fn from(text: &'static str) -> Self {
+        Self::Text(text.into())
+    }
+}
+
+impl From<String> for RadarLabel {
+    fn from(text: String) -> Self {
+        Self::Text(text.into())
+    }
+}
+
+impl From<SharedString> for RadarLabel {
+    fn from(text: SharedString) -> Self {
+        Self::Text(text)
+    }
+}
+
+impl From<AnyElement> for RadarLabel {
+    fn from(element: AnyElement) -> Self {
+        Self::Element(element)
+    }
+}
+
 /// A radar (spider) chart.
 ///
 /// Each datum is one dimension (a spoke), placed clockwise around the center
@@ -46,7 +81,11 @@ where
     strokes: Vec<Hsla>,
     fills: Vec<Background>,
     names: Vec<SharedString>,
-    label: Option<Rc<dyn Fn(&T) -> SharedString + 'static>>,
+    label: Option<Rc<dyn Fn(&T) -> RadarLabel + 'static>>,
+    /// The text of each dimension's label, resolved once per frame in `prepaint`;
+    /// element labels leave `None`. Read by `paint` (to draw them) and `tooltip`
+    /// (as the title), so the label closure runs once per dimension per frame.
+    label_texts: Vec<Option<SharedString>>,
     label_color: Option<Hsla>,
     label_gap: f32,
     max_value: Option<Y>,
@@ -72,6 +111,7 @@ where
             fills: vec![],
             names: vec![],
             label: None,
+            label_texts: vec![],
             label_color: None,
             label_gap: DEFAULT_LABEL_GAP,
             max_value: None,
@@ -127,13 +167,33 @@ where
         self
     }
 
-    /// Set the label text for each dimension, shown outside the outer ring.
-    pub fn label(mut self, label: impl Fn(&T) -> SharedString + 'static) -> Self {
-        self.label = Some(Rc::new(label));
+    /// Set the label for each dimension, shown outside the outer ring.
+    ///
+    /// Return a string for a plain text label, or `element.into_any_element()`
+    /// for a custom one; see [`RadarLabel`] for how the two differ.
+    ///
+    /// ```ignore
+    /// RadarChart::new(data).label(|d| d.month.clone())
+    ///
+    /// RadarChart::new(data).label(|d| {
+    ///     v_flex()
+    ///         .items_center()
+    ///         .child(Icon::new(IconName::Star).xsmall())
+    ///         .child(d.month.clone())
+    ///         .into_any_element()
+    /// })
+    /// ```
+    pub fn label<L>(mut self, label: impl Fn(&T) -> L + 'static) -> Self
+    where
+        L: Into<RadarLabel> + 'static,
+    {
+        self.label = Some(Rc::new(move |d| label(d).into()));
         self
     }
 
-    /// Set the label text color (defaults to `cx.theme().muted_foreground`).
+    /// Set the text label color (defaults to `cx.theme().muted_foreground`).
+    ///
+    /// Element labels style themselves; this does not apply to them.
     pub fn label_color(mut self, color: impl Into<Hsla>) -> Self {
         self.label_color = Some(color.into());
         self
@@ -209,6 +269,30 @@ where
         }
     }
 
+    /// Where the label of dimension `ix` attaches, in bounds-relative coordinates,
+    /// plus the outward radial direction at that dimension (a unit vector).
+    ///
+    /// The anchor sits on the label ring at the dimension's angle; callers offset
+    /// their own box from it along `direction`. Shared by `prepaint` and `paint`
+    /// so element and text labels land in the same place.
+    fn label_anchor(
+        &self,
+        ix: usize,
+        outer_radius: f32,
+        bounds: &Bounds<Pixels>,
+    ) -> (Point<f32>, Point<f32>) {
+        let label_radius = outer_radius + self.label_gap;
+        let angle = ix as f32 * TAU / self.data.len() as f32 - HALF_PI;
+        let direction = point(angle.cos(), angle.sin());
+
+        let anchor = point(
+            bounds.size.width.as_f32() / 2. + label_radius * direction.x,
+            bounds.size.height.as_f32() / 2. + label_radius * direction.y,
+        );
+
+        (anchor, direction)
+    }
+
     /// Build the radius scale from the center to the outer ring.
     ///
     /// The domain includes zero so non-negative data starts at the center.
@@ -252,6 +336,61 @@ impl<T, Y> Plot for RadarChart<T, Y>
 where
     Y: Clone + Copy + PartialOrd + Num + ToPrimitive + Sealed + 'static,
 {
+    /// Resolve every dimension's label, keeping the text ones for `paint` and
+    /// laying out the element ones here (measuring is illegal in `paint`).
+    fn prepaint(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Vec<AnyElement> {
+        self.label_texts.clear();
+
+        // Same guard as `paint`: without a series nothing is drawn at all.
+        let n = self.data.len();
+        if n == 0 || self.values.is_empty() {
+            return vec![];
+        }
+        let Some(label_fn) = self.label.clone() else {
+            return vec![];
+        };
+
+        let outer_radius = self.resolve_outer_radius(&bounds);
+        let mut texts = Vec::with_capacity(n);
+        let mut elements = vec![];
+
+        for (ix, d) in self.data.iter().enumerate() {
+            match label_fn(d) {
+                RadarLabel::Text(text) => texts.push(Some(text)),
+                RadarLabel::Element(mut element) => {
+                    texts.push(None);
+
+                    // Only `AvailableSpace::Definite` makes text wrap, so this
+                    // measures the label at its natural, unwrapped size.
+                    let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
+                    let (anchor, direction) = self.label_anchor(ix, outer_radius, &bounds);
+
+                    // Push the box radially outward until its inner edge meets the
+                    // anchor, so a tall label clears the ring instead of straddling
+                    // it. Reduces to "centered on the anchor" across that axis when
+                    // the dimension is square-on to it.
+                    let origin = bounds.origin
+                        + point(
+                            px(anchor.x + (direction.x - 1.) * size.width.as_f32() / 2.),
+                            px(anchor.y + (direction.y - 1.) * size.height.as_f32() / 2.),
+                        );
+
+                    element.prepaint_at(origin, window, cx);
+                    elements.push(element);
+                }
+            }
+        }
+
+        self.label_texts = texts;
+
+        elements
+    }
+
     fn paint(&mut self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut App) {
         let n = self.data.len();
         if n == 0 || self.values.is_empty() {
@@ -319,35 +458,37 @@ where
             line.paint(&bounds, window);
         }
 
-        // Draw dimension labels outside the outer ring (only when `label` is set).
-        let Some(label_fn) = self.label.as_ref() else {
-            return;
-        };
-
-        let label_radius = outer_radius + self.label_gap;
+        // Draw the text labels outside the outer ring; `prepaint` resolved them and
+        // already placed the element ones.
         let label_color = self.label_color.unwrap_or(cx.theme().muted_foreground);
+        let labels = self
+            .label_texts
+            .iter()
+            .enumerate()
+            .filter_map(|(ix, text)| {
+                let text = text.clone()?;
+                let (anchor, direction) = self.label_anchor(ix, outer_radius, &bounds);
 
-        let labels = self.data.iter().enumerate().map(|(i, d)| {
-            let angle = i as f32 * angle_step - HALF_PI;
-            let dx = label_radius * angle.cos();
-            let dy = label_radius * angle.sin();
-            // Labels on the right are left-aligned, on the left right-aligned,
-            // and near the vertical axis centered.
-            let align = if dx > 1. {
-                TextAlign::Left
-            } else if dx < -1. {
-                TextAlign::Right
-            } else {
-                TextAlign::Center
-            };
+                // Labels on the right are left-aligned, on the left right-aligned,
+                // and near the vertical axis centered. `direction` is a unit vector,
+                // so the epsilon only absorbs float noise at 12 and 6 o'clock.
+                let align = if direction.x > 1e-3 {
+                    TextAlign::Left
+                } else if direction.x < -1e-3 {
+                    TextAlign::Right
+                } else {
+                    TextAlign::Center
+                };
 
-            Text::new(
-                label_fn(d),
-                point(px(center_x + dx), px(center_y + dy - TEXT_SIZE / 2.)),
-                label_color,
-            )
-            .align(align)
-        });
+                Some(
+                    Text::new(
+                        text,
+                        point(px(anchor.x), px(anchor.y - TEXT_SIZE / 2.)),
+                        label_color,
+                    )
+                    .align(align),
+                )
+            });
 
         PlotLabel::new(labels.collect()).paint(&bounds, window, cx);
     }
@@ -413,8 +554,9 @@ where
                         .fill(self.series_stroke(i, cx))
                 }));
 
-        if let Some(label_fn) = self.label.as_ref() {
-            tooltip = tooltip.title(label_fn(d));
+        // Filled by `prepaint`, which runs first; element labels leave no title.
+        if let Some(title) = self.label_texts.get(state.index).cloned().flatten() {
+            tooltip = tooltip.title(title);
         }
 
         // One row per series: swatch + label + value.
@@ -485,6 +627,21 @@ mod tests {
 
         let values = (chart.values[0](&data[0]), chart.values[1](&data[0]));
         assert_eq!(values, (80., 60.));
+    }
+
+    /// Every string form the `label` closure may return lands on the text path,
+    /// which is what keeps `label_color` and the tooltip title working.
+    #[test]
+    fn test_radar_label_from_text() {
+        let labels = [
+            RadarLabel::from("Sales"),
+            RadarLabel::from("Sales".to_string()),
+            RadarLabel::from(SharedString::from("Sales")),
+        ];
+
+        for label in labels {
+            assert!(matches!(label, RadarLabel::Text(text) if text == "Sales"));
+        }
     }
 
     #[test]

--- a/crates/ui/src/plot/mod.rs
+++ b/crates/ui/src/plot/mod.rs
@@ -21,6 +21,26 @@ pub use label::PlotLabel;
 use tooltip::TooltipState;
 
 pub trait Plot: IntoElement {
+    /// Lay out and place the child elements this plot hosts (e.g. element labels).
+    ///
+    /// Called during the element's prepaint phase, so implementations may use
+    /// [`AnyElement::layout_as_root`] / [`AnyElement::prepaint_at`] to measure and
+    /// position children — neither is legal from [`Plot::paint`]. The returned
+    /// elements are painted right after `paint`, below the tooltip overlay.
+    ///
+    /// Runs before [`Plot::tooltip_state`] and [`Plot::tooltip`], so anything
+    /// resolved here can be reused by them.
+    ///
+    /// The default returns no children.
+    fn prepaint(
+        &mut self,
+        _bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Vec<AnyElement> {
+        vec![]
+    }
+
     fn paint(&mut self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut App);
 
     /// A stable element id that enables interactive tooltip support for this plot.

--- a/docs/docs/components/chart.md
+++ b/docs/docs/components/chart.md
@@ -343,6 +343,43 @@ RadarChart::new(data)
     .stroke(cx.theme().chart_2)
 ```
 
+#### Element Labels
+
+`label` accepts either a string or a custom element. Return
+`element.into_any_element()` to render anything you like around the outer ring —
+an icon, several lines, per-dimension colors.
+
+```rust
+RadarChart::new(data)
+    .label({
+        let foreground = cx.theme().foreground;
+        let muted_foreground = cx.theme().muted_foreground;
+
+        move |d: &Device| {
+            v_flex()
+                .items_center()
+                .child(div().text_xs().text_color(foreground).child(d.month.clone()))
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(muted_foreground)
+                        .child(format!("{:.0}", d.desktop)),
+                )
+                .into_any_element()
+        }
+    })
+    .value(|d| d.desktop)
+```
+
+Each label is measured at its natural size and pushed radially outward from its
+dimension, so even a tall one clears the outer ring. Element labels style
+themselves, so `.label_color()` does not apply to them, and they supply no
+tooltip title (a string label does).
+
+The ring is not shrunk to make room: the default outer radius is 40% of the
+chart's height, so a label much taller than a line of text needs a smaller
+`.outer_radius()` to keep it inside the chart's bounds.
+
 #### Radar Chart Customization
 
 ```rust

--- a/docs/zh-CN/docs/components/chart.md
+++ b/docs/zh-CN/docs/components/chart.md
@@ -329,6 +329,39 @@ RadarChart::new(data)
     .stroke(cx.theme().chart_2)
 ```
 
+#### 元素标签
+
+`label` 既接受字符串，也接受自定义元素。返回 `element.into_any_element()`
+即可在外圈周围渲染任意内容——图标、多行、按维度换色都可以。
+
+```rust
+RadarChart::new(data)
+    .label({
+        let foreground = cx.theme().foreground;
+        let muted_foreground = cx.theme().muted_foreground;
+
+        move |d: &Device| {
+            v_flex()
+                .items_center()
+                .child(div().text_xs().text_color(foreground).child(d.month.clone()))
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(muted_foreground)
+                        .child(format!("{:.0}", d.desktop)),
+                )
+                .into_any_element()
+        }
+    })
+    .value(|d| d.desktop)
+```
+
+每个标签按自然尺寸测量，并沿径向朝外推开，所以即使很高也不会压到外圈上。
+元素标签自带样式，因此 `.label_color()` 对它无效，也不会提供 tooltip 标题（字符串标签会）。
+
+外圈不会为标签自动让位：默认外圈半径是图表高度的 40%，所以标签比单行文字高很多时，
+需要调小 `.outer_radius()` 才能让它留在图表范围内。
+
 #### 自定义
 
 ```rust


### PR DESCRIPTION
<img width="335" height="416" alt="image" src="https://github.com/user-attachments/assets/6197adaf-5bea-41bc-81b0-ba75dbf733c8" />
