### PR TITLE
title_bar: Only draw the window controls the WM supports

### DIFF
--- a/crates/ui/src/title_bar.rs
+++ b/crates/ui/src/title_bar.rs
@@ -211,16 +211,25 @@ impl RenderOnce for WindowControls {
             return div().id("window-controls");
         }
 
+        // The window manager declares which controls it can honor; a tiling
+        // compositor may support neither minimize nor maximize. Close is
+        // always ours to offer.
+        let supported = window.window_controls();
+
         h_flex()
             .id("window-controls")
             .items_center()
             .flex_shrink_0()
             .h_full()
-            .child(ControlIcon::minimize())
-            .child(if window.is_maximized() {
-                ControlIcon::restore()
-            } else {
-                ControlIcon::maximize()
+            .when(supported.minimize, |this| {
+                this.child(ControlIcon::minimize())
+            })
+            .when(supported.maximize, |this| {
+                this.child(if window.is_maximized() {
+                    ControlIcon::restore()
+                } else {
+                    ControlIcon::maximize()
+                })
             })
             .child(ControlIcon::close(self.on_close_window))
     }


### PR DESCRIPTION
`WindowControls` draws minimize and maximize on every non-macOS platform, whether or not the window manager can honor them. On niri — a scrollable-tiling Wayland compositor that advertises maximize but not minimize — that leaves a minimize button that does nothing, and an app using `TitleBar` has no way to opt out.

GPUI already knows the answer: it parses xdg-shell's `wm_capabilities` into `Window::window_controls()`. Zed's own title bar filters its buttons on exactly that (`crates/platform_title_bar/src/platforms/platform_linux.rs`). This does the same, and keeps close unconditional.

## Effect

- **Wayland** — the buttons follow what the compositor advertises.
- **X11, Windows, macOS** — unchanged: `WindowControls::default()` is all-true, and macOS still returns early.

No API change.

## Testing

Built and run on NixOS under niri, in an app using `TitleBar`:

- close — shown, works
- maximize — shown, works, including restore
- minimize — no longer drawn (niri does not advertise it)

Also built and run on macOS, where the path is unchanged, and `cargo test -p gpui-component` passes (348 tests).

## AI assistance

Per CONTRIBUTING: this patch was proposed and written by Claude (Anthropic), which found `window_controls()` and the Zed precedent while we were building a desktop app on this kit. Reviewed and tested by me.
