### PR TITLE
select: Reset search before setting selected value

### DIFF
--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -73,6 +73,7 @@ pub struct ListState<D: ListDelegate> {
     options: ListOptions,
     delegate: D,
     last_query: Option<String>,
+    search_pending: bool,
     scroll_handle: VirtualListScrollHandle,
     rows_cache: RowsCache,
     selected_index: Option<IndexPath>,
@@ -105,6 +106,7 @@ where
             rows_cache: RowsCache::default(),
             query_input,
             last_query: None,
+            search_pending: false,
             selected_index: None,
             selectable: true,
             searchable: false,
@@ -214,6 +216,27 @@ where
     /// Set the query text of the search input, this will trigger a search.
     pub fn set_query(&mut self, query: &str, window: &mut Window, cx: &mut Context<Self>) {
         let query = query.to_string();
+        self.set_query_input(query.clone(), window, cx);
+        self.start_search(query, None, window, cx);
+    }
+
+    pub(crate) fn is_search_pending(&self) -> bool {
+        self.search_pending
+    }
+
+    pub(crate) fn set_query_with_completion(
+        &mut self,
+        query: &str,
+        on_complete: impl FnOnce(&mut Self, &mut Window, &mut Context<Self>) + 'static,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let query = query.to_string();
+        self.set_query_input(query.clone(), window, cx);
+        self.start_search(query, Some(Box::new(on_complete)), window, cx);
+    }
+
+    fn set_query_input(&mut self, query: String, window: &mut Window, cx: &mut Context<Self>) {
         self.query_input.update(cx, |input, cx| {
             input.set_value(query, window, cx);
         });
@@ -277,35 +300,59 @@ where
                     return;
                 }
 
-                self.set_searching(true, window, cx);
-                let search = self.delegate.perform_search(&text, window, cx);
-
-                if self.rows_cache.len() > 0 {
-                    self._set_selected_index(Some(IndexPath::default()), window, cx);
-                } else {
-                    self._set_selected_index(None, window, cx);
-                }
-
-                self._search_task = cx.spawn_in(window, async move |this, window| {
-                    search.await;
-
-                    _ = this.update_in(window, |this, _, _| {
-                        this.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
-                        this.last_query = Some(text);
-                    });
-
-                    // Always wait 100ms to avoid flicker
-                    window
-                        .background_executor()
-                        .timer(Duration::from_millis(100))
-                        .await;
-                    _ = this.update_in(window, |this, window, cx| {
-                        this.set_searching(false, window, cx);
-                    });
-                });
+                self.start_search(text, None, window, cx);
             }
             _ => {}
         }
