### PR TITLE
tooltip: hide overlay when trigger is removed

### DIFF
--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -1,10 +1,15 @@
-use std::{cell::Cell, rc::Rc, time::Duration};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+    time::Duration,
+};
 
 use gpui::{
     Action, AnyElement, AnyView, App, AppContext, Bounds, Context, Display, Element, ElementId,
-    GlobalElementId, Half, InspectorElementId, IntoElement, LayoutId, MouseButton, ParentElement,
-    Pixels, Point, Position, Render, SharedString, Size, StatefulInteractiveElement, Style,
-    StyleRefinement, Styled, Task, Window, deferred, div, point, prelude::FluentBuilder, px,
+    Entity, GlobalElementId, Half, InspectorElementId, IntoElement, LayoutId, MouseButton,
+    ParentElement, Pixels, Point, Position, Render, SharedString, Size, StatefulInteractiveElement,
+    Style, StyleRefinement, Styled, Subscription, Task, WeakEntity, Window, deferred, div, point,
+    prelude::FluentBuilder, px,
 };
 
 use crate::{
@@ -354,6 +359,90 @@ impl IntoElement for TooltipOverlayPositioner {
 pub(crate) struct TooltipContent {
     pub build: Rc<dyn Fn(&mut Window, &mut App) -> AnyView>,
     pub trigger_bounds: Bounds<Pixels>,
+    trigger_lifecycle: WeakEntity<TooltipTriggerLease>,
+}
+
+impl TooltipContent {
+    fn trigger_is_alive(&self) -> bool {
+        self.trigger_lifecycle.upgrade().is_some()
+    }
+}
+
+struct TooltipTriggerLease;
+
+struct TooltipTriggerLifecycle {
+    lease: Rc<RefCell<Option<WeakEntity<TooltipTriggerLease>>>>,
+}
+
+impl TooltipTriggerLifecycle {
+    fn new(lease: Rc<RefCell<Option<WeakEntity<TooltipTriggerLease>>>>) -> Self {
+        Self { lease }
+    }
+}
+
+impl IntoElement for TooltipTriggerLifecycle {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for TooltipTriggerLifecycle {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some("tooltip-trigger-lifecycle".into())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let lifecycle = window.with_element_state(
+            id.expect("tooltip lifecycle element must have an id"),
+            |lifecycle: Option<Entity<TooltipTriggerLease>>, _| {
+                let lifecycle = lifecycle.unwrap_or_else(|| cx.new(|_| TooltipTriggerLease));
+                (lifecycle.downgrade(), lifecycle)
+            },
+        );
+        *self.lease.borrow_mut() = Some(lifecycle);
+
+        let mut style = Style::default();
+        style.position = Position::Absolute;
+        (window.request_layout(style, [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
 }
 
 /// Manages tooltip lifecycle: delay, grace period, animations, and rendering.
@@ -370,6 +459,7 @@ pub struct TooltipOverlay {
 
     _show_task: Option<Task<()>>,
     _hide_task: Option<Task<()>>,
+    _trigger_release_subscription: Option<Subscription>,
 }
 
 impl TooltipOverlay {
@@ -383,12 +473,30 @@ impl TooltipOverlay {
             is_switching: false,
             _show_task: None,
             _hide_task: None,
+            _trigger_release_subscription: None,
         }
     }
 
     fn next_epoch(&mut self) -> usize {
         self.epoch += 1;
         self.epoch
+    }
+
+    fn observe_trigger_release(
+        &mut self,
+        content: &TooltipContent,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(trigger) = content.trigger_lifecycle.upgrade() else {
+            return false;
+        };
+        let overlay = cx.weak_entity();
+        self._trigger_release_subscription =
+            Some(window.observe_release(&trigger, cx, move |_, _, cx| {
+                let _ = overlay.update(cx, |overlay, cx| overlay.hide(cx));
+            }));
+        true
     }
 
     /// Request showing a tooltip. If another tooltip is active or was recently
@@ -412,6 +520,11 @@ impl TooltipOverlay {
             self._show_task = None;
             self.is_switching = was_visible;
             self.animation_epoch += 1;
+            let content = self.content.as_ref().unwrap().clone();
+            if !self.observe_trigger_release(&content, window, cx) {
+                self.hide(cx);
+                return;
+            }
             cx.notify();
         } else {
             // New: delay then show with slideDown
@@ -419,8 +532,12 @@ impl TooltipOverlay {
             let content = content.clone();
             self._show_task = Some(cx.spawn_in(window, async move |this, cx| {
                 cx.background_executor().timer(SHOW_DELAY).await;
-                let _ = this.update_in(cx, |this, _, cx| {
+                let _ = this.update_in(cx, |this, window, cx| {
                     if this.epoch != epoch {
+                        return;
+                    }
+                    if !content.trigger_is_alive() {
+                        this._show_task = None;
                         return;
                     }
 
@@ -428,6 +545,11 @@ impl TooltipOverlay {
                     this.prev_trigger_bounds = None;
                     this.is_switching = false;
                     this.animation_epoch += 1;
+                    let content = this.content.as_ref().unwrap().clone();
+                    if !this.observe_trigger_release(&content, window, cx) {
+                        this.hide(cx);
+                        return;
+                    }
                     cx.notify();
                 });
             }));
@@ -456,6 +578,7 @@ impl TooltipOverlay {
                 this.content = None;
                 this.prev_trigger_bounds = None;
                 this.had_recent_tooltip = false;
+                this._trigger_release_subscription = None;
                 cx.notify();
             });
         }));
@@ -473,7 +596,8 @@ impl TooltipOverlay {
             || self.had_recent_tooltip
             || self.is_switching
             || self._show_task.is_some()
-            || self._hide_task.is_some();
+            || self._hide_task.is_some()
+            || self._trigger_release_subscription.is_some();
 
         self.content = None;
         self.prev_trigger_bounds = None;
@@ -481,6 +605,7 @@ impl TooltipOverlay {
         self.is_switching = false;
         self._show_task = None;
         self._hide_task = None;
+        self._trigger_release_subscription = None;
 
         changed
     }
@@ -591,43 +716,50 @@ pub(crate) trait ManagedTooltipExt:
     ) -> Self {
         let build_tooltip = Rc::new(build_tooltip);
         let trigger_bounds_cell: Rc<Cell<Bounds<Pixels>>> = Rc::new(Cell::new(Bounds::default()));
+        let trigger_lifecycle = Rc::new(RefCell::new(None));
         let bounds_writer = trigger_bounds_cell.clone();
 
-        self.on_prepaint(move |bounds, _, _| {
-            bounds_writer.set(bounds);
-        })
-        .on_hover({
-            let trigger_bounds_cell = trigger_bounds_cell.clone();
-            let build_tooltip = build_tooltip.clone();
-            move |hovered, window, cx| {
-                if let Some(overlay) = Root::tooltip_overlay(window, cx) {
-                    if *hovered {
-                        let bounds = trigger_bounds_cell.get();
-                        overlay.update(cx, |o: &mut TooltipOverlay, cx| {
-                            o.request_show(
-                                TooltipContent {
-                                    build: build_tooltip.clone(),
-                                    trigger_bounds: bounds,
-                                },
-                                window,
-                                cx,
-                            );
-                        });
-                    } else {
-                        overlay.update(cx, |o: &mut TooltipOverlay, cx| {
-                            o.request_hide(window, cx);
-                        });
+        self.child(TooltipTriggerLifecycle::new(trigger_lifecycle.clone()))
+            .on_prepaint(move |bounds, _, _| {
+                bounds_writer.set(bounds);
+            })
+            .on_hover({
+                let trigger_bounds_cell = trigger_bounds_cell.clone();
+                let trigger_lifecycle = trigger_lifecycle.clone();
+                let build_tooltip = build_tooltip.clone();
+                move |hovered, window, cx| {
+                    if let Some(overlay) = Root::tooltip_overlay(window, cx) {
+                        if *hovered {
+                            let bounds = trigger_bounds_cell.get();
+                            overlay.update(cx, |o: &mut TooltipOverlay, cx| {
+                                o.request_show(
+                                    TooltipContent {
+                                        build: build_tooltip.clone(),
+                                        trigger_bounds: bounds,
+                                        trigger_lifecycle: trigger_lifecycle
+                                            .borrow()
+                                            .clone()
+                                            .expect("tooltip trigger must be painted before hover"),
+                                    },
+                                    window,
+                                    cx,
+                                );
+                            });
+                        } else {
+                            overlay.update(cx, |o: &mut TooltipOverlay, cx| {
+                                o.request_hide(window, cx);
+                            });
+                        }
                     }
                 }
-            }
-        })
-        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-            if let Some(overlay) = Root::tooltip_overlay(window, cx) {
-                overlay.update(cx, |overlay, cx| {
-                    overlay.hide(cx);
-                });
-            }
-        })
+            })
+            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                if let Some(overlay) = Root::tooltip_overlay(window, cx) {
+                    overlay.update(cx, |overlay, cx| {
+                        overlay.hide(cx);
+                    });
+                }
+            })
     }
 }
 
@@ -636,13 +768,48 @@ impl<E: StatefulInteractiveElement + crate::ElementExt> ManagedTooltipExt for E 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::size;
+    use gpui::{InteractiveElement as _, Modifiers, TestAppContext, VisualTestContext, size};
 
-    fn test_content(bounds: Bounds<Pixels>) -> TooltipContent {
-        TooltipContent {
+    struct TooltipLifecycleTestView {
+        show_trigger: bool,
+    }
+
+    impl Render for TooltipLifecycleTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().when(self.show_trigger, |this| {
+                this.child(
+                    div()
+                        .id("tooltip-lifecycle-test-trigger")
+                        .w(px(100.))
+                        .h(px(40.))
+                        .debug_selector(|| "tooltip-lifecycle-test-trigger".into())
+                        .managed_tooltip(|window, cx| {
+                            Tooltip::new("Lifecycle tooltip").build(window, cx)
+                        }),
+                )
+            })
+        }
+    }
+
+    fn draw_window(cx: &mut VisualTestContext) {
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+        cx.run_until_parked();
+    }
+
+    fn test_content(
+        bounds: Bounds<Pixels>,
+        cx: &TestAppContext,
+    ) -> (TooltipContent, Entity<TooltipTriggerLease>) {
+        let lifecycle = cx.update(|cx| cx.new(|_| TooltipTriggerLease));
+        let content = TooltipContent {
             build: Rc::new(|window, cx| Tooltip::new("Test tooltip").build(window, cx)),
             trigger_bounds: bounds,
-        }
+            trigger_lifecycle: lifecycle.downgrade(),
+        };
+        (content, lifecycle)
     }
 
     fn test_bounds(x: f32, y: f32, width: f32, height: f32) -> Bounds<Pixels> {
@@ -653,11 +820,12 @@ mod tests {
         size(px(width), px(height))
     }
 
-    #[test]
-    fn tooltip_overlay_clear_state_resets_active_tooltip() {
+    #[gpui::test]
+    fn tooltip_overlay_clear_state_resets_active_tooltip(cx: &mut TestAppContext) {
         let mut overlay = TooltipOverlay::new();
+        let (content, _lifecycle) = test_content(test_bounds(10., 10., 40., 20.), cx);
 
-        overlay.content = Some(test_content(test_bounds(10., 10., 40., 20.)));
+        overlay.content = Some(content);
         overlay.prev_trigger_bounds = Some(test_bounds(0., 0., 40., 20.));
         overlay.had_recent_tooltip = true;
         overlay.is_switching = true;
@@ -670,6 +838,48 @@ mod tests {
         assert!(!overlay.is_switching);
         assert!(overlay._show_task.is_none());
         assert!(overlay._hide_task.is_none());
+    }
+
+    #[gpui::test]
+    fn tooltip_content_tracks_its_trigger_lifecycle(cx: &mut TestAppContext) {
+        let (content, lifecycle) = test_content(test_bounds(10., 10., 40., 20.), cx);
+
+        assert!(content.trigger_is_alive());
+        drop(lifecycle);
+        cx.run_until_parked();
+        assert!(!content.trigger_is_alive());
+    }
+
+    #[gpui::test]
+    fn managed_tooltip_hides_when_trigger_stops_rendering(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|_| TooltipLifecycleTestView { show_trigger: true });
+            Root::new(view, window, cx)
+        });
+        let view = root.read_with(cx, |root, _| {
+            root.view()
+                .clone()
+                .downcast::<TooltipLifecycleTestView>()
+                .unwrap()
+        });
+        let overlay = root.read_with(cx, |root, _| root.tooltip_overlay.clone());
+
+        draw_window(cx);
+        let trigger_bounds = cx.debug_bounds("tooltip-lifecycle-test-trigger").unwrap();
+        cx.simulate_mouse_move(trigger_bounds.center(), None, Modifiers::default());
+        cx.background_executor.advance_clock(SHOW_DELAY);
+        draw_window(cx);
+
+        assert!(overlay.read_with(cx, |overlay, _| overlay.content.is_some()));
+
+        view.update(cx, |view, cx| {
+            view.show_trigger = false;
+            cx.notify();
+        });
+        draw_window(cx);
+
+        assert!(overlay.read_with(cx, |overlay, _| overlay.content.is_none()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #[issue number]

## Description

Managed tooltips could remain visible after their trigger stopped rendering, for example when navigating back with a mouse side button while the pointer was still over the trigger. In that case, the trigger disappeared before GPUI emitted a hover-leave event, so the shared tooltip overlay retained stale content.

This PR ties each managed tooltip to the lifecycle of its trigger element. The overlay observes the trigger's lifecycle lease and clears itself when that lease is released. It also verifies that the trigger is still alive before completing a delayed show request, preventing a tooltip from appearing after its trigger has already been removed.

The lifecycle marker is an invisible, absolutely positioned, zero-size element, so it does not affect the trigger's layout. A regression test renders a real managed tooltip, removes its trigger, and verifies that the overlay is cleared.

AI-assisted code in this change was reviewed for correctness and tested.

## Screenshot

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/a5275d7a-a3c1-4bd2-aae6-25dc77850220) | ![After](https://github.com/user-attachments/assets/4f79b501-f353-4c47-9648-dfc743f3044e) |

## How to Test

The original issue was manually verified in my own application because the `gpui-component` story app does not provide a built-in navigation flow for mouse side-button back actions.

Manual verification:

1. Open a page containing a component with a managed tooltip.
2. Hover over the trigger and wait for the tooltip to appear.
3. While the tooltip is still visible, press the mouse side button to navigate back.
4. Confirm that the previous page is shown and the tooltip disappears immediately.

Automated regression coverage was added to `gpui-component`. The test renders a real managed tooltip, waits for it to appear, removes the trigger without emitting a hover-leave event, and verifies that the tooltip overlay is cleared.

Run the tooltip test suite with:

```bash
cargo test -p gpui-component tooltip --lib
```

All 7 tooltip tests pass.

The story app was also compiled and launched successfully with:

```bash
cargo run
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes. The story app launches successfully; the mouse side-button navigation scenario was verified in my application because the story app does not provide that navigation flow.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific). Not applicable: this change is platform-independent.
