### PR TITLE
text: Allow applications to handle TextView link clicks

### DIFF
--- a/crates/story/examples/fixtures/test.md
+++ b/crates/story/examples/fixtures/test.md
@@ -8,6 +8,8 @@ This is first paragraph, there have **BOLD**, _italic_, and ~~strikethrough~~, `
 
 This is an additional demonstration paragraph in English demonstrating more content for [Markdown GFM]. It includes various stylistic elements and plain text.
 
+Link click handling: [open this link](https://github.com/longbridge/gpui-component) to see the custom `TextView` callback in the application log.
+
 ![Img](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*WgEz5f3n3lD7MfC7NeQGOA.jpeg)
 
 这是一个中文演示段落，用于展示更多的 [Markdown GFM] 内容。您可以在此尝试使用使用**粗体**、*斜体*和`代码`等样式。これは日本語のデモ段落です。Markdown の多言語サポートを示すためのテキストが含まれています。例えば、、**ボールド**、_イタリック_、および`コード`のスタイルなどを試すことができます。

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -1275,6 +1275,14 @@ impl Render for Example {
                                             ))
                                             .plugin(UserCardPlugin::new())
                                             .plugin(MathPlugin::new())
+                                            .on_link_click(|url, event, _window, cx| {
+                                                println!(
+                                                    "Markdown link clicked: {url} ({event:?})"
+                                                );
+                                                if !event.is_right_click() {
+                                                    cx.open_url(url);
+                                                }
+                                            })
                                             // Tables scroll horizontally by default; the
                                             // status bar toggle switches to wrapping.
                                             .style(self.text_view_style())

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -7,9 +7,9 @@ use std::{
 
 use gpui::{
     App, BorderStyle, Bounds, CursorStyle, Edges, Element, ElementId, GlobalElementId, Half,
-    HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, StyledText,
-    TextLayout, Window, point, px, quad,
+    ClickEvent, HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId,
+    MouseButton, MouseClickEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
+    SharedString, StyledText, TextLayout, Window, point, px, quad,
 };
 
 use crate::{
@@ -530,11 +530,20 @@ impl Element for Inline {
                     {
                         window.end_text_selection(cx);
                         cx.stop_propagation();
+                        let click = ClickEvent::Mouse(MouseClickEvent {
+                            down: MouseDownEvent {
+                                button: event.button,
+                                position: event.position,
+                                modifiers: event.modifiers,
+                                click_count: event.click_count,
+                                first_mouse: false,
+                            },
+                            up: event.clone(),
+                        });
                         handle_link_click(
                             &link_click_handler,
                             link.url,
-                            event.button,
-                            event.modifiers,
+                            click,
                             window,
                             cx,
                         );

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -13,8 +13,13 @@ use gpui::{
 };
 
 use crate::{
-    ActiveTheme, WindowExt as _, global_state::GlobalState, input::Selection,
-    text::TextViewMultiClickKind, text::node::LinkMark, text::selection::word_range_at,
+    ActiveTheme, WindowExt as _,
+    global_state::GlobalState,
+    input::Selection,
+    text::TextViewMultiClickKind,
+    text::node::LinkMark,
+    text::selection::word_range_at,
+    text::text_view::{LinkClickHandlerFn, handle_link_click},
 };
 
 /// A inline element used to render a inline text and support selectable.
@@ -26,6 +31,7 @@ pub(super) struct Inline {
     links: Rc<Vec<(Range<usize>, LinkMark)>>,
     highlights: Vec<(Range<usize>, HighlightStyle)>,
     styled_text: StyledText,
+    link_click_handler: Option<Arc<LinkClickHandlerFn>>,
 
     state: Arc<Mutex<InlineState>>,
 }
@@ -52,6 +58,7 @@ impl Inline {
         state: Arc<Mutex<InlineState>>,
         links: Vec<(Range<usize>, LinkMark)>,
         highlights: Vec<(Range<usize>, HighlightStyle)>,
+        link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     ) -> Self {
         let text = state
             .lock()
@@ -64,6 +71,7 @@ impl Inline {
             highlights,
             text: text.clone(),
             styled_text: StyledText::new(text),
+            link_click_handler,
             state,
         }
     }
@@ -438,7 +446,6 @@ impl Element for Inline {
                 let inline_state = self.state.clone();
                 let text = self.text.clone();
                 let text_view_state = GlobalState::global(cx).text_view_state().cloned();
-
                 move |event: &MouseDownEvent, phase, window, cx| {
                     if !phase.bubble()
                         || !hitbox.is_hovered(window)
@@ -505,6 +512,7 @@ impl Element for Inline {
                 let text_layout = text_layout.clone();
                 let hitbox = hitbox.clone();
                 let text_view_state = GlobalState::global(cx).text_view_state().cloned();
+                let link_click_handler = self.link_click_handler.clone();
 
                 move |event: &MouseUpEvent, phase, window, cx| {
                     if !phase.bubble() || !hitbox.is_hovered(window) {
@@ -522,7 +530,14 @@ impl Element for Inline {
                     {
                         window.end_text_selection(cx);
                         cx.stop_propagation();
-                        cx.open_url(&link.url);
+                        handle_link_click(
+                            &link_click_handler,
+                            link.url,
+                            event.button,
+                            event.modifiers,
+                            window,
+                            cx,
+                        );
                     }
                 }
             });

--- a/crates/ui/src/text/inline_flow.rs
+++ b/crates/ui/src/text/inline_flow.rs
@@ -133,21 +133,33 @@ impl InlineFlow {
             .h(size.height)
             .when_some(link.clone(), |this, link| {
                 let title = title.to_string();
+                let aux_link = link.clone();
+                let aux_link_click_handler = link_click_handler.clone();
                 this.cursor_pointer()
                     .tooltip(move |window, cx| Tooltip::new(title.clone()).build(window, cx))
                     .on_click(move |event, window, cx| {
                         window.end_text_selection(cx);
                         cx.stop_propagation();
-                        let button = if event.is_middle_click() {
-                            gpui::MouseButton::Middle
-                        } else if event.is_right_click() {
-                            gpui::MouseButton::Right
-                        } else {
-                            gpui::MouseButton::Left
-                        };
                         handle_link_click(
                             &link_click_handler,
                             link.url.clone(),
+                            gpui::MouseButton::Left,
+                            event.modifiers(),
+                            window,
+                            cx,
+                        );
+                    })
+                    .on_aux_click(move |event, window, cx| {
+                        window.end_text_selection(cx);
+                        cx.stop_propagation();
+                        let button = if event.is_middle_click() {
+                            gpui::MouseButton::Middle
+                        } else {
+                            gpui::MouseButton::Right
+                        };
+                        handle_link_click(
+                            &aux_link_click_handler,
+                            aux_link.url.clone(),
                             button,
                             event.modifiers(),
                             window,

--- a/crates/ui/src/text/inline_flow.rs
+++ b/crates/ui/src/text/inline_flow.rs
@@ -5,10 +5,11 @@ use std::{
 
 use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, DefiniteLength, Element, ElementId,
-    GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _, IntoElement,
-    LayoutId, LineFragment as WrapLineFragment, ObjectFit, Pixels, ShapedLine, SharedString,
-    SharedUri, Size, StatefulInteractiveElement as _, Styled, StyledImage as _, TextRun, TextStyle,
-    WhiteSpace, Window, img, point, prelude::FluentBuilder as _, px, relative, size,
+    GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _,
+    IntoElement, LayoutId, LineFragment as WrapLineFragment, ObjectFit, Pixels, ShapedLine,
+    SharedString, SharedUri, Size, StatefulInteractiveElement as _, Styled, StyledImage as _,
+    TextRun, TextStyle, WhiteSpace, Window, img, point, prelude::FluentBuilder as _, px, relative,
+    size,
 };
 
 use crate::{
@@ -143,8 +144,7 @@ impl InlineFlow {
                         handle_link_click(
                             &link_click_handler,
                             link.url.clone(),
-                            gpui::MouseButton::Left,
-                            event.modifiers(),
+                            event.clone(),
                             window,
                             cx,
                         );
@@ -152,16 +152,10 @@ impl InlineFlow {
                     .on_aux_click(move |event, window, cx| {
                         window.end_text_selection(cx);
                         cx.stop_propagation();
-                        let button = if event.is_middle_click() {
-                            gpui::MouseButton::Middle
-                        } else {
-                            gpui::MouseButton::Right
-                        };
                         handle_link_click(
                             &aux_link_click_handler,
                             aux_link.url.clone(),
-                            button,
-                            event.modifiers(),
+                            event.clone(),
                             window,
                             cx,
                         );

--- a/crates/ui/src/text/inline_flow.rs
+++ b/crates/ui/src/text/inline_flow.rs
@@ -11,7 +11,11 @@ use gpui::{
     WhiteSpace, Window, img, point, prelude::FluentBuilder as _, px, relative, size,
 };
 
-use crate::{WindowExt as _, tooltip::Tooltip};
+use crate::{
+    WindowExt as _,
+    text::text_view::{LinkClickHandlerFn, handle_link_click},
+    tooltip::Tooltip,
+};
 
 use super::{
     inline::{Inline, InlineState},
@@ -23,6 +27,7 @@ const IMAGE_LEN: usize = 1;
 pub(super) struct InlineFlow {
     id: ElementId,
     items: Vec<InlineFlowItem>,
+    link_click_handler: Option<Arc<LinkClickHandlerFn>>,
 }
 
 pub(super) enum InlineFlowItem {
@@ -100,10 +105,15 @@ enum LineFragmentKind {
 }
 
 impl InlineFlow {
-    pub(super) fn new(id: impl Into<ElementId>, items: Vec<InlineFlowItem>) -> Self {
+    pub(super) fn new(
+        id: impl Into<ElementId>,
+        items: Vec<InlineFlowItem>,
+        link_click_handler: Option<Arc<LinkClickHandlerFn>>,
+    ) -> Self {
         Self {
             id: id.into(),
             items,
+            link_click_handler,
         }
     }
 
@@ -113,6 +123,7 @@ impl InlineFlow {
         link: &Option<LinkMark>,
         title: &str,
         size: Size<Pixels>,
+        link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     ) -> AnyElement {
         img(url.clone())
             .id(ix)
@@ -124,10 +135,24 @@ impl InlineFlow {
                 let title = title.to_string();
                 this.cursor_pointer()
                     .tooltip(move |window, cx| Tooltip::new(title.clone()).build(window, cx))
-                    .on_click(move |_, window, cx| {
+                    .on_click(move |event, window, cx| {
                         window.end_text_selection(cx);
                         cx.stop_propagation();
-                        cx.open_url(&link.url);
+                        let button = if event.is_middle_click() {
+                            gpui::MouseButton::Middle
+                        } else if event.is_right_click() {
+                            gpui::MouseButton::Right
+                        } else {
+                            gpui::MouseButton::Left
+                        };
+                        handle_link_click(
+                            &link_click_handler,
+                            link.url.clone(),
+                            button,
+                            event.modifiers(),
+                            window,
+                            cx,
+                        );
                     })
             })
             .into_any_element()
@@ -254,8 +279,14 @@ impl Element for InlineFlow {
                         state.set_text(text);
                     }
 
-                    let mut element =
-                        Inline::new(elements.len(), state, links, highlights).into_any_element();
+                    let mut element = Inline::new(
+                        elements.len(),
+                        state,
+                        links,
+                        highlights,
+                        self.link_click_handler.clone(),
+                    )
+                    .into_any_element();
                     element.prepaint_as_root(
                         bounds.origin + origin,
                         size(
@@ -284,6 +315,7 @@ impl Element for InlineFlow {
                         link,
                         title.as_str(),
                         fragment_size,
+                        self.link_click_handler.clone(),
                     );
                     element.prepaint_as_root(
                         bounds.origin + origin,

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -7,9 +7,9 @@ use std::{
 
 use gpui::{
     AnyElement, App, DefiniteLength, Div, ElementId, FontStyle, FontWeight, Half, HighlightStyle,
-    Hsla, InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement,
-    ScrollHandle, SharedString, SharedUri, StatefulInteractiveElement, Styled, StyledImage as _,
-    Window, div, img, prelude::FluentBuilder as _, px, relative, rems,
+    Hsla, InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow,
+    ParentElement, ScrollHandle, SharedString, SharedUri, StatefulInteractiveElement, Styled,
+    StyledImage as _, Window, div, img, prelude::FluentBuilder as _, px, relative, rems,
 };
 use markdown::mdast;
 use ropey::Rope;
@@ -884,8 +884,7 @@ impl Paragraph {
                                     handle_link_click(
                                         &link_click_handler,
                                         link.url.clone(),
-                                        gpui::MouseButton::Left,
-                                        event.modifiers(),
+                                        event.clone(),
                                         window,
                                         cx,
                                     );
@@ -893,16 +892,10 @@ impl Paragraph {
                                 .on_aux_click(move |event, window, cx| {
                                     window.end_text_selection(cx);
                                     cx.stop_propagation();
-                                    let button = if event.is_middle_click() {
-                                        gpui::MouseButton::Middle
-                                    } else {
-                                        gpui::MouseButton::Right
-                                    };
                                     handle_link_click(
                                         &aux_link_click_handler,
                                         aux_link.url.clone(),
-                                        button,
-                                        event.modifiers(),
+                                        event.clone(),
                                         window,
                                         cx,
                                     );

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -20,10 +20,11 @@ use crate::{
     input::{InputEdit, Point, RopeExt as _},
     scroll::horizontal_scroll_area,
     text::{
-        CodeBlockActionsFn, MarkdownExtensions, MarkdownNode,
+        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, MarkdownNode,
         document::NodeRenderOptions,
         inline::{Inline, InlineState},
         inline_flow::{InlineFlow, InlineFlowItem},
+        text_view::handle_link_click,
     },
     tooltip::Tooltip,
     v_flex,
@@ -773,6 +774,7 @@ impl CodeBlock {
                         self.state.clone(),
                         vec![],
                         self.styles(&cx.theme().highlight_theme),
+                        node_cx.link_click_handler.clone(),
                     ))
                     .when_some(node_cx.code_block_actions.clone(), |this, actions| {
                         this.child(
@@ -800,6 +802,7 @@ pub(crate) struct NodeContext {
     pub(crate) link_refs: HashMap<SharedString, LinkMark>,
     pub(crate) style: TextViewStyle,
     pub(crate) code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    pub(crate) link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     pub(crate) markdown_extensions: Arc<MarkdownExtensions>,
 }
 
@@ -826,6 +829,7 @@ impl Paragraph {
             return InlineFlow::new(
                 span.unwrap_or_default(),
                 self.inline_flow_items(node_cx, cx),
+                node_cx.link_click_handler.clone(),
             )
             .into_any_element();
         }
@@ -853,10 +857,12 @@ impl Paragraph {
                             inline_node.state.clone(),
                             links.clone(),
                             highlights.clone(),
+                            node_cx.link_click_handler.clone(),
                         )
                         .into_any_element(),
                     );
                 }
+                let link_click_handler = node_cx.link_click_handler.clone();
                 child_nodes.push(
                     img(image.url.clone())
                         .id(ix)
@@ -865,14 +871,29 @@ impl Paragraph {
                         .when_some(image.width, |this, width| this.w(width))
                         .when_some(image.link.clone(), |this, link| {
                             let title = image.title();
+                            let link_click_handler = link_click_handler.clone();
                             this.cursor_pointer()
                                 .tooltip(move |window, cx| {
                                     Tooltip::new(title.clone()).build(window, cx)
                                 })
-                                .on_click(move |_, window, cx| {
+                                .on_click(move |event, window, cx| {
                                     window.end_text_selection(cx);
                                     cx.stop_propagation();
-                                    cx.open_url(&link.url);
+                                    let button = if event.is_middle_click() {
+                                        gpui::MouseButton::Middle
+                                    } else if event.is_right_click() {
+                                        gpui::MouseButton::Right
+                                    } else {
+                                        gpui::MouseButton::Left
+                                    };
+                                    handle_link_click(
+                                        &link_click_handler,
+                                        link.url.clone(),
+                                        button,
+                                        event.modifiers(),
+                                        window,
+                                        cx,
+                                    );
                                 })
                         })
                         .into_any_element(),
@@ -944,8 +965,16 @@ impl Paragraph {
             if let Ok(mut state) = self.state.lock() {
                 state.set_text(text.into());
             }
-            child_nodes
-                .push(Inline::new(ix, self.state.clone(), links, highlights).into_any_element());
+            child_nodes.push(
+                Inline::new(
+                    ix,
+                    self.state.clone(),
+                    links,
+                    highlights,
+                    node_cx.link_click_handler.clone(),
+                )
+                .into_any_element(),
+            );
         }
 
         div()

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -872,6 +872,8 @@ impl Paragraph {
                         .when_some(image.link.clone(), |this, link| {
                             let title = image.title();
                             let link_click_handler = link_click_handler.clone();
+                            let aux_link = link.clone();
+                            let aux_link_click_handler = link_click_handler.clone();
                             this.cursor_pointer()
                                 .tooltip(move |window, cx| {
                                     Tooltip::new(title.clone()).build(window, cx)
@@ -879,16 +881,26 @@ impl Paragraph {
                                 .on_click(move |event, window, cx| {
                                     window.end_text_selection(cx);
                                     cx.stop_propagation();
-                                    let button = if event.is_middle_click() {
-                                        gpui::MouseButton::Middle
-                                    } else if event.is_right_click() {
-                                        gpui::MouseButton::Right
-                                    } else {
-                                        gpui::MouseButton::Left
-                                    };
                                     handle_link_click(
                                         &link_click_handler,
                                         link.url.clone(),
+                                        gpui::MouseButton::Left,
+                                        event.modifiers(),
+                                        window,
+                                        cx,
+                                    );
+                                })
+                                .on_aux_click(move |event, window, cx| {
+                                    window.end_text_selection(cx);
+                                    cx.stop_propagation();
+                                    let button = if event.is_middle_click() {
+                                        gpui::MouseButton::Middle
+                                    } else {
+                                        gpui::MouseButton::Right
+                                    };
+                                    handle_link_click(
+                                        &aux_link_click_handler,
+                                        aux_link.url.clone(),
                                         button,
                                         event.modifiers(),
                                         window,

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -13,7 +13,7 @@ use crate::{
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
-        CodeBlockActionsFn, MarkdownExtensions, TextViewStyle,
+        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, TextViewStyle,
         document::ParsedDocument,
         format,
         node::{self, NodeContext},
@@ -60,6 +60,7 @@ pub struct TextViewState {
     pub(super) scrollable: bool,
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
+    pub(super) link_click_handler: Option<std::sync::Arc<LinkClickHandlerFn>>,
     pub(super) markdown_extensions: Arc<MarkdownExtensions>,
 
     pub(super) is_selecting: bool,
@@ -145,6 +146,7 @@ impl TextViewState {
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)).measure_all(),
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
+            link_click_handler: None,
             markdown_extensions: Arc::default(),
             is_selecting: false,
             auto_scroll: AutoScroll::default(),
@@ -441,6 +443,7 @@ impl Render for TextViewState {
         let mut node_cx = self.parsed_content.node_cx.clone();
 
         node_cx.code_block_actions = self.code_block_actions.clone();
+        node_cx.link_click_handler = self.link_click_handler.clone();
         node_cx.markdown_extensions = self.markdown_extensions.clone();
         node_cx.style = self.text_view_style.clone();
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -690,6 +690,91 @@ mod tests {
     }
 
     #[gpui::test]
+    fn linked_image_handler_receives_left_middle_and_right_clicks(cx: &mut TestAppContext) {
+        use std::sync::{Arc, Mutex};
+
+        struct LinkedImageRoot {
+            text_view: Entity<TextViewState>,
+            clicks: Arc<Mutex<Vec<super::TextViewLinkClick>>>,
+        }
+
+        impl Render for LinkedImageRoot {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                let clicks = self.clicks.clone();
+                div().w(px(160.)).child(
+                    TextView::new(&self.text_view)
+                        .selectable(true)
+                        .on_link_click(move |event, _, _| {
+                            clicks.lock().unwrap().push(event.clone());
+                        }),
+                )
+            }
+        }
+
+        cx.update(crate::init);
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let captured = clicks.clone();
+        let (_, cx) = cx.add_window_view(move |window, cx| {
+            let content = cx.new(|cx| LinkedImageRoot {
+                text_view: cx.new(|cx| {
+                    TextViewState::markdown(
+                        r#"Before [<img src="https://example.com/image.svg" width="32" height="32">](https://example.com/image-link) after."#,
+                        cx,
+                    )
+                }),
+                clicks,
+            });
+            crate::Root::new(content, window, cx)
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let inline_bounds = cx.update(|window, cx| {
+            crate::Root::read(window, cx)
+                .selectable_text_inlines
+                .values()
+                .next()
+                .cloned()
+                .unwrap_or_default()
+        });
+        assert!(
+            inline_bounds.len() >= 2,
+            "linked image needs text bounds on both sides: {inline_bounds:?}"
+        );
+        assert!(
+            inline_bounds[1].left() - inline_bounds[0].right() >= px(24.),
+            "linked image did not reserve the expected click target: {inline_bounds:?}"
+        );
+        let position = point(
+            inline_bounds[0].right() + (inline_bounds[1].left() - inline_bounds[0].right()) * 0.5,
+            inline_bounds[0].top() + px(8.),
+        );
+        for button in [MouseButton::Left, MouseButton::Middle, MouseButton::Right] {
+            cx.simulate_mouse_down(position, button, Modifiers::default());
+            cx.simulate_mouse_up(position, button, Modifiers::default());
+        }
+
+        let clicks = captured.lock().unwrap();
+        assert_eq!(clicks.len(), 3);
+        assert!(
+            clicks
+                .iter()
+                .all(|event| event.url == "https://example.com/image-link")
+        );
+        assert_eq!(clicks[0].button, MouseButton::Left);
+        assert_eq!(clicks[1].button, MouseButton::Middle);
+        assert_eq!(clicks[2].button, MouseButton::Right);
+        assert_eq!(cx.opened_url(), None);
+    }
+
+    #[gpui::test]
     fn clipped_markdown_cannot_start_selection(cx: &mut TestAppContext) {
         cx.update(crate::init);
         let (view, cx) = cx

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, Bounds, Element, ElementId, Entity, GlobalElementId, Hitbox, HitboxBehavior,
-    InspectorElementId, InteractiveElement, IntoElement, LayoutId, ParentElement, Pixels,
-    SharedString, StyleRefinement, Styled, Window, div,
+    InspectorElementId, InteractiveElement, IntoElement, LayoutId, Modifiers, MouseButton,
+    ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
 };
 
 use crate::StyledExt;
@@ -18,6 +18,43 @@ use crate::{global_state::GlobalState, text::TextViewStyle};
 /// Type for code block actions generator function.
 pub(crate) type CodeBlockActionsFn =
     dyn Fn(&CodeBlock, &mut Window, &mut App) -> AnyElement + Send + Sync;
+
+/// A pointer event on a link rendered by a TextView.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextViewLinkClick {
+    /// The resolved link target.
+    pub url: SharedString,
+    /// The mouse button released over the link.
+    pub button: MouseButton,
+    /// Keyboard modifiers held when the button was released.
+    pub modifiers: Modifiers,
+}
+
+pub(crate) type LinkClickHandlerFn =
+    dyn Fn(&TextViewLinkClick, &mut Window, &mut App) + Send + Sync;
+
+pub(crate) fn handle_link_click(
+    handler: &Option<Arc<LinkClickHandlerFn>>,
+    url: SharedString,
+    button: MouseButton,
+    modifiers: Modifiers,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if let Some(handler) = handler {
+        handler(
+            &TextViewLinkClick {
+                url,
+                button,
+                modifiers,
+            },
+            window,
+            cx,
+        );
+    } else {
+        cx.open_url(&url);
+    }
+}
 
 /// A text view that can render Markdown or HTML.
 ///
@@ -46,6 +83,7 @@ pub struct TextView {
     selectable: bool,
     scrollable: bool,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     markdown_extensions: Arc<MarkdownExtensions>,
 }
 
@@ -85,6 +123,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -101,6 +140,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -117,6 +157,7 @@ impl TextView {
             selectable: false,
             scrollable: false,
             code_block_actions: None,
+            link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -162,6 +203,17 @@ impl TextView {
         self.code_block_actions = Some(Arc::new(move |code_block, window, cx| {
             f(&code_block, window, cx).into_any_element()
         }));
+        self
+    }
+
+    /// Handle pointer events on rendered links.
+    ///
+    /// Without a handler, links open through App::open_url.
+    pub fn on_link_click<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&TextViewLinkClick, &mut Window, &mut App) + Send + Sync + 'static,
+    {
+        self.link_click_handler = Some(Arc::new(handler));
         self
     }
 
@@ -278,6 +330,7 @@ impl Element for TextView {
 
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
+            state.link_click_handler = self.link_click_handler.clone();
             state.set_markdown_extensions(self.markdown_extensions.clone(), cx);
             state.selectable = self.selectable;
             state.scrollable = self.scrollable;
@@ -531,6 +584,76 @@ mod tests {
 
         cx.simulate_click(point(px(10.), px(34.)), Modifiers::default());
 
+        assert_eq!(cx.opened_url(), None);
+    }
+
+    #[gpui::test]
+    fn markdown_link_opens_url_without_handler(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) =
+            cx.add_window_view(|_, cx| TextViewTestRoot::new("[example](https://example.com)", cx));
+        let cx: &mut VisualTestContext = cx;
+
+        cx.simulate_click(point(px(10.), px(10.)), Modifiers::default());
+
+        assert_eq!(cx.opened_url(), Some("https://example.com".to_string()));
+    }
+
+    #[gpui::test]
+    fn link_handler_receives_button_and_modifiers(cx: &mut TestAppContext) {
+        use std::sync::{Arc, Mutex};
+
+        struct LinkRoot {
+            text_view: Entity<TextViewState>,
+            clicks: Arc<Mutex<Vec<super::TextViewLinkClick>>>,
+        }
+
+        impl Render for LinkRoot {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                let clicks = self.clicks.clone();
+                div()
+                    .w(px(240.))
+                    .child(
+                        TextView::new(&self.text_view).on_link_click(move |event, _, _| {
+                            clicks.lock().unwrap().push(event.clone());
+                        }),
+                    )
+            }
+        }
+
+        cx.update(crate::init);
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let captured = clicks.clone();
+        let (_, cx) = cx.add_window_view(move |_, cx| LinkRoot {
+            text_view: cx.new(|cx| TextViewState::markdown("[example](https://example.com)", cx)),
+            clicks,
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        let mut modifiers = Modifiers::default();
+        modifiers.control = true;
+        cx.simulate_click(point(px(10.), px(10.)), modifiers);
+        cx.simulate_mouse_down(
+            point(px(10.), px(10.)),
+            MouseButton::Middle,
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_up(
+            point(px(10.), px(10.)),
+            MouseButton::Middle,
+            Modifiers::default(),
+        );
+
+        let clicks = captured.lock().unwrap();
+        assert_eq!(clicks.len(), 2);
+        assert_eq!(clicks[0].url, "https://example.com");
+        assert_eq!(clicks[0].button, MouseButton::Left);
+        assert!(clicks[0].modifiers.control);
+        assert_eq!(clicks[1].button, MouseButton::Middle);
         assert_eq!(cx.opened_url(), None);
     }
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -51,7 +51,7 @@ pub(crate) fn handle_link_click(
             window,
             cx,
         );
-    } else {
+    } else if matches!(button, MouseButton::Left | MouseButton::Middle) {
         cx.open_url(&url);
     }
 }
@@ -600,6 +600,27 @@ mod tests {
     }
 
     #[gpui::test]
+    fn right_click_does_not_open_url_without_handler(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) =
+            cx.add_window_view(|_, cx| TextViewTestRoot::new("[example](https://example.com)", cx));
+        let cx: &mut VisualTestContext = cx;
+
+        cx.simulate_mouse_down(
+            point(px(10.), px(10.)),
+            MouseButton::Right,
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_up(
+            point(px(10.), px(10.)),
+            MouseButton::Right,
+            Modifiers::default(),
+        );
+
+        assert_eq!(cx.opened_url(), None);
+    }
+
+    #[gpui::test]
     fn link_handler_receives_button_and_modifiers(cx: &mut TestAppContext) {
         use std::sync::{Arc, Mutex};
 
@@ -647,13 +668,24 @@ mod tests {
             MouseButton::Middle,
             Modifiers::default(),
         );
+        cx.simulate_mouse_down(
+            point(px(10.), px(10.)),
+            MouseButton::Right,
+            Modifiers::default(),
+        );
+        cx.simulate_mouse_up(
+            point(px(10.), px(10.)),
+            MouseButton::Right,
+            Modifiers::default(),
+        );
 
         let clicks = captured.lock().unwrap();
-        assert_eq!(clicks.len(), 2);
+        assert_eq!(clicks.len(), 3);
         assert_eq!(clicks[0].url, "https://example.com");
         assert_eq!(clicks[0].button, MouseButton::Left);
         assert!(clicks[0].modifiers.control);
         assert_eq!(clicks[1].button, MouseButton::Middle);
+        assert_eq!(clicks[2].button, MouseButton::Right);
         assert_eq!(cx.opened_url(), None);
     }
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, Bounds, Element, ElementId, Entity, GlobalElementId, Hitbox, HitboxBehavior,
-    InspectorElementId, InteractiveElement, IntoElement, LayoutId, Modifiers, MouseButton,
+    ClickEvent, InspectorElementId, InteractiveElement, IntoElement, LayoutId, MouseButton,
     ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
 };
 
@@ -19,39 +19,30 @@ use crate::{global_state::GlobalState, text::TextViewStyle};
 pub(crate) type CodeBlockActionsFn =
     dyn Fn(&CodeBlock, &mut Window, &mut App) -> AnyElement + Send + Sync;
 
-/// A pointer event on a link rendered by a TextView.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TextViewLinkClick {
-    /// The resolved link target.
-    pub url: SharedString,
-    /// The mouse button released over the link.
-    pub button: MouseButton,
-    /// Keyboard modifiers held when the button was released.
-    pub modifiers: Modifiers,
-}
-
 pub(crate) type LinkClickHandlerFn =
-    dyn Fn(&TextViewLinkClick, &mut Window, &mut App) + Send + Sync;
+    dyn Fn(&SharedString, &ClickEvent, &mut Window, &mut App) + Send + Sync;
 
 pub(crate) fn handle_link_click(
     handler: &Option<Arc<LinkClickHandlerFn>>,
     url: SharedString,
-    button: MouseButton,
-    modifiers: Modifiers,
+    event: ClickEvent,
     window: &mut Window,
     cx: &mut App,
 ) {
     if let Some(handler) = handler {
         handler(
-            &TextViewLinkClick {
-                url,
-                button,
-                modifiers,
-            },
+            &url,
+            &event,
             window,
             cx,
         );
-    } else if matches!(button, MouseButton::Left | MouseButton::Middle) {
+    } else if match &event {
+        ClickEvent::Mouse(click) => {
+            matches!(click.up.button, MouseButton::Left | MouseButton::Middle)
+        }
+        ClickEvent::Keyboard(_) => true,
+        ClickEvent::Touch(click) => !click.long_press,
+    } {
         cx.open_url(&url);
     }
 }
@@ -208,10 +199,11 @@ impl TextView {
 
     /// Handle pointer events on rendered links.
     ///
+    /// The handler receives the resolved URL and the original GPUI click event.
     /// Without a handler, links open through App::open_url.
     pub fn on_link_click<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&TextViewLinkClick, &mut Window, &mut App) + Send + Sync + 'static,
+        F: Fn(&SharedString, &ClickEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.link_click_handler = Some(Arc::new(handler));
         self
@@ -411,9 +403,9 @@ mod tests {
     use super::{TextView, TextViewPlugin};
     use crate::text::TextViewState;
     use gpui::{
-        AppContext as _, Context, Entity, InteractiveElement as _, IntoElement, Modifiers,
-        MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render, Styled as _,
-        TestAppContext, VisualTestContext, Window, div, point, px,
+        AppContext as _, ClickEvent, Context, Entity, InteractiveElement as _, IntoElement,
+        Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render,
+        SharedString, Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
     };
 
     struct TextViewTestRoot {
@@ -626,7 +618,7 @@ mod tests {
 
         struct LinkRoot {
             text_view: Entity<TextViewState>,
-            clicks: Arc<Mutex<Vec<super::TextViewLinkClick>>>,
+            clicks: Arc<Mutex<Vec<(SharedString, ClickEvent)>>>,
         }
 
         impl Render for LinkRoot {
@@ -639,8 +631,8 @@ mod tests {
                 div()
                     .w(px(240.))
                     .child(
-                        TextView::new(&self.text_view).on_link_click(move |event, _, _| {
-                            clicks.lock().unwrap().push(event.clone());
+                        TextView::new(&self.text_view).on_link_click(move |url, event, _, _| {
+                            clicks.lock().unwrap().push((url.clone(), event.clone()));
                         }),
                     )
             }
@@ -681,11 +673,11 @@ mod tests {
 
         let clicks = captured.lock().unwrap();
         assert_eq!(clicks.len(), 3);
-        assert_eq!(clicks[0].url, "https://example.com");
-        assert_eq!(clicks[0].button, MouseButton::Left);
-        assert!(clicks[0].modifiers.control);
-        assert_eq!(clicks[1].button, MouseButton::Middle);
-        assert_eq!(clicks[2].button, MouseButton::Right);
+        assert_eq!(clicks[0].0, "https://example.com");
+        assert!(!clicks[0].1.is_right_click() && !clicks[0].1.is_middle_click());
+        assert!(clicks[0].1.modifiers().control);
+        assert!(clicks[1].1.is_middle_click());
+        assert!(clicks[2].1.is_right_click());
         assert_eq!(cx.opened_url(), None);
     }
 
@@ -695,7 +687,7 @@ mod tests {
 
         struct LinkedImageRoot {
             text_view: Entity<TextViewState>,
-            clicks: Arc<Mutex<Vec<super::TextViewLinkClick>>>,
+            clicks: Arc<Mutex<Vec<(SharedString, ClickEvent)>>>,
         }
 
         impl Render for LinkedImageRoot {
@@ -708,8 +700,8 @@ mod tests {
                 div().w(px(160.)).child(
                     TextView::new(&self.text_view)
                         .selectable(true)
-                        .on_link_click(move |event, _, _| {
-                            clicks.lock().unwrap().push(event.clone());
+                        .on_link_click(move |url, event, _, _| {
+                            clicks.lock().unwrap().push((url.clone(), event.clone()));
                         }),
                 )
             }
@@ -766,11 +758,11 @@ mod tests {
         assert!(
             clicks
                 .iter()
-                .all(|event| event.url == "https://example.com/image-link")
+                .all(|(url, _)| url == "https://example.com/image-link")
         );
-        assert_eq!(clicks[0].button, MouseButton::Left);
-        assert_eq!(clicks[1].button, MouseButton::Middle);
-        assert_eq!(clicks[2].button, MouseButton::Right);
+        assert!(!clicks[0].1.is_right_click() && !clicks[0].1.is_middle_click());
+        assert!(clicks[1].1.is_middle_click());
+        assert!(clicks[2].1.is_right_click());
         assert_eq!(cx.opened_url(), None);
     }
 

--- a/docs/docs/components/text-view.md
+++ b/docs/docs/components/text-view.md
@@ -42,6 +42,38 @@ TextView::markdown("preview", markdown_source)
 TextView::html("html-preview", "<strong>Hello</strong>")
 ```
 
