### PR TITLE
button: Only expose toggled state on toggle buttons

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -1211,6 +1211,78 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_button_emits_toggle_state_only_when_selected_is_configured(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        use crate::ElementExt as _;
+        use gpui::{Element as _, IntoElement as _, Render};
+        use std::sync::{Arc, Mutex};
+
+        struct ButtonA11yProbe {
+            states: Arc<Mutex<Vec<Option<gpui::accesskit::Toggled>>>>,
+        }
+
+        impl Render for ButtonA11yProbe {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut gpui::Context<Self>,
+            ) -> impl IntoElement {
+                let states = self.states.clone();
+                div().on_prepaint(move |_, window, cx| {
+                    let ordinary = Button::new("ordinary")
+                        .label("Ordinary")
+                        .render(window, cx)
+                        .into_element();
+                    let mut ordinary_node = gpui::accesskit::Node::new(Role::Button);
+                    ordinary.write_a11y_info(&mut ordinary_node);
+                    let ordinary_state = ordinary_node.toggled();
+                    drop(ordinary);
+
+                    let unselected = Button::new("unselected")
+                        .label("Unselected")
+                        .selected(false)
+                        .render(window, cx)
+                        .into_element();
+                    let mut unselected_node = gpui::accesskit::Node::new(Role::Button);
+                    unselected.write_a11y_info(&mut unselected_node);
+                    let unselected_state = unselected_node.toggled();
+                    drop(unselected);
+
+                    let selected = Button::new("selected")
+                        .label("Selected")
+                        .selected(true)
+                        .render(window, cx)
+                        .into_element();
+                    let mut selected_node = gpui::accesskit::Node::new(Role::Button);
+                    selected.write_a11y_info(&mut selected_node);
+                    let selected_state = selected_node.toggled();
+
+                    *states.lock().unwrap() =
+                        vec![ordinary_state, unselected_state, selected_state];
+                })
+            }
+        }
+
+        cx.update(crate::init);
+        let states = Arc::new(Mutex::new(Vec::new()));
+        let captured = states.clone();
+        let (_, cx) = cx.add_window_view(move |_, _| ButtonA11yProbe { states });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert_eq!(
+            *captured.lock().unwrap(),
+            vec![
+                None,
+                Some(gpui::accesskit::Toggled::False),
+                Some(gpui::accesskit::Toggled::True),
+            ]
+        );
+    }
+
+    #[gpui::test]
     fn test_button_variant_methods(_cx: &mut gpui::TestAppContext) {
         // Test variant check methods
         assert!(ButtonVariant::Link.is_link());

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -191,7 +191,7 @@ pub struct Button {
     children: Vec<AnyElement>,
     disabled: bool,
     pub(crate) selected: bool,
-    selection_exposed: bool,
+    toggled: Option<bool>,
     variant: ButtonVariant,
     rounded: ButtonRounded,
     outline: bool,
@@ -234,7 +234,7 @@ impl Button {
             label: None,
             disabled: false,
             selected: false,
-            selection_exposed: false,
+            toggled: None,
             variant: ButtonVariant::default(),
             rounded: ButtonRounded::Medium,
             border_corners: Corners {
@@ -376,6 +376,17 @@ impl Button {
         self
     }
 
+    /// Expose this button as a toggle button to assistive technology, with
+    /// `toggled` as its pressed state.
+    ///
+    /// Only affects accessibility metadata. Use [`Selectable::selected`] for
+    /// the selected styling, and call this in addition when the button really
+    /// is a toggle, otherwise the button stays an ordinary push button.
+    pub fn toggled(mut self, toggled: bool) -> Self {
+        self.toggled = Some(toggled);
+        self
+    }
+
     #[inline]
     fn clickable(&self) -> bool {
         !(self.disabled || self.loading) && self.on_click.is_some()
@@ -397,7 +408,6 @@ impl Disableable for Button {
 impl Selectable for Button {
     fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
-        self.selection_exposed = true;
         self
     }
 
@@ -474,8 +484,8 @@ impl RenderOnce for Button {
             .when_some(self.label.as_ref(), |this, label| {
                 this.aria_label(label.clone())
             })
-            .when(self.selection_exposed, |this| {
-                this.aria_toggled(if self.selected {
+            .when_some(self.toggled, |this, toggled| {
+                this.aria_toggled(if toggled {
                     gpui::accesskit::Toggled::True
                 } else {
                     gpui::accesskit::Toggled::False
@@ -1187,7 +1197,7 @@ mod tests {
         assert!(!button.loading);
         assert!(!button.disabled);
         assert!(!button.selected);
-        assert!(button.selection_exposed);
+        assert_eq!(button.toggled, None);
         assert_eq!(button.tab_index, 1);
         assert!(button.tab_stop);
         assert!(!button.dropdown_caret);
@@ -1199,7 +1209,6 @@ mod tests {
         // Button with click handler should be clickable
         let clickable = Button::new("test").on_click(|_, _, _| {});
         assert!(clickable.clickable());
-        assert!(!clickable.selection_exposed);
 
         // Disabled button should not be clickable
         let disabled = Button::new("test").disabled(true).on_click(|_, _, _| {});
@@ -1210,62 +1219,45 @@ mod tests {
         assert!(!loading.clickable());
     }
 
+    /// `selected` is styling only; the toggle state must be opted into, so that
+    /// ordinary buttons are not announced as toggle buttons.
     #[gpui::test]
-    fn test_button_emits_toggle_state_only_when_selected_is_configured(
-        cx: &mut gpui::TestAppContext,
-    ) {
+    fn test_button_toggle_state_is_opt_in(cx: &mut gpui::TestAppContext) {
         use crate::ElementExt as _;
-        use gpui::{Element as _, IntoElement as _, Render};
+        use gpui::{Element as _, IntoElement as _, Render, accesskit::Toggled};
         use std::sync::{Arc, Mutex};
 
+        type States = Arc<Mutex<Vec<Option<Toggled>>>>;
+
         struct ButtonA11yProbe {
-            states: Arc<Mutex<Vec<Option<gpui::accesskit::Toggled>>>>,
+            states: States,
         }
 
         impl Render for ButtonA11yProbe {
-            fn render(
-                &mut self,
-                _window: &mut Window,
-                _cx: &mut gpui::Context<Self>,
-            ) -> impl IntoElement {
+            fn render(&mut self, _: &mut Window, _: &mut gpui::Context<Self>) -> impl IntoElement {
                 let states = self.states.clone();
                 div().on_prepaint(move |_, window, cx| {
-                    let ordinary = Button::new("ordinary")
-                        .label("Ordinary")
-                        .render(window, cx)
-                        .into_element();
-                    let mut ordinary_node = gpui::accesskit::Node::new(Role::Button);
-                    ordinary.write_a11y_info(&mut ordinary_node);
-                    let ordinary_state = ordinary_node.toggled();
-                    drop(ordinary);
+                    let mut toggled_of = |button: Button| {
+                        let mut node = gpui::accesskit::Node::new(Role::Button);
+                        button
+                            .render(window, cx)
+                            .into_element()
+                            .write_a11y_info(&mut node);
+                        node.toggled()
+                    };
 
-                    let unselected = Button::new("unselected")
-                        .label("Unselected")
-                        .selected(false)
-                        .render(window, cx)
-                        .into_element();
-                    let mut unselected_node = gpui::accesskit::Node::new(Role::Button);
-                    unselected.write_a11y_info(&mut unselected_node);
-                    let unselected_state = unselected_node.toggled();
-                    drop(unselected);
-
-                    let selected = Button::new("selected")
-                        .label("Selected")
-                        .selected(true)
-                        .render(window, cx)
-                        .into_element();
-                    let mut selected_node = gpui::accesskit::Node::new(Role::Button);
-                    selected.write_a11y_info(&mut selected_node);
-                    let selected_state = selected_node.toggled();
-
-                    *states.lock().unwrap() =
-                        vec![ordinary_state, unselected_state, selected_state];
+                    *states.lock().unwrap() = vec![
+                        toggled_of(Button::new("ordinary").label("Ordinary")),
+                        toggled_of(Button::new("selected").label("Selected").selected(true)),
+                        toggled_of(Button::new("off").label("Off").toggled(false)),
+                        toggled_of(Button::new("on").label("On").toggled(true)),
+                    ];
                 })
             }
         }
 
         cx.update(crate::init);
-        let states = Arc::new(Mutex::new(Vec::new()));
+        let states: States = Arc::new(Mutex::new(Vec::new()));
         let captured = states.clone();
         let (_, cx) = cx.add_window_view(move |_, _| ButtonA11yProbe { states });
         cx.update(|window, cx| {
@@ -1274,11 +1266,7 @@ mod tests {
 
         assert_eq!(
             *captured.lock().unwrap(),
-            vec![
-                None,
-                Some(gpui::accesskit::Toggled::False),
-                Some(gpui::accesskit::Toggled::True),
-            ]
+            vec![None, None, Some(Toggled::False), Some(Toggled::True)]
         );
     }
 

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -191,6 +191,7 @@ pub struct Button {
     children: Vec<AnyElement>,
     disabled: bool,
     pub(crate) selected: bool,
+    selection_exposed: bool,
     variant: ButtonVariant,
     rounded: ButtonRounded,
     outline: bool,
@@ -233,6 +234,7 @@ impl Button {
             label: None,
             disabled: false,
             selected: false,
+            selection_exposed: false,
             variant: ButtonVariant::default(),
             rounded: ButtonRounded::Medium,
             border_corners: Corners {
@@ -395,6 +397,7 @@ impl Disableable for Button {
 impl Selectable for Button {
     fn selected(mut self, selected: bool) -> Self {
         self.selected = selected;
+        self.selection_exposed = true;
         self
     }
 
@@ -471,7 +474,13 @@ impl RenderOnce for Button {
             .when_some(self.label.as_ref(), |this, label| {
                 this.aria_label(label.clone())
             })
-            .aria_selected(self.selected)
+            .when(self.selection_exposed, |this| {
+                this.aria_toggled(if self.selected {
+                    gpui::accesskit::Toggled::True
+                } else {
+                    gpui::accesskit::Toggled::False
+                })
+            })
             .when(!self.disabled, |this| {
                 this.track_focus(
                     &focus_handle
@@ -1178,6 +1187,7 @@ mod tests {
         assert!(!button.loading);
         assert!(!button.disabled);
         assert!(!button.selected);
+        assert!(button.selection_exposed);
         assert_eq!(button.tab_index, 1);
         assert!(button.tab_stop);
         assert!(!button.dropdown_caret);
@@ -1189,6 +1199,7 @@ mod tests {
         // Button with click handler should be clickable
         let clickable = Button::new("test").on_click(|_, _, _| {});
         assert!(clickable.clickable());
+        assert!(!clickable.selection_exposed);
 
         // Disabled button should not be clickable
         let disabled = Button::new("test").disabled(true).on_click(|_, _, _| {});

--- a/crates/ui/src/button/button_group.rs
+++ b/crates/ui/src/button/button_group.rs
@@ -175,6 +175,10 @@ impl RenderOnce for ButtonGroup {
                     .enumerate()
                     .map(|(child_index, child)| {
                         let state = Rc::clone(&state);
+                        // The group as a whole is a toggle control, so every
+                        // child advertises its pressed state.
+                        let selected = child.selected;
+                        let child = child.toggled(selected);
                         let child = if children_len == 1 {
                             child
                         } else if child_index == 0 {

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -481,7 +481,7 @@ impl TabPanel {
                             .ghost()
                             .tab_stop(false)
                             .tooltip_with_action(tooltip, &ToggleZoom, None)
-                            .when(zoomed, |this| this.selected(true))
+                            .selected(zoomed)
                             .on_click(cx.listener(|view, _, window, cx| {
                                 view.on_action_toggle_zoom(&ToggleZoom, window, cx)
                             })),

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -500,6 +500,7 @@ impl Render for SearchPanel {
                                     .suffix(
                                         Button::new("case-insensitive")
                                             .selected(!self.case_insensitive)
+                                            .toggled(!self.case_insensitive)
                                             .xsmall()
                                             .compact()
                                             .text()
@@ -528,6 +529,7 @@ impl Render for SearchPanel {
                                 .ghost()
                                 .icon(IconName::Replace)
                                 .selected(self.replace_mode)
+                                .toggled(self.replace_mode)
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.replace_mode = !this.replace_mode;
                                     if this.replace_mode {

--- a/crates/ui/src/inspector.rs
+++ b/crates/ui/src/inspector.rs
@@ -514,6 +514,7 @@ fn render_inspector(
                             Button::new("inspect")
                                 .icon(IconName::Inspector)
                                 .selected(inspector.is_picking())
+                                .toggled(inspector.is_picking())
                                 .small()
                                 .ghost()
                                 .on_click(cx.listener(|this, _, window, _| {

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -666,6 +666,7 @@ impl Calendar {
                                 .tab_stop(false)
                                 .with_size(self.size)
                                 .selected(view_mode.is_month())
+                                .toggled(view_mode.is_month())
                                 .on_click(window.listener_for(
                                     &self.state,
                                     move |view, _, window, cx| {
@@ -686,6 +687,7 @@ impl Calendar {
                                 .tab_stop(false)
                                 .with_size(self.size)
                                 .selected(view_mode.is_year())
+                                .toggled(view_mode.is_year())
                                 .on_click(window.listener_for(
                                     &self.state,
                                     |view, _, window, cx| {


### PR DESCRIPTION
Closes #2635

### Description

Track whether the caller explicitly configured `.selected(...)`. Emit AccessKit `Toggled::False` or `Toggled::True` only in that case. Ordinary buttons retain their button role and press action without advertising toggle state.

This changes only accessibility metadata. It does not change selected styling or the public `.selected(...)` API.

### Screenshot

Not applicable. Rendering does not change.

### How to Test

Exact candidate `e4720a3b` on Rust 1.97.1:

- `cargo test -p gpui-component button --lib`: 9 passed
- `cargo test -p gpui-component`: 344 passed
- `cargo clippy -p gpui-component --all-targets -- -D warnings`
- story application compile: passed

The rendered-element regression writes the actual AccessKit node and proves ordinary `None`, explicit false `Toggled::False`, and explicit true `Toggled::True`.

### AI Assistance

The implementation and tests were AI-assisted by Friday. Chris Hynes defined the behavior and owns the final review.

### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes. The story application compiles; it has not been launched.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific). This is a cross-platform metadata change with rendered-node unit coverage, not live platform E2E coverage.
