### PR TITLE
menu: Split action context and previous focus handler

### DIFF
--- a/crates/ui/src/menu/context_menu.rs
+++ b/crates/ui/src/menu/context_menu.rs
@@ -280,12 +280,12 @@ impl<E: ParentElement + Styled + IntoElement + 'static> Element for ContextMenu<
                         && hitbox.is_hovered(window)
                     {
                         // Capture the focused element to restore focus to on dismiss.
-                        // If focus is still on the previous menu, keep its action context.
+                        // If focus is still on the previous menu, keep its captured focus.
                         let previous_focus_handle = window.focused(cx).and_then(|focused| {
                             let shared_state = shared_state.borrow();
                             match shared_state.menu_view.as_ref() {
                                 Some(menu) if menu.read(cx).focus_handle == focused => {
-                                    menu.read(cx).action_context.clone()
+                                    menu.read(cx).previous_focus_handle.clone()
                                 }
                                 _ => Some(focused),
                             }
@@ -313,7 +313,7 @@ impl<E: ParentElement + Styled + IntoElement + 'static> Element for ContextMenu<
                                     build(menu, window, cx)
                                 });
                                 menu.update(cx, |menu, cx| {
-                                    menu.set_action_context(previous_focus_handle, cx);
+                                    menu.set_previous_focus(previous_focus_handle, cx);
                                 });
 
                                 // Set up the subscription for dismiss handling
@@ -338,5 +338,108 @@ impl<E: ParentElement + Styled + IntoElement + 'static> Element for ContextMenu<
                 });
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Theme;
+    use gpui::{
+        Context, FocusHandle, IntoElement, Render, TestAppContext, VisualTestContext, actions,
+        point, px,
+    };
+    use std::cell::Cell;
+
+    actions!(context_menu_test, [RemoveTab]);
+
+    /// The regression shape: the action handler lives on the trigger's
+    /// ancestor (like an action bar), which is NOT on the focus path while
+    /// focus is in the content area.
+    struct TestRoot {
+        content_focus: FocusHandle,
+        received: Rc<Cell<bool>>,
+    }
+
+    impl Render for TestRoot {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let received = self.received.clone();
+            div()
+                .size_full()
+                .child(
+                    div()
+                        .id("content")
+                        .h(px(40.))
+                        .track_focus(&self.content_focus),
+                )
+                .child(
+                    div()
+                        .id("action-bar")
+                        .h(px(60.))
+                        .on_action(move |_: &RemoveTab, _, _| received.set(true))
+                        .child(
+                            div()
+                                .id("tab")
+                                .size_full()
+                                .context_menu(|menu, _, _| menu.menu("Close", Box::new(RemoveTab))),
+                        ),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn action_bubbles_from_trigger_and_focus_restores_on_dismiss(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.set_global(Theme::default());
+            super::super::popup_menu::init(cx);
+        });
+
+        let received = Rc::new(Cell::new(false));
+        let (root, cx) = cx.add_window_view({
+            let received = received.clone();
+            move |window, cx| {
+                let content_focus = cx.focus_handle();
+                content_focus.focus(window, cx);
+                TestRoot {
+                    content_focus,
+                    received,
+                }
+            }
+        });
+        let content_focus = root.read_with(cx, |root, _| root.content_focus.clone());
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // Right-click inside the tab to open the context menu.
+        cx.simulate_event(MouseDownEvent {
+            button: MouseButton::Right,
+            position: point(px(50.), px(70.)),
+            modifiers: Default::default(),
+            click_count: 1,
+            first_mouse: false,
+        });
+        // The menu entity is built in a deferred callback, then rendered
+        // (which also focuses it) on the next draw.
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // Select "Close" and confirm. Keyboard confirm and mouse click share
+        // the same `confirm` path in `PopupMenu`.
+        cx.simulate_keystrokes("down enter");
+        cx.run_until_parked();
+
+        // The action must reach the handler on the trigger's ancestor chain,
+        // even though the action bar was never on the focus path.
+        assert!(received.get());
+        // And dismiss must restore focus to where it was before the menu
+        // opened, keeping the dangling-focus fix (#2614).
+        cx.update(|window, cx| {
+            assert_eq!(window.focused(cx).as_ref(), Some(&content_focus));
+        });
     }
 }

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -284,6 +284,10 @@ pub struct PopupMenu {
     pub(crate) menu_items: Vec<PopupMenuItem>,
     /// The focus handle of Entity to handle actions.
     pub(crate) action_context: Option<FocusHandle>,
+    /// The focus to restore on dismiss. Unlike `action_context`, this does not
+    /// change where actions are dispatched: they still bubble from the menu's
+    /// own focus path (through the trigger element's ancestors).
+    pub(crate) previous_focus_handle: Option<FocusHandle>,
     selected_index: Option<usize>,
     min_width: Option<Pixels>,
     max_width: Option<Pixels>,
@@ -321,6 +325,7 @@ impl PopupMenu {
         Self {
             focus_handle: cx.focus_handle(),
             action_context: None,
+            previous_focus_handle: None,
             parent_menu: None,
             menu_items: Vec::new(),
             selected_index: None,
@@ -368,6 +373,24 @@ impl PopupMenu {
             if let PopupMenuItem::Submenu { menu, .. } = item {
                 menu.update(cx, |menu, cx| {
                     menu.set_action_context(action_context.clone(), cx);
+                });
+            }
+        }
+    }
+
+    /// Set the focus to restore when the menu is dismissed, without changing
+    /// where actions are dispatched.
+    pub(crate) fn set_previous_focus(
+        &mut self,
+        handle: Option<FocusHandle>,
+        cx: &mut Context<Self>,
+    ) {
+        self.previous_focus_handle = handle.clone();
+
+        for item in &self.menu_items {
+            if let PopupMenuItem::Submenu { menu, .. } = item {
+                menu.update(cx, |menu, cx| {
+                    menu.set_previous_focus(handle.clone(), cx);
                 });
             }
         }
@@ -1007,8 +1030,12 @@ impl PopupMenu {
         cx.emit(DismissEvent);
 
         // Focus back to the previous focused handle.
-        if let Some(action_context) = self.action_context.as_ref() {
-            window.focus(action_context, cx);
+        if let Some(handle) = self
+            .previous_focus_handle
+            .as_ref()
+            .or(self.action_context.as_ref())
+        {
+            window.focus(handle, cx);
         }
 
         let Some(parent_menu) = self.parent_menu.clone() else {
@@ -1060,6 +1087,7 @@ impl PopupMenu {
         match self
             .action_context
             .as_ref()
+            .or(self.previous_focus_handle.as_ref())
             .and_then(|handle| Kbd::binding_for_action_in(action.as_ref(), handle, window))
         {
             Some(kbd) => Some(kbd),


### PR DESCRIPTION
Contine #2614.