+    }
+
+    fn start_search(
+        &mut self,
+        query: String,
+        on_complete: Option<Box<dyn FnOnce(&mut Self, &mut Window, &mut Context<Self>) + 'static>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Dropping a GPUI Task cancels it. Cancel the previous search before the delegate starts
+        // new work so a stale result cannot race the replacement query.
+        self._search_task = Task::ready(());
+        self.search_pending = true;
+        self.set_searching(true, window, cx);
+        let search = self.delegate.perform_search(&query, window, cx);
+
+        // Preserve the existing cursor behavior for regular list searches. Completion-driven
+        // callers, such as Select resetting a filter before selecting a value, choose their
+        // final cursor after the delegate has restored its items.
+        if on_complete.is_none() {
+            if self.rows_cache.len() > 0 {
+                self._set_selected_index(Some(IndexPath::default()), window, cx);
+            } else {
+                self._set_selected_index(None, window, cx);
+            }
+        }
+
+        self._search_task = cx.spawn_in(window, async move |this, window| {
+            search.await;
+
+            _ = this.update_in(window, move |this, window, cx| {
+                this.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
+                this.last_query = Some(query);
+                this.search_pending = false;
+
+                if let Some(on_complete) = on_complete {
+                    on_complete(this, window, cx);
+                }
+            });
+
+            // Always wait 100ms to avoid flicker
+            window
+                .background_executor()
+                .timer(Duration::from_millis(100))
+                .await;
+            _ = this.update_in(window, |this, window, cx| {
+                this.set_searching(false, window, cx);
+            });
+        });
     }
 
     fn set_searching(&mut self, searching: bool, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -837,9 +837,9 @@ mod tests {
     use std::{cell::Cell, rc::Rc};
 
     use gpui::{
-        AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
-        Modifiers, ParentElement as _, Render, SharedString, Styled as _, Task, TestAppContext,
-        VisualTestContext, WeakEntity, Window, div, px,
+        AnyElement, App, AppContext as _, Context, Entity, Focusable as _, InteractiveElement as _,
+        IntoElement, Modifiers, ParentElement as _, Render, SharedString, Styled as _, Task,
+        TestAppContext, VisualTestContext, WeakEntity, Window, div, px,
     };
 
     use crate::{
@@ -1228,9 +1228,22 @@ mod tests {
             .debug_bounds("select-trigger")
             .expect("select trigger is rendered");
         cx.simulate_click(trigger.center(), Modifiers::default());
+
+        // GPUI TestWindow has no native platform handle. Keep the trigger focused while drawing
+        // the open menu so macOS does not try to synchronize the search input with an NSView.
+        // Once the input has rendered and registered its handlers, focus it without another draw.
+        cx.update(|window, cx| {
+            let focus_handle = state.read(cx).state.focus_handle.clone();
+            focus_handle.focus(window, cx);
+        });
         draw(cx);
+
+        cx.update(|window, cx| {
+            let focus_handle = state.read(cx).focus_handle(cx);
+            focus_handle.focus(window, cx);
+        });
         cx.simulate_input("Rust");
-        draw(cx);
+        cx.run_until_parked();
 
         cx.update(|_, cx| {
             let state = state.read(cx);
@@ -1244,7 +1257,7 @@ mod tests {
                 state.set_selected_value(&"Go", window, cx);
             });
         });
-        draw(cx);
+        cx.run_until_parked();
 
         cx.update(|_, cx| {
             let state = state.read(cx);
@@ -1254,6 +1267,15 @@ mod tests {
             assert_eq!(list.query_input.read(cx).value(), "");
             assert_eq!(list.delegate().delegate.items_count(0), 3);
         });
+
+        cx.update(|window, cx| {
+            state.update(cx, |state, cx| {
+                state.set_open(false, cx);
+                state.focus(window, cx);
+            });
+        });
+        draw(cx);
+
         assert!(
             cx.debug_bounds("selected-title-go").is_some(),
             "the actual Select trigger should render the programmatically selected item"

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -307,23 +307,63 @@ where
 
     /// Set selected value for the select.
     ///
-    /// Looks up the position from the delegate and sets the selected index accordingly.
-    /// Passes `None` when the value is not found.
+    /// Clears an active search query before looking up the value, so the lookup uses the
+    /// delegate's unfiltered items and their restored index paths. For delegates with
+    /// asynchronous search, the selection is updated after the reset search completes.
+    /// Clears the current selection when the value is not found.
     pub fn set_selected_value(
         &mut self,
         selected_value: &<D::Item as SearchableListItem>::Value,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let selected_index = self
-            .state
-            .list
-            .read(cx)
-            .delegate()
-            .delegate
-            .position(selected_value);
+        let (selected_index, can_select_immediately) = {
+            let list = self.state.list.read(cx);
+            (
+                list.delegate().delegate.position(selected_value),
+                list.query_input.read(cx).value().is_empty() && !list.is_search_pending(),
+            )
+        };
 
-        self.set_selected_index(selected_index, window, cx);
+        if can_select_immediately {
+            self.set_selected_index(selected_index, window, cx);
+            return;
+        }
+
+        let selected_value = selected_value.clone();
+        let weak = cx.entity().downgrade();
+        self.state.list.update(cx, |list, cx| {
+            list.set_query_with_completion(
+                "",
+                move |list, window, cx| {
+                    let selected_index = list.delegate().delegate.position(&selected_value);
+                    let selection = selected_index
+                        .and_then(|ix| {
+                            list.delegate()
+                                .delegate
+                                .item(ix)
+                                .cloned()
+                                .map(|item| (ix, item))
+                        })
+                        .into_iter()
+                        .collect::<Vec<_>>();
+
+                    list._set_selected_index(selected_index, window, cx);
+                    // The list entity is already mutably borrowed by the search-completion
+                    // callback, so update its adapter snapshot directly instead of calling
+                    // `SelectState::set_selected_index`, which would re-enter the list entity.
+                    list.delegate_mut()
+                        .update_selection_snapshot(selection.clone());
+
+                    _ = weak.update(cx, |select, cx| {
+                        select.state.selection = selection;
+                        cx.notify();
+                    });
+                },
+                window,
+                cx,
+            );
+        });
     }
 
     /// Replace the delegate (item data) for the select state.
@@ -794,13 +834,48 @@ where
 
 #[cfg(test)]
 mod tests {
-    use gpui::{AppContext as _, TestAppContext};
+    use std::{cell::Cell, rc::Rc};
+
+    use gpui::{
+        AnyElement, App, AppContext as _, Context, Entity, InteractiveElement as _, IntoElement,
+        Modifiers, ParentElement as _, Render, SharedString, Styled as _, Task, TestAppContext,
+        VisualTestContext, WeakEntity, Window, div, px,
+    };
 
     use crate::{
         IndexPath,
-        searchable_list::SearchableVec,
-        select::{SelectGroup, SelectState},
+        list::ListState,
+        searchable_list::{
+            SearchableListAdapter, SearchableListDelegate, SearchableListItem, SearchableVec,
+        },
+        select::{Select, SelectGroup, SelectState},
     };
+
+    fn filter_select<D>(
+        state: &Entity<SelectState<D>>,
+        query: &str,
+        window: &mut Window,
+        cx: &mut App,
+    ) where
+        D: SearchableListDelegate + 'static,
+        <D::Item as SearchableListItem>::Value: PartialEq + Clone,
+    {
+        state.update(cx, |state, cx| {
+            state.state.list.update(cx, |list, cx| {
+                list.query_input.update(cx, |input, cx| {
+                    input.set_value(query, window, cx);
+                });
+                let search = list
+                    .delegate_mut()
+                    .delegate
+                    .perform_search(query, window, cx);
+                assert!(
+                    search.is_ready(),
+                    "this helper is only for synchronous test delegates"
+                );
+            });
+        });
+    }
 
     #[gpui::test]
     fn test_select_initial_selection_seeds_cursor(cx: &mut TestAppContext) {
@@ -834,5 +909,354 @@ mod tests {
             assert_eq!(state.read(cx).selected_index(cx), Some(initial));
             assert_eq!(state.read(cx).selected_value(), Some(&"Blueberry"));
         });
+    }
+
+    #[gpui::test]
+    fn test_set_selected_value_resets_search_filter(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        let state = cx.update(|window, cx| {
+            cx.new(|cx| {
+                SelectState::new(
+                    SearchableVec::new(vec!["Rust", "Go", "C++"]),
+                    None,
+                    window,
+                    cx,
+                )
+                .searchable(true)
+            })
+        });
+
+        cx.update(|window, cx| {
+            filter_select(&state, "Rust", window, cx);
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Go", window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            let state = state.read(cx);
+            assert_eq!(state.selected_value(), Some(&"Go"));
+            assert_eq!(state.selected_index(cx), Some(IndexPath::new(1)));
+            assert_eq!(state.state.list.read(cx).query_input.read(cx).value(), "");
+            assert_eq!(
+                state.state.list.read(cx).delegate().delegate.items_count(0),
+                3
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_programmatic_list_query_runs_search_delegate(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        let state = cx.update(|window, cx| {
+            cx.new(|cx| {
+                SelectState::new(
+                    SearchableVec::new(vec!["Rust", "Go", "C++"]),
+                    None,
+                    window,
+                    cx,
+                )
+                .searchable(true)
+            })
+        });
+
+        cx.update(|window, cx| {
+            let list = state.read(cx).state.list.clone();
+            list.update(cx, |list, cx| {
+                list.set_query("Rust", window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            let list = state.read(cx).state.list.read(cx);
+            assert_eq!(list.query_input.read(cx).value(), "Rust");
+            assert_eq!(list.delegate().delegate.items_count(0), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_selected_value_without_filter_remains_synchronous(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let state = cx.new(|cx| {
+                SelectState::new(
+                    SearchableVec::new(vec!["Rust", "Go", "C++"]),
+                    Some(IndexPath::new(0)),
+                    window,
+                    cx,
+                )
+            });
+
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Missing", window, cx);
+                assert_eq!(state.selected_value(), None);
+                assert_eq!(state.selected_index(cx), None);
+                assert!(!state.state.list.read(cx).is_search_pending());
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_selected_value_restores_grouped_index_after_search(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        let state = cx.update(|window, cx| {
+            let mut groups: SearchableVec<SelectGroup<&'static str>> = SearchableVec::new(vec![]);
+            groups.push(SelectGroup::new("A").items(["Apple", "Avocado"]));
+            groups.push(SelectGroup::new("B").items(["Banana", "Blueberry"]));
+
+            cx.new(|cx| SelectState::new(groups, None, window, cx).searchable(true))
+        });
+
+        cx.update(|window, cx| {
+            filter_select(&state, "Blue", window, cx);
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Banana", window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            let state = state.read(cx);
+            assert_eq!(state.selected_value(), Some(&"Banana"));
+            assert_eq!(state.selected_index(cx), Some(IndexPath::new(0).section(1)));
+        });
+    }
+
+    struct AsyncSearchDelegate {
+        items: Vec<&'static str>,
+        matched_items: Vec<&'static str>,
+        release_search: async_channel::Receiver<()>,
+        search_count: Rc<Cell<usize>>,
+        list: Option<WeakEntity<ListState<SearchableListAdapter<AsyncSearchDelegate>>>>,
+    }
+
+    impl SearchableListDelegate for AsyncSearchDelegate {
+        type Item = &'static str;
+
+        fn items_count(&self, _: usize) -> usize {
+            self.matched_items.len()
+        }
+
+        fn item(&self, ix: IndexPath) -> Option<&Self::Item> {
+            self.matched_items.get(ix.row)
+        }
+
+        fn position<V>(&self, value: &V) -> Option<IndexPath>
+        where
+            Self::Item: SearchableListItem<Value = V>,
+            V: PartialEq,
+        {
+            self.matched_items
+                .iter()
+                .position(|item| item.value() == value)
+                .map(IndexPath::new)
+        }
+
+        fn perform_search(&mut self, query: &str, _: &mut Window, cx: &mut App) -> Task<()> {
+            self.search_count.set(self.search_count.get() + 1);
+
+            let items = self.items.clone();
+            let query = query.to_string();
+            let release_search = self.release_search.clone();
+            let list = self.list.clone().expect("test list handle is initialized");
+
+            cx.spawn(async move |cx| {
+                release_search
+                    .recv()
+                    .await
+                    .expect("test search gate should stay open");
+
+                _ = list.update(cx, |list, cx| {
+                    list.delegate_mut().delegate.matched_items = items
+                        .into_iter()
+                        .filter(|item| item.matches(&query))
+                        .collect();
+                    cx.notify();
+                });
+            })
+        }
+    }
+
+    #[gpui::test]
+    fn test_latest_set_selected_value_waits_for_async_filter_reset(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        let (release_search, wait_for_search) = async_channel::unbounded();
+        let search_count = Rc::new(Cell::new(0));
+        let state = cx.update(|window, cx| {
+            let delegate = AsyncSearchDelegate {
+                items: vec!["Rust", "Go", "C++"],
+                matched_items: vec!["Rust"],
+                release_search: wait_for_search,
+                search_count: search_count.clone(),
+                list: None,
+            };
+            let state = cx.new(|cx| SelectState::new(delegate, None, window, cx).searchable(true));
+            let list = state.read(cx).state.list.clone();
+
+            list.update(cx, |list_state, cx| {
+                list_state.delegate_mut().delegate.list = Some(list.downgrade());
+                list_state.query_input.update(cx, |input, cx| {
+                    input.set_value("Rust", window, cx);
+                });
+            });
+
+            state
+        });
+
+        cx.update(|window, cx| {
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Go", window, cx);
+            });
+        });
+        cx.run_until_parked();
+        assert_eq!(search_count.get(), 1);
+
+        cx.update(|window, cx| {
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"C++", window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            assert_eq!(
+                state.read(cx).selected_value(),
+                None,
+                "selection must not use the still-filtered delegate before async reset completes"
+            );
+            assert_eq!(search_count.get(), 2);
+        });
+
+        release_search
+            .try_send(())
+            .expect("release the latest reset search");
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            let state = state.read(cx);
+            assert_eq!(state.selected_value(), Some(&"C++"));
+            assert_eq!(state.selected_index(cx), Some(IndexPath::new(2)));
+        });
+    }
+
+    #[derive(Clone)]
+    struct VisualItem(&'static str);
+
+    impl SearchableListItem for VisualItem {
+        type Value = &'static str;
+
+        fn title(&self) -> SharedString {
+            self.0.into()
+        }
+
+        fn display_title(&self) -> Option<AnyElement> {
+            let selector = format!("selected-title-{}", self.0.to_lowercase());
+            Some(
+                div()
+                    .debug_selector(move || selector)
+                    .child(self.0)
+                    .into_any_element(),
+            )
+        }
+
+        fn value(&self) -> &Self::Value {
+            &self.0
+        }
+    }
+
+    struct SelectResetVisualTest {
+        select: Entity<SelectState<SearchableVec<VisualItem>>>,
+    }
+
+    impl Render for SelectResetVisualTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(320.))
+                .h(px(36.))
+                .debug_selector(|| "select-trigger".to_string())
+                .child(Select::new(&self.select))
+        }
+    }
+
+    fn draw(cx: &mut VisualTestContext) {
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_selected_value_after_real_search_interaction(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let state_slot = Rc::new(std::cell::RefCell::new(None));
+        let (_, cx) = cx.add_window_view({
+            let state_slot = state_slot.clone();
+            move |window, cx| {
+                let select = cx.new(|cx| {
+                    SelectState::new(
+                        SearchableVec::new(vec![
+                            VisualItem("Rust"),
+                            VisualItem("Go"),
+                            VisualItem("C++"),
+                        ]),
+                        None,
+                        window,
+                        cx,
+                    )
+                    .searchable(true)
+                });
+                *state_slot.borrow_mut() = Some(select.clone());
+                let content = cx.new(|_| SelectResetVisualTest { select });
+                crate::Root::new(content, window, cx)
+            }
+        });
+        let state = state_slot
+            .borrow()
+            .clone()
+            .expect("select state is created with the test window");
+        let cx: &mut VisualTestContext = cx;
+
+        draw(cx);
+        let trigger = cx
+            .debug_bounds("select-trigger")
+            .expect("select trigger is rendered");
+        cx.simulate_click(trigger.center(), Modifiers::default());
+        draw(cx);
+        cx.simulate_input("Rust");
+        draw(cx);
+
+        cx.update(|_, cx| {
+            let state = state.read(cx);
+            let list = state.state.list.read(cx);
+            assert_eq!(list.query_input.read(cx).value(), "Rust");
+            assert_eq!(list.delegate().delegate.items_count(0), 1);
+        });
+
+        cx.update(|window, cx| {
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Go", window, cx);
+            });
+        });
+        draw(cx);
+
+        cx.update(|_, cx| {
+            let state = state.read(cx);
+            let list = state.state.list.read(cx);
+            assert_eq!(state.selected_value(), Some(&"Go"));
+            assert_eq!(state.selected_index(cx), Some(IndexPath::new(1)));
+            assert_eq!(list.query_input.read(cx).value(), "");
+            assert_eq!(list.delegate().delegate.items_count(0), 3);
+        });
+        assert!(
+            cx.debug_bounds("selected-title-go").is_some(),
+            "the actual Select trigger should render the programmatically selected item"
+        );
     }
 }

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -837,9 +837,10 @@ mod tests {
     use std::{cell::Cell, rc::Rc};
 
     use gpui::{
-        AnyElement, App, AppContext as _, Context, Entity, Focusable as _, InteractiveElement as _,
-        IntoElement, Modifiers, ParentElement as _, Render, SharedString, Styled as _, Task,
-        TestAppContext, VisualTestContext, WeakEntity, Window, div, px,
+        AnyElement, App, AppContext as _, Context, Entity, InputEvent as _,
+        InteractiveElement as _, IntoElement, Modifiers, MouseButton, MouseDownEvent, MouseUpEvent,
+        ParentElement as _, Render, SharedString, Styled as _, Task, TestAppContext,
+        VisualTestContext, WeakEntity, Window, div, px,
     };
 
     use crate::{
@@ -1227,22 +1228,52 @@ mod tests {
         let trigger = cx
             .debug_bounds("select-trigger")
             .expect("select trigger is rendered");
-        cx.simulate_click(trigger.center(), Modifiers::default());
 
-        // GPUI TestWindow has no native platform handle. Keep the trigger focused while drawing
-        // the open menu so macOS does not try to synchronize the search input with an NSView.
-        // Once the input has rendered and registered its handlers, focus it without another draw.
+        // GPUI TestWindow has no native platform handle. Dispatch the click synchronously and
+        // restore trigger focus before the test executor can redraw the newly focused query input.
         cx.update(|window, cx| {
+            let position = trigger.center();
+            let modifiers = Modifiers::default();
+            window.dispatch_event(
+                MouseDownEvent {
+                    position,
+                    modifiers,
+                    button: MouseButton::Left,
+                    click_count: 1,
+                    first_mouse: false,
+                }
+                .to_platform_input(),
+                cx,
+            );
+            window.dispatch_event(
+                MouseUpEvent {
+                    position,
+                    modifiers,
+                    button: MouseButton::Left,
+                    click_count: 1,
+                }
+                .to_platform_input(),
+                cx,
+            );
+            assert!(
+                state.read(cx).state.open,
+                "the actual trigger click should open the Select"
+            );
+
             let focus_handle = state.read(cx).state.focus_handle.clone();
             focus_handle.focus(window, cx);
         });
+        cx.run_until_parked();
         draw(cx);
 
+        // Insert through the real query Input so its Change event drives the List search without
+        // requiring TestWindow to provide a native IME-backed view.
         cx.update(|window, cx| {
-            let focus_handle = state.read(cx).focus_handle(cx);
-            focus_handle.focus(window, cx);
+            let query_input = state.read(cx).state.list.read(cx).query_input.clone();
+            query_input.update(cx, |input, cx| {
+                input.insert("Rust", window, cx);
+            });
         });
-        cx.simulate_input("Rust");
         cx.run_until_parked();
 
         cx.update(|_, cx| {


### PR DESCRIPTION
Closes #2522

## Description

`SelectState::set_selected_value` previously looked up the requested value against the delegate's current, potentially filtered items. When an active search hid that value, `position` returned `None`, so the programmatic selection was cleared and the trigger did not display the requested item.

This change:

- makes `ListState::set_query` run the search delegate, matching its existing documented contract;
- centralizes user-entered and programmatic searches in the same task lifecycle;
- cancels a superseded search before starting its replacement;
- resets an active Select search and waits for the delegate to restore its items before resolving the requested value;
- preserves the existing synchronous `set_selected_value` behavior when no search is active;
- preserves the existing cursor behavior for ordinary List searches; and
- ensures the latest programmatic selection wins when an asynchronous reset is replaced.

The completion hook used by Select is crate-private. This does not add a new public API or emit a user selection event from the programmatic setter.

## Screenshot

Both screenshots use the same `SelectState` and unchanged item source. The Select is first filtered to `Rust`; `set_selected_value("Go")` is then called programmatically.

| Before | After |
| ------ | ----- |
| <img width="1530" height="1054" alt="Before: the active Rust filter prevents the Go value from being selected" src="https://github.com/user-attachments/assets/99650355-7dbd-4258-8970-09f7c490414c" /> | <img width="1530" height="1054" alt="After: the filter is reset and the Go value is selected and rendered" src="https://github.com/user-attachments/assets/96a6af99-2891-4e92-b414-9a80eed5f1bb" /> |

Before the fix, the `Rust` filter remains active, the committed value is empty, and the trigger still shows its placeholder. After the fix, the query is cleared, all rows are restored, `Go` is committed, and the trigger renders `Go`.

## How to Test

[GitHub Actions](https://github.com/longbridge/gpui-component/actions/runs/30601643916) passed on Linux, Windows, and macOS. The new regression coverage is not ignored or platform-gated.

The new regression cases were first run against upstream commit `88f102d13654fe25aa2fede076274b6b751a3704` without the fix. Five relevant paths failed as expected: synchronous filtered selection, grouped selection, asynchronous/latest-call selection, real Select interaction, and programmatic `ListState::set_query`.

After the fix:

- `cargo test --locked --offline -p gpui-component select::tests` — 8 passed
- `cargo test --locked --offline --all` — passed, including all 366 `gpui-component` tests and workspace/example/doc tests
- `cargo clippy --locked --offline --workspace --all-targets -- --deny warnings` — passed
- `cargo check --locked --offline -p gpui-component --no-default-features` — passed
- `cargo check --locked --offline -p gpui-component --no-default-features --target wasm32-unknown-unknown` — passed
- `rustfmt --check --config-path .rustfmt.toml crates/ui/src/list/list.rs crates/ui/src/select.rs` — passed
- Manual Linux story reproduction — passed; before/after screenshots captured

The automated coverage includes:

- the original filtered Select regression;
- public programmatic List search;
- unchanged synchronous behavior without a filter;
- grouped index restoration;
- an asynchronous delegate with cancellation and latest-call-wins behavior; and
- an end-to-end `VisualTestContext` interaction that dispatches the actual trigger click, edits the actual query `Input`, applies a programmatic value, and verifies both state and rendered trigger output.

The first test-only adjustment (`9f61e43`) still failed on macOS because `VisualTestContext::simulate_click` runs the executor after mouse-up. That allowed the focused query `Input` to redraw and request `TestWindow::window_handle` before focus could be restored.

The final test change (`4170a4a`) dispatches mouse-down/up in one update, restores trigger focus before executor refresh, and edits the actual query `Input` through its normal `InputEvent::Change` path. No production code was changed for this synthetic `TestWindow` limitation, no platform test was skipped, and the latest Linux, Windows, and macOS CI run passed.

## AI Assistance

AI assisted with implementation and test scaffolding. The contributor reviewed the final diff, generated code, and test evidence before marking this PR ready.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] Passed the related story reproduction on Linux.
- [x] Not platform-specific; no platform-specific rendering or performance path was changed.
