### PR TITLE
input: Add aria_label to set the accessible name

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -429,11 +429,24 @@ impl RenderOnce for Input {
             && state.mode.is_single_line();
         let has_suffix = suffix.is_some() || state.loading || self.mask_toggle || show_clear_button;
 
+        let placeholder = Some(state.placeholder.clone()).filter(|p| !p.is_empty());
+
+        // Don't use a mask-derived placeholder ("(___)___-___") as an aria_label fallback.
+        let placeholder_is_mask =
+            state.mask_pattern.placeholder().as_deref() == placeholder.as_deref();
+
+        let aria_label = match self.aria_label {
+            Some(label) => Some(label),
+            None if placeholder_is_mask => None,
+            None => placeholder.clone(),
+        };
+
         div()
             .id(("input", self.state.entity_id()))
             .role(accessibility_role)
-            .when_some(self.aria_label.clone(), |this, label| {
-                this.aria_label(label)
+            .when_some(aria_label, |this, label| this.aria_label(label))
+            .when_some(placeholder, |this, placeholder| {
+                this.aria_placeholder(placeholder)
             })
             .when_some(accessibility_value, |this, value| this.aria_value(value))
             .flex()

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -4,8 +4,8 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AccessibleAction, AnyElement, App, DefiniteLength, Edges, EdgesRefinement, Entity, Hsla,
     InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent, ParentElement as _, Rems,
-    RenderOnce, Role, StatefulInteractiveElement as _, StyleRefinement, Styled, TextAlign, Window,
-    div, px, relative,
+    RenderOnce, Role, SharedString, StatefulInteractiveElement as _, StyleRefinement, Styled,
+    TextAlign, Window, div, px, relative,
 };
 
 use crate::button::{Button, ButtonVariants as _};
@@ -52,6 +52,7 @@ pub struct Input {
     selected: bool,
     content_type: Option<InputContentType>,
     role: Option<Role>,
+    aria_label: Option<SharedString>,
 
     /// An optional context menu builder to allow a custom context menu on the input.
     ///
@@ -97,8 +98,14 @@ impl Input {
             selected: false,
             content_type: None,
             role: None,
+            aria_label: None,
             context_menu_builder: None,
         }
+    }
+
+    pub fn aria_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.aria_label = Some(label.into());
+        self
     }
 
     pub fn prefix(mut self, prefix: impl IntoElement) -> Self {
@@ -425,6 +432,9 @@ impl RenderOnce for Input {
         div()
             .id(("input", self.state.entity_id()))
             .role(accessibility_role)
+            .when_some(self.aria_label.clone(), |this, label| {
+                this.aria_label(label)
+            })
             .when_some(accessibility_value, |this, value| this.aria_value(value))
             .flex()
             .key_context(crate::input::CONTEXT)


### PR DESCRIPTION
## Description

`Input` emitted a role-bearing AccessKit node with no way to name it, so assistive technology announced every input as an unnamed text field.

## How to Test

Use a screen reader to announce an `Input` element.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] ~Passed `cargo run` for story tests related to the changes.~ **Not needed.**
- [ ] ~Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)~ **Only tested on macOS.**
