### PR TITLE
input: Support configurable wrapping indent

### DIFF
--- a/crates/ui/src/input/display_map/display_map.rs
+++ b/crates/ui/src/input/display_map/display_map.rs
@@ -12,6 +12,7 @@ use ropey::Rope;
 use super::fold_map::FoldMap;
 use super::folding::FoldRange;
 use super::text_wrapper::{LineItem, WrapDisplayPoint};
+pub use super::text_wrapper::WrappingIndent;
 use super::wrap_map::WrapMap;
 use super::{BufferPoint, DisplayPoint};
 use crate::input::Point as TreeSitterPoint;
@@ -227,6 +228,12 @@ impl DisplayMap {
     /// Update layout parameters (wrap width or font)
     pub fn on_layout_changed(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
         self.wrap_map.on_layout_changed(wrap_width, cx);
+        self.rebuild_fold_projection();
+    }
+
+    /// Set the wrapping indent for continuation lines.
+    pub fn set_wrapping_indent(&mut self, wrapping_indent: WrappingIndent, cx: &mut App) {
+        self.wrap_map.set_wrapping_indent(wrapping_indent, cx);
         self.rebuild_fold_projection();
     }
 

--- a/crates/ui/src/input/display_map/mod.rs
+++ b/crates/ui/src/input/display_map/mod.rs
@@ -17,7 +17,7 @@ mod text_wrapper;
 mod wrap_map;
 
 // Re-export public API
-pub use self::display_map::DisplayMap;
+pub use self::display_map::{ DisplayMap, WrappingIndent };
 pub(crate) use self::text_wrapper::LineLayout;
 
 // Re-export FoldRange and extract_fold_ranges

--- a/crates/ui/src/input/display_map/mod.rs
+++ b/crates/ui/src/input/display_map/mod.rs
@@ -17,13 +17,13 @@ mod text_wrapper;
 mod wrap_map;
 
 // Re-export public API
-pub use self::display_map::{ DisplayMap, WrappingIndent };
+pub use self::display_map::{DisplayMap, WrappingIndent};
 pub(crate) use self::text_wrapper::LineLayout;
 
 // Re-export FoldRange and extract_fold_ranges
-pub use folding::{FoldRange, extract_fold_ranges};
 #[cfg(not(feature = "tree-sitter"))]
 pub use folding::Tree;
+pub use folding::{FoldRange, extract_fold_ranges};
 
 /// Position in the buffer (logical text).
 ///

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -10,6 +10,16 @@ use sum_tree::{Bias, Dimensions, SumTree};
 
 use crate::input::{LastLayout, Point as TreeSitterPoint, RopeExt, WhitespaceIndicators};
 
+/// Controls how soft-wrapped continuation lines are indented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WrappingIndent {
+    /// Continuation lines start flush-left at the full editor width.
+    #[default]
+    None,
+    /// Continuation lines keep the same indentation as the first line.
+    Same,
+}
+
 /// A line with soft wrapped lines info.
 #[derive(Debug, Clone)]
 pub(crate) struct LineItem {
@@ -126,6 +136,7 @@ pub(crate) struct TextWrapper {
     font_size: Pixels,
     /// If is none, it means the text is not wrapped
     wrap_width: Option<Pixels>,
+    wrapping_indent: WrappingIndent,
     /// The lines by split \n
     pub(crate) lines: SumTree<LineItem>,
 
@@ -140,6 +151,7 @@ impl TextWrapper {
             font,
             font_size,
             wrap_width,
+            wrapping_indent: WrappingIndent::default(),
             lines: SumTree::new(&()),
             _initialized: false,
         }
@@ -221,6 +233,15 @@ impl TextWrapper {
         }
 
         self.wrap_width = wrap_width;
+        self.update_all(&self.text.clone(), cx);
+    }
+
+    pub(crate) fn set_wrapping_indent(&mut self, wrapping_indent: WrappingIndent, cx: &mut App) {
+        if wrapping_indent == self.wrapping_indent {
+            return;
+        }
+
+        self.wrapping_indent = wrapping_indent;
         self.update_all(&self.text.clone(), cx);
     }
 

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -14,9 +14,9 @@ use crate::input::{LastLayout, Point as TreeSitterPoint, RopeExt, WhitespaceIndi
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WrappingIndent {
     /// Continuation lines start flush-left at the full editor width.
-    #[default]
     None,
     /// Continuation lines keep the same indentation as the first line.
+    #[default]
     Same,
 }
 
@@ -25,6 +25,11 @@ pub enum WrappingIndent {
 pub(crate) struct LineItem {
     /// The byte length of the line, without the end `\n`.
     len: usize,
+    /// Number of leading characters of the line reserved as indentation for continuation wrapped
+    /// lines, when [`WrappingIndent::Same`] is used.
+    ///
+    /// Zero when [`WrappingIndent::None`] is used or the line is not wrapped.
+    pub(crate) indent: u32,
     /// The soft wrapped lines relative byte range (0..len) of this line (Include first line).
     ///
     /// Not contains the line end `\n`.
@@ -328,6 +333,7 @@ impl TextWrapper {
             let line_str = line.to_string();
             let mut wrapped_lines = SmallVec::<[Range<usize>; 1]>::new();
             let mut prev_boundary_ix = 0;
+            let mut indent_chars = 0;
 
             // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
             if let Some(wrap_width) = wrap_width {
@@ -338,6 +344,7 @@ impl TextWrapper {
                         for boundary in wrap_line(&line_str, wrap_width) {
                             wrapped_lines.push(prev_boundary_ix..boundary.ix);
                             prev_boundary_ix = boundary.ix;
+                            indent_chars = boundary.next_indent;
                         }
                     }
                     WrappingIndent::None => {
@@ -366,6 +373,7 @@ impl TextWrapper {
 
             new_lines.push(LineItem {
                 len: line.len(),
+                indent: indent_chars,
                 wrapped_lines,
             });
         }
@@ -493,6 +501,9 @@ pub(crate) struct LineLayout {
     len: usize,
     /// The soft wrapped lines of this line (Include the first line).
     pub(crate) wrapped_lines: SmallVec<[ShapedLine; 1]>,
+    /// Extra left offset applied to continuation wrapped lines, used to reserve the first line's
+    /// indentation when [`WrappingIndent::Same`] is used.
+    pub(crate) wrap_indent: Pixels,
     pub(crate) longest_width: Pixels,
     pub(crate) whitespace_indicators: Option<WhitespaceIndicators>,
     /// Whitespace indicators: (line_index, x_position, is_tab)
@@ -505,25 +516,47 @@ impl LineLayout {
             len: 0,
             longest_width: px(0.),
             wrapped_lines: SmallVec::new(),
+            wrap_indent: px(0.),
             whitespace_chars: Vec::new(),
             whitespace_indicators: None,
         }
     }
 
-    pub(crate) fn lines(mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) -> Self {
-        self.set_wrapped_lines(wrapped_lines);
+    /// The pixel indent applied to the given visual line, relative to the line's
+    /// leading text. Only continuation lines (index > 0) are indented.
+    #[inline]
+    fn line_indent(&self, line_index: usize) -> Pixels {
+        if line_index == 0 {
+            px(0.)
+        } else {
+            self.wrap_indent
+        }
+    }
+
+    pub(crate) fn lines(
+        mut self,
+        wrapped_lines: SmallVec<[ShapedLine; 1]>,
+        wrap_indent: Pixels,
+    ) -> Self {
+        self.set_wrapped_lines(wrapped_lines, wrap_indent);
         self
     }
 
-    pub(crate) fn set_wrapped_lines(&mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) {
+    pub(crate) fn set_wrapped_lines(
+        &mut self,
+        wrapped_lines: SmallVec<[ShapedLine; 1]>,
+        wrap_indent: Pixels,
+    ) {
         self.len = wrapped_lines.iter().map(|l| l.len).sum();
         let width = wrapped_lines
             .iter()
-            .map(|l| l.width)
+            .enumerate()
+            .map(|(i, l)| l.width + self.line_indent(i))
             .max()
             .unwrap_or_default();
         self.longest_width = width;
         self.wrapped_lines = wrapped_lines;
+        self.wrap_indent = wrap_indent;
     }
 
     pub(crate) fn with_whitespaces(mut self, indicators: Option<WhitespaceIndicators>) -> Self {
@@ -535,6 +568,7 @@ impl LineLayout {
         let space_indicator_offset = indicators.space.width.half();
 
         for (line_index, wrapped_line) in self.wrapped_lines.iter().enumerate() {
+            let line_indent = self.line_indent(line_index);
             for (relative_offset, c) in wrapped_line.text.char_indices() {
                 if matches!(c, ' ' | '\t') {
                     let is_tab = c == '\t';
@@ -547,7 +581,8 @@ impl LineLayout {
                         start_x
                     };
 
-                    self.whitespace_chars.push((line_index, x_position, is_tab));
+                    self.whitespace_chars
+                        .push((line_index, x_position + line_indent, is_tab));
                 }
             }
         }
@@ -591,7 +626,9 @@ impl LineLayout {
             };
 
             if matches {
-                let x = line.x_for_index(offset.saturating_sub(acc_len)) + x_offset;
+                let x = line.x_for_index(offset.saturating_sub(acc_len))
+                    + x_offset
+                    + self.line_indent(i);
                 return Some(point(x, offset_y));
             }
 
@@ -612,8 +649,9 @@ impl LineLayout {
 
         for (i, line) in self.wrapped_lines.iter().enumerate() {
             let is_last = i + 1 == self.wrapped_lines.len();
-            if x <= line.width {
-                let mut ix = line.closest_index_for_x(x);
+            let line_indent = self.line_indent(i);
+            if x <= line_indent + line.width {
+                let mut ix = line.closest_index_for_x(x - line_indent);
                 if !is_last && ix == line.text.len() {
                     // For soft wrap line, we can't put the cursor at the end of the line.
                     let c_len = line.text.chars().last().map(|c| c.len_utf8()).unwrap_or(0);
@@ -644,7 +682,7 @@ impl LineLayout {
             let is_last = i + 1 == self.wrapped_lines.len();
             let line_bottom = line_top + last_layout.line_height;
             if pos.y >= line_top && pos.y < line_bottom {
-                let mut ix = line.closest_index_for_x(pos.x - x_offset);
+                let mut ix = line.closest_index_for_x(pos.x - x_offset - self.line_indent(i));
                 if !is_last && ix == line.text.len() {
                     // For soft wrap line, we can't put the cursor at the end of the line.
                     let c_len = line.text.chars().last().map(|c| c.len_utf8()).unwrap_or(0);
@@ -668,10 +706,10 @@ impl LineLayout {
         let mut offset = 0;
         let mut line_top = px(0.);
         let x_offset = last_layout.alignment_offset(self.longest_width);
-        for line in self.wrapped_lines.iter() {
+        for (i, line) in self.wrapped_lines.iter().enumerate() {
             let line_bottom = line_top + last_layout.line_height;
             if pos.y >= line_top && pos.y < line_bottom {
-                let ix = line.index_for_x(pos.x - x_offset)?;
+                let ix = line.index_for_x(pos.x - x_offset - self.line_indent(i))?;
                 return Some(offset + ix);
             }
 
@@ -683,7 +721,14 @@ impl LineLayout {
     }
 
     pub(crate) fn size(&self, line_height: Pixels) -> Size<Pixels> {
-        size(self.longest_width, self.wrapped_lines.len() * line_height)
+        let width = self
+            .wrapped_lines
+            .iter()
+            .enumerate()
+            .map(|(ix, line)| line.width + self.line_indent(ix))
+            .max()
+            .unwrap_or(self.longest_width);
+        size(width, self.wrapped_lines.len() * line_height)
     }
 
     pub(crate) fn paint(
@@ -697,7 +742,7 @@ impl LineLayout {
     ) {
         for (ix, line) in self.wrapped_lines.iter().enumerate() {
             _ = line.paint(
-                pos + point(px(0.), ix * line_height),
+                pos + point(self.line_indent(ix), ix * line_height),
                 line_height,
                 text_align,
                 align_width,
@@ -993,14 +1038,17 @@ mod tests {
             vec![
                 LineItem {
                     len: 2,
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..2],
                 },
                 LineItem {
                     len: 4,
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..2, 2..4],
                 },
                 LineItem {
                     len: 1,
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..1],
                 },
             ],
@@ -1072,7 +1120,7 @@ mod tests {
         let line1 = ShapedLine::default().with_len(100);
         let line2 = ShapedLine::default().with_len(50);
         let wrapped_lines = smallvec::smallvec![line1, line2];
-        line_layout.set_wrapped_lines(wrapped_lines);
+        line_layout.set_wrapped_lines(wrapped_lines, px(0.));
         assert_eq!(line_layout.len(), 150);
         assert_eq!(line_layout.wrapped_lines.len(), 2);
     }
@@ -1080,11 +1128,14 @@ mod tests {
     #[test]
     fn test_position_for_index_prefers_first_leading_empty_visual_line() {
         let mut line_layout = LineLayout::new();
-        line_layout.set_wrapped_lines(smallvec::smallvec![
-            ShapedLine::default(),
-            ShapedLine::default(),
-            ShapedLine::default().with_len(3),
-        ]);
+        line_layout.set_wrapped_lines(
+            smallvec::smallvec![
+                ShapedLine::default(),
+                ShapedLine::default(),
+                ShapedLine::default().with_len(3),
+            ],
+            px(0.),
+        );
 
         let last_layout = LastLayout {
             visible_range: 0..1,
@@ -1127,21 +1178,25 @@ mod tests {
                 // range: 0..15
                 LineItem {
                     len: Rope::from("Hello, 世界!\r").len(),
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..15],
                 },
                 // range: 16..36
                 LineItem {
                     len: Rope::from("This is second line.\n").len(),
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..10, 10..20],
                 },
                 // range: 37..56
                 LineItem {
                     len: Rope::from("This is third line.\n").len(),
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..9, 9..15, 15..20],
                 },
                 // range: 57..79
                 LineItem {
                     len: Rope::from("这里是第 4 行。").len(),
+                    indent: 0,
                     wrapped_lines: smallvec::smallvec![0..22],
                 },
             ],
@@ -1239,16 +1294,15 @@ mod tests {
 
         wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
 
-        assert_eq!(
-            wrapper.line(0).unwrap().wrapped_lines.as_slice(),
-            [0..5, 5..24]
-        );
+        let line = wrapper.line(0).unwrap();
+        assert_eq!(line.indent, 2);
+        assert_eq!(line.wrapped_lines.as_slice(), [0..5, 5..24]);
     }
 
     #[test]
     fn test_wrapping_indent_none_continuation_lines_wrapped_at_full_width() {
         let mut wrapper = TextWrapper::new(test_font(), px(14.0), Some(px(10.)));
-        wrapper.wrapping_indent = WrappingIndent::default();
+        wrapper.wrapping_indent = WrappingIndent::None;
         let text = Rope::from("  abcdefghijklmnopqrstuv");
         let mut fake_wrap_line = |line: &str, _wrap_width: Pixels| {
             if line.starts_with(' ') {
@@ -1272,9 +1326,8 @@ mod tests {
 
         wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
 
-        assert_eq!(
-            wrapper.line(0).unwrap().wrapped_lines.as_slice(),
-            [0..5, 5..13, 13..21, 21..24]
-        );
+        let line = wrapper.line(0).unwrap();
+        assert_eq!(line.indent, 0);
+        assert_eq!(line.wrapped_lines.as_slice(), [0..5, 5..13, 13..21, 21..24]);
     }
 }

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -522,6 +522,12 @@ impl LineLayout {
         }
     }
 
+    /// Set the left offset reserved for continuation wrapped lines.
+    pub(crate) fn wrap_indent(mut self, wrap_indent: Pixels) -> Self {
+        self.wrap_indent = wrap_indent;
+        self
+    }
+
     /// The pixel indent applied to the given visual line, relative to the line's
     /// leading text. Only continuation lines (index > 0) are indented.
     #[inline]
@@ -533,30 +539,20 @@ impl LineLayout {
         }
     }
 
-    pub(crate) fn lines(
-        mut self,
-        wrapped_lines: SmallVec<[ShapedLine; 1]>,
-        wrap_indent: Pixels,
-    ) -> Self {
-        self.set_wrapped_lines(wrapped_lines, wrap_indent);
+    pub(crate) fn lines(mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) -> Self {
+        self.set_wrapped_lines(wrapped_lines);
         self
     }
 
-    pub(crate) fn set_wrapped_lines(
-        &mut self,
-        wrapped_lines: SmallVec<[ShapedLine; 1]>,
-        wrap_indent: Pixels,
-    ) {
+    pub(crate) fn set_wrapped_lines(&mut self, wrapped_lines: SmallVec<[ShapedLine; 1]>) {
         self.len = wrapped_lines.iter().map(|l| l.len).sum();
         let width = wrapped_lines
             .iter()
-            .enumerate()
-            .map(|(i, l)| l.width + self.line_indent(i))
+            .map(|l| l.width)
             .max()
             .unwrap_or_default();
         self.longest_width = width;
         self.wrapped_lines = wrapped_lines;
-        self.wrap_indent = wrap_indent;
     }
 
     pub(crate) fn with_whitespaces(mut self, indicators: Option<WhitespaceIndicators>) -> Self {
@@ -1120,7 +1116,7 @@ mod tests {
         let line1 = ShapedLine::default().with_len(100);
         let line2 = ShapedLine::default().with_len(50);
         let wrapped_lines = smallvec::smallvec![line1, line2];
-        line_layout.set_wrapped_lines(wrapped_lines, px(0.));
+        line_layout.set_wrapped_lines(wrapped_lines);
         assert_eq!(line_layout.len(), 150);
         assert_eq!(line_layout.wrapped_lines.len(), 2);
     }
@@ -1133,8 +1129,7 @@ mod tests {
                 ShapedLine::default(),
                 ShapedLine::default(),
                 ShapedLine::default().with_len(3),
-            ],
-            px(0.),
+            ]
         );
 
         let last_layout = LastLayout {

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -564,7 +564,6 @@ impl LineLayout {
         let space_indicator_offset = indicators.space.width.half();
 
         for (line_index, wrapped_line) in self.wrapped_lines.iter().enumerate() {
-            let line_indent = self.line_indent(line_index);
             for (relative_offset, c) in wrapped_line.text.char_indices() {
                 if matches!(c, ' ' | '\t') {
                     let is_tab = c == '\t';
@@ -577,8 +576,7 @@ impl LineLayout {
                         start_x
                     };
 
-                    self.whitespace_chars
-                        .push((line_index, x_position + line_indent, is_tab));
+                    self.whitespace_chars.push((line_index, x_position, is_tab));
                 }
             }
         }
@@ -757,7 +755,7 @@ impl LineLayout {
                 };
 
                 let origin = point(
-                    pos.x + *x_position,
+                    pos.x + *x_position + self.line_indent(*line_index),
                     pos.y + *line_index as f32 * line_height,
                 );
 
@@ -1124,13 +1122,11 @@ mod tests {
     #[test]
     fn test_position_for_index_prefers_first_leading_empty_visual_line() {
         let mut line_layout = LineLayout::new();
-        line_layout.set_wrapped_lines(
-            smallvec::smallvec![
-                ShapedLine::default(),
-                ShapedLine::default(),
-                ShapedLine::default().with_len(3),
-            ]
-        );
+        line_layout.set_wrapped_lines(smallvec::smallvec![
+            ShapedLine::default(),
+            ShapedLine::default(),
+            ShapedLine::default().with_len(3),
+        ]);
 
         let last_layout = LastLayout {
             visible_range: 0..1,

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -331,10 +331,31 @@ impl TextWrapper {
 
             // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
             if let Some(wrap_width) = wrap_width {
-                // Here only have wrapped line, if there is no wrap meet, the `line_wraps` result will empty.
-                for boundary in wrap_line(&line_str, wrap_width) {
-                    wrapped_lines.push(prev_boundary_ix..boundary.ix);
-                    prev_boundary_ix = boundary.ix;
+                match self.wrapping_indent {
+                    WrappingIndent::Same => {
+                        // Here only have wrapped line, if there is no wrap meet, the `line_wraps`
+                        // result will empty.
+                        for boundary in wrap_line(&line_str, wrap_width) {
+                            wrapped_lines.push(prev_boundary_ix..boundary.ix);
+                            prev_boundary_ix = boundary.ix;
+                        }
+                    }
+                    WrappingIndent::None => {
+                        // The first visual line keeps the line's leading indentation, so it is
+                        // wrapped as is.
+                        let bondaries = wrap_line(&line_str, wrap_width);
+                        if let Some(first) = bondaries.first() {
+                            let first_ix = first.ix;
+                            wrapped_lines.push(prev_boundary_ix..first_ix);
+                            prev_boundary_ix = first_ix;
+
+                            for boundary in wrap_line(&line_str[first_ix..], wrap_width) {
+                                let ix = first_ix + boundary.ix;
+                                wrapped_lines.push(prev_boundary_ix..ix);
+                                prev_boundary_ix = ix;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1187,6 +1208,72 @@ mod tests {
         assert_eq!(
             wrapper.display_point_to_offset(WrapDisplayPoint::new(0, 0, 15)),
             15
+        );
+    }
+
+    #[test]
+    fn test_wrapping_indent_same_keeps_indent_reserved() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.0), Some(px(10.)));
+        wrapper.wrapping_indent = WrappingIndent::Same;
+        let text = Rope::from("  abcdefghijklmnopqrstuv");
+        let mut fake_wrap_line = |line: &str, _wrap_width: Pixels| {
+            if line.starts_with(' ') {
+                vec![Boundary {
+                    ix: 5,
+                    next_indent: 2,
+                }]
+            } else {
+                let mut boundaries = vec![];
+                let mut i = 8;
+                while i < line.len() {
+                    boundaries.push(Boundary {
+                        ix: i,
+                        next_indent: 0,
+                    });
+                    i += 8;
+                }
+                boundaries
+            }
+        };
+
+        wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
+
+        assert_eq!(
+            wrapper.line(0).unwrap().wrapped_lines.as_slice(),
+            [0..5, 5..24]
+        );
+    }
+
+    #[test]
+    fn test_wrapping_indent_none_continuation_lines_wrapped_at_full_width() {
+        let mut wrapper = TextWrapper::new(test_font(), px(14.0), Some(px(10.)));
+        wrapper.wrapping_indent = WrappingIndent::default();
+        let text = Rope::from("  abcdefghijklmnopqrstuv");
+        let mut fake_wrap_line = |line: &str, _wrap_width: Pixels| {
+            if line.starts_with(' ') {
+                vec![Boundary {
+                    ix: 5,
+                    next_indent: 2,
+                }]
+            } else {
+                let mut boundaries = vec![];
+                let mut i = 8;
+                while i < line.len() {
+                    boundaries.push(Boundary {
+                        ix: i,
+                        next_indent: 0,
+                    });
+                    i += 8;
+                }
+                boundaries
+            }
+        };
+
+        wrapper._update(&text, &(0..text.len()), &text, &mut fake_wrap_line);
+
+        assert_eq!(
+            wrapper.line(0).unwrap().wrapped_lines.as_slice(),
+            [0..5, 5..13, 13..21, 21..24]
         );
     }
 }

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -1321,4 +1321,41 @@ mod tests {
         assert_eq!(line.indent, 0);
         assert_eq!(line.wrapped_lines.as_slice(), [0..5, 5..13, 13..21, 21..24]);
     }
+
+    #[test]
+    fn test_wrap_indent_offsets_continuation_lines() {
+        let mut line_layout = LineLayout::new();
+        line_layout.set_wrapped_lines(smallvec::smallvec![
+            ShapedLine::default().with_len(5),
+            ShapedLine::default().with_len(10),
+        ]);
+
+        line_layout = line_layout.wrap_indent(px(20.0));
+
+        let last_layout = LastLayout{
+           visible_range: 0..1,
+           visible_buffer_lines: vec![0],
+           visible_line_byte_offsets: vec![0],
+           visible_top: px(0.),
+           visible_range_offset: 0..0,
+           lines: Rc::new(vec![]),
+           line_height: px(20.0),
+           wrap_width: Some(px(10.)),
+           wrapping_indent: WrappingIndent::Same,
+           line_number_width: px(0.),
+            cursor_bounds: None,
+            text_align: TextAlign::Left,
+            content_width: px(0.),
+        };
+
+        assert_eq!(
+            line_layout.position_for_index(0, &last_layout, false),
+            Some(point(px(0.), px(0.))),
+        );
+
+        assert_eq!(
+            line_layout.position_for_index(6, &last_layout, false),
+            Some(point(px(20.), px(20.))),
+        )
+    }
 }

--- a/crates/ui/src/input/display_map/text_wrapper.rs
+++ b/crates/ui/src/input/display_map/text_wrapper.rs
@@ -1095,6 +1095,7 @@ mod tests {
             lines: Rc::new(vec![]),
             line_height: px(20.),
             wrap_width: None,
+            wrapping_indent: WrappingIndent::default(),
             line_number_width: px(0.),
             cursor_bounds: None,
             text_align: TextAlign::Left,

--- a/crates/ui/src/input/display_map/wrap_map.rs
+++ b/crates/ui/src/input/display_map/wrap_map.rs
@@ -10,7 +10,7 @@ use gpui::{App, Font, Pixels};
 use ropey::Rope;
 
 use super::fold_map::FoldMap;
-use super::text_wrapper::{LineItem, TextWrapper, WrapDisplayPoint};
+use super::text_wrapper::{LineItem, TextWrapper, WrapDisplayPoint, WrappingIndent};
 use super::{BufferPoint, WrapPoint};
 use crate::input::rope_ext::RopeExt;
 
@@ -113,6 +113,11 @@ impl WrapMap {
     /// Update layout parameters (wrap width or font)
     pub fn on_layout_changed(&mut self, wrap_width: Option<Pixels>, cx: &mut App) {
         self.wrapper.set_wrap_width(wrap_width, cx);
+    }
+
+    /// Set the wrapping indent mode for continuation lines.
+    pub fn set_wrapping_indent(&mut self, wrapping_indent: WrappingIndent, cx: &mut App) {
+        self.wrapper.set_wrapping_indent(wrapping_indent, cx);
     }
 
     /// Set font parameters

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -654,7 +654,8 @@ impl TextElement {
 
                 // wrapped lines
                 for i in 1..=wrapped_lines {
-                    let start = point(px(0.), start.y + i as f32 * line_height);
+                    let indent = line.wrap_indent;
+                    let start = point(indent, start.y + i as f32 * line_height);
                     let mut end = point(end.x, end.y + i as f32 * line_height);
                     if i < wrapped_lines {
                         end.x = line_size.width;
@@ -1254,7 +1255,7 @@ impl TextElement {
             );
 
             let line_layout = LineLayout::new()
-                .lines(smallvec::smallvec![shaped_line])
+                .lines(smallvec::smallvec![shaped_line], px(0.))
                 .with_whitespaces(whitespace_indicators);
             return vec![line_layout];
         }
@@ -1276,7 +1277,7 @@ impl TextElement {
 
             // Keep placeholder lines in a single layout to stay parallel with visible_* metadata.
             let line_layout = LineLayout::new()
-                .lines(placeholder_lines)
+                .lines(placeholder_lines, px(0.))
                 .with_whitespaces(whitespace_indicators);
             return vec![line_layout];
         }
@@ -1296,7 +1297,7 @@ impl TextElement {
 
             debug_assert_eq!(line_item.len(), line_text.len());
 
-            let mut wrapped_lines = SmallVec::with_capacity(1);
+            let mut wrapped_lines: SmallVec<[ShapedLine; 1]> = SmallVec::with_capacity(1);
 
             for range in &line_item.wrapped_lines {
                 let line_runs = runs_for_range(runs, run_offset, &range);
@@ -1318,8 +1319,20 @@ impl TextElement {
                 wrapped_lines.push(shaped_line);
             }
 
+            // Use the first visual line's indentation width for continuation lines.
+            let wrap_indent = if line_item.indent > 0 && wrapped_lines.len() > 1 {
+                let indent_byte_len = line_text
+                    .char_indices()
+                    .nth(line_item.indent as usize)
+                    .map(|(ix, _)| ix)
+                    .unwrap_or(line_text.len());
+                wrapped_lines[0].x_for_index(indent_byte_len)
+            } else {
+                px(0.)
+            };
+
             let line_layout = LineLayout::new()
-                .lines(wrapped_lines)
+                .lines(wrapped_lines, wrap_indent)
                 .with_whitespaces(whitespace_indicators.clone());
             lines.push(line_layout);
 

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1255,7 +1255,7 @@ impl TextElement {
             );
 
             let line_layout = LineLayout::new()
-                .lines(smallvec::smallvec![shaped_line], px(0.))
+                .lines(smallvec::smallvec![shaped_line])
                 .with_whitespaces(whitespace_indicators);
             return vec![line_layout];
         }
@@ -1277,7 +1277,7 @@ impl TextElement {
 
             // Keep placeholder lines in a single layout to stay parallel with visible_* metadata.
             let line_layout = LineLayout::new()
-                .lines(placeholder_lines, px(0.))
+                .lines(placeholder_lines)
                 .with_whitespaces(whitespace_indicators);
             return vec![line_layout];
         }
@@ -1332,7 +1332,8 @@ impl TextElement {
             };
 
             let line_layout = LineLayout::new()
-                .lines(wrapped_lines, wrap_indent)
+                .lines(wrapped_lines)
+                .wrap_indent(wrap_indent)
                 .with_whitespaces(whitespace_indicators.clone());
             lines.push(line_layout);
 

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -1633,15 +1633,23 @@ impl Element for TextElement {
             None
         };
 
+        let wrapping_indent = state.wrapping_indent;
         let wrap_width_changed = state
             .last_layout
             .as_ref()
             .map(|l| l.wrap_width != wrap_width)
             .unwrap_or(true);
 
-        if wrap_width_changed {
+        let wrapping_indent_changed = state
+            .last_layout
+            .as_ref()
+            .map(|l| l.wrapping_indent != wrapping_indent)
+            .unwrap_or(true);
+
+        if wrap_width_changed || wrapping_indent_changed {
             self.state.update(cx, |state, cx| {
                 state.display_map.on_layout_changed(wrap_width, cx);
+                state.display_map.set_wrapping_indent(wrapping_indent, cx);
             });
         }
 
@@ -1694,6 +1702,7 @@ impl Element for TextElement {
             visible_range_offset,
             line_height,
             wrap_width,
+            wrapping_indent,
             line_number_width,
             lines: Rc::new(vec![]),
             cursor_bounds: None,

--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -700,7 +700,7 @@ impl TextElement {
         while let Some(corners) = rev_line_corners.next() {
             points.push(corners.top_left);
             if let Some(next) = rev_line_corners.peek() {
-                if next.top_left.x > corners.top_left.x {
+                if next.top_left.x != corners.top_left.x {
                     points.push(point(next.top_left.x, corners.top_left.y));
                 }
             }

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -31,7 +31,7 @@ pub use cursor::*;
 pub use decorations::*;
 #[cfg(not(feature = "tree-sitter"))]
 pub use display_map::Tree;
-pub use display_map::{BufferPoint, DisplayMap, DisplayPoint, FoldRange};
+pub use display_map::{BufferPoint, DisplayMap, DisplayPoint, FoldRange, WrappingIndent};
 pub use indent::TabSize;
 pub use input::*;
 pub use lsp::*;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -967,8 +967,7 @@ impl InputState {
         self
     }
 
-    /// Set how soft-wrapped continuation lines are indented, default is [`WrappingIndent::None`]
-    /// (flush-left at the fiull editor width).
+    /// Set how soft-wrapped continuation lines are indented, default is [`WrappingIndent::Same`]
     pub fn wrapping_indent(mut self, wrapping_indent: WrappingIndent) -> Self {
         debug_assert!(self.mode.is_multi_line());
         self.wrapping_indent = wrapping_indent;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -22,7 +22,7 @@ use sum_tree::Bias;
 use unicode_segmentation::*;
 
 use super::{
-    DisplayMap, MASK_CHAR,
+    DisplayMap, MASK_CHAR, WrappingIndent,
     blink_cursor::BlinkCursor,
     change::Change,
     decorations::DecorationCollections,
@@ -303,10 +303,12 @@ pub(super) struct LastLayout {
     pub(super) visible_range_offset: Range<usize>,
     /// The last layout lines (Only have visible lines, no empty entries for hidden lines).
     pub(super) lines: Rc<Vec<LineLayout>>,
-    /// The line_height of text layout, this will change will InputElement painted.
+    /// The line_height of text layout, this may change when InputElement is painted.
     pub(super) line_height: Pixels,
-    /// The wrap width of text layout, this will change will InputElement painted.
+    /// The wrap width of text layout, this may change when InputElement is painted.
     pub(super) wrap_width: Option<Pixels>,
+    /// The wrapping indent mode of text layout, this may change when InputElement is painted.
+    pub(super) wrapping_indent: WrappingIndent,
     /// The line number area width of text layout, if not line number, this will be 0px.
     pub(super) line_number_width: Pixels,
     /// The cursor position (top, left) in pixels.
@@ -373,6 +375,7 @@ pub struct InputState {
     pub(super) clean_on_escape: bool,
     pub(super) submit_on_enter: bool,
     pub(super) soft_wrap: bool,
+    pub(super) wrapping_indent: WrappingIndent,
     /// See [`Self::scroll_beyond_last_line`].
     pub(super) scroll_beyond_last_line: Option<usize>,
     /// See [`Self::cursor_surrounding_lines`].
@@ -505,6 +508,7 @@ impl InputState {
             clean_on_escape: false,
             submit_on_enter: false,
             soft_wrap: true,
+            wrapping_indent: WrappingIndent::default(),
             scroll_beyond_last_line: None,
             cursor_surrounding_lines: None,
             show_whitespaces: false,
@@ -963,6 +967,14 @@ impl InputState {
         self
     }
 
+    /// Set how soft-wrapped continuation lines are indented, default is [`WrappingIndent::None`]
+    /// (flush-left at the fiull editor width).
+    pub fn wrapping_indent(mut self, wrapping_indent: WrappingIndent) -> Self {
+        debug_assert!(self.mode.is_multi_line());
+        self.wrapping_indent = wrapping_indent;
+        self
+    }
+
     /// Update the soft wrap mode for multi-line input, default is true.
     pub fn set_soft_wrap(&mut self, wrap: bool, _: &mut Window, cx: &mut Context<Self>) {
         debug_assert!(self.mode.is_multi_line());
@@ -989,6 +1001,18 @@ impl InputState {
     /// Update whether to show whitespace characters.
     pub fn set_show_whitespaces(&mut self, show: bool, _: &mut Window, cx: &mut Context<Self>) {
         self.show_whitespaces = show;
+        cx.notify();
+    }
+
+    /// Update how soft-wrapped continuation lines are indented.
+    pub fn set_wrapping_indent(
+        &mut self,
+        wrapping_indent: WrappingIndent,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.wrapping_indent = wrapping_indent;
+        self.display_map.set_wrapping_indent(wrapping_indent, cx);
         cx.notify();
     }
 


### PR DESCRIPTION
## Description

- Support `WrappingIndent`
  - Some: Wrapped lines get the same indentation as the parent
  - None: No indentation. Wrapped lines begin at column 1
- Fix the current long text rendering with `soft_wrap` enabled
  - Add left offset on continuation wrapped lines
  - Fix selection corner segments

## Screenshot

**Before**
<img width="548" height="819" alt="Before" src="https://github.com/user-attachments/assets/a52cdd86-39e9-4f21-a4ce-e40f88596b1b" />

**After**
| Same                       | None                       |
| ---------------------------- | --------------------------- |
| <img width="592" height="863" alt="Screenshot 2026-08-04 at 10 52 15 PM" src="https://github.com/user-attachments/assets/1e826050-d597-4cd9-a092-fd351aad3027" /> | <img width="592" height="863" alt="After" src="https://github.com/user-attachments/assets/897eb26c-fbd8-4655-b8a4-e2e2721abd8a" /> |

## Break Changes

Set the default wrapping indent to `Same`.

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
