### PR TITLE
select: Look up a value in all items, not the search results

### DIFF
--- a/crates/ui/src/list/list.rs
+++ b/crates/ui/src/list/list.rs
@@ -215,8 +215,11 @@ where
     pub fn set_query(&mut self, query: &str, window: &mut Window, cx: &mut Context<Self>) {
         let query = query.to_string();
         self.query_input.update(cx, |input, cx| {
-            input.set_value(query, window, cx);
+            input.set_value(query.clone(), window, cx);
         });
+
+        // `set_value` does not emit `InputEvent::Change`, so start the search here.
+        self.start_search(query, window, cx);
     }
 
     /// Set a specific list item for measurement.
@@ -277,35 +280,39 @@ where
                     return;
                 }
 
-                self.set_searching(true, window, cx);
-                let search = self.delegate.perform_search(&text, window, cx);
-
-                if self.rows_cache.len() > 0 {
-                    self._set_selected_index(Some(IndexPath::default()), window, cx);
-                } else {
-                    self._set_selected_index(None, window, cx);
-                }
-
-                self._search_task = cx.spawn_in(window, async move |this, window| {
-                    search.await;
-
-                    _ = this.update_in(window, |this, _, _| {
-                        this.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
-                        this.last_query = Some(text);
-                    });
-
-                    // Always wait 100ms to avoid flicker
-                    window
-                        .background_executor()
-                        .timer(Duration::from_millis(100))
-                        .await;
-                    _ = this.update_in(window, |this, window, cx| {
-                        this.set_searching(false, window, cx);
-                    });
-                });
+                self.start_search(text, window, cx);
             }
             _ => {}
         }
+    }
+
+    fn start_search(&mut self, query: String, window: &mut Window, cx: &mut Context<Self>) {
+        self.set_searching(true, window, cx);
+        let search = self.delegate.perform_search(&query, window, cx);
+
+        if self.rows_cache.len() > 0 {
+            self._set_selected_index(Some(IndexPath::default()), window, cx);
+        } else {
+            self._set_selected_index(None, window, cx);
+        }
+
+        self._search_task = cx.spawn_in(window, async move |this, window| {
+            search.await;
+
+            _ = this.update_in(window, |this, _, _| {
+                this.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
+                this.last_query = Some(query);
+            });
+
+            // Always wait 100ms to avoid flicker
+            window
+                .background_executor()
+                .timer(Duration::from_millis(100))
+                .await;
+            _ = this.update_in(window, |this, window, cx| {
+                this.set_searching(false, window, cx);
+            });
+        });
     }
 
     fn set_searching(&mut self, searching: bool, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -309,12 +309,21 @@ where
     ///
     /// Looks up the position from the delegate and sets the selected index accordingly.
     /// Passes `None` when the value is not found.
+    ///
+    /// The delegate looks the value up in its matched items, so an active search query is
+    /// cleared first to get an index into the full item list.
     pub fn set_selected_value(
         &mut self,
         selected_value: &<D::Item as SearchableListItem>::Value,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.state.list.update(cx, |list, cx| {
+            if !list.query_input.read(cx).value().is_empty() {
+                list.set_query("", window, cx);
+            }
+        });
+
         let selected_index = self
             .state
             .list
@@ -798,7 +807,7 @@ mod tests {
 
     use crate::{
         IndexPath,
-        searchable_list::SearchableVec,
+        searchable_list::{SearchableListDelegate as _, SearchableVec},
         select::{SelectGroup, SelectState},
     };
 
@@ -833,6 +842,53 @@ mod tests {
 
             assert_eq!(state.read(cx).selected_index(cx), Some(initial));
             assert_eq!(state.read(cx).selected_value(), Some(&"Blueberry"));
+        });
+    }
+
+    #[gpui::test]
+    fn test_select_set_selected_value_clears_search_query(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["Rust", "Go", "C++"]);
+            let state = cx.new(|cx| SelectState::new(items, None, window, cx).searchable(true));
+            let list = state.read(cx).state.list.clone();
+
+            list.update(cx, |list, cx| list.set_query("Rust", window, cx));
+            assert_eq!(list.read(cx).delegate().delegate.items_count(0), 1);
+
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Go", window, cx);
+            });
+
+            assert_eq!(state.read(cx).selected_value(), Some(&"Go"));
+            assert_eq!(state.read(cx).selected_index(cx), Some(IndexPath::new(1)));
+            assert_eq!(list.read(cx).query_input.read(cx).value(), "");
+        });
+    }
+
+    #[gpui::test]
+    fn test_select_set_selected_value_clears_grouped_search_query(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let mut groups: SearchableVec<SelectGroup<&'static str>> = SearchableVec::new(vec![]);
+            groups.push(SelectGroup::new("A").items(["Apple", "Avocado"]));
+            groups.push(SelectGroup::new("B").items(["Banana", "Blueberry"]));
+
+            let state = cx.new(|cx| SelectState::new(groups, None, window, cx).searchable(true));
+            let list = state.read(cx).state.list.clone();
+
+            list.update(cx, |list, cx| list.set_query("Blue", window, cx));
+            state.update(cx, |state, cx| {
+                state.set_selected_value(&"Banana", window, cx);
+            });
+
+            assert_eq!(state.read(cx).selected_value(), Some(&"Banana"));
+            assert_eq!(
+                state.read(cx).selected_index(cx),
+                Some(IndexPath::new(0).section(1)),
+            );
         });
     }
 }


### PR DESCRIPTION
## Problem

`SelectState::set_selected_value` asks the delegate for the position of a value, and a delegate answers from its matched items. With a search query active, that position is an index into the filtered view, so the Select picks the wrong row — or nothing at all when the value is filtered out.

Along the way: `ListState::set_query` documents that it triggers a search, but it only wrote to the input. `InputState::set_value` does not emit `InputEvent::Change`, so no search ran.

## Fix

- `set_selected_value` clears an active query first, so the lookup runs against the full item list.
- `set_query` starts the search itself, which is what its doc already promised.

The search body moves out of the input-event handler into `start_search` unchanged, so both callers share it.

## Test

Two tests in `crates/ui/src/select.rs`: a flat list and a grouped list, both selecting a value that the active filter had hidden. Both fail without the fix.

Closes #2522, #2627

AI-generated with Claude Code, reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)