### PR TITLE
color_picker: use on_hover insted of on_mouse_move to reduce rerenders

### DIFF
--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -426,12 +426,14 @@ impl ColorPicker {
                         .bg(color.lighten(0.1))
                 })
                 .active(|this| this.border_color(color.darken(0.5)).bg(color.darken(0.2)))
-                .on_mouse_move(window.listener_for(&state, move |state, _, window, cx| {
-                    state.hovered_color = Some(color);
-                    state.state.update(cx, |input, cx| {
-                        input.set_value(color.to_hex(), window, cx);
-                    });
-                    cx.notify();
+                .on_hover(window.listener_for(&state, move |state, enter, window, cx| {
+                    if *enter {
+                        state.hovered_color = Some(color);
+                        state.state.update(cx, |input, cx| {
+                            input.set_value(color.to_hex(), window, cx);
+                        });
+                        cx.notify();
+                    }
                 }))
                 .on_click(window.listener_for(
                     &state,


### PR DESCRIPTION
## Description

Whenever the cursor moved on top of the colors the entire component was redrawn, with this it gets redrawn only when the cursor enters over a color

## How to Test

Pass the cursor on top of the colors in the color picker rapidly, the CPU usage should spike less

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] ~~Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)~~ **Tested on Windows only**
