### PR TITLE
button, checkbox: Add RoleOverride; and ability to specify Presentational

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use crate::{
-    ActiveTheme, Colorize as _, Disableable, FocusableExt as _, Icon, Selectable, Sizable, Size,
-    StyleSized, StyledExt,
+    ActiveTheme, Colorize as _, Disableable, FocusableExt as _, Icon, RoleOverride, Selectable,
+    Sizable, Size, StyleSized, StyledExt,
     button::ButtonIcon,
     h_flex,
     select::Caret,
@@ -192,6 +192,7 @@ pub struct Button {
     disabled: bool,
     pub(crate) selected: bool,
     toggled: Option<bool>,
+    role: RoleOverride,
     variant: ButtonVariant,
     rounded: ButtonRounded,
     outline: bool,
@@ -235,6 +236,7 @@ impl Button {
             disabled: false,
             selected: false,
             toggled: None,
+            role: RoleOverride::default(),
             variant: ButtonVariant::default(),
             rounded: ButtonRounded::Medium,
             border_corners: Corners {
@@ -258,6 +260,15 @@ impl Button {
             tab_index: 0,
             tab_stop: true,
         }
+    }
+
+    /// Override the accessible role for the button, or pass
+    /// [`RoleOverride::Presentational`] to make it presentational.
+    ///
+    /// If unset, the role is `Button`, or `Link` for link-variant buttons.
+    pub fn role(mut self, role: impl Into<RoleOverride>) -> Self {
+        self.role = role.into();
+        self
     }
 
     /// Set the outline style of the Button.
@@ -490,12 +501,15 @@ impl RenderOnce for Button {
             ButtonRounded::None => Pixels::ZERO,
         };
 
-        self.base
-            .role(if self.variant.is_link() {
+        let role = self.role.resolve(|| {
+            if self.variant.is_link() {
                 Role::Link
             } else {
                 Role::Button
-            })
+            }
+        });
+        self.base
+            .when_some(role, |this, role| this.role(role))
             .when_some(self.label.as_ref(), |this, label| {
                 this.aria_label(label.clone())
             })

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,8 +1,8 @@
 use std::{rc::Rc, time::Duration};
 
 use crate::{
-    ActiveTheme, Disableable, FocusableExt, IconName, Selectable, Sizable, Size, StyledExt as _,
-    icon::IconNamed, text::Text, tooltip::ComponentTooltip, v_flex,
+    ActiveTheme, Disableable, FocusableExt, IconName, RoleOverride, Selectable, Sizable, Size,
+    StyledExt as _, icon::IconNamed, text::Text, tooltip::ComponentTooltip, v_flex,
 };
 use gpui::{
     Animation, AnimationExt, AnyElement, App, Div, ElementId, InteractiveElement, IntoElement,
@@ -25,6 +25,7 @@ pub struct Checkbox {
     tab_index: isize,
     on_click: Option<Rc<dyn Fn(&bool, &mut Window, &mut App) + 'static>>,
     tooltip: ComponentTooltip,
+    role: RoleOverride,
 }
 
 impl Checkbox {
@@ -43,7 +44,17 @@ impl Checkbox {
             tab_stop: true,
             tab_index: 0,
             tooltip: ComponentTooltip::default(),
+            role: RoleOverride::default(),
         }
+    }
+
+    /// Override the accessible role for the checkbox, or pass
+    /// [`RoleOverride::Presentational`] to make it presentational.
+    ///
+    /// If unset, the role is `CheckBox`.
+    pub fn role(mut self, role: impl Into<RoleOverride>) -> Self {
+        self.role = role.into();
+        self
     }
 
     /// Set tooltip text for the checkbox.
@@ -219,9 +230,10 @@ impl RenderOnce for Checkbox {
         };
         let radius = cx.theme().radius.min(px(4.));
 
+        let role = self.role.resolve(|| Role::CheckBox);
         self.base
             .id(self.id.clone())
-            .role(Role::CheckBox)
+            .when_some(role, |this, role| this.role(role))
             .aria_toggled(if checked {
                 Toggled::True
             } else {

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -14,7 +14,7 @@ use crate::native_menu::NativeMenu;
 use crate::spinner::Spinner;
 use crate::{ActiveTheme, Colorize, v_flex};
 use crate::{IconName, Size};
-use crate::{Selectable, StyledExt, h_flex};
+use crate::{RoleOverride, Selectable, StyledExt, h_flex};
 use crate::{Sizable, StyleSized};
 
 use super::{
@@ -51,7 +51,7 @@ pub struct Input {
     tab_index: isize,
     selected: bool,
     content_type: Option<InputContentType>,
-    role: Option<Role>,
+    role: RoleOverride,
     accessibility_id: Option<SharedString>,
     aria_label: Option<SharedString>,
 
@@ -98,7 +98,7 @@ impl Input {
             tab_index: 0,
             selected: false,
             content_type: None,
-            role: None,
+            role: RoleOverride::default(),
             accessibility_id: None,
             aria_label: None,
             context_menu_builder: None,
@@ -177,11 +177,12 @@ impl Input {
         self
     }
 
-    /// Override the accessible role for the input.
+    /// Override the accessible role for the input, or pass
+    /// [`RoleOverride::Presentational`] to make it presentational.
     ///
     /// If unset, the role is inferred from multi-line mode and content type.
-    pub fn role(mut self, role: Role) -> Self {
-        self.role = Some(role);
+    pub fn role(mut self, role: impl Into<RoleOverride>) -> Self {
+        self.role = role.into();
         self
     }
 
@@ -243,65 +244,65 @@ impl Input {
     fn accessibility_role(
         is_multi_line: bool,
         content_type: Option<InputContentType>,
-        role: Option<Role>,
-    ) -> Role {
-        if let Some(role) = role {
-            return role;
-        }
+        role: RoleOverride,
+    ) -> Option<Role> {
+        role.resolve(|| {
+            if is_multi_line {
+                return Role::MultilineTextInput;
+            }
 
-        if is_multi_line {
-            return Role::MultilineTextInput;
-        }
-
-        match content_type {
-            None => Role::TextInput,
-            Some(InputContentType::TelephoneNumber) => Role::PhoneNumberInput,
-            Some(InputContentType::EmailAddress) => Role::EmailInput,
-            Some(InputContentType::Url) => Role::UrlInput,
-            Some(InputContentType::Password | InputContentType::NewPassword) => Role::PasswordInput,
-            Some(InputContentType::DateTime) => Role::DateTimeInput,
-            Some(InputContentType::Birthdate) => Role::DateInput,
-            Some(
-                InputContentType::Name
-                | InputContentType::NamePrefix
-                | InputContentType::GivenName
-                | InputContentType::MiddleName
-                | InputContentType::FamilyName
-                | InputContentType::NameSuffix
-                | InputContentType::Nickname
-                | InputContentType::JobTitle
-                | InputContentType::OrganizationName
-                | InputContentType::Location
-                | InputContentType::FullStreetAddress
-                | InputContentType::StreetAddressLine1
-                | InputContentType::StreetAddressLine2
-                | InputContentType::AddressCity
-                | InputContentType::AddressState
-                | InputContentType::AddressCityAndState
-                | InputContentType::Sublocality
-                | InputContentType::CountryName
-                | InputContentType::PostalCode
-                | InputContentType::CreditCardNumber
-                | InputContentType::CreditCardName
-                | InputContentType::CreditCardGivenName
-                | InputContentType::CreditCardMiddleName
-                | InputContentType::CreditCardFamilyName
-                | InputContentType::CreditCardSecurityCode
-                | InputContentType::CreditCardExpiration
-                | InputContentType::CreditCardExpirationMonth
-                | InputContentType::CreditCardExpirationYear
-                | InputContentType::CreditCardType
-                | InputContentType::Username
-                | InputContentType::OneTimeCode
-                | InputContentType::ShipmentTrackingNumber
-                | InputContentType::FlightNumber
-                | InputContentType::BirthdateDay
-                | InputContentType::BirthdateMonth
-                | InputContentType::BirthdateYear
-                | InputContentType::CellularEid
-                | InputContentType::CellularImei,
-            ) => Role::TextInput,
-        }
+            match content_type {
+                None => Role::TextInput,
+                Some(InputContentType::TelephoneNumber) => Role::PhoneNumberInput,
+                Some(InputContentType::EmailAddress) => Role::EmailInput,
+                Some(InputContentType::Url) => Role::UrlInput,
+                Some(InputContentType::Password | InputContentType::NewPassword) => {
+                    Role::PasswordInput
+                }
+                Some(InputContentType::DateTime) => Role::DateTimeInput,
+                Some(InputContentType::Birthdate) => Role::DateInput,
+                Some(
+                    InputContentType::Name
+                    | InputContentType::NamePrefix
+                    | InputContentType::GivenName
+                    | InputContentType::MiddleName
+                    | InputContentType::FamilyName
+                    | InputContentType::NameSuffix
+                    | InputContentType::Nickname
+                    | InputContentType::JobTitle
+                    | InputContentType::OrganizationName
+                    | InputContentType::Location
+                    | InputContentType::FullStreetAddress
+                    | InputContentType::StreetAddressLine1
+                    | InputContentType::StreetAddressLine2
+                    | InputContentType::AddressCity
+                    | InputContentType::AddressState
+                    | InputContentType::AddressCityAndState
+                    | InputContentType::Sublocality
+                    | InputContentType::CountryName
+                    | InputContentType::PostalCode
+                    | InputContentType::CreditCardNumber
+                    | InputContentType::CreditCardName
+                    | InputContentType::CreditCardGivenName
+                    | InputContentType::CreditCardMiddleName
+                    | InputContentType::CreditCardFamilyName
+                    | InputContentType::CreditCardSecurityCode
+                    | InputContentType::CreditCardExpiration
+                    | InputContentType::CreditCardExpirationMonth
+                    | InputContentType::CreditCardExpirationYear
+                    | InputContentType::CreditCardType
+                    | InputContentType::Username
+                    | InputContentType::OneTimeCode
+                    | InputContentType::ShipmentTrackingNumber
+                    | InputContentType::FlightNumber
+                    | InputContentType::BirthdateDay
+                    | InputContentType::BirthdateMonth
+                    | InputContentType::BirthdateYear
+                    | InputContentType::CellularEid
+                    | InputContentType::CellularImei,
+                ) => Role::TextInput,
+            }
+        })
     }
 
     fn exposes_accessibility_value(masked: bool, content_type: Option<InputContentType>) -> bool {
@@ -451,7 +452,7 @@ impl RenderOnce for Input {
 
         div()
             .id(("input", self.state.entity_id()))
-            .role(accessibility_role)
+            .when_some(accessibility_role, |this, role| this.role(role))
             .when_some(self.accessibility_id, |this, id| this.accessibility_id(id))
             .when_some(aria_label, |this, label| this.aria_label(label))
             .when_some(placeholder, |this, placeholder| {
@@ -694,15 +695,22 @@ mod tests {
         ];
 
         for (content_type, role) in cases {
-            assert_eq!(Input::accessibility_role(false, content_type, None), role);
+            assert_eq!(
+                Input::accessibility_role(false, content_type, RoleOverride::Implicit),
+                Some(role)
+            );
         }
     }
 
     #[test]
     fn multiline_inputs_keep_multiline_accessibility_role() {
         assert_eq!(
-            Input::accessibility_role(true, Some(InputContentType::Password), None),
-            Role::MultilineTextInput
+            Input::accessibility_role(
+                true,
+                Some(InputContentType::Password),
+                RoleOverride::Implicit
+            ),
+            Some(Role::MultilineTextInput)
         );
     }
 
@@ -712,18 +720,43 @@ mod tests {
             Input::accessibility_role(
                 false,
                 Some(InputContentType::Password),
-                Some(Role::TextInput)
+                Role::TextInput.into()
             ),
-            Role::TextInput
+            Some(Role::TextInput)
         );
         assert_eq!(
             Input::accessibility_role(
                 true,
                 Some(InputContentType::Password),
-                Some(Role::TextInput)
+                Role::TextInput.into()
             ),
-            Role::TextInput
+            Some(Role::TextInput)
         );
+    }
+
+    #[test]
+    fn presentational_role_emits_no_accessibility_node() {
+        assert_eq!(
+            Input::accessibility_role(
+                false,
+                Some(InputContentType::Password),
+                RoleOverride::Presentational
+            ),
+            None
+        );
+        assert_eq!(
+            Input::accessibility_role(true, None, RoleOverride::Presentational),
+            None
+        );
+    }
+
+    #[test]
+    fn role_option_converts_to_the_matching_override() {
+        assert_eq!(
+            RoleOverride::from(Some(Role::Button)),
+            RoleOverride::Role(Role::Button)
+        );
+        assert_eq!(RoleOverride::from(None), RoleOverride::Presentational);
     }
 
     #[gpui::test]

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -1,7 +1,7 @@
 use crate::ActiveTheme;
 use gpui::{
     App, BoxShadow, Corners, DefiniteLength, Div, Edges, FocusHandle, Hsla, ParentElement, Pixels,
-    Refineable, StyleRefinement, Styled, Window, div, point, px,
+    Refineable, Role, StyleRefinement, Styled, Window, div, point, px,
 };
 use serde::{Deserialize, Serialize};
 
@@ -363,6 +363,53 @@ impl Size {
 impl From<Pixels> for Size {
     fn from(size: Pixels) -> Self {
         Size::Size(size)
+    }
+}
+
+/// The accessible role a component instance reports to assistive technology.
+///
+/// Components infer a role from their own state by default; this overrides that
+/// inference, including suppressing the node entirely so an ancestor can carry
+/// the role instead.
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub enum RoleOverride {
+    /// Use the role the component infers for itself.
+    #[default]
+    Implicit,
+
+    /// Emit no accessibility node, so an ancestor can carry the role.
+    ///
+    /// The analog of the HTML `role="presentation"` or `role="none"`.
+    Presentational,
+
+    /// Use this role instead of the inferred one.
+    Role(Role),
+}
+
+impl RoleOverride {
+    /// Resolve to the role to report, given the role the component infers for
+    /// itself. Returns `None` when no accessibility node should be emitted.
+    pub fn resolve(self, default: impl FnOnce() -> Role) -> Option<Role> {
+        match self {
+            Self::Implicit => Some(default()),
+            Self::Presentational => None,
+            Self::Role(role) => Some(role),
+        }
+    }
+}
+
+impl From<Role> for RoleOverride {
+    fn from(role: Role) -> Self {
+        Self::Role(role)
+    }
+}
+
+impl From<Option<Role>> for RoleOverride {
+    fn from(role: Option<Role>) -> Self {
+        match role {
+            Some(role) => Self::Role(role),
+            None => Self::Presentational,
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This extends `Input`'s existing `role` override to `Button` and `Checkbox`, and lets all three take `RoleOverride::Presentational` — the HTML `role="presentation"` or `role="none"` analog where the component instance emits no `AccessKit`/etc node of its own.

This solves uses that annotate a wrapping element as the accessible control (a labelled row with an embedded remove button, a labelled field wrapping an input) which otherwise present two nodes per control to assistive technology.

## How to Test

Override a role and navigate with a screen reader or similar assistive technology.

## Break Changes

This should not break any existing uses, as `role: impl Into<Option<Role>>` will still accept any concrete `Role` passed to an existing `Input`'s `.role(r)`. It's unlikely but theoretically possible that `.role(x.into())` has been used by some consuming app, which would become ambiguous.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] ~Passed `cargo run` for story tests related to the changes.~ **Not needed.**
- [ ] ~Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)~ **Only tested on macOS.**