+## Link Click Handling
+
+Use `on_link_click` when links should be routed by the application instead of
+being opened directly by `App::open_url`. The callback receives the resolved
+URL and the original GPUI `ClickEvent`, so it can distinguish mouse buttons,
+keyboard activation, touch, and modifier keys:
+
+```rust
+use gpui::ClickEvent;
+use gpui_component::text::markdown;
+
+markdown("[Open the project](https://github.com/longbridge/gpui-component)")
+    .on_link_click(|url, event, _window, cx| {
+        if event.is_right_click() {
+            println!("Show a context menu for {url}");
+            return;
+        }
+
+        match event {
+            ClickEvent::Mouse(click) if click.up.modifiers.control => {
+                println!("Open {url} in an internal view");
+            }
+            _ => cx.open_url(url),
+        }
+    })
+```
+
+Installing a handler consumes the link event and disables the default URL
+opening behavior. If no handler is installed, links continue to use
+`App::open_url` as usual. The callback is used for both text links and linked
+images.
+
 ## Markdown Plugins
 
 Use `.plugin(...)` to support custom Markdown formats. A plugin owns both parsing and rendering, so callers only need to attach it to the `TextView`:


### PR DESCRIPTION
## Description

Adds an optional `TextView::on_link_click` callback carrying the resolved URL, mouse button, and keyboard modifiers. Applications can route rendered Markdown or HTML links internally and distinguish ordinary, modified, middle, and right clicks.

When a handler is installed, the click is consumed and the application owns routing. Without a handler, links retain the existing `App::open_url` behavior. The implementation covers inline text links and linked images. Linked images register both primary and auxiliary click listeners so middle and right clicks reach the callback; right clicks without a handler retain the prior fallback behavior.

Closes #2620.

## Testing

Exact candidate `11bb95f2` on Rust 1.97.1:

- `cargo test -p gpui-component text_view --lib`: 12 passed
- `cargo test -p gpui-component`: 347 passed
- `cargo clippy -p gpui-component --all-targets -- -D warnings`
- rendered linked-image regression proves left, middle, and right delivery to the custom handler and proves that the default URL opener is not called

The current public head is green on Windows, macOS, and Linux.

## AI Assistance

The implementation and tests were AI-assisted by Friday. Chris Hynes defined the API requirements, directed the auxiliary-click fixes, and owns the final review.