### PR TITLE
list: Implement `InteractiveElement` for `ListItem` to support drag and drop

### DIFF
--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -2,9 +2,9 @@ use std::{rc::Rc, time::Duration};
 
 use fake::Fake;
 use gpui::{
-    App, AppContext, Context, ElementId, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, RenderOnce, ScrollStrategy, SharedString,
-    StatefulInteractiveElement, Styled, Subscription, Task, Window, actions, div,
+    App, AppContext, Context, DragMoveEvent, ElementId, Entity, FocusHandle, Focusable,
+    InteractiveElement, IntoElement, ParentElement, Render, RenderOnce, ScrollStrategy,
+    SharedString, StatefulInteractiveElement, Styled, Subscription, Task, Window, actions, div,
     prelude::FluentBuilder as _, px,
 };
 
@@ -44,6 +44,13 @@ impl Company {
     }
 }
 
+/// Where the dragged item will be inserted relative to the drop target row.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DropPosition {
+    Before,
+    After,
+}
+
 #[derive(Clone)]
 struct DragCompany {
     ix: IndexPath,
@@ -69,6 +76,7 @@ struct CompanyListItem {
     base: ListItem,
     company: Rc<Company>,
     selected: bool,
+    drop_position: Option<DropPosition>,
 }
 
 impl CompanyListItem {
@@ -77,6 +85,7 @@ impl CompanyListItem {
             company,
             base: ListItem::new(id).selected(selected),
             selected,
+            drop_position: None,
         }
     }
 
@@ -85,6 +94,8 @@ impl CompanyListItem {
     pub fn draggable(
         mut self,
         ix: IndexPath,
+        drop_position: Option<DropPosition>,
+        on_drag_move: impl Fn(&DragMoveEvent<DragCompany>, &mut Window, &mut App) + 'static,
         on_drop: impl Fn(&DragCompany, &mut Window, &mut App) + 'static,
     ) -> Self {
         let drag = DragCompany {
@@ -92,10 +103,11 @@ impl CompanyListItem {
             name: self.company.name.clone(),
         };
 
+        self.drop_position = drop_position;
         self.base = self
             .base
             .on_drag(drag, |drag, _, _, cx| cx.new(|_| drag.clone()))
-            .drag_over::<DragCompany>(|style, _, _, cx| style.bg(cx.theme().drop_target))
+            .on_drag_move(on_drag_move)
             .on_drop(on_drop);
         self
     }
@@ -138,6 +150,23 @@ impl RenderOnce for CompanyListItem {
                     .justify_between()
                     .gap_2()
                     .text_color(text_color)
+                    .when_some(
+                        self.drop_position.filter(|_| cx.has_active_drag()),
+                        |this, position| {
+                            let line = div()
+                                .absolute()
+                                .left_0()
+                                .right_0()
+                                .h(px(2.))
+                                .rounded_full()
+                                .bg(cx.theme().drag_border);
+
+                            this.child(match position {
+                                DropPosition::Before => line.top(px(-5.)),
+                                DropPosition::After => line.bottom(px(-5.)),
+                            })
+                        },
+                    )
                     .child(
                         h_flex().gap_2().child(
                             v_flex()
@@ -186,6 +215,7 @@ struct CompanyListDelegate {
     eof: bool,
     lazy_load: bool,
     draggable: bool,
+    drop_target: Option<(IndexPath, DropPosition)>,
 }
 
 impl CompanyListDelegate {
@@ -229,8 +259,31 @@ impl CompanyListDelegate {
             .cloned()
     }
 
-    /// Move the company at `from` to the position of `to`.
-    fn move_company(&mut self, from: IndexPath, to: IndexPath) {
+    /// Record the pending drop target row, returns true if it changed.
+    fn update_drop_target(&mut self, ix: IndexPath, position: Option<DropPosition>) -> bool {
+        match position {
+            Some(position) => {
+                if self.drop_target != Some((ix, position)) {
+                    self.drop_target = Some((ix, position));
+                    true
+                } else {
+                    false
+                }
+            }
+            None => {
+                if self.drop_target.is_some_and(|(target, _)| target == ix) {
+                    self.drop_target = None;
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Move the company at `from` to before or after the company at `to`.
+    fn move_company(&mut self, from: IndexPath, to: IndexPath, position: DropPosition) {
+        self.drop_target = None;
         if from == to {
             return;
         }
@@ -244,8 +297,11 @@ impl CompanyListDelegate {
             return;
         };
 
-        let mut row = to.row;
-        if from.section == to.section && from.row < to.row {
+        let mut row = match position {
+            DropPosition::Before => to.row,
+            DropPosition::After => to.row + 1,
+        };
+        if from.section == to.section && from.row < row {
             row -= 1;
         }
 
@@ -364,10 +420,39 @@ impl ListDelegate for CompanyListDelegate {
         if let Some(company) = self.matched_companies[ix.section].get(ix.row) {
             let item =
                 CompanyListItem::new(ix, company.clone(), selected).when(self.draggable, |this| {
+                    let drop_position = self
+                        .drop_target
+                        .filter(|(target, _)| *target == ix)
+                        .map(|(_, position)| position);
+
                     this.draggable(
                         ix,
+                        drop_position,
+                        cx.listener(move |this, e: &DragMoveEvent<DragCompany>, _, cx| {
+                            let bounds = e.bounds;
+                            let position =
+                                if e.drag(cx).ix != ix && bounds.contains(&e.event.position) {
+                                    if e.event.position.y < bounds.center().y {
+                                        Some(DropPosition::Before)
+                                    } else {
+                                        Some(DropPosition::After)
+                                    }
+                                } else {
+                                    None
+                                };
+
+                            if this.delegate_mut().update_drop_target(ix, position) {
+                                cx.notify();
+                            }
+                        }),
                         cx.listener(move |this, drag: &DragCompany, _, cx| {
-                            this.delegate_mut().move_company(drag.ix, ix);
+                            let position = this
+                                .delegate()
+                                .drop_target
+                                .filter(|(target, _)| *target == ix)
+                                .map(|(_, position)| position)
+                                .unwrap_or(DropPosition::Before);
+                            this.delegate_mut().move_company(drag.ix, ix, position);
                             cx.notify();
                         }),
                     )
@@ -458,6 +543,7 @@ impl ListStory {
             eof: false,
             lazy_load: false,
             draggable: false,
+            drop_target: None,
         };
         delegate.extend_more(100);
 

--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -3,8 +3,9 @@ use std::{rc::Rc, time::Duration};
 use fake::Fake;
 use gpui::{
     App, AppContext, Context, ElementId, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, RenderOnce, ScrollStrategy, SharedString, Styled,
-    Subscription, Task, Window, actions, div, px,
+    IntoElement, ParentElement, Render, RenderOnce, ScrollStrategy, SharedString,
+    StatefulInteractiveElement, Styled, Subscription, Task, Window, actions, div,
+    prelude::FluentBuilder as _, px,
 };
 
 use gpui_component::{
@@ -43,6 +44,26 @@ impl Company {
     }
 }
 
+#[derive(Clone)]
+struct DragCompany {
+    ix: IndexPath,
+    name: SharedString,
+}
+
+impl Render for DragCompany {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .px_2()
+            .py_1()
+            .text_sm()
+            .bg(cx.theme().accent)
+            .text_color(cx.theme().accent_foreground)
+            .rounded(cx.theme().radius)
+            .shadow_md()
+            .child(self.name.clone())
+    }
+}
+
 #[derive(IntoElement)]
 struct CompanyListItem {
     base: ListItem,
@@ -57,6 +78,26 @@ impl CompanyListItem {
             base: ListItem::new(id).selected(selected),
             selected,
         }
+    }
+
+    /// Make this item draggable for reordering, by using the
+    /// `InteractiveElement` methods on the inner [`ListItem`].
+    pub fn draggable(
+        mut self,
+        ix: IndexPath,
+        on_drop: impl Fn(&DragCompany, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        let drag = DragCompany {
+            ix,
+            name: self.company.name.clone(),
+        };
+
+        self.base = self
+            .base
+            .on_drag(drag, |drag, _, _, cx| cx.new(|_| drag.clone()))
+            .drag_over::<DragCompany>(|style, _, _, cx| style.bg(cx.theme().drop_target))
+            .on_drop(on_drop);
+        self
     }
 }
 
@@ -144,6 +185,7 @@ struct CompanyListDelegate {
     loading: bool,
     eof: bool,
     lazy_load: bool,
+    draggable: bool,
 }
 
 impl CompanyListDelegate {
@@ -185,6 +227,33 @@ impl CompanyListDelegate {
             .get(ix.section)
             .and_then(|c| c.get(ix.row))
             .cloned()
+    }
+
+    /// Move the company at `from` to the position of `to`.
+    fn move_company(&mut self, from: IndexPath, to: IndexPath) {
+        if from == to {
+            return;
+        }
+
+        let Some(company) = self
+            .matched_companies
+            .get_mut(from.section)
+            .filter(|companies| from.row < companies.len())
+            .map(|companies| companies.remove(from.row))
+        else {
+            return;
+        };
+
+        let mut row = to.row;
+        if from.section == to.section && from.row < to.row {
+            row -= 1;
+        }
+
+        if let Some(companies) = self.matched_companies.get_mut(to.section) {
+            let row = row.min(companies.len());
+            companies.insert(row, company);
+            self.selected_index = Some(IndexPath::new(row).section(to.section));
+        }
     }
 }
 
@@ -289,11 +358,22 @@ impl ListDelegate for CompanyListDelegate {
         &mut self,
         ix: IndexPath,
         _: &mut Window,
-        _: &mut Context<ListState<Self>>,
+        cx: &mut Context<ListState<Self>>,
     ) -> Option<Self::Item> {
         let selected = Some(ix) == self.selected_index || Some(ix) == self.confirmed_index;
         if let Some(company) = self.matched_companies[ix.section].get(ix.row) {
-            return Some(CompanyListItem::new(ix, company.clone(), selected));
+            let item =
+                CompanyListItem::new(ix, company.clone(), selected).when(self.draggable, |this| {
+                    this.draggable(
+                        ix,
+                        cx.listener(move |this, drag: &DragCompany, _, cx| {
+                            this.delegate_mut().move_company(drag.ix, ix);
+                            cx.notify();
+                        }),
+                    )
+                });
+
+            return Some(item);
         }
 
         None
@@ -377,6 +457,7 @@ impl ListStory {
             loading: false,
             eof: false,
             lazy_load: false,
+            draggable: false,
         };
         delegate.extend_more(100);
 
@@ -476,6 +557,7 @@ impl Focusable for ListStory {
 impl Render for ListStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let lazy_load = self.company_list.read(cx).delegate().lazy_load;
+        let draggable = self.company_list.read(cx).delegate().draggable;
 
         v_flex()
             .track_focus(&self.focus_handle)
@@ -586,6 +668,17 @@ impl Render for ListStory {
                             .on_click(cx.listener(|this, check: &bool, _, cx| {
                                 this.company_list.update(cx, |this, cx| {
                                     this.delegate_mut().lazy_load = *check;
+                                    cx.notify();
+                                })
+                            })),
+                    )
+                    .child(
+                        Checkbox::new("draggable")
+                            .label("Draggable")
+                            .checked(draggable)
+                            .on_click(cx.listener(|this, check: &bool, _, cx| {
+                                this.company_list.update(cx, |this, cx| {
+                                    this.delegate_mut().draggable = *check;
                                     cx.notify();
                                 })
                             })),

--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -51,6 +51,16 @@ enum DropPosition {
     After,
 }
 
+impl DropPosition {
+    /// The insertion gap index (0..=len) this position resolves to for `row`.
+    fn gap(self, row: usize) -> usize {
+        match self {
+            DropPosition::Before => row,
+            DropPosition::After => row + 1,
+        }
+    }
+}
+
 #[derive(Clone)]
 struct DragCompany {
     ix: IndexPath,
@@ -297,10 +307,7 @@ impl CompanyListDelegate {
             return;
         };
 
-        let mut row = match position {
-            DropPosition::Before => to.row,
-            DropPosition::After => to.row + 1,
-        };
+        let mut row = position.gap(to.row);
         if from.section == to.section && from.row < row {
             row -= 1;
         }
@@ -420,38 +427,65 @@ impl ListDelegate for CompanyListDelegate {
         if let Some(company) = self.matched_companies[ix.section].get(ix.row) {
             let item =
                 CompanyListItem::new(ix, company.clone(), selected).when(self.draggable, |this| {
-                    let drop_position = self
-                        .drop_target
-                        .filter(|(target, _)| *target == ix)
-                        .map(|(_, position)| position);
+                    // Normalize the pending drop target to an insertion gap, so the
+                    // indicator renders at the same edge no matter which of the two
+                    // rows around the gap the cursor is over.
+                    let count = self.matched_companies[ix.section].len();
+                    let drop_position = self.drop_target.and_then(|(target, position)| {
+                        if target.section != ix.section {
+                            return None;
+                        }
+
+                        let gap = position.gap(target.row);
+                        if gap == ix.row {
+                            Some(DropPosition::Before)
+                        } else if gap == count && ix.row + 1 == count {
+                            Some(DropPosition::After)
+                        } else {
+                            None
+                        }
+                    });
 
                     this.draggable(
                         ix,
                         drop_position,
                         cx.listener(move |this, e: &DragMoveEvent<DragCompany>, _, cx| {
                             let bounds = e.bounds;
-                            let position =
-                                if e.drag(cx).ix != ix && bounds.contains(&e.event.position) {
-                                    if e.event.position.y < bounds.center().y {
-                                        Some(DropPosition::Before)
-                                    } else {
-                                        Some(DropPosition::After)
-                                    }
+                            let from = e.drag(cx).ix;
+                            let position = if bounds.contains(&e.event.position) {
+                                let position = if e.event.position.y < bounds.center().y {
+                                    DropPosition::Before
                                 } else {
-                                    None
+                                    DropPosition::After
                                 };
+
+                                // Gaps adjacent to the dragged row are no-op moves.
+                                let gap = position.gap(ix.row);
+                                if from.section == ix.section
+                                    && (gap == from.row || gap == from.row + 1)
+                                {
+                                    None
+                                } else {
+                                    Some(position)
+                                }
+                            } else {
+                                None
+                            };
 
                             if this.delegate_mut().update_drop_target(ix, position) {
                                 cx.notify();
                             }
                         }),
                         cx.listener(move |this, drag: &DragCompany, _, cx| {
-                            let position = this
+                            let Some(position) = this
                                 .delegate()
                                 .drop_target
                                 .filter(|(target, _)| *target == ix)
                                 .map(|(_, position)| position)
-                                .unwrap_or(DropPosition::Before);
+                            else {
+                                return;
+                            };
+
                             this.delegate_mut().move_company(drag.ix, ix, position);
                             cx.notify();
                         }),

--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -105,6 +105,7 @@ impl CompanyListItem {
         mut self,
         ix: IndexPath,
         drop_position: Option<DropPosition>,
+        on_drag_start: impl Fn(&mut App) + 'static,
         on_drag_move: impl Fn(&DragMoveEvent<DragCompany>, &mut Window, &mut App) + 'static,
         on_drop: impl Fn(&DragCompany, &mut Window, &mut App) + 'static,
     ) -> Self {
@@ -116,7 +117,10 @@ impl CompanyListItem {
         self.drop_position = drop_position;
         self.base = self
             .base
-            .on_drag(drag, |drag, _, _, cx| cx.new(|_| drag.clone()))
+            .on_drag(drag, move |drag, _, _, cx| {
+                on_drag_start(cx);
+                cx.new(|_| drag.clone())
+            })
             .on_drag_move(on_drag_move)
             .on_drop(on_drop);
         self
@@ -446,9 +450,19 @@ impl ListDelegate for CompanyListDelegate {
                         }
                     });
 
+                    let state = cx.entity().downgrade();
                     this.draggable(
                         ix,
                         drop_position,
+                        // A drag may end without a drop (e.g. released outside the
+                        // list), clear the stale drop target when a new one starts.
+                        move |cx| {
+                            _ = state.update(cx, |this, cx| {
+                                if this.delegate_mut().drop_target.take().is_some() {
+                                    cx.notify();
+                                }
+                            });
+                        },
                         cx.listener(move |this, e: &DragMoveEvent<DragCompany>, _, cx| {
                             let bounds = e.bounds;
                             let from = e.drag(cx).ix;

--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -169,7 +169,7 @@ impl RenderOnce for CompanyListItem {
                                 .right_0()
                                 .h(px(2.))
                                 .rounded_full()
-                                .bg(cx.theme().drag_border);
+                                .bg(cx.theme().blue);
 
                             this.child(match position {
                                 DropPosition::Before => line.top(px(-5.)),

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -161,6 +161,9 @@ impl ParentElement for ListItem {
     }
 }
 
+/// Note: Listeners registered via these traits are not gated by
+/// `disabled`/`separator`. The hover style is managed internally, use
+/// `on_hover` instead of `.hover()`.
 impl InteractiveElement for ListItem {
     fn interactivity(&mut self) -> &mut Interactivity {
         self.base.interactivity()
@@ -274,7 +277,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn interactivity_delegates_to_base(_cx: &mut gpui::TestAppContext) {
+    fn test_list_item_interactivity(_cx: &mut gpui::TestAppContext) {
         let mut item = ListItem::new("item")
             .on_drag(DragPreview, |_, _, _, cx| cx.new(|_| DragPreview))
             .drag_over::<DragPreview>(|style, _, _, _| style)

--- a/crates/ui/src/list/list_item.rs
+++ b/crates/ui/src/list/list_item.rs
@@ -1,9 +1,8 @@
 use crate::{ActiveTheme, Disableable, Icon, Selectable, Sizable as _, StyledExt, h_flex};
 use gpui::{
-    AnyElement, App, ClickEvent, Div, ElementId, InteractiveElement, IntoElement, MouseButton,
-    MouseDownEvent, MouseMoveEvent, ParentElement, RenderOnce, Stateful,
-    StatefulInteractiveElement as _, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder as _,
+    AnyElement, App, ClickEvent, Div, ElementId, InteractiveElement, Interactivity, IntoElement,
+    MouseButton, MouseDownEvent, MouseMoveEvent, ParentElement, RenderOnce, Stateful,
+    StatefulInteractiveElement, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _,
 };
 use smallvec::SmallVec;
 use std::collections::HashMap;
@@ -162,6 +161,14 @@ impl ParentElement for ListItem {
     }
 }
 
+impl InteractiveElement for ListItem {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl StatefulInteractiveElement for ListItem {}
+
 impl RenderOnce for ListItem {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let is_active = self.confirmed || self.selected || self.secondary_selected;
@@ -250,5 +257,30 @@ impl RenderOnce for ListItem {
                     this
                 }
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{AppContext as _, Context, Render};
+
+    struct DragPreview;
+
+    impl Render for DragPreview {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+        }
+    }
+
+    #[gpui::test]
+    fn interactivity_delegates_to_base(_cx: &mut gpui::TestAppContext) {
+        let mut item = ListItem::new("item")
+            .on_drag(DragPreview, |_, _, _, cx| cx.new(|_| DragPreview))
+            .drag_over::<DragPreview>(|style, _, _, _| style)
+            .on_drop(|_: &DragPreview, _, _| {})
+            .on_hover(|_, _, _| {});
+
+        assert_eq!(item.interactivity().element_id, Some("item".into()));
     }
 }

--- a/docs/docs/components/list.md
+++ b/docs/docs/components/list.md
@@ -303,6 +303,45 @@ ListSeparatorItem::new()
     )
 ```
 
+### Drag and Drop Reordering
+
+`ListItem` implements GPUI's `InteractiveElement` and `StatefulInteractiveElement`
+traits, so all native interaction APIs such as `on_drag`, `on_drop`, `drag_over`
+and `on_hover` are directly available:
+
+```rust
+#[derive(Clone)]
+struct DragItem {
+    ix: IndexPath,
+    name: SharedString,
+}
+
+impl Render for DragItem {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // The preview element that follows the cursor while dragging.
+        div()
+            .px_2()
+            .py_1()
+            .bg(cx.theme().accent)
+            .text_color(cx.theme().accent_foreground)
+            .rounded(cx.theme().radius)
+            .child(self.name.clone())
+    }
+}
+
+// In `render_item` of your `ListDelegate`:
+ListItem::new(ix)
+    .child(Label::new(item.name.clone()))
+    .on_drag(DragItem { ix, name: item.name.clone() }, |drag, _, _, cx| {
+        cx.new(|_| drag.clone())
+    })
+    .drag_over::<DragItem>(|style, _, _, cx| style.bg(cx.theme().drop_target))
+    .on_drop(cx.listener(move |this, drag: &DragItem, _, cx| {
+        this.delegate_mut().move_item(drag.ix, ix);
+        cx.notify();
+    }))
+```
+
 ### Custom Empty State
 
 ```rust

--- a/docs/zh-CN/docs/components/list.md
+++ b/docs/zh-CN/docs/components/list.md
@@ -249,6 +249,44 @@ let _subscription = cx.subscribe(&state, |_, _, event: &ListEvent, _| {
 });
 ```
 
+### 拖拽重排
+
+`ListItem` 实现了 GPUI 的 `InteractiveElement` 和 `StatefulInteractiveElement` trait，
+因此 `on_drag`、`on_drop`、`drag_over`、`on_hover` 等原生交互 API 均可直接使用：
+
+```rust
+#[derive(Clone)]
+struct DragItem {
+    ix: IndexPath,
+    name: SharedString,
+}
+
+impl Render for DragItem {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // 拖拽时跟随光标的预览元素。
+        div()
+            .px_2()
+            .py_1()
+            .bg(cx.theme().accent)
+            .text_color(cx.theme().accent_foreground)
+            .rounded(cx.theme().radius)
+            .child(self.name.clone())
+    }
+}
+
+// 在 `ListDelegate` 的 `render_item` 中：
+ListItem::new(ix)
+    .child(Label::new(item.name.clone()))
+    .on_drag(DragItem { ix, name: item.name.clone() }, |drag, _, _, cx| {
+        cx.new(|_| drag.clone())
+    })
+    .drag_over::<DragItem>(|style, _, _, cx| style.bg(cx.theme().drop_target))
+    .on_drop(cx.listener(move |this, drag: &DragItem, _, cx| {
+        this.delegate_mut().move_item(drag.ix, ix);
+        cx.notify();
+    }))
+```
+
 ### 自定义空状态
 
 ```rust


### PR DESCRIPTION
## Description

Implement `InteractiveElement` and `StatefulInteractiveElement` for `ListItem` by delegating to the inner `Stateful<Div>`, the same pattern used by `Button`, `Checkbox`, `Radio`, and `Tab`.

- All GPUI native interaction APIs (`on_drag`, `on_drop`, `drag_over`, `can_drop`, `on_hover`, `tooltip`, ...) become directly available on `ListItem`, so rows can act as drag sources and drop targets inside `Tree` or any custom list.
- Inherent `on_click` / `on_mouse_down` / `on_mouse_enter` keep their precedence and disabled/separator gating, so existing consumers are unaffected.
- Add a "Draggable" toggle to the List story that demonstrates real reordering on drop.
- Document drag-and-drop usage in the List docs (en and zh-CN).

This supersedes #2553. Exposing the interactive traits gives the full native API surface with unchanged semantics, instead of forwarding `on_drag` / `on_drop` / `on_drag_hover` one method at a time (`on_drag_hover` there is actually plain `on_hover`, which also fires outside of drags).

## How to Test

- `cargo test -p gpui-component --lib list_item` — 3 passed
- `cargo clippy -- --deny warnings`
- `cargo run -- List`, check "Draggable", then drag a row onto another row: a preview follows the cursor, an indicator line on the target row's top or bottom edge shows the insertion position, and dropping reorders the list. Click selection still works.
