### PR TITLE
text: Keep blocks scrolled past in the selected text

### DIFF
--- a/crates/ui/src/text/document.rs
+++ b/crates/ui/src/text/document.rs
@@ -3,6 +3,8 @@ use gpui::{
     Styled as _, Window, div,
 };
 
+use std::ops::RangeInclusive;
+
 use crate::text::node::{BlockNode, NodeContext};
 
 /// The parsed document AST.
@@ -38,10 +40,51 @@ impl ParsedDocument {
         text
     }
 
-    pub(super) fn selected_text(&self) -> String {
+    /// The selected text across all blocks.
+    ///
+    /// A block only learns its selection when it is painted, so in a scrollable
+    /// (virtualized) view every block the user scrolled past reports nothing.
+    /// A selection is one continuous range, so the blocks it spans that came up
+    /// empty are inside it and are emitted whole rather than dropped.
+    ///
+    /// `blocks` bounds that span. It comes from the selection endpoints, which
+    /// hold on to their block index even after it scrolls out of view — the
+    /// painted blocks alone cannot bound the span, because the press that
+    /// starts a drag leaves an empty selection that never reaches paint.
+    /// Without it, fall back to the painted blocks.
+    pub(super) fn selected_text(&self, blocks: Option<RangeInclusive<usize>>) -> String {
+        let painted = self
+            .blocks
+            .iter()
+            .map(|block| block.has_selection())
+            .collect::<Vec<_>>();
+        let (Some(first), Some(last)) = (
+            painted.iter().position(|painted| *painted),
+            painted.iter().rposition(|painted| *painted),
+        ) else {
+            return String::new();
+        };
+
+        let last_ix = self.blocks.len().saturating_sub(1);
+        let (first, last) = match blocks {
+            Some(blocks) => (
+                first.min(*blocks.start()),
+                last.max(*blocks.end()).min(last_ix),
+            ),
+            None => (first, last),
+        };
+
         let mut text = String::new();
-        for block in self.blocks.iter() {
-            text.push_str(&block.selected_text());
+        for (ix, block) in self.blocks.iter().enumerate().take(last + 1).skip(first) {
+            let selected = block.selected_text();
+            if !selected.is_empty() {
+                text.push_str(&selected);
+            } else if !painted[ix] {
+                // Never painted, so it cannot report a selection of its own
+                // even though the span covers it. A painted block that came up
+                // empty really has nothing selected, and stays empty.
+                text.push_str(&block.text());
+            }
         }
         text
     }

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -237,6 +237,36 @@ impl BlockNode {
     ///
     /// Mirrors the [`selected_text`](Self::selected_text) traversal so the
     /// selection can be cleared without relying on a repaint.
+    /// Whether this block carries a selection, even an empty one.
+    ///
+    /// A block only learns its selection when it is painted, so this doubles as
+    /// "this block was on screen while the selection was made". An empty
+    /// selection is the caret left by the press that started the drag, which is
+    /// why it counts (see [`ParsedDocument::selected_text`]).
+    pub(super) fn has_selection(&self) -> bool {
+        match self {
+            BlockNode::Root { children, .. }
+            | BlockNode::Blockquote { children, .. }
+            | BlockNode::List { children, .. }
+            | BlockNode::ListItem { children, .. } => {
+                children.iter().any(|child| child.has_selection())
+            }
+            BlockNode::Paragraph(paragraph) => paragraph.has_selection(),
+            BlockNode::Heading { children, .. } => children.has_selection(),
+            BlockNode::Table(table) => table.children.iter().any(|row| {
+                row.children
+                    .iter()
+                    .any(|cell| cell.children.has_selection())
+            }),
+            BlockNode::CodeBlock(code_block) => code_block.has_selection(),
+            BlockNode::Custom { .. }
+            | BlockNode::Definition { .. }
+            | BlockNode::Break { .. }
+            | BlockNode::HorizontalRule { .. }
+            | BlockNode::Unknown { .. } => false,
+        }
+    }
+
     pub(super) fn clear_selection(&self) {
         match self {
             BlockNode::Root { children, .. }
@@ -490,6 +520,16 @@ impl Paragraph {
     /// Synchronously clear the selection stored in every inline state.
     ///
     /// Mirrors the [`selected_text`](Self::selected_text) traversal.
+    pub(super) fn has_selection(&self) -> bool {
+        self.children
+            .iter()
+            .any(|c| c.state.lock().is_ok_and(|state| state.selection.is_some()))
+            || self
+                .state
+                .lock()
+                .is_ok_and(|state| state.selection.is_some())
+    }
+
     pub(super) fn clear_selection(&self) {
         for c in self.children.iter() {
             if let Ok(mut state) = c.state.lock() {
@@ -737,6 +777,12 @@ impl CodeBlock {
     /// Synchronously clear the selection stored in the inline state.
     ///
     /// Mirrors the [`selected_text`](Self::selected_text) traversal.
+    pub(super) fn has_selection(&self) -> bool {
+        self.state
+            .lock()
+            .is_ok_and(|state| state.selection.is_some())
+    }
+
     pub(super) fn clear_selection(&self) {
         if let Ok(mut state) = self.state.lock() {
             state.selection = None;

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -1,5 +1,5 @@
 use futures::Stream as _;
-use std::{pin::Pin, sync::Arc, task::Poll};
+use std::{ops::RangeInclusive, pin::Pin, sync::Arc, task::Poll};
 
 use gpui::{
     App, AppContext as _, Bounds, Context, FocusHandle, IntoElement, KeyBinding, ListState,
@@ -232,6 +232,16 @@ impl TextViewState {
 
     /// Return the selected text.
     pub fn selected_text(&self) -> String {
+        self.selected_text_in(None)
+    }
+
+    /// Return the selected text, with `blocks` bounding which top-level blocks
+    /// the selection covers.
+    ///
+    /// The range comes from the selection endpoints, which know their block
+    /// even after it scrolls out of view; see
+    /// [`ParsedDocument::selected_text`](crate::text::document::ParsedDocument).
+    pub(super) fn selected_text_in(&self, blocks: Option<RangeInclusive<usize>>) -> String {
         if self.select_all {
             return self.parsed_content.document.text();
         }
@@ -240,7 +250,7 @@ impl TextViewState {
             return text.clone();
         }
 
-        self.parsed_content.document.selected_text()
+        self.parsed_content.document.selected_text(blocks)
     }
 
     fn increment_update(&mut self, text: &str, append: bool, cx: &mut Context<Self>) {
@@ -287,6 +297,34 @@ impl TextViewState {
             self.reset_selection();
         }
         self.bounds = bounds;
+    }
+
+    /// The index of the top-level block at `content_y`, in this view's content
+    /// coordinates (the same space [`SelectionEndpoint`] stores its point in).
+    ///
+    /// Only laid-out blocks can be located, which is enough for a selection
+    /// endpoint: the user can only put one where they can see it. Returns
+    /// `None` for a view that is not virtualized, where every block paints and
+    /// the range is not needed.
+    ///
+    /// [`SelectionEndpoint`]: crate::text::window_selection::SelectionEndpoint
+    pub(super) fn block_ix_at(&self, content_y: Pixels) -> Option<usize> {
+        if !self.scrollable {
+            return None;
+        }
+
+        let origin = self.bounds.origin.y + self.scroll_offset().y;
+        let count = self.list_state.item_count();
+        let mut ix = self.list_state.logical_scroll_top().item_ix;
+        while ix < count {
+            let bounds = self.list_state.bounds_for_item(ix)?;
+            if content_y < bounds.bottom() - origin {
+                return Some(ix);
+            }
+            ix += 1;
+        }
+
+        count.checked_sub(1)
     }
 
     pub(super) fn bounds(&self) -> Bounds<Pixels> {

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use gpui::{
     App, Bounds, Context, Element, ElementId, Entity, EntityId, GlobalElementId, Hitbox,
     InspectorElementId, IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
@@ -164,6 +166,11 @@ pub(crate) struct SelectionEndpoint {
     /// True when the endpoint hit an Inline text run, not just blank space in
     /// the parent TextView bounds.
     pub(crate) inside_text: bool,
+    /// The top-level block `point` falls in, for a scrollable (virtualized)
+    /// view. Resolved once, while the block is on screen, because the block
+    /// stops reporting its selection as soon as it scrolls out of view (see
+    /// [`ParsedDocument::selected_text`](crate::text::document::ParsedDocument)).
+    pub(crate) block_ix: Option<usize>,
 }
 
 impl SelectionEndpoint {
@@ -215,6 +222,20 @@ impl WindowTextSelection {
     /// correct. When the two endpoints anchor to different views, all
     /// registered views participate and the per-character geometric test (in
     /// `Inline`) decides what is actually selected.
+    /// The top-level blocks the selection spans inside `view`, when both of its
+    /// endpoints are anchored there. Only a scrollable view records these (see
+    /// [`SelectionEndpoint::block_ix`]).
+    pub(crate) fn block_range(&self, view: EntityId) -> Option<RangeInclusive<usize>> {
+        let anchor = self.anchor.as_ref()?;
+        let cursor = self.cursor.as_ref()?;
+        if anchor.view_id() != Some(view) || cursor.view_id() != Some(view) {
+            return None;
+        }
+
+        let (anchor, cursor) = (anchor.block_ix?, cursor.block_ix?);
+        Some(anchor.min(cursor)..=anchor.max(cursor))
+    }
+
     pub(crate) fn single_view(&self) -> Option<EntityId> {
         let anchor = self.anchor.as_ref()?.view_id()?;
         let cursor = self.cursor.as_ref()?.view_id()?;
@@ -318,7 +339,7 @@ impl Root {
             if !state.has_view_selection() && !in_window_selection {
                 continue;
             }
-            let text = state.selected_text();
+            let text = state.selected_text_in(self.text_selection.block_range(*id));
             if text.trim().is_empty() {
                 continue;
             }
@@ -574,11 +595,13 @@ impl Root {
                 .selectable_text_inlines
                 .get(&state.entity_id)
                 .is_some_and(|bounds| bounds.iter().any(|bounds| bounds.contains(&position)));
+            let point = position - state.bounds().origin - state.scroll_offset();
             return SelectionEndpoint {
-                point: position - state.bounds().origin - state.scroll_offset(),
+                point,
                 view: Some(view),
                 inside: true,
                 inside_text,
+                block_ix: state.block_ix_at(point.y),
             };
         }
 
@@ -618,11 +641,13 @@ impl Root {
                 match entity {
                     Some(entity) => {
                         let state = entity.read(cx);
+                        let point = position - state.bounds().origin - state.scroll_offset();
                         SelectionEndpoint {
-                            point: position - state.bounds().origin - state.scroll_offset(),
+                            point,
                             view: Some(view),
                             inside: false,
                             inside_text: false,
+                            block_ix: state.block_ix_at(point.y),
                         }
                     }
                     None => SelectionEndpoint {
@@ -630,6 +655,7 @@ impl Root {
                         point: position,
                         inside: false,
                         inside_text: false,
+                        block_ix: None,
                     },
                 }
             }
@@ -638,6 +664,7 @@ impl Root {
                 point: position,
                 inside: false,
                 inside_text: false,
+                block_ix: None,
             },
         }
     }
@@ -944,6 +971,129 @@ mod tests {
             let _ = window.draw(cx);
         });
         (chat, cx)
+    }
+
+    /// A `scrollable(true)` TextView virtualizes its blocks, so a block only
+    /// learns its selection once it has been painted. Pressing at the top,
+    /// scrolling with the wheel and releasing at the bottom leaves every block
+    /// in between unpainted — copying used to drop all of them.
+    struct ScrollableTextViewTest {
+        text_view: Entity<TextViewState>,
+    }
+
+    impl Render for ScrollableTextViewTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(
+                div().h(px(60.)).child(
+                    TextView::new(&self.text_view)
+                        .selectable(true)
+                        .scrollable(true),
+                ),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn selection_spans_blocks_scrolled_past(cx: &mut TestAppContext) {
+        use gpui::{ScrollDelta, ScrollWheelEvent};
+
+        const BLOCKS: usize = 20;
+
+        cx.update(crate::init);
+        let source = (0..BLOCKS)
+            .map(|ix| format!("Paragraph{ix}"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| ScrollableTextViewTest {
+                text_view: cx.new(|cx| TextViewState::markdown(&source, cx)),
+            });
+            Root::new(view, window, cx)
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        // Press inside the first block, then wheel-scroll to the end. The
+        // blocks scrolled past are never painted while the drag is active.
+        cx.simulate_mouse_down(
+            point(px(0.), px(1.)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        for _ in 0..BLOCKS {
+            cx.simulate_event(ScrollWheelEvent {
+                position: point(px(10.), px(30.)),
+                delta: ScrollDelta::Pixels(point(px(0.), px(-40.))),
+                ..Default::default()
+            });
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+        }
+
+        // Release over the last visible block.
+        cx.simulate_mouse_move(
+            point(px(150.), px(58.)),
+            Some(MouseButton::Left),
+            Modifiers::default(),
+        );
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.simulate_mouse_up(
+            point(px(150.), px(58.)),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let text = window_selected_text(cx);
+        let missing = (0..BLOCKS)
+            .filter(|ix| !text.contains(&format!("Paragraph{ix}")))
+            .collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "blocks scrolled past were dropped: {missing:?} in {text:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn selection_inside_one_block_leaves_the_rest(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let source = (0..20)
+            .map(|ix| format!("Paragraph{ix}"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| ScrollableTextViewTest {
+                text_view: cx.new(|cx| TextViewState::markdown(&source, cx)),
+            });
+            Root::new(view, window, cx)
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        // Stay inside the first block. The blocks below are on screen and
+        // simply not selected, so none of them may be filled in.
+        drag(cx, point(px(2.), px(4.)), point(px(40.), px(4.)));
+
+        let text = window_selected_text(cx);
+        assert!(!text.trim().is_empty(), "nothing selected");
+        assert!(
+            !text.contains("Paragraph1"),
+            "unselected block was filled in: {text:?}"
+        );
     }
 
     fn drag(


### PR DESCRIPTION
## Description

Copying a selection from a scrollable `TextView` dropped everything the user scrolled over. Press at the top of the view, wheel down to the bottom, release — only the last screenful ends up on the clipboard.

A block learns its selection during paint, so the blocks a scrollable (virtualized) view never rendered report nothing. The painted blocks cannot bound the selection either: the press that starts a drag leaves an empty selection, and an empty selection never reaches paint, so the block the drag started in looks untouched.

So each selection endpoint now resolves its top-level block index while that block is still on screen, and `ParsedDocument::selected_text` emits the blocks in that span that were never painted whole. A block that *was* painted and simply has nothing selected stays empty, so a selection inside one block does not pull in its neighbours.

`Cmd-A` was never affected — select-all reads the parsed document directly.

## How to Test

```
cargo run --example markdown
```

Press inside the first paragraph of the preview, scroll to the bottom with the wheel, release, and copy. Everything between the two ends is on the clipboard.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
