### PR TITLE
text_view: Make the scroll table layout responsive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4629,6 +4629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown_table"
+version = "0.5.1"
+dependencies = [
+ "gpui",
+ "gpui-component",
+ "gpui-component-assets",
+ "gpui_platform",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "examples/text_selection",
     "examples/root_borderless",
     "examples/table_in_scrollable",
+    "examples/markdown_table",
 ]
 resolver = "2"
 

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -9,7 +9,7 @@ use gpui::{
     AnyElement, App, DefiniteLength, Div, ElementId, FontStyle, FontWeight, Half, HighlightStyle,
     Hsla, InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow, ParentElement,
     ScrollHandle, SharedString, SharedUri, StatefulInteractiveElement, Styled, StyledImage as _,
-    Window, div, img, prelude::FluentBuilder as _, px, relative, rems,
+    WhiteSpace, Window, div, img, prelude::FluentBuilder as _, px, relative, rems,
 };
 use markdown::mdast;
 use ropey::Rope;
@@ -1463,8 +1463,18 @@ impl BlockNode {
     /// Column widths come from the **measured** shaped text of each cell (the
     /// widest per column across all rows), so columns line up and fit their
     /// content exactly — char-count heuristics are inaccurate on proportional
-    /// fonts. A narrow table stretches to fill the frame (cells `flex_grow`
-    /// proportionally); a wide table keeps its content widths and scrolls.
+    /// fonts. The layout adapts to the frame like CSS auto table layout:
+    ///
+    /// - Wider than the content: cells `flex_grow` proportionally to fill.
+    /// - Narrower: columns shrink and their text wraps, but not below a
+    ///   per-column floor.
+    /// - Narrower than the floors: the table keeps the floor widths and
+    ///   scrolls horizontally, so no content ever becomes unreachable.
+    ///
+    /// `white_space: nowrap` on `style.table_cell` composes like in CSS: the
+    /// refinement keeps cell text on a single line, and the floors are raised
+    /// to the full content widths so the single-line columns never shrink —
+    /// the table scrolls as soon as the content is wider than the frame.
     fn render_scroll_table(
         table: &Table,
         col_count: usize,
@@ -1475,9 +1485,20 @@ impl BlockNode {
     ) -> AnyElement {
         const CELL_PAD_PX: f32 = 16.0; // px_2 horizontal padding
         const CELL_MIN_PX: f32 = 48.0;
-        const CELL_MAX_PX: f32 = 480.0;
+        // Shrinking columns stop (and the table starts to scroll) at a floor
+        // scaled to their content: roughly the width at which the text wraps
+        // to `CELL_WRAP_MAX_LINES` lines, clamped between the two bounds so
+        // moderate columns can still wrap meaningfully while one huge column
+        // cannot push the scroll threshold arbitrarily high.
+        const CELL_WRAP_MAX_LINES: f32 = 2.0;
+        const CELL_WRAP_MIN_PX: f32 = 160.0;
+        const CELL_WRAP_MAX_PX: f32 = 480.0;
+        const CELL_BORDER_PX: f32 = 1.0; // border_r_1 drawn by every column but the last
+        const TABLE_BORDER_PX: f32 = 2.0; // the track's border_1, left + right
 
-        // Measure the widest text per column.
+        // Measure the widest text per column (max-content width). Never
+        // capped: a cap would clip overflowing text *and* leave it outside
+        // the scrollable width, making it unreachable.
         let text_style = window.text_style();
         let font_size = text_style.font_size.to_pixels(window.rem_size());
         let mut col_w = vec![CELL_MIN_PX; col_count];
@@ -1499,12 +1520,35 @@ impl BlockNode {
                         .width;
                     w = w.max(f32::from(line_w));
                 }
-                *slot = slot.max((w + CELL_PAD_PX).min(CELL_MAX_PX));
+                // Border-box widths, so the padding and border the cell draws
+                // must leave the measured text its full width.
+                let border = if ix + 1 < col_count {
+                    CELL_BORDER_PX
+                } else {
+                    0.
+                };
+                *slot = slot.max(w + CELL_PAD_PX + border);
             }
         }
-        let total_w: f32 = col_w.iter().sum();
-
         let style = &node_cx.style;
+        // Nowrap cells (via the `table_cell` refinement, which cascades to
+        // the cell text) must never shrink below their single-line content,
+        // so their floor is the content width itself.
+        let nowrap = style.table_cell.text.white_space == Some(WhiteSpace::Nowrap);
+        let col_min_w: Vec<f32> = if nowrap {
+            col_w.clone()
+        } else {
+            col_w
+                .iter()
+                .map(|w| {
+                    (w / CELL_WRAP_MAX_LINES)
+                        .clamp(CELL_WRAP_MIN_PX, CELL_WRAP_MAX_PX)
+                        .min(*w)
+                })
+                .collect()
+        };
+        let min_total_w: f32 = col_min_w.iter().sum::<f32>() + TABLE_BORDER_PX;
+
         let table_scroll_key = if let Some(span) = table.span {
             SharedString::from(format!(
                 "{}-table-scroll-{}:{}",
@@ -1531,19 +1575,21 @@ impl BlockNode {
                 let align = table.column_align(ix);
                 let is_last_col = ix == row.children.len() - 1;
                 let width = col_w.get(ix).copied().unwrap_or(CELL_MIN_PX);
+                let min_width = col_min_w.get(ix).copied().unwrap_or(CELL_MIN_PX);
                 cells.push(
                     div()
                         .id(("cell", ix))
-                        // Measured content width is the flex-basis; `flex_grow`
-                        // (proportional to it) distributes any extra space so a
-                        // narrow table still fills the frame, while `flex_shrink_0`
-                        // keeps columns from collapsing when the table is wider
-                        // than the viewport and scrolls.
+                        // Measured max-content width is the flex-basis;
+                        // `flex_grow` (proportional to it) distributes extra
+                        // space so a narrow table still fills the frame, while
+                        // shrinking is clamped at `min_w` — the flex engine
+                        // squeezes columns (their text wraps) down to the
+                        // floors before the track starts to scroll.
                         .flex_basis(px(width))
                         .flex_grow(width)
-                        .flex_shrink_0()
+                        .flex_shrink(1.)
+                        .min_w(px(min_width))
                         .overflow_hidden()
-                        .whitespace_nowrap()
                         .when(align == ColumnumnAlign::Center, |this| this.text_center())
                         .when(align == ColumnumnAlign::Right, |this| this.text_right())
                         .px_2()
@@ -1579,14 +1625,14 @@ impl BlockNode {
                     ("table", options.ix),
                     &scroll_handle,
                     &style.table,
-                    // Bordered track sized to `max(viewport, total table
-                    // width)`: `min_w_full` fills the frame when the table is
-                    // narrow (cells then grow to fill), the definite `w(total_w)`
-                    // lets it exceed the viewport and scroll when the content is
-                    // wider.
+                    // Bordered track sized to `max(viewport, column floors)`:
+                    // `min_w_full` fills the frame while the columns can still
+                    // shrink-to-fit (their text wrapping), the definite
+                    // `w(min_total_w)` keeps the floors once they are reached,
+                    // letting the track exceed the viewport and scroll.
                     div()
                         .min_w_full()
-                        .w(px(total_w))
+                        .w(px(min_total_w))
                         .border_1()
                         .border_color(cx.theme().border)
                         .rounded(cx.theme().radius)

--- a/crates/ui/src/text/style.rs
+++ b/crates/ui/src/text/style.rs
@@ -23,11 +23,17 @@ pub struct TextViewStyle {
     /// Style refinement applied to the table container (the bordered wrapper
     /// in wrap mode, the scroll viewport in horizontal-scroll mode).
     ///
-    /// Set `overflow_x: scroll` here to keep table cells on a single line and
-    /// scroll the table horizontally instead of wrapping cell content, e.g.
+    /// Set `overflow_x: scroll` here for adaptive table layout: columns fit
+    /// their content when space allows, shrink (wrapping cell text) down to a
+    /// per-column floor when the frame is narrower, and below that the table
+    /// scrolls horizontally instead of squeezing further, e.g.
     /// `TextViewStyle::default().table({ let mut s = StyleRefinement::default(); s.overflow.x = Some(Overflow::Scroll); s })`.
     pub table: StyleRefinement,
     /// Style refinement applied to each table cell.
+    ///
+    /// With the scroll layout, set `white_space: nowrap` here to keep cells
+    /// on a single line — columns then never shrink and the table scrolls as
+    /// soon as the content is wider than the frame.
     pub table_cell: StyleRefinement,
     pub is_dark: bool,
 }
@@ -78,14 +84,19 @@ impl TextViewStyle {
 
     /// Set extra style for the table container.
     ///
-    /// Set `overflow_x: scroll` on the refinement to make wide tables scroll
-    /// horizontally (cells stop wrapping) instead of shrinking to fit.
+    /// Set `overflow_x: scroll` on the refinement for adaptive layout: cells
+    /// wrap as the frame narrows, and once columns reach their minimum width
+    /// the table scrolls horizontally instead of shrinking further.
     pub fn table(mut self, style: StyleRefinement) -> Self {
         self.table = style;
         self
     }
 
     /// Set extra style for each table cell.
+    ///
+    /// With the scroll table layout, `white_space: nowrap` here keeps cells
+    /// on a single line and the table scrolls whenever the content is wider
+    /// than the frame.
     pub fn table_cell(mut self, style: StyleRefinement) -> Self {
         self.table_cell = style;
         self

--- a/examples/markdown_table/Cargo.toml
+++ b/examples/markdown_table/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "markdown_table"
+description = "A minimal markdown viewer for debugging table rendering."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+gpui.workspace = true
+gpui_platform.workspace = true
+gpui-component = { workspace = true }
+gpui-component-assets.workspace = true
+
+[lints]
+workspace = true

--- a/examples/markdown_table/src/main.rs
+++ b/examples/markdown_table/src/main.rs
@@ -1,0 +1,150 @@
+//! A minimal markdown viewer for debugging table rendering.
+//!
+//! Cycle between the three table layouts:
+//! - wrap (default): cells wrap, columns shrink to fit the frame.
+//! - adaptive (`style.table` overflow-x: scroll): columns fit their content,
+//!   wrap down to a floor as the frame narrows, then scroll horizontally.
+//! - nowrap (adaptive + `style.table_cell` white-space: nowrap): cells stay
+//!   on a single line, the table scrolls as soon as the content overflows.
+//!
+//! Edit `src/report.md` to change the markdown source.
+//!
+//! Run: `cargo run -p markdown_table`
+
+use gpui::*;
+use gpui_component::{
+    button::Button,
+    text::{TextView, TextViewStyle},
+    *,
+};
+use gpui_component_assets::Assets;
+
+const SOURCE: &str = include_str!("report.md");
+
+/// Markdown source: `MD_FILE=<path>` overrides the bundled `report.md`, so you
+/// can iterate on a repro without recompiling.
+fn source() -> SharedString {
+    match std::env::var("MD_FILE") {
+        Ok(path) => std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| format!("Failed to read `{path}`: {err}"))
+            .into(),
+        Err(_) => SOURCE.into(),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum TableMode {
+    Wrap,
+    Adaptive,
+    Nowrap,
+}
+
+impl TableMode {
+    /// `TABLE_MODE=wrap|adaptive|nowrap` picks the initial mode.
+    fn initial() -> Self {
+        match std::env::var("TABLE_MODE").as_deref() {
+            Ok("wrap") => Self::Wrap,
+            Ok("nowrap") => Self::Nowrap,
+            _ => Self::Adaptive,
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            Self::Wrap => Self::Adaptive,
+            Self::Adaptive => Self::Nowrap,
+            Self::Nowrap => Self::Wrap,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Wrap => "Table: wrap",
+            Self::Adaptive => "Table: scroll (adaptive)",
+            Self::Nowrap => "Table: scroll (nowrap)",
+        }
+    }
+
+    fn style(self) -> TextViewStyle {
+        if self == Self::Wrap {
+            return TextViewStyle::default();
+        }
+
+        let mut table = StyleRefinement::default();
+        table.overflow.x = Some(Overflow::Scroll);
+        let style = TextViewStyle::default().table(table);
+
+        if self == Self::Nowrap {
+            let mut cell = StyleRefinement::default();
+            cell.text.white_space = Some(WhiteSpace::Nowrap);
+            style.table_cell(cell)
+        } else {
+            style
+        }
+    }
+}
+
+struct Example {
+    mode: TableMode,
+}
+
+impl Render for Example {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .size_full()
+            .child(
+                h_flex()
+                    .p_2()
+                    .gap_2()
+                    .border_b_1()
+                    .border_color(cx.theme().border)
+                    .child(
+                        Button::new("toggle")
+                            .label(self.mode.label())
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.mode = this.mode.next();
+                                cx.notify();
+                            })),
+                    ),
+            )
+            .child(
+                TextView::markdown("report", source())
+                    .style(self.mode.style())
+                    .p_4()
+                    .scrollable(true)
+                    .selectable(true),
+            )
+    }
+}
+
+fn main() {
+    let app = gpui_platform::application().with_assets(Assets);
+
+    app.run(move |cx| {
+        // This must be called before using any GPUI Component features.
+        gpui_component::init(cx);
+
+        // `WIN_W=<px>` overrides the window width, to check how the table
+        // adapts at different frame widths.
+        let width = std::env::var("WIN_W")
+            .ok()
+            .and_then(|w| w.parse().ok())
+            .unwrap_or(900.);
+        let window_options = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(width), px(700.)), cx)),
+            ..Default::default()
+        };
+
+        cx.spawn(async move |cx| {
+            cx.open_window(window_options, |window, cx| {
+                let view = cx.new(|_| Example {
+                    mode: TableMode::initial(),
+                });
+                // The first level view on the window should be a Root.
+                cx.new(|cx| Root::new(view, window, cx).bg(cx.theme().background))
+            })
+            .expect("Failed to open window");
+        })
+        .detach();
+    });
+}

--- a/examples/markdown_table/src/report.md
+++ b/examples/markdown_table/src/report.md
@@ -1,0 +1,96 @@
+## Storage Engine Evaluation for the Telemetry Pipeline
+
+Key takeaway: the embedded candidates cover about 80% of our query patterns out of the box. The columnar engine takes a near-rewrite hit on point lookups, but the hot paths (ingest and range scans) never touch that code, and batching can partially offset the lookup cost.
+
+---
+
+### 1. Candidate overview
+
+Based on the v2025 benchmark suite and public documentation:
+
+| Engine | Data model | Written in | Embedded |
+|--------|------------|------------|----------|
+| **RocksJar** (LSM tree) | ~69% key-value | C++ | **Yes** |
+| **ColumnForge** (columnar) | ~15-18% analytical | Rust | **Yes** (static lib) |
+| **TinyBtree** | ~5.2% key-value, **single writer** | Rust | **Yes** |
+| **PagedHeap** | ~3.1% document | Go | **No** (sidecar process) |
+| **Others** (remote OLAP, time-series) | ~3-5% | mixed | **No** |
+
+**Directly affected paths:**
+
+- **Ingest workers**: the pipeline holds a 63-shard write fan-out with one writer per shard [1]. Pre-migration throughput was about 650k rows/s; in the March 2026 load test the columnar prototype dropped roughly 80% on unbatched writes [2][3]
+- **Dashboard queries**: an indirect dependency through two aggregation services, together serving about 29k queries/day in 2023 [1]. Point lookups can partially bypass the columnar store via the row cache, but that cache was also invalidated too aggressively in the May 2026 test [4]
+
+**Unaffected core paths:** range scans (69%) plus the downsampling jobs (25% of load, now above 900k rows/s) [5] and the retention sweeps all run against immutable segments and never touch the lookup path.
+
+---
+
+### 2. Operational risk assessment
+
+| Risk dimension | Severity | Details |
+|----------------|----------|---------|
+| **Unbatched writes stall** | **Severe** | Ingest workers were forced to cut throughput by 80% under the columnar prototype; back-pressure kicked in once the WAL saturated [6][7]. Single-row upserts through the compatibility shim effectively cannot be sustained |
+| **Row cache constrained** | **Moderate** | The compatibility shim is capacity-limited (~1.5M entries), and eviction churn spiked after the cache-key change |
+| **Cross-region replication lag** | **Moderate** | Replication fan-out costs jumped 50%, and p99 catch-up time surged 584% in the failover drill [8]. Snapshot shipping costs rise materially for the two largest regions |
+| **Downsampling jobs** | **None** | Segment merges run against local immutable files and involve no cross-store traffic |
+
+**Key fact**: the range-scan and downsampling paths — the pipeline's most important growth surface — never touch the lookup shim. Segment readers stream directly from immutable files onto the aggregation tier [9][10].
+
+---
+
+### 3. Benchmark summary
+
+Using the v2025 suite as the baseline [11]:
+
+| Metric | Result | Notes |
+|--------|--------|-------|
+| Sustained ingest | 556k rows/s | -5.3% vs current |
+| Range scan p50 | 4.8ms (86.1% of SLO) | Core dashboard driver |
+| Compaction debt | 43.3GB steady state | ~78% below ceiling |
+| Point lookup p99 | 17.1ms | |
+
+**Scenario estimate (pipeline level):**
+
+- **Direct throughput loss**: shim-routed upserts (roughly 40-60k rows/s of normal load) plus cache misses (~29k queries/day) ≈ 3-5% of total traffic
+- **Batching offset**: the March test briefly pushed batched ingest above 120-130% of the current baseline [8]. With segment write amplification holding near 1.28-1.30, per-shard headroom on the scan and downsampling paths expands sharply
+- **Net effect**: a 3-5% loss on lookups versus a 20-30% gain on scans. If dashboards keep their current query mix, the scan-side gains likely cover or exceed the lookup regression
+
+---
+
+### 4. Key risks and buffers
+
+**Risks:**
+
+1. Long compaction pauses may degrade the read amplification budget; some shards might never return to pre-migration latencies [12]
+2. Restoring full dual-write parity is expected to take 6+ weeks [12], during which rollback drills contribute zero coverage
+3. Roughly 33-45% of dashboard traffic transits the lookup shim [13][8]; hot tenants could be redirected to prioritize interactive queries, compressing batch windows
+
+**Buffers:**
+
+1. Low concentration risk — 69% of traffic is range scans and independent of the lookup path
+2. The downsampling tier is still ramping (the segment-cache project adds 250k rows/s in 2026) [5], which can backfill the ingest shortfall
+3. Batching improves the economics of the highest-volume shards
+4. Retained WAL of ~1.39bn rows (about 120 days of replay) [14] keeps near-term recovery unaffected
+
+---
+
+### 5. Summary
+
+Among the three finalists, the columnar engine has **the lowest direct exposure to the lookup regression** — its core traffic comes from range scans (69%) and immutable segment reads rather than point lookups. Directly impaired paths total only about 3-5% of traffic. The bigger risks are indirect: compaction pressure from the write path, and long-tail uncertainty over restoring dual-write parity. On the latency dimension, the scan-side tailwind most likely covers the lookup-side loss.
+
+If you want the latency sensitivity quantified across batch sizes of 1k / 10k / 100k rows, I can run that analysis next.
+
+[1]: https://example.com/architecture "Pipeline architecture overview"
+[2]: https://example.com/load-test "March 2026 load test results"
+[3]: https://example.com/load-test-2 "Unbatched write throughput follow-up"
+[4]: https://example.com/cache-report "Row cache weekly report"
+[5]: https://example.com/downsampling "Downsampling tier capacity forecast"
+[6]: https://example.com/wal-saturation "Ingest throughput collapses with WAL saturated under load"
+[7]: https://example.com/recovery "Ingest could restore pre-migration throughput within a week"
+[8]: https://example.com/failover "Analysis of the failover drill impact on replication"
+[9]: https://example.com/segments "Segment readers"
+[10]: https://example.com/aggregation "Aggregation tier: the upcoming star of the pipeline"
+[11]: https://example.com/benchmarks "v2025 benchmark suite results"
+[12]: https://example.com/parity "Dual-write parity still weeks away"
+[13]: https://example.com/traffic "Lookup shim: traffic security and query routing"
+[14]: https://example.com/wal-retention "Implications of WAL retention for recovery"


### PR DESCRIPTION
## Summary
The `overflow-x: scroll` table capped columns at 480px while keeping cells `nowrap`, so text beyond the cap was clipped *and* excluded from the scrollable width — unreachable by scrolling.

Rework the layout to behave like CSS auto table layout: columns get their measured max-content width when space allows, shrink (wrapping cell text) down to a content-scaled floor as the frame narrows, and only below the floors does the table keep its width and scroll horizontally. `white_space: nowrap` on `table_cell` composes like in CSS: cells stay on a single line and the floors rise to the content widths, restoring the previous single-line behavior without the clipping bug.

Also add a `markdown_table` example to exercise the three layouts at different frame widths.

https://github.com/user-attachments/assets/991b37fc-6e97-4957-837c-320fd3576e8d