### PR TITLE
switch: Add AccessKit role, toggle state, and label

### DIFF
--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -4,8 +4,9 @@ use crate::{
 };
 use gpui::{
     Animation, AnimationExt as _, App, Background, ElementId, Hsla, InteractiveElement,
-    IntoElement, ParentElement as _, RenderOnce, SharedString, StyleRefinement, Styled, Window,
-    div, prelude::FluentBuilder as _, px,
+    IntoElement, ParentElement as _, RenderOnce, Role, SharedString,
+    StatefulInteractiveElement as _, StyleRefinement, Styled, Toggled, Window, div,
+    prelude::FluentBuilder as _, px,
 };
 use std::{rc::Rc, time::Duration};
 
@@ -142,6 +143,16 @@ impl RenderOnce for Switch {
         div().refine_style(&self.style).child(
             h_flex()
                 .id(self.id.clone())
+                .role(Role::Switch)
+                .aria_toggled(if checked {
+                    Toggled::True
+                } else {
+                    Toggled::False
+                })
+                .when_some(
+                    self.label.as_ref().map(|l| l.get_text(cx)),
+                    |this, label| this.aria_label(label),
+                )
                 .gap_2()
                 .items_start()
                 .when(self.label_side.is_left(), |this| this.flex_row_reverse())


### PR DESCRIPTION
## Description

`Switch` rendered no accessibility annotations at all, so assistive technology could not perceive it.

This annotates the interactive element with `Role::Switch` (`accesskit_macos` maps it to the checkbox role with the switch subrole), `aria_toggled`, and the label text.

## How to Test

Use accessibility tools on a `Switch` element.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] ~Passed `cargo run` for story tests related to the changes.~ **Not needed.**
- [ ] ~Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)~ **Only tested on macOS.**
