### PR TITLE
accessibility: Expose control IDs on Button and Input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1197,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.7"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2874,7 +2874,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.58.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2969,6 +2969,7 @@ dependencies = [
  "sum_tree",
  "taffy",
  "thiserror 2.0.18",
+ "tracing",
  "ttf-parser",
  "url",
  "usvg 0.46.0",
@@ -2979,6 +2980,7 @@ dependencies = [
  "windows 0.61.3",
  "zed-font-kit",
  "zed-scap",
+ "ztracing",
 ]
 
 [[package]]
@@ -3148,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3200,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3249,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3260,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3273,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "schemars",
  "serde",
@@ -3283,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "log",
@@ -3293,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3316,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3346,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3662,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3682,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -3763,7 +3765,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4425,15 +4427,15 @@ checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "link-section"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014e440054ce8170890229eeef5bcda955305e056ec713de40ed366944483f09"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4727,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5733,7 +5735,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "collections",
  "serde",
@@ -6731,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "derive_refineable",
 ]
@@ -6783,7 +6785,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7220,7 +7222,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7841,7 +7843,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "heapless",
  "log",
@@ -9322,7 +9324,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "perf",
  "quote",
@@ -9898,6 +9900,7 @@ dependencies = [
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-naga-bridge",
@@ -9918,6 +9921,15 @@ name = "wgpu-core-deps-emscripten"
 version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
 dependencies = [
  "wgpu-hal",
 ]
@@ -11321,7 +11333,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11338,7 +11350,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -11349,7 +11361,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1"
+source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 
 [[package]]
 name = "zune-core"

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -290,6 +290,12 @@ impl Button {
         self
     }
 
+    /// Set the developer-assigned identifier exposed to accessibility clients.
+    pub fn accessibility_id(mut self, id: impl Into<SharedString>) -> Self {
+        self.base = self.base.accessibility_id(id);
+        self
+    }
+
     /// Set the icon of the button, if the Button have no label, the button well in Icon Button mode.
     pub fn icon(mut self, icon: impl Into<ButtonIcon>) -> Self {
         self.icon = Some(icon.into());
@@ -1267,6 +1273,53 @@ mod tests {
         assert_eq!(
             *captured.lock().unwrap(),
             vec![None, None, Some(Toggled::False), Some(Toggled::True)]
+        );
+    }
+
+    #[gpui::test]
+    fn test_button_emits_accessibility_id(cx: &mut gpui::TestAppContext) {
+        use crate::ElementExt as _;
+        use gpui::{Element as _, IntoElement as _, Render};
+        use std::sync::{Arc, Mutex};
+
+        type AuthorIds = Arc<Mutex<Vec<Option<String>>>>;
+
+        struct ButtonA11yProbe {
+            author_ids: AuthorIds,
+        }
+
+        impl Render for ButtonA11yProbe {
+            fn render(&mut self, _: &mut Window, _: &mut gpui::Context<Self>) -> impl IntoElement {
+                let author_ids = self.author_ids.clone();
+                div().on_prepaint(move |_, window, cx| {
+                    let mut author_id_of = |button: Button| {
+                        let mut node = gpui::accesskit::Node::new(Role::Button);
+                        button
+                            .render(window, cx)
+                            .into_element()
+                            .write_a11y_info(&mut node);
+                        node.author_id().map(ToOwned::to_owned)
+                    };
+
+                    *author_ids.lock().unwrap() = vec![
+                        author_id_of(Button::new("ordinary")),
+                        author_id_of(Button::new("identified").accessibility_id("toolbar.export")),
+                    ];
+                })
+            }
+        }
+
+        cx.update(crate::init);
+        let author_ids: AuthorIds = Arc::new(Mutex::new(Vec::new()));
+        let captured = author_ids.clone();
+        let (_, cx) = cx.add_window_view(move |_, _| ButtonA11yProbe { author_ids });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert_eq!(
+            *captured.lock().unwrap(),
+            vec![None, Some("toolbar.export".into())]
         );
     }
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -52,6 +52,7 @@ pub struct Input {
     selected: bool,
     content_type: Option<InputContentType>,
     role: Option<Role>,
+    accessibility_id: Option<SharedString>,
     aria_label: Option<SharedString>,
 
     /// An optional context menu builder to allow a custom context menu on the input.
@@ -98,9 +99,16 @@ impl Input {
             selected: false,
             content_type: None,
             role: None,
+            accessibility_id: None,
             aria_label: None,
             context_menu_builder: None,
         }
+    }
+
+    /// Set the developer-assigned identifier exposed to accessibility clients.
+    pub fn accessibility_id(mut self, id: impl Into<SharedString>) -> Self {
+        self.accessibility_id = Some(id.into());
+        self
     }
 
     pub fn aria_label(mut self, label: impl Into<SharedString>) -> Self {
@@ -444,6 +452,7 @@ impl RenderOnce for Input {
         div()
             .id(("input", self.state.entity_id()))
             .role(accessibility_role)
+            .when_some(self.accessibility_id, |this, id| this.accessibility_id(id))
             .when_some(aria_label, |this, label| this.aria_label(label))
             .when_some(placeholder, |this, placeholder| {
                 this.aria_placeholder(placeholder)
@@ -775,6 +784,62 @@ mod tests {
             Input::handle_accessibility_set_value(&state, Some(&action), window, cx);
         });
         assert_eq!(state.read_with(cx, |state, _| state.value()), "updated");
+    }
+
+    #[gpui::test]
+    fn input_emits_accessibility_id(cx: &mut gpui::TestAppContext) {
+        use crate::ElementExt as _;
+        use gpui::{AppContext as _, Element as _, IntoElement as _, Render};
+        use std::sync::{Arc, Mutex};
+
+        type EmittedIds = Vec<Option<String>>;
+
+        struct InputA11yProbe {
+            state: Entity<InputState>,
+            emitted: Arc<Mutex<EmittedIds>>,
+        }
+
+        impl Render for InputA11yProbe {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut gpui::Context<Self>,
+            ) -> impl IntoElement {
+                let state = self.state.clone();
+                let emitted = self.emitted.clone();
+                div().on_prepaint(move |_, window, cx| {
+                    let mut author_id_of = |input: Input| {
+                        let mut node = gpui::accesskit::Node::new(Role::TextInput);
+                        input
+                            .render(window, cx)
+                            .into_element()
+                            .write_a11y_info(&mut node);
+                        node.author_id().map(ToOwned::to_owned)
+                    };
+
+                    *emitted.lock().unwrap() = vec![
+                        author_id_of(Input::new(&state)),
+                        author_id_of(Input::new(&state).accessibility_id("search.query")),
+                    ];
+                })
+            }
+        }
+
+        cx.update(crate::init);
+        let emitted = Arc::new(Mutex::new(Vec::new()));
+        let captured = emitted.clone();
+        let (_, cx) = cx.add_window_view(move |window, cx| InputA11yProbe {
+            state: cx.new(|cx| InputState::new(window, cx)),
+            emitted,
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert_eq!(
+            *captured.lock().unwrap(),
+            vec![None, Some("search.query".into())]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds opt-in developer-assigned accessibility identifiers to `Button` and `Input`.

`Button::accessibility_id` forwards the identifier through the component's base element. `Input::accessibility_id` applies it to the rendered text-input element. Controls emit no identifier unless the caller sets one.

The lockfile advances Zed/GPUI to the upstream revision that exposes the base `accessibility_id` API.

## Testing

Exact candidate `5775a0e46d8a27adf0e0a1b5e919b1cea13e2706` on Rust 1.97.1:

- `cargo test -p gpui-component accessibility_id --lib`: 2 passed
- `cargo test -p gpui-component`: 375 passed
- `cargo clippy -p gpui-component --all-targets -- -D warnings`
- `cargo check -p gpui-component-story`
- targeted `rustfmt --check` for both changed Rust files

The rendered regressions inspect AccessKit author IDs. They verify the explicit IDs and confirm that ordinary buttons and inputs still emit no ID.

## AI Assistance

The implementation and tests were AI-assisted by Friday. Chris Hynes defined the API boundary and owns the final review.
