### PR TITLE
text_view: Fix code block highlighting after theme changes

### DIFF
--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -3,29 +3,20 @@ use std::ops::Range;
 use gpui::SharedString;
 use markdown::mdast::{self, Node};
 
-use crate::{
-    highlighter::HighlightTheme,
-    text::{
-        document::ParsedDocument,
-        markdown_ext::MarkdownParseContext,
-        node::{
-            self, BlockNode, CodeBlock, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph,
-            Span, Table, TableRow, TextMark,
-        },
+use crate::text::{
+    document::ParsedDocument,
+    markdown_ext::MarkdownParseContext,
+    node::{
+        self, BlockNode, CodeBlock, ImageNode, InlineNode, LinkMark, NodeContext, Paragraph, Span,
+        Table, TableRow, TextMark,
     },
 };
 
 /// Parse Markdown into a tree of nodes.
-///
-/// TODO: Remove `highlight_theme` option, this should in render stage.
-pub(crate) fn parse(
-    source: &str,
-    cx: &mut NodeContext,
-    highlight_theme: &HighlightTheme,
-) -> Result<ParsedDocument, SharedString> {
+pub(crate) fn parse(source: &str, cx: &mut NodeContext) -> Result<ParsedDocument, SharedString> {
     let options = cx.markdown_extensions.parse_options();
     markdown::to_mdast(&source, &options)
-        .map(|n| ast_to_document(source, n, cx, highlight_theme))
+        .map(|n| ast_to_document(source, n, cx))
         .map_err(|e| e.to_string().into())
 }
 
@@ -301,12 +292,7 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
     text
 }
 
-fn ast_to_document(
-    source: &str,
-    root: mdast::Node,
-    cx: &mut NodeContext,
-    highlight_theme: &HighlightTheme,
-) -> ParsedDocument {
+fn ast_to_document(source: &str, root: mdast::Node, cx: &mut NodeContext) -> ParsedDocument {
     let root = match root {
         Node::Root(r) => r,
         _ => panic!("expected root node"),
@@ -315,7 +301,7 @@ fn ast_to_document(
     let blocks = root
         .children
         .into_iter()
-        .map(|c| ast_to_node(source, c, cx, highlight_theme))
+        .map(|c| ast_to_node(source, c, cx))
         .collect();
     ParsedDocument {
         source: source.to_string().into(),
@@ -332,12 +318,7 @@ fn new_span(pos: Option<markdown::unist::Position>, cx: &NodeContext) -> Option<
     })
 }
 
-fn ast_to_node(
-    source: &str,
-    value: mdast::Node,
-    cx: &mut NodeContext,
-    highlight_theme: &HighlightTheme,
-) -> BlockNode {
+fn ast_to_node(source: &str, value: mdast::Node, cx: &mut NodeContext) -> BlockNode {
     let span = new_span(value.position().cloned(), cx);
     let parse_cx = MarkdownParseContext::new(source, cx.offset);
     if let Some(mut node) = cx.markdown_extensions.parse_block(&value, &parse_cx) {
@@ -359,7 +340,7 @@ fn ast_to_node(
             let children = val
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(source, c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx))
                 .collect();
             BlockNode::Blockquote {
                 children,
@@ -370,7 +351,7 @@ fn ast_to_node(
             let children = list
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(source, c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx))
                 .collect();
             BlockNode::List {
                 ordered: list.ordered,
@@ -382,7 +363,7 @@ fn ast_to_node(
             let children = val
                 .children
                 .into_iter()
-                .map(|c| ast_to_node(source, c, cx, highlight_theme))
+                .map(|c| ast_to_node(source, c, cx))
                 .collect();
             BlockNode::ListItem {
                 children,
@@ -398,7 +379,6 @@ fn ast_to_node(
         Node::Code(raw) => BlockNode::CodeBlock(CodeBlock::new(
             raw.value.into(),
             raw.lang.map(|s| s.into()),
-            highlight_theme,
             new_span(raw.position, cx),
         )),
         Node::Heading(val) => {
@@ -416,7 +396,6 @@ fn ast_to_node(
         Node::Math(val) => BlockNode::CodeBlock(CodeBlock::new(
             val.value.into(),
             None,
-            highlight_theme,
             new_span(val.position, cx),
         )),
         Node::Html(val) => match super::html::parse(&val.value, cx) {
@@ -435,19 +414,16 @@ fn ast_to_node(
         Node::MdxFlowExpression(val) => BlockNode::CodeBlock(CodeBlock::new(
             val.value.into(),
             Some("mdx".into()),
-            highlight_theme,
             new_span(val.position, cx),
         )),
         Node::Yaml(val) => BlockNode::CodeBlock(CodeBlock::new(
             val.value.into(),
             Some("yml".into()),
-            highlight_theme,
             new_span(val.position, cx),
         )),
         Node::Toml(val) => BlockNode::CodeBlock(CodeBlock::new(
             val.value.into(),
             Some("toml".into()),
-            highlight_theme,
             new_span(val.position, cx),
         )),
         Node::MdxJsxTextElement(val) => {
@@ -539,12 +515,7 @@ mod tests {
     #[test]
     fn test_nested_emphasis_merges_text_marks() {
         let mut cx = NodeContext::default();
-        let document = parse(
-            "This has **_bold and italic_** text.",
-            &mut cx,
-            &HighlightTheme::default_light(),
-        )
-        .unwrap();
+        let document = parse("This has **_bold and italic_** text.", &mut cx).unwrap();
 
         let BlockNode::Paragraph(paragraph) = &document.blocks[0] else {
             panic!("expected paragraph");
@@ -571,7 +542,6 @@ mod tests {
         let document = parse(
             r#"Before <img src="https://example.com/avatar.png" alt="Avatar" width="32" height="32" /> after."#,
             &mut cx,
-            &HighlightTheme::default_light(),
         )
         .unwrap();
 
@@ -598,7 +568,6 @@ mod tests {
         let document = parse(
             r#"Before <img src="https://avatars.githubusercontent.com/u/5518"> after."#,
             &mut cx,
-            &HighlightTheme::default_light(),
         )
         .unwrap();
 
@@ -652,7 +621,7 @@ mod tests {
             markdown_extensions: extensions.into(),
             ..NodeContext::default()
         };
-        let document = parse("$TSLA.US", &mut cx, &HighlightTheme::default_light()).unwrap();
+        let document = parse("$TSLA.US", &mut cx).unwrap();
 
         let BlockNode::Custom(node) = &document.blocks[0] else {
             panic!("expected custom markdown node");
@@ -711,7 +680,7 @@ mod tests {
             markdown_extensions: extensions.into(),
             ..NodeContext::default()
         };
-        let document = parse("$TSLA.US", &mut cx, &HighlightTheme::default_light()).unwrap();
+        let document = parse("$TSLA.US", &mut cx).unwrap();
 
         let BlockNode::Custom(node) = &document.blocks[0] else {
             panic!("expected custom markdown node");

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -667,13 +667,18 @@ impl CodeBlock {
             return Vec::new();
         };
 
-        // Pointer identity is the common render-path fast check; value equality
-        // also preserves the cache when an equivalent theme is reallocated.
-        if let Some(cached) = styles.as_ref()
-            && (Arc::ptr_eq(&cached.highlight_theme, highlight_theme)
-                || cached.highlight_theme.as_ref() == highlight_theme.as_ref())
-        {
-            return cached.styles.clone();
+        // Pointer identity is the common render-path fast check. If an
+        // equivalent theme is reallocated, adopt its Arc while preserving the
+        // computed styles so subsequent renders also use the fast path.
+        if let Some(cached) = styles.as_mut() {
+            if Arc::ptr_eq(&cached.highlight_theme, highlight_theme) {
+                return cached.styles.clone();
+            }
+
+            if cached.highlight_theme.as_ref() == highlight_theme.as_ref() {
+                cached.highlight_theme = highlight_theme.clone();
+                return cached.styles.clone();
+            }
         }
 
         let code = self.code();
@@ -1919,9 +1924,13 @@ mod tests {
         let repeated_light_styles = block.styles(&equivalent_light_theme);
         assert_eq!(repeated_light_styles, light_styles);
         assert!(
-            Arc::ptr_eq(&cached_highlight_theme(&block).unwrap(), &light_theme),
-            "an equivalent theme should reuse the existing cache entry"
+            Arc::ptr_eq(
+                &cached_highlight_theme(&block).unwrap(),
+                &equivalent_light_theme
+            ),
+            "an equivalent replacement should become the cache identity"
         );
+        assert_eq!(block.styles(&equivalent_light_theme), light_styles);
 
         let dark_styles = block.styles(&dark_theme);
         assert_eq!(

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -603,10 +603,16 @@ impl Paragraph {
 }
 
 #[derive(Debug, Clone)]
+struct CachedCodeBlockStyles {
+    /// The active theme used to compute `styles`.
+    highlight_theme: Arc<HighlightTheme>,
+    styles: Vec<(Range<usize>, HighlightStyle)>,
+}
+
+#[derive(Debug, Clone)]
 pub struct CodeBlock {
     lang: Option<SharedString>,
-    styles: Arc<Mutex<Option<Vec<(Range<usize>, HighlightStyle)>>>>,
-    highlight_theme: Arc<HighlightTheme>,
+    styles: Arc<Mutex<Option<CachedCodeBlockStyles>>>,
     state: Arc<Mutex<InlineState>>,
     pub span: Option<Span>,
 }
@@ -634,7 +640,6 @@ impl CodeBlock {
     pub(crate) fn new(
         code: SharedString,
         lang: Option<SharedString>,
-        highlight_theme: &HighlightTheme,
         span: Option<impl Into<Span>>,
     ) -> Self {
         let state = Arc::new(Mutex::new(InlineState::default()));
@@ -645,13 +650,15 @@ impl CodeBlock {
         Self {
             lang,
             styles: Arc::new(Mutex::new(None)),
-            highlight_theme: Arc::new(highlight_theme.clone()),
             state,
             span: span.map(|s| s.into()),
         }
     }
 
-    pub(crate) fn styles(&self) -> Vec<(Range<usize>, HighlightStyle)> {
+    pub(crate) fn styles(
+        &self,
+        highlight_theme: &Arc<HighlightTheme>,
+    ) -> Vec<(Range<usize>, HighlightStyle)> {
         let Some(lang) = &self.lang else {
             return Vec::new();
         };
@@ -660,8 +667,13 @@ impl CodeBlock {
             return Vec::new();
         };
 
-        if let Some(styles) = styles.as_ref() {
-            return styles.clone();
+        // Pointer identity is the common render-path fast check; value equality
+        // also preserves the cache when an equivalent theme is reallocated.
+        if let Some(cached) = styles.as_ref()
+            && (Arc::ptr_eq(&cached.highlight_theme, highlight_theme)
+                || cached.highlight_theme.as_ref() == highlight_theme.as_ref())
+        {
+            return cached.styles.clone();
         }
 
         let code = self.code();
@@ -691,9 +703,12 @@ impl CodeBlock {
             };
 
             highlighter.update(Some(edit), &code_rope, None);
-            highlighter.styles(&(0..code.len()), &self.highlight_theme)
+            highlighter.styles(&(0..code.len()), highlight_theme)
         });
-        *styles = Some(computed_styles.clone());
+        *styles = Some(CachedCodeBlockStyles {
+            highlight_theme: highlight_theme.clone(),
+            styles: computed_styles.clone(),
+        });
         computed_styles
     }
 
@@ -752,7 +767,7 @@ impl CodeBlock {
                         "code",
                         self.state.clone(),
                         vec![],
-                        self.styles(),
+                        self.styles(&cx.theme().highlight_theme),
                     ))
                     .when_some(node_cx.code_block_actions.clone(), |this, actions| {
                         this.child(
@@ -1788,21 +1803,27 @@ impl BlockNode {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "tree-sitter")]
+    use crate::{
+        Theme, ThemeMode,
+        text::{TextView, TextViewState},
+    };
+    #[cfg(feature = "tree-sitter")]
+    use gpui::{AppContext as _, Context, Entity, Render, TestAppContext, VisualTestContext};
+
+    #[cfg(feature = "tree-sitter")]
+    fn cached_highlight_theme(block: &CodeBlock) -> Option<Arc<HighlightTheme>> {
+        block
+            .styles
+            .lock()
+            .ok()
+            .and_then(|styles| styles.as_ref().map(|styles| styles.highlight_theme.clone()))
+    }
+
     #[test]
     fn code_block_equality_includes_code_content() {
-        let theme = HighlightTheme::default_light();
-        let first = CodeBlock::new(
-            "let value = 1;".into(),
-            Some("rust".into()),
-            &theme,
-            None::<Span>,
-        );
-        let second = CodeBlock::new(
-            "let value = 2;".into(),
-            Some("rust".into()),
-            &theme,
-            None::<Span>,
-        );
+        let first = CodeBlock::new("let value = 1;".into(), Some("rust".into()), None::<Span>);
+        let second = CodeBlock::new("let value = 2;".into(), Some("rust".into()), None::<Span>);
 
         assert_ne!(first, second);
     }
@@ -1817,13 +1838,9 @@ mod tests {
             cache.borrow_mut().remove(&lang);
         });
 
-        let unknown_block = CodeBlock::new(
-            "{\"value\": 1}".into(),
-            Some(lang.clone()),
-            &theme,
-            None::<Span>,
-        );
-        _ = unknown_block.styles();
+        let unknown_block =
+            CodeBlock::new("{\"value\": 1}".into(), Some(lang.clone()), None::<Span>);
+        _ = unknown_block.styles(&theme);
 
         let cached_language = CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
             cache
@@ -1849,13 +1866,9 @@ mod tests {
             ),
         );
 
-        let registered_block = CodeBlock::new(
-            "{\"value\": 2}".into(),
-            Some(lang.clone()),
-            &theme,
-            None::<Span>,
-        );
-        _ = registered_block.styles();
+        let registered_block =
+            CodeBlock::new("{\"value\": 2}".into(), Some(lang.clone()), None::<Span>);
+        _ = registered_block.styles(&theme);
 
         let cached_language = CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
             cache
@@ -1864,5 +1877,156 @@ mod tests {
                 .map(|highlighter| highlighter.language().clone())
         });
         assert_eq!(cached_language.as_deref(), Some(lang.as_ref()));
+    }
+
+    #[cfg(feature = "tree-sitter")]
+    #[test]
+    fn code_block_styles_follow_the_current_highlight_theme() {
+        let lang = SharedString::from("json-theme-cache-test");
+        let light_theme = HighlightTheme::default_light();
+        let dark_theme = HighlightTheme::default_dark();
+        let code = SharedString::from(r#"{"value": 42}"#);
+        let number_range = code.find("42").unwrap()..code.find("42").unwrap() + 2;
+
+        let light_number = light_theme.style("number").and_then(|style| style.color);
+        let dark_number = dark_theme.style("number").and_then(|style| style.color);
+        assert_ne!(
+            light_number, dark_number,
+            "the test themes must use different number colors"
+        );
+
+        CODE_BLOCK_HIGHLIGHTERS.with(|cache| {
+            cache.borrow_mut().remove(&lang);
+        });
+        LanguageRegistry::singleton().register(
+            lang.as_ref(),
+            &crate::highlighter::LanguageConfig::new(
+                lang.clone(),
+                tree_sitter_json::LANGUAGE.into(),
+                vec![],
+                "(number) @number",
+                "",
+                "",
+            ),
+        );
+
+        let block = CodeBlock::new(code.clone(), Some(lang), None::<Span>);
+        let light_styles = block.styles(&light_theme);
+        let cached_light_theme = cached_highlight_theme(&block).unwrap();
+        assert!(Arc::ptr_eq(&cached_light_theme, &light_theme));
+
+        let equivalent_light_theme = Arc::new(light_theme.as_ref().clone());
+        let repeated_light_styles = block.styles(&equivalent_light_theme);
+        assert_eq!(repeated_light_styles, light_styles);
+        assert!(
+            Arc::ptr_eq(&cached_highlight_theme(&block).unwrap(), &light_theme),
+            "an equivalent theme should reuse the existing cache entry"
+        );
+
+        let dark_styles = block.styles(&dark_theme);
+        assert_eq!(
+            cached_highlight_theme(&block).as_deref(),
+            Some(dark_theme.as_ref())
+        );
+
+        let color_for_number = |styles: &[(Range<usize>, HighlightStyle)]| -> Option<Hsla> {
+            styles
+                .iter()
+                .find(|(range, _)| {
+                    range.start <= number_range.start && range.end >= number_range.end
+                })
+                .and_then(|(_, style)| style.color)
+        };
+
+        assert_eq!(color_for_number(&light_styles), light_number);
+        assert_eq!(
+            color_for_number(&dark_styles),
+            dark_number,
+            "a theme change must not reuse syntax styles from the previous theme"
+        );
+    }
+
+    #[cfg(feature = "tree-sitter")]
+    #[gpui::test]
+    fn rendered_markdown_code_block_follows_theme_without_reparsing(cx: &mut TestAppContext) {
+        struct CodeBlockThemeRoot {
+            text_view: Entity<TextViewState>,
+        }
+
+        impl Render for CodeBlockThemeRoot {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                div().w(px(480.)).child(TextView::new(&self.text_view))
+            }
+        }
+
+        let lang = SharedString::from("json-theme-render-test");
+        LanguageRegistry::singleton().register(
+            lang.as_ref(),
+            &crate::highlighter::LanguageConfig::new(
+                lang.clone(),
+                tree_sitter_json::LANGUAGE.into(),
+                vec![],
+                "(number) @number",
+                "",
+                "",
+            ),
+        );
+
+        cx.update(crate::init);
+        let markdown = format!("```{lang}\n{{\"value\": 42}}\n```");
+        let (view, cx) = cx.add_window_view(|_, cx| CodeBlockThemeRoot {
+            text_view: cx.new(|cx| TextViewState::markdown(&markdown, cx)),
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let light_theme = cx.update(|_, cx| cx.theme().highlight_theme.clone());
+        let light_block = view.read_with(cx, |root, cx| {
+            let state = root.text_view.read(cx);
+            let BlockNode::CodeBlock(block) = &state.parsed_content.document.blocks[0] else {
+                panic!("expected a code block");
+            };
+
+            block.clone()
+        });
+        let cached_light_theme = cached_highlight_theme(&light_block)
+            .expect("initial render should populate the highlight cache");
+        assert_eq!(cached_light_theme.as_ref(), light_theme.as_ref());
+
+        cx.update(|window, cx| {
+            Theme::change(ThemeMode::Dark, Some(&mut *window), cx);
+            let _ = window.draw(cx);
+        });
+
+        let dark_theme = cx.update(|_, cx| cx.theme().highlight_theme.clone());
+        let dark_block = view.read_with(cx, |root, cx| {
+            let state = root.text_view.read(cx);
+            let BlockNode::CodeBlock(block) = &state.parsed_content.document.blocks[0] else {
+                panic!("expected a code block");
+            };
+
+            block.clone()
+        });
+        let cached_dark_theme = cached_highlight_theme(&dark_block)
+            .expect("theme-change render should refresh the highlight cache");
+
+        assert_ne!(
+            light_theme.as_ref(),
+            dark_theme.as_ref(),
+            "the test themes must have distinct highlight palettes"
+        );
+        assert!(
+            Arc::ptr_eq(&dark_block.styles, &light_block.styles),
+            "changing the theme must not require reparsing the Markdown document"
+        );
+        assert_eq!(cached_dark_theme.as_ref(), dark_theme.as_ref());
     }
 }

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -8,9 +8,8 @@ use gpui::{
 };
 
 use crate::{
-    ActiveTheme, ElementExt,
+    ElementExt,
     async_util::{Receiver, Sender, unbounded},
-    highlighter::HighlightTheme,
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
@@ -250,7 +249,6 @@ impl TextViewState {
             revision: self.revision,
             append,
             pending_text: text.to_string(),
-            highlight_theme: cx.theme().highlight_theme.clone(),
             markdown_extensions: self.markdown_extensions.clone(),
         };
 
@@ -547,7 +545,6 @@ struct UpdateOptions {
     revision: usize,
     pending_text: String,
     append: bool,
-    highlight_theme: std::sync::Arc<HighlightTheme>,
     markdown_extensions: Arc<MarkdownExtensions>,
 }
 
@@ -556,7 +553,6 @@ impl UpdateOptions {
         if next.append {
             self.pending_text.push_str(&next.pending_text);
             self.revision = next.revision;
-            self.highlight_theme = next.highlight_theme;
         } else {
             *self = next;
         }
@@ -608,9 +604,7 @@ fn parse_content(
     }
 
     let new_document = match format {
-        TextViewFormat::Markdown => {
-            format::markdown::parse(&source, &mut node_cx, &options.highlight_theme)
-        }
+        TextViewFormat::Markdown => format::markdown::parse(&source, &mut node_cx),
         TextViewFormat::Html => format::html::parse(&source, &mut node_cx),
     }?;
 
@@ -662,12 +656,10 @@ mod tests {
 
     #[test]
     fn update_options_merge_keeps_latest_full_text() {
-        let theme = HighlightTheme::default_light();
         let mut options = UpdateOptions {
             revision: 1,
             pending_text: "old".to_string(),
             append: true,
-            highlight_theme: theme.clone(),
             markdown_extensions: Arc::default(),
         };
 
@@ -675,14 +667,12 @@ mod tests {
             revision: 2,
             pending_text: "new".to_string(),
             append: false,
-            highlight_theme: theme.clone(),
             markdown_extensions: Arc::default(),
         });
         options.merge(UpdateOptions {
             revision: 3,
             pending_text: " text".to_string(),
             append: true,
-            highlight_theme: theme,
             markdown_extensions: Arc::default(),
         });
 
@@ -693,7 +683,6 @@ mod tests {
 
     #[test]
     fn update_future_yields_before_coalescing_all_queued_updates() {
-        let theme = HighlightTheme::default_light();
         let (tx, rx) = unbounded::<UpdateOptions>();
         let (tx_result, rx_result) = unbounded::<ParsedUpdate>();
         let total_updates = 128;
@@ -703,7 +692,6 @@ mod tests {
                 revision,
                 pending_text: format!("{revision}\n"),
                 append: revision != 1,
-                highlight_theme: theme.clone(),
                 markdown_extensions: Arc::default(),
             })
             .unwrap();


### PR DESCRIPTION
Closes #2618

## Description

This PR fixes Markdown code blocks keeping syntax colors from the theme that was
active when the Markdown was parsed.

The root cause was that `CodeBlock` captured the active `HighlightTheme` during
Markdown parsing and cached only the computed syntax styles. Re-rendering the
same `TextViewState` after a theme change therefore kept returning that
theme-independent cache entry, even though the rest of the view used the new
active theme.

This change:

- removes the highlight theme from the Markdown parsing and background update
  pipeline
- resolves the current `ActiveTheme` when a code block is rendered
- stores the theme alongside cached code-block styles and recomputes them when
  that theme changes
- keeps the normal render path inexpensive with an `Arc` identity fast path,
  while treating separately allocated but equivalent themes as the same cache
  key and adopting the current `Arc` after an equivalent-value match
- adds a focused syntax-color regression test and a GPUI render-level
  regression test

The render-level test keeps the same parsed `CodeBlock` alive, changes the
global theme from light to dark, redraws the window, and verifies that the
existing block's highlight cache is updated without reparsing the Markdown.

This preserves the existing behavior in which Markdown code blocks follow the
current `ActiveTheme`. It does not introduce new per-view override semantics for
the public `TextViewStyle::highlight_theme` field.

## Review Follow-up

During a second review of the fix, I found an efficiency edge case in the
initial cache implementation. When an equivalent `HighlightTheme` arrived in a
separately allocated `Arc`, the cache correctly reused the computed syntax
styles but retained the previous `Arc`. Every later render would therefore miss
the pointer-identity fast path and repeat a full `HighlightTheme` value
comparison. This did not affect rendered colors, but it made the steady-state
render path unnecessarily expensive after an equivalent theme reload.

The cache now adopts the current `Arc` when the theme values are equal, while
preserving the already computed syntax styles. Subsequent renders then return
to the O(1) pointer-identity check without re-highlighting. The focused
regression test verifies that an equivalent replacement becomes the cached
identity before testing a genuinely different theme.

The new cache-identity assertion was also run against the initial implementation
and failed because the cache still pointed to the previous `Arc`. It passes
after the follow-up change.

## Branch Synchronization

After contributor review, this branch was synchronized with
`upstream/main@de5859b2` through merge commits `fcb4a97a` and `0554ed16`. The
upstream changes touched only `crates/ui/src/input/state.rs` and
`crates/ui/src/input/element.rs`, did not overlap this PR, and merged without
conflict. The proposed diff relative to the current base remains limited to the
three text files listed in this PR, and the relevant local validation was rerun
after synchronization.

## Screenshot

Both screenshots show the same persistent `TextViewState` after switching the
global theme from light to dark. The Markdown source is unchanged and is not
reparsed. They compare the buggy and fixed builds; both screenshots are taken
in the final dark-theme state.

Before the fix, the view background changed to dark, but the code block kept
syntax styles cached under the light theme, producing stale and low-contrast
token colors. After the fix, the existing code block detects the active theme
change during rendering and refreshes its syntax styles with the dark
highlighting palette.

| Before | After |
| ------ | ----- |
| <img width="1360" height="816" alt="before-active" src="https://github.com/user-attachments/assets/e4ee16ec-d051-4ca2-8567-ae2c2ac91183" /> | <img width="1360" height="816" alt="after-active" src="https://github.com/user-attachments/assets/5dec0f5b-9904-4e19-a6ae-b4cf2e052df8" /> |

## Break Changes

None.

## How to Test

The regression test was first run against the old cache behavior and failed
because the dark-theme render returned the light-theme number color. It passes
after this change.

Focused regression and render-level tests:

```bash
cargo test --locked --offline -p gpui-component \
  --features tree-sitter-languages theme -- --nocapture --test-threads=1
```

Full component and workspace tests:

```bash
cargo test --locked --offline -p gpui-component \
  --features tree-sitter-languages -- --test-threads=1
cargo test --locked --offline -p gpui-component \
  --no-default-features -- --test-threads=1
cargo test --locked --offline --all -- --test-threads=1
```

Lint and cross-target checks:

```bash
cargo clippy --locked --offline -- --deny warnings
cargo clippy --locked --offline -p gpui-component --tests \
  --features tree-sitter-languages -- --deny warnings
cargo check --locked --offline -p gpui-component --no-default-features
cargo check --locked --offline --target wasm32-unknown-unknown \
  -p gpui-component --no-default-features
rustfmt --edition 2024 --check \
  crates/ui/src/text/node.rs \
  crates/ui/src/text/format/markdown.rs \
  crates/ui/src/text/state.rs
git diff --check
```

Results:

- `gpui-component` with tree-sitter languages: 358 passed
- `gpui-component` without default features: 340 passed
- full workspace tests: passed
- both Clippy invocations with warnings denied: passed
- native and WASM no-default checks: passed
- GitHub CI on macOS, Linux, and Windows for the synchronized head: passed

Manual visual verification was performed on Linux with a dedicated local story
reproduction. It changed only `Theme::change(...)` after the initial parse and
produced the before/after screenshots above.

## AI Assistance

Codex assisted with root-cause analysis, implementation, regression tests,
validation, screenshots, and drafting this PR description. The automated and
manual checks listed above were run locally. The contributor reviewed the final
diff, including follow-up commit `bf1483f3`, and confirmed that the AI-assisted
changes are accurate.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes. A dedicated local reproduction was run before and after the fix.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific). Not platform-specific; the synchronized head passed CI on all three platforms, the visual behavior was manually verified on Linux, and the crate was compiled for WASM.
