### PR TITLE
sidebar: Show tooltips for collapsed menu items

### DIFF
--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,9 +1,10 @@
 use crate::{
-    ActiveTheme as _, Collapsible, Icon, IconName, Sizable as _, StyledExt,
+    ActiveTheme as _, Collapsible, Icon, IconName, Placement, Sizable as _, StyledExt,
     button::{Button, ButtonVariants as _},
     h_flex,
     menu::{ContextMenuExt, PopupMenu},
     sidebar::SidebarItem,
+    tooltip::{ManagedTooltipExt as _, Tooltip},
     v_flex,
 };
 use gpui::{
@@ -205,6 +206,10 @@ impl SidebarMenuItem {
         self.children.len() > 0
     }
 
+    fn collapsed_tooltip(&self) -> Option<SharedString> {
+        (self.collapsed && self.icon.is_some()).then(|| self.label.clone())
+    }
+
     /// Set the context menu for the menu item.
     pub fn context_menu(
         mut self,
@@ -238,6 +243,7 @@ impl SidebarItem for SidebarMenuItem {
         let click_to_open = self.click_to_open;
         let click_to_toggle = self.click_to_toggle;
         let default_open = self.default_open;
+        let collapsed_tooltip = self.collapsed_tooltip();
         let id = id.into();
         let is_submenu = self.is_submenu();
         let open_state = if is_submenu {
@@ -355,6 +361,15 @@ impl SidebarItem for SidebarMenuItem {
                         })
                     })
                     .map(|this| {
+                        if let Some(tooltip) = collapsed_tooltip {
+                            this.managed_tooltip_at(Placement::Right, move |window, cx| {
+                                Tooltip::new(tooltip.clone()).build(window, cx)
+                            })
+                        } else {
+                            this
+                        }
+                    })
+                    .map(|this| {
                         if let Some(context_menu) = self.context_menu {
                             this.context_menu(move |menu, window, cx| {
                                 context_menu(menu, window, cx)
@@ -381,5 +396,28 @@ impl SidebarItem for SidebarMenuItem {
                         })),
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapsed_icon_item_uses_label_as_tooltip() {
+        let item = SidebarMenuItem::new("Projects")
+            .icon(Icon::default())
+            .collapsed(true);
+
+        assert_eq!(item.collapsed_tooltip().as_deref(), Some("Projects"));
+    }
+
+    #[test]
+    fn expanded_or_iconless_item_has_no_collapsed_tooltip() {
+        let expanded = SidebarMenuItem::new("Projects").icon(Icon::default());
+        let iconless = SidebarMenuItem::new("Projects").collapsed(true);
+
+        assert!(expanded.collapsed_tooltip().is_none());
+        assert!(iconless.collapsed_tooltip().is_none());
     }
 }

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -10,6 +10,7 @@ use gpui::{
 use crate::{
     ActiveTheme, StyledExt,
     animation::{Transition, ease_in_out_cubic, ease_out_cubic},
+    geometry::Placement,
     h_flex,
     kbd::Kbd,
     root::Root,
@@ -153,15 +154,9 @@ const SLIDE_DURATION: Duration = Duration::from_millis(200);
 const TOOLTIP_WINDOW_MARGIN: Pixels = px(4.);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum TooltipPlacement {
-    Above,
-    Below,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
 struct TooltipOverlayPosition {
     bounds: Bounds<Pixels>,
-    placement: TooltipPlacement,
+    placement: Placement,
 }
 
 fn tooltip_overlay_position(
@@ -169,27 +164,43 @@ fn tooltip_overlay_position(
     tooltip_size: Size<Pixels>,
     viewport_size: Size<Pixels>,
     margin: Pixels,
+    preferred_placement: Option<Placement>,
 ) -> TooltipOverlayPosition {
-    let centered_x = trigger_bounds.center().x - tooltip_size.width.half();
-    let above_bounds = Bounds::new(
-        point(centered_x, trigger_bounds.top() - tooltip_size.height),
-        tooltip_size,
-    );
-    let below_bounds = Bounds::new(point(centered_x, trigger_bounds.bottom()), tooltip_size);
-
+    let right_limit = (viewport_size.width - margin).max(margin);
     let bottom_limit = (viewport_size.height - margin).max(margin);
+    let available_left = (trigger_bounds.left() - margin).max(px(0.));
+    let available_right = (right_limit - trigger_bounds.right()).max(px(0.));
     let available_above = (trigger_bounds.top() - margin).max(px(0.));
     let available_below = (bottom_limit - trigger_bounds.bottom()).max(px(0.));
 
-    let (bounds, placement) = if above_bounds.top() >= margin {
-        (above_bounds, TooltipPlacement::Above)
-    } else if below_bounds.bottom() <= bottom_limit {
-        (below_bounds, TooltipPlacement::Below)
-    } else if available_below >= available_above {
-        (below_bounds, TooltipPlacement::Below)
-    } else {
-        (above_bounds, TooltipPlacement::Above)
+    let placement = match preferred_placement {
+        Some(Placement::Right) if tooltip_size.width <= available_right => Placement::Right,
+        Some(Placement::Right) if tooltip_size.width <= available_left => Placement::Left,
+        Some(Placement::Right) if available_right >= available_left => Placement::Right,
+        Some(Placement::Right) => Placement::Left,
+        Some(Placement::Left) if tooltip_size.width <= available_left => Placement::Left,
+        Some(Placement::Left) if tooltip_size.width <= available_right => Placement::Right,
+        Some(Placement::Left) if available_left >= available_right => Placement::Left,
+        Some(Placement::Left) => Placement::Right,
+        Some(Placement::Bottom) if tooltip_size.height <= available_below => Placement::Bottom,
+        Some(Placement::Bottom) if tooltip_size.height <= available_above => Placement::Top,
+        Some(Placement::Bottom) if available_below >= available_above => Placement::Bottom,
+        Some(Placement::Bottom) => Placement::Top,
+        Some(Placement::Top) | None if tooltip_size.height <= available_above => Placement::Top,
+        Some(Placement::Top) | None if tooltip_size.height <= available_below => Placement::Bottom,
+        Some(Placement::Top) | None if available_below >= available_above => Placement::Bottom,
+        Some(Placement::Top) | None => Placement::Top,
     };
+
+    let centered_x = trigger_bounds.center().x - tooltip_size.width.half();
+    let centered_y = trigger_bounds.center().y - tooltip_size.height.half();
+    let origin = match placement {
+        Placement::Top => point(centered_x, trigger_bounds.top() - tooltip_size.height),
+        Placement::Bottom => point(centered_x, trigger_bounds.bottom()),
+        Placement::Left => point(trigger_bounds.left() - tooltip_size.width, centered_y),
+        Placement::Right => point(trigger_bounds.right(), centered_y),
+    };
+    let bounds = Bounds::new(origin, tooltip_size);
 
     TooltipOverlayPosition {
         bounds: clamp_tooltip_bounds(bounds, viewport_size, margin),
@@ -224,6 +235,7 @@ fn clamp_tooltip_bounds(
 
 struct TooltipOverlayPositioner {
     trigger_bounds: Bounds<Pixels>,
+    preferred_placement: Option<Placement>,
     children: Vec<AnyElement>,
 }
 
@@ -231,9 +243,13 @@ struct TooltipOverlayPositionerState {
     child_layout_ids: Vec<LayoutId>,
 }
 
-fn tooltip_overlay_positioner(trigger_bounds: Bounds<Pixels>) -> TooltipOverlayPositioner {
+fn tooltip_overlay_positioner(
+    trigger_bounds: Bounds<Pixels>,
+    preferred_placement: Option<Placement>,
+) -> TooltipOverlayPositioner {
     TooltipOverlayPositioner {
         trigger_bounds,
+        preferred_placement,
         children: Vec::new(),
     }
 }
@@ -313,6 +329,7 @@ impl Element for TooltipOverlayPositioner {
             tooltip_size,
             window.viewport_size(),
             TOOLTIP_WINDOW_MARGIN + client_inset,
+            self.preferred_placement,
         );
 
         let offset = tooltip_position.bounds.origin - bounds.origin;
@@ -354,6 +371,7 @@ impl IntoElement for TooltipOverlayPositioner {
 pub(crate) struct TooltipContent {
     pub build: Rc<dyn Fn(&mut Window, &mut App) -> AnyView>,
     pub trigger_bounds: Bounds<Pixels>,
+    pub preferred_placement: Option<Placement>,
 }
 
 /// Manages tooltip lifecycle: delay, grace period, animations, and rendering.
@@ -494,49 +512,58 @@ impl Render for TooltipOverlay {
 
         let content_view = (content.build)(window, cx);
         let trigger_bounds = content.trigger_bounds;
+        let preferred_placement = content.preferred_placement;
         let animation_epoch = self.animation_epoch;
         let is_switching = self.is_switching;
         let prev_trigger_bounds = self.prev_trigger_bounds;
 
         deferred(
-            tooltip_overlay_positioner(trigger_bounds).child(div().child(content_view).map(|el| {
-                if is_switching {
-                    let Some(prev_bounds) = prev_trigger_bounds else {
-                        return el.into_any_element();
-                    };
+            tooltip_overlay_positioner(trigger_bounds, preferred_placement).child(
+                div().child(content_view).map(|el| {
+                    if is_switching {
+                        let Some(prev_bounds) = prev_trigger_bounds else {
+                            return el.into_any_element();
+                        };
 
-                    let is_same_y =
-                        (trigger_bounds.origin.y - prev_bounds.origin.y).abs() < px(10.);
-                    if !is_same_y {
-                        // If the new trigger is at a different Y level, don't slide horizontally
-                        // to avoid weird diagonal movement. (We could consider sliding vertically
-                        // in this case, but it might be less visually clear.)
-                        return el.into_any_element();
+                        let is_same_y =
+                            (trigger_bounds.origin.y - prev_bounds.origin.y).abs() < px(10.);
+                        if !is_same_y {
+                            // If the new trigger is at a different Y level, don't slide horizontally
+                            // to avoid weird diagonal movement. (We could consider sliding vertically
+                            // in this case, but it might be less visually clear.)
+                            return el.into_any_element();
+                        }
+
+                        let dx = trigger_bounds.center().x - prev_bounds.center().x;
+
+                        Transition::new(SLIDE_DURATION)
+                            .ease(ease_in_out_cubic)
+                            .slide_x(-dx, px(0.))
+                            .apply(
+                                el,
+                                ElementId::NamedInteger(
+                                    "tooltip-slide".into(),
+                                    animation_epoch as u64,
+                                ),
+                            )
+                            .into_any_element()
+                    } else {
+                        // New tooltip: slideDown + fadeIn
+                        Transition::new(ENTER_DURATION)
+                            .ease(ease_out_cubic)
+                            .slide_y(px(4.), px(0.))
+                            .fade(0.0, 1.0)
+                            .apply(
+                                el,
+                                ElementId::NamedInteger(
+                                    "tooltip-enter".into(),
+                                    animation_epoch as u64,
+                                ),
+                            )
+                            .into_any_element()
                     }
-
-                    let dx = trigger_bounds.center().x - prev_bounds.center().x;
-
-                    Transition::new(SLIDE_DURATION)
-                        .ease(ease_in_out_cubic)
-                        .slide_x(-dx, px(0.))
-                        .apply(
-                            el,
-                            ElementId::NamedInteger("tooltip-slide".into(), animation_epoch as u64),
-                        )
-                        .into_any_element()
-                } else {
-                    // New tooltip: slideDown + fadeIn
-                    Transition::new(ENTER_DURATION)
-                        .ease(ease_out_cubic)
-                        .slide_y(px(4.), px(0.))
-                        .fade(0.0, 1.0)
-                        .apply(
-                            el,
-                            ElementId::NamedInteger("tooltip-enter".into(), animation_epoch as u64),
-                        )
-                        .into_any_element()
-                }
-            })),
+                }),
+            ),
         )
         .with_priority(2)
         .into_any_element()
@@ -589,6 +616,22 @@ pub(crate) trait ManagedTooltipExt:
         self,
         build_tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
     ) -> Self {
+        self.managed_tooltip_with_placement(None, build_tooltip)
+    }
+
+    fn managed_tooltip_at(
+        self,
+        placement: Placement,
+        build_tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
+    ) -> Self {
+        self.managed_tooltip_with_placement(Some(placement), build_tooltip)
+    }
+
+    fn managed_tooltip_with_placement(
+        self,
+        preferred_placement: Option<Placement>,
+        build_tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
+    ) -> Self {
         let build_tooltip = Rc::new(build_tooltip);
         let trigger_bounds_cell: Rc<Cell<Bounds<Pixels>>> = Rc::new(Cell::new(Bounds::default()));
         let bounds_writer = trigger_bounds_cell.clone();
@@ -608,6 +651,7 @@ pub(crate) trait ManagedTooltipExt:
                                 TooltipContent {
                                     build: build_tooltip.clone(),
                                     trigger_bounds: bounds,
+                                    preferred_placement,
                                 },
                                 window,
                                 cx,
@@ -642,6 +686,7 @@ mod tests {
         TooltipContent {
             build: Rc::new(|window, cx| Tooltip::new("Test tooltip").build(window, cx)),
             trigger_bounds: bounds,
+            preferred_placement: None,
         }
     }
 
@@ -680,9 +725,10 @@ mod tests {
             test_size(120., 30.),
             test_size(300., 200.),
             TOOLTIP_WINDOW_MARGIN,
+            None,
         );
 
-        assert_eq!(position.placement, TooltipPlacement::Above);
+        assert_eq!(position.placement, Placement::Top);
         assert_eq!(position.bounds.origin.x, px(80.));
         assert_eq!(position.bounds.origin.y, px(50.));
         assert_eq!(position.bounds.bottom(), trigger_bounds.top());
@@ -696,9 +742,10 @@ mod tests {
             test_size(240., 32.),
             test_size(520., 260.),
             TOOLTIP_WINDOW_MARGIN,
+            None,
         );
 
-        assert_eq!(position.placement, TooltipPlacement::Below);
+        assert_eq!(position.placement, Placement::Bottom);
         assert_eq!(position.bounds.top(), trigger_bounds.bottom());
         assert!(position.bounds.top() >= trigger_bounds.bottom());
     }
@@ -711,9 +758,10 @@ mod tests {
             test_size(120., 30.),
             test_size(300., 200.),
             TOOLTIP_WINDOW_MARGIN,
+            None,
         );
 
-        assert_eq!(position.placement, TooltipPlacement::Above);
+        assert_eq!(position.placement, Placement::Top);
         assert_eq!(position.bounds.left(), TOOLTIP_WINDOW_MARGIN);
     }
 
@@ -725,10 +773,58 @@ mod tests {
             test_size(160., 120.),
             test_size(300., 100.),
             TOOLTIP_WINDOW_MARGIN,
+            None,
         );
 
-        assert_eq!(position.placement, TooltipPlacement::Below);
+        assert_eq!(position.placement, Placement::Bottom);
         assert_eq!(position.bounds.top(), TOOLTIP_WINDOW_MARGIN);
         assert_eq!(position.bounds.left(), px(60.));
+    }
+
+    #[test]
+    fn tooltip_overlay_position_places_tooltip_to_the_right() {
+        let trigger_bounds = test_bounds(20., 60., 32., 32.);
+        let position = tooltip_overlay_position(
+            trigger_bounds,
+            test_size(120., 30.),
+            test_size(300., 200.),
+            TOOLTIP_WINDOW_MARGIN,
+            Some(Placement::Right),
+        );
+
+        assert_eq!(position.placement, Placement::Right);
+        assert_eq!(position.bounds.left(), trigger_bounds.right());
+        assert_eq!(position.bounds.center().y, trigger_bounds.center().y);
+    }
+
+    #[test]
+    fn tooltip_overlay_position_flips_left_near_right_edge() {
+        let trigger_bounds = test_bounds(260., 60., 32., 32.);
+        let position = tooltip_overlay_position(
+            trigger_bounds,
+            test_size(120., 30.),
+            test_size(300., 200.),
+            TOOLTIP_WINDOW_MARGIN,
+            Some(Placement::Right),
+        );
+
+        assert_eq!(position.placement, Placement::Left);
+        assert_eq!(position.bounds.right(), trigger_bounds.left());
+    }
+
+    #[test]
+    fn tooltip_overlay_position_clamps_vertical_edges_for_right_placement() {
+        let trigger_bounds = test_bounds(20., 2., 32., 20.);
+        let position = tooltip_overlay_position(
+            trigger_bounds,
+            test_size(120., 40.),
+            test_size(300., 200.),
+            TOOLTIP_WINDOW_MARGIN,
+            Some(Placement::Right),
+        );
+
+        assert_eq!(position.placement, Placement::Right);
+        assert_eq!(position.bounds.top(), TOOLTIP_WINDOW_MARGIN);
+        assert_eq!(position.bounds.left(), trigger_bounds.right());
     }
 }


### PR DESCRIPTION
## Description

Collapsed icon-only sidebar menu items hide their labels, leaving their meaning unclear on hover. This change shows each item's existing label as a managed tooltip while the item is collapsed. Expanded and iconless menu items keep their existing behavior.

The interaction is based on the collapsed icon sidebar demonstrated by [shadcn/ui Base Sidebar](https://ui.shadcn.com/docs/components/base/sidebar), where hovering an icon-only menu item reveals its label beside the sidebar.

The tooltip prefers the right side of the trigger, falls back to the left when needed, and remains clamped to the viewport. Existing managed tooltips preserve their current top/bottom placement behavior, and no new public API is introduced.

## Screenshot

<img width="946" height="1020" alt="图片" src="https://github.com/user-attachments/assets/461fff95-d916-41fe-97d6-ad86caa0669e" />

## How to Test

- `rustfmt --edition 2024 --check crates/ui/src/tooltip.rs crates/ui/src/sidebar/menu.rs`
- `git diff --check`
- `cargo test -p gpui-component`: 368 passed
- `cargo clippy -p gpui-component --lib -- -D warnings`

Manual verification steps:

1. Collapse an icon sidebar.
2. Hover a menu item and confirm its label appears to the right of the icon.
3. Expand the sidebar and confirm hovering the same item no longer shows the label tooltip.

## AI Assistance

The implementation and tests were AI-assisted by Codex. The behavior and final scope were directed and manually verified by the author.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)