### PR TITLE
title_bar: Let the title bar own dragging and double clicking

### DIFF
--- a/crates/story/examples/dock.rs
+++ b/crates/story/examples/dock.rs
@@ -383,8 +383,6 @@ impl StoryWorkspace {
         cx.spawn(async move |cx| {
             let options = WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(window_bounds)),
-                #[cfg(not(target_os = "linux"))]
-                titlebar: Some(gpui_component::TitleBar::title_bar_options()),
                 window_min_size: Some(gpui::Size {
                     width: px(640.),
                     height: px(480.),
@@ -394,7 +392,7 @@ impl StoryWorkspace {
                 #[cfg(target_os = "linux")]
                 window_decorations: Some(gpui::WindowDecorations::Client),
                 kind: WindowKind::Normal,
-                ..Default::default()
+                ..gpui_component::TitleBar::window_options()
             };
 
             let window = cx.open_window(options, |window, cx| {

--- a/crates/story/examples/tiles.rs
+++ b/crates/story/examples/tiles.rs
@@ -363,11 +363,6 @@ impl StoryTiles {
         cx.spawn(async move |cx| {
             let options = WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(window_bounds)),
-                titlebar: Some(TitlebarOptions {
-                    title: None,
-                    appears_transparent: true,
-                    traffic_light_position: Some(point(px(9.0), px(9.0))),
-                }),
                 window_min_size: Some(gpui::Size {
                     width: px(640.),
                     height: px(480.),
@@ -377,7 +372,7 @@ impl StoryTiles {
                 window_background: gpui::WindowBackgroundAppearance::Transparent,
                 #[cfg(target_os = "linux")]
                 window_decorations: Some(gpui::WindowDecorations::Client),
-                ..Default::default()
+                ..TitleBar::window_options()
             };
 
             let window = cx.open_window(options, |window, cx| {

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -113,7 +113,6 @@ pub fn create_new_window_with_size<F, E>(
     cx.spawn(async move |cx| {
         let options = WindowOptions {
             window_bounds: Some(WindowBounds::Windowed(window_bounds)),
-            titlebar: Some(TitleBar::title_bar_options()),
             window_min_size: Some(gpui::Size {
                 width: px(480.),
                 height: px(320.),
@@ -123,7 +122,7 @@ pub fn create_new_window_with_size<F, E>(
             window_background: gpui::WindowBackgroundAppearance::Transparent,
             #[cfg(target_os = "linux")]
             window_decorations: Some(gpui::WindowDecorations::Client),
-            ..Default::default()
+            ..TitleBar::window_options()
         };
 
         let window = cx

--- a/crates/ui/src/title_bar.rs
+++ b/crates/ui/src/title_bar.rs
@@ -6,7 +6,7 @@ use crate::{
 use gpui::{
     AnyElement, App, ClickEvent, Context, Decorations, Hsla, InteractiveElement, IntoElement,
     MouseButton, ParentElement, Pixels, Render, RenderOnce, StatefulInteractiveElement as _,
-    StyleRefinement, Styled, TitlebarOptions, Window, WindowControlArea, div,
+    StyleRefinement, Styled, TitlebarOptions, Window, WindowControlArea, WindowOptions, div,
     prelude::FluentBuilder as _, px,
 };
 use smallvec::SmallVec;
@@ -43,6 +43,31 @@ impl TitleBar {
             title: None,
             appears_transparent: true,
             traffic_light_position: Some(gpui::point(px(9.0), px(9.0))),
+        }
+    }
+
+    /// Returns the default window options for compatible with the [`crate::TitleBar`].
+    ///
+    /// Use this as the base of the [`WindowOptions`] of any window that renders a
+    /// [`crate::TitleBar`], so the title bar owns dragging and double clicking itself:
+    ///
+    /// ```no_run
+    /// # use gpui::WindowOptions;
+    /// # use gpui_component::TitleBar;
+    /// let options = WindowOptions {
+    ///     window_min_size: None,
+    ///     ..TitleBar::window_options()
+    /// };
+    /// ```
+    pub fn window_options() -> WindowOptions {
+        WindowOptions {
+            titlebar: Some(Self::title_bar_options()),
+            // The title bar draws itself and moves the window via `start_window_move`,
+            // so AppKit must not treat it as a system window-move region. Otherwise macOS
+            // handles title bar double clicks on its own (in addition to `on_double_click`
+            // below) and delays title bar clicks while disambiguating double clicks.
+            app_owns_titlebar_drag: true,
+            ..Default::default()
         }
     }
 

--- a/docs/docs/components/title-bar.md
+++ b/docs/docs/components/title-bar.md
@@ -93,11 +93,29 @@ TitleBar::new()
 
 ### Title Bar Options for Window
 
+Use `TitleBar::window_options()` as the base of the window options, it sets up
+everything the title bar needs, including letting the title bar own dragging and
+double clicking instead of the system.
+
 ```rust
-use gpui::{WindowOptions, TitlebarOptions};
+use gpui::WindowOptions;
+
+WindowOptions {
+    window_bounds: Some(window_bounds),
+    ..TitleBar::window_options()
+}
+```
+
+If you build the [`WindowOptions`] yourself, set both fields:
+
+```rust
+use gpui::WindowOptions;
 
 WindowOptions {
     titlebar: Some(TitleBar::title_bar_options()),
+    // Required on macOS, otherwise the system also handles title bar double
+    // clicks and delays title bar clicks to disambiguate double clicks.
+    app_owns_titlebar_drag: true,
     ..Default::default()
 }
 ```
@@ -138,14 +156,16 @@ WindowOptions {
 | `child(element)`      | Add child element to the title bar       |
 | `on_close_window(fn)` | Custom close window handler (Linux only) |
 | `title_bar_options()` | Get default titlebar options for window  |
+| `window_options()`    | Get default window options for the title bar |
 
 ### Window Configuration
 
-| Property                 | Description                                         |
-| ------------------------ | --------------------------------------------------- |
-| `appears_transparent`    | Make title bar transparent (default: true)          |
-| `traffic_light_position` | Position of macOS traffic lights                    |
-| `title`                  | Window title (optional when using custom title bar) |
+| Property                 | Description                                                    |
+| ------------------------ | -------------------------------------------------------------- |
+| `appears_transparent`    | Make title bar transparent (default: true)                     |
+| `traffic_light_position` | Position of macOS traffic lights                               |
+| `title`                  | Window title (optional when using custom title bar)            |
+| `app_owns_titlebar_drag` | Let the title bar own dragging and double clicking (macOS only) |
 
 ### Title Bar Element (Internal)
 

--- a/docs/zh-CN/docs/components/title-bar.md
+++ b/docs/zh-CN/docs/components/title-bar.md
@@ -91,11 +91,28 @@ TitleBar::new()
 
 ### 窗口配置
 
+推荐以 `TitleBar::window_options()` 作为窗口配置的基础，它会配置好标题栏所需的
+全部选项，其中包括让标题栏（而不是系统）来处理拖动和双击。
+
 ```rust
-use gpui::{WindowOptions, TitlebarOptions};
+use gpui::WindowOptions;
+
+WindowOptions {
+    window_bounds: Some(window_bounds),
+    ..TitleBar::window_options()
+}
+```
+
+如果自行构造 [`WindowOptions`]，需要同时设置这两个字段：
+
+```rust
+use gpui::WindowOptions;
 
 WindowOptions {
     titlebar: Some(TitleBar::title_bar_options()),
+    // macOS 上必须设置，否则系统也会处理标题栏双击，
+    // 并且会为了判定双击而延迟投递标题栏点击。
+    app_owns_titlebar_drag: true,
     ..Default::default()
 }
 ```
@@ -136,6 +153,16 @@ WindowOptions {
 | `child(element)` | 向标题栏中添加子元素 |
 | `on_close_window(fn)` | 自定义关闭行为，仅 Linux 有效 |
 | `title_bar_options()` | 获取窗口可用的默认标题栏配置 |
+| `window_options()` | 获取标题栏配套的默认窗口配置 |
+
+### 窗口配置项
+
+| 属性 | 说明 |
+| --- | --- |
+| `appears_transparent` | 标题栏透明（默认 true） |
+| `traffic_light_position` | macOS 红黄绿按钮位置 |
+| `title` | 窗口标题（使用自定义标题栏时可选） |
+| `app_owns_titlebar_drag` | 由标题栏自行处理拖动与双击（仅 macOS） |
 
 ### 常量
 

--- a/examples/dialog_overlay/src/main.rs
+++ b/examples/dialog_overlay/src/main.rs
@@ -111,17 +111,11 @@ fn main() {
         gpui_component::init(cx);
 
         cx.spawn(async move |cx| {
-            cx.open_window(
-                WindowOptions {
-                    titlebar: Some(TitleBar::title_bar_options()),
-                    ..Default::default()
-                },
-                |window, cx| {
-                    let view = cx.new(|_| HelloWorld);
-                    // This first level on the window, should be a Root.
-                    cx.new(|cx| Root::new(view, window, cx))
-                },
-            )
+            cx.open_window(TitleBar::window_options(), |window, cx| {
+                let view = cx.new(|_| HelloWorld);
+                // This first level on the window, should be a Root.
+                cx.new(|cx| Root::new(view, window, cx))
+            })
             .expect("Failed to open window");
         })
         .detach();

--- a/examples/system_monitor/src/main.rs
+++ b/examples/system_monitor/src/main.rs
@@ -617,9 +617,8 @@ fn main() {
         });
 
         let window_options = WindowOptions {
-            titlebar: Some(TitleBar::title_bar_options()),
             window_bounds: Some(WindowBounds::centered(size(px(680.), px(600.)), cx)),
-            ..Default::default()
+            ..TitleBar::window_options()
         };
 
         cx.spawn(async move |cx| {

--- a/examples/window_title/src/main.rs
+++ b/examples/window_title/src/main.rs
@@ -46,11 +46,8 @@ fn main() {
         gpui_component::init(cx);
 
         cx.spawn(async move |cx| {
-            let window_options = WindowOptions {
-                // Setup GPUI to use custom title bar
-                titlebar: Some(TitleBar::title_bar_options()),
-                ..Default::default()
-            };
+            // Setup GPUI to use custom title bar
+            let window_options = TitleBar::window_options();
 
             cx.open_window(window_options, |window, cx| {
                 let view = cx.new(|_| Example);


### PR DESCRIPTION
Double clicking the title bar zoomed the window even when the two clicks were seconds apart, which is not what a double click should do.

## Cause

`WindowOptions::app_owns_titlebar_drag` was never set anywhere in this repo, so it defaulted to `false`. GPUI documents that field as:

> Set this to `true` for windows that draw their own titlebar and move the window themselves via `Window::start_window_move`. It marks the whole content view as app-owned titlebar content, so AppKit neither drags the window from the titlebar nor delays titlebar clicks while disambiguating double-clicks (a delay first observed on macOS 27).

`TitleBar` is exactly that kind of title bar — it renders itself and calls `start_window_move` — but never claimed the ownership. So on macOS AppKit still treated the title bar as a system window-move region and ran its own `AppleActionOnDoubleClick` handling in parallel with the `on_double_click` handler in `TitleBar`. The zoom came from the system path, which is why it could not be fixed from inside the component.

## Changes

- Add `TitleBar::window_options()`, the window options counterpart of the existing `title_bar_options()`. It sets both `titlebar` and `app_owns_titlebar_drag`, so a window that renders a `TitleBar` gets this right by just using it as the base of its `WindowOptions`.
- Use it in the stories and all examples that render a `TitleBar`.
- `tiles.rs` had an inlined copy of `title_bar_options()`; it now shares the same base.
- Drop the `#[cfg(not(target_os = "linux"))]` on the `titlebar` field in `dock.rs`. `appears_transparent` is only read by the macOS and Windows backends, so the cfg produced no behavior difference.
- Document both the recommended `window_options()` and the manual `app_owns_titlebar_drag` setup, in English and Chinese.

## Testing

Verified on macOS (Darwin 27): two clicks a few seconds apart no longer zoom the window, and a real double click still zooms.

AI generated: the patch was written with Claude Code and reviewed by me.