### PR TITLE
docs: Change Context type from TableState to ListState in list docs

### DIFF
--- a/docs/docs/components/list.md
+++ b/docs/docs/components/list.md
@@ -37,7 +37,7 @@ impl ListDelegate for MyListDelegate {
         &mut self,
         ix: IndexPath,
         _window: &mut Window,
-        _cx: &mut Context<TableState<Self>>,
+        _cx: &mut Context<ListState<Self>>,
     ) -> Option<Self::Item> {
         self.items.get(ix.row).map(|item| {
             ListItem::new(ix)
@@ -98,7 +98,7 @@ impl ListDelegate for MyListDelegate {
         &mut self,
         section: usize,
         _window: &mut Window,
-        cx: &mut Context<TableState<Self>>,
+        cx: &mut Context<ListState<Self>>,
     ) -> Option<impl IntoElement> {
         let title = match section {
             0 => "Section 1",
@@ -123,7 +123,7 @@ impl ListDelegate for MyListDelegate {
         &mut self,
         section: usize,
         _window: &mut Window,
-        cx: &mut Context<TableState<Self>>,
+        cx: &mut Context<ListState<Self>>,
     ) -> Option<impl IntoElement> {
         Some(
             div()
@@ -144,7 +144,7 @@ fn render_item(
     &mut self,
     ix: IndexPath,
     _window: &mut Window,
-    cx: &mut Context<TableState<Self>>,
+    cx: &mut Context<ListState<Self>>,
 ) -> Option<Self::Item> {
     self.items.get(ix.row).map(|item| {
         ListItem::new(ix)
@@ -209,7 +209,7 @@ impl ListDelegate for MyListDelegate {
     fn render_loading(
         &mut self,
         _window: &mut Window,
-        _cx: &mut Context<TableState<Self>>,
+        _cx: &mut Context<ListState<Self>>,
     ) -> impl IntoElement {
         // Custom loading view
         v_flex()
@@ -346,7 +346,7 @@ ListItem::new(ix)
 
 ```rust
 impl ListDelegate for MyListDelegate {
-    fn render_empty(&mut self, _window: &mut Window, cx: &mut Context<TableState<Self>>) -> impl IntoElement {
+    fn render_empty(&mut self, _window: &mut Window, cx: &mut Context<ListState<Self>>) -> impl IntoElement {
         v_flex()
             .size_full()
             .justify_center()
@@ -421,7 +421,7 @@ struct FileInfo {
 impl ListDelegate for FileBrowserDelegate {
     type Item = ListItem;
 
-    fn render_item(&mut self, ix: IndexPath, window: &mut Window, cx: &mut Context<TableState<Self>>) -> Option<Self::Item> {
+    fn render_item(&mut self, ix: IndexPath, window: &mut Window, cx: &mut Context<ListState<Self>>) -> Option<Self::Item> {
         self.files.get(ix.row).map(|file| {
             let icon = if file.is_directory {
                 IconName::Folder
@@ -471,7 +471,7 @@ impl ListDelegate for ContactListDelegate {
         self.contacts_by_letter.len()
     }
 
-    fn render_section_header(&mut self, section: usize, _window: &mut Window, cx: &mut Context<TableState<Self>>) -> Option<impl IntoElement> {
+    fn render_section_header(&mut self, section: usize, _window: &mut Window, cx: &mut Context<ListState<Self>>) -> Option<impl IntoElement> {
         let letter = self.contacts_by_letter.keys().nth(section)?;
 
         Some(


### PR DESCRIPTION
Fix incorrect TableState reference in the list component documentation.

Rename the context type to ListState.
No functional changes.