### PR TITLE
accordion: Animate expanding and collapsing

### DIFF
--- a/crates/story/src/stories/accordion_story.rs
+++ b/crates/story/src/stories/accordion_story.rs
@@ -1,6 +1,6 @@
 use gpui::{
     App, AppContext, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement as _,
-    Render, Styled as _, Window, prelude::FluentBuilder as _,
+    Render, Styled as _, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     IconName, Selectable, Sizable, Size,
@@ -46,7 +46,7 @@ impl AccordionStory {
     fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         Self {
             bordered: false,
-            open_ixs: vec![0, 1, 2],
+            open_ixs: vec![0],
             size: Size::default(),
             disabled: false,
             multiple: true,
@@ -159,58 +159,62 @@ impl Render for AccordionStory {
                     ),
             )
             .child(
-                section("Normal").max_w_lg().child(
-                    Accordion::new("test")
-                        .bordered(self.bordered)
-                        .with_size(self.size)
-                        .disabled(self.disabled)
-                        .multiple(self.multiple)
-                        .item(|this| {
-                            this.open(self.open_ixs.contains(&0))
-                                .when(self.show_icon, |this| this.icon(IconName::Info))
-                                .title("Is it accessible?")
-                                .child(
-                                    "Yes. Each item is a button with an aria-expanded state, \
+                section("Normal").child(
+                    div().w(px(480.)).child(
+                        Accordion::new("test")
+                            .bordered(self.bordered)
+                            .with_size(self.size)
+                            .disabled(self.disabled)
+                            .multiple(self.multiple)
+                            .item(|this| {
+                                this.open(self.open_ixs.contains(&0))
+                                    .when(self.show_icon, |this| this.icon(IconName::Info))
+                                    .title("Is it accessible?")
+                                    .child(
+                                        "Yes. Each item is a button with an aria-expanded state, \
                                     so screen readers announce whether the section is open, \
                                     and the whole group can be reached with the keyboard.",
-                                )
-                        })
-                        .item(|this| {
-                            this.open(self.open_ixs.contains(&1))
-                                .when(self.show_icon, |this| this.icon(IconName::Inbox))
-                                .title("Can it hold any content?")
-                                .child(
-                                    v_flex()
-                                        .gap_3()
-                                        .child(
-                                            "An item takes any element as its content, \
+                                    )
+                            })
+                            .item(|this| {
+                                this.open(self.open_ixs.contains(&1))
+                                    .when(self.show_icon, |this| this.icon(IconName::Inbox))
+                                    .title("Can it hold any content?")
+                                    .child(
+                                        v_flex()
+                                            .gap_3()
+                                            .child(
+                                                "An item takes any element as its content, \
                                             not just text. The height animation measures \
                                             whatever you put in it.",
-                                        )
-                                        .child(
-                                            h_flex()
-                                                .gap_4()
-                                                .child(Switch::new("switch1").label("Switch"))
-                                                .child(
-                                                    Checkbox::new("checkbox1")
-                                                        .label("Or a Checkbox"),
-                                                ),
-                                        ),
-                                )
-                        })
-                        .item(|this| {
-                            this.open(self.open_ixs.contains(&2))
-                                .when(self.show_icon, |this| this.icon(IconName::Moon))
-                                .title("Is it animated?")
-                                .child(
-                                    "Yes. Expanding and collapsing animates the height of \
+                                            )
+                                            .child(
+                                                h_flex()
+                                                    .gap_4()
+                                                    .child(Switch::new("switch1").label("Switch"))
+                                                    .child(
+                                                        Checkbox::new("checkbox1")
+                                                            .label("Or a Checkbox"),
+                                                    ),
+                                            ),
+                                    )
+                            })
+                            .item(|this| {
+                                this.open(self.open_ixs.contains(&2))
+                                    .when(self.show_icon, |this| this.icon(IconName::Moon))
+                                    .title("Is it animated?")
+                                    .child(
+                                        "Yes. Expanding and collapsing animates the height of \
                                     the content, and the chevron rotates to follow. \
                                     Items below move along with it.",
-                                )
-                        })
-                        .on_toggle_click(cx.listener(|this, open_ixs: &[usize], window, cx| {
-                            this.toggle_accordion(open_ixs.to_vec(), window, cx);
-                        })),
+                                    )
+                            })
+                            .on_toggle_click(cx.listener(
+                                |this, open_ixs: &[usize], window, cx| {
+                                    this.toggle_accordion(open_ixs.to_vec(), window, cx);
+                                },
+                            )),
+                    ),
                 ),
             )
     }

--- a/crates/story/src/stories/accordion_story.rs
+++ b/crates/story/src/stories/accordion_story.rs
@@ -1,21 +1,70 @@
 use gpui::{
-    App, AppContext, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement as _,
-    Render, Styled as _, Window, div, prelude::FluentBuilder as _, px,
+    App, AppContext, Context, Entity, FocusHandle, Focusable, Hsla, IntoElement,
+    ParentElement as _, Render, StyleRefinement, Styled as _, Window, div,
+    prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    IconName, Selectable, Sizable, Size,
-    accordion::Accordion,
+    ActiveTheme as _, Icon, IconName, Selectable, Sizable, Size, StyledExt as _,
+    accordion::{Accordion, AccordionItem},
     button::{Button, ButtonGroup},
     checkbox::Checkbox,
     h_flex,
     switch::Switch,
+    tag::Tag,
     v_flex,
 };
 
 use crate::section;
 
+/// A settings row: the icon sits in a rounded square, and the content lines up
+/// with the title rather than with the icon.
+fn settings_item(
+    item: AccordionItem,
+    icon: IconName,
+    title: &'static str,
+    tag: Option<Tag>,
+    body: &'static str,
+    icon_bg: Hsla,
+    muted: Hsla,
+) -> AccordionItem {
+    item.title(
+        h_flex()
+            .gap_2()
+            .items_center()
+            .child(
+                h_flex()
+                    .flex_none()
+                    .size(px(32.))
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(8.))
+                    .bg(icon_bg)
+                    .child(Icon::new(icon).small().text_color(muted)),
+            )
+            .child(div().font_semibold().child(title))
+            .children(tag.map(|tag| tag.small())),
+    )
+    .title_style({
+        let mut style = StyleRefinement::default();
+        style.padding.top = Some(px(8.).into());
+        style.padding.bottom = Some(px(8.).into());
+        style
+    })
+    .content_style({
+        let mut style = StyleRefinement::default();
+        style.text.color = Some(muted);
+        // Past the icon square, so the text starts under the title.
+        style.padding.left = Some(px(52.).into());
+        style.padding.top = Some(px(0.).into());
+        style.padding.bottom = Some(px(12.).into());
+        style
+    })
+    .child(body)
+}
+
 pub struct AccordionStory {
     open_ixs: Vec<usize>,
+    styled_open_ixs: Vec<usize>,
     size: Size,
     bordered: bool,
     disabled: bool,
@@ -47,6 +96,7 @@ impl AccordionStory {
         Self {
             bordered: false,
             open_ixs: vec![0],
+            styled_open_ixs: vec![0],
             size: Size::default(),
             disabled: false,
             multiple: true,
@@ -74,6 +124,9 @@ impl Focusable for AccordionStory {
 
 impl Render for AccordionStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let icon_bg = cx.theme().secondary.opacity(0.5);
+        let muted_fg = cx.theme().muted_foreground;
+
         v_flex()
             .gap_5()
             .child(
@@ -215,6 +268,67 @@ impl Render for AccordionStory {
                                 },
                             )),
                     ),
+                ),
+            )
+            .child(
+                section("Custom Style").child(
+                    // A tinted frame around the card.
+                    div()
+                        .w(px(480.))
+                        .p(px(4.))
+                        .rounded(px(16.))
+                        .bg(cx.theme().secondary.opacity(0.5))
+                        .border_1()
+                        .border_color(cx.theme().border.opacity(0.5))
+                        .child(
+                            Accordion::new("custom-style")
+                                .multiple(self.multiple)
+                                .disabled(self.disabled)
+                                .item(|this| {
+                                    settings_item(
+                                        this,
+                                        IconName::Settings,
+                                        "Account Settings",
+                                        Some(Tag::success().outline().child("New")),
+                                        "Manage your account preferences, security settings, \
+                                    and personal information. You can also configure \
+                                    two-factor authentication here.",
+                                        icon_bg,
+                                        muted_fg,
+                                    )
+                                    .open(self.styled_open_ixs.contains(&0))
+                                })
+                                .item(|this| {
+                                    settings_item(
+                                        this,
+                                        IconName::Eye,
+                                        "Privacy & Security",
+                                        None,
+                                        "Control who can see your profile and how your data \
+                                    is used.",
+                                        icon_bg,
+                                        muted_fg,
+                                    )
+                                    .open(self.styled_open_ixs.contains(&1))
+                                })
+                                .item(|this| {
+                                    settings_item(
+                                        this,
+                                        IconName::Info,
+                                        "Help & Support",
+                                        None,
+                                        "Browse the documentation, or get in touch with the \
+                                    support team.",
+                                        icon_bg,
+                                        muted_fg,
+                                    )
+                                    .open(self.styled_open_ixs.contains(&2))
+                                })
+                                .on_toggle_click(cx.listener(|this, open_ixs: &[usize], _, cx| {
+                                    this.styled_open_ixs = open_ixs.to_vec();
+                                    cx.notify();
+                                })),
+                        ),
                 ),
             )
     }

--- a/crates/story/src/stories/accordion_story.rs
+++ b/crates/story/src/stories/accordion_story.rs
@@ -159,7 +159,7 @@ impl Render for AccordionStory {
                     ),
             )
             .child(
-                section("Normal").max_w_md().child(
+                section("Normal").max_w_lg().child(
                     Accordion::new("test")
                         .bordered(self.bordered)
                         .with_size(self.size)
@@ -169,35 +169,43 @@ impl Render for AccordionStory {
                             this.open(self.open_ixs.contains(&0))
                                 .when(self.show_icon, |this| this.icon(IconName::Info))
                                 .title("Is it accessible?")
-                                .child("Yes. It adheres to the WAI-ARIA design pattern.")
+                                .child(
+                                    "Yes. Each item is a button with an aria-expanded state, \
+                                    so screen readers announce whether the section is open, \
+                                    and the whole group can be reached with the keyboard.",
+                                )
                         })
                         .item(|this| {
                             this.open(self.open_ixs.contains(&1))
-                            .when(self.show_icon, |this| this.icon(IconName::Inbox))
-                            .title("Is it styled with complex elements?")
-                            .child(
-                                v_flex()
-                                    .gap_4()
-                                    .child(
-                                        "We can put any view here, like a v_flex with a text view",
-                                    )
-                                    .child(
-                                        h_flex()
-                                            .gap_4()
-                                            .child(Switch::new("switch1").label("Switch"))
-                                            .child(
-                                                Checkbox::new("checkbox1").label("Or a Checkbox"),
-                                            ),
-                                    ),
-                            )
+                                .when(self.show_icon, |this| this.icon(IconName::Inbox))
+                                .title("Can it hold any content?")
+                                .child(
+                                    v_flex()
+                                        .gap_3()
+                                        .child(
+                                            "An item takes any element as its content, \
+                                            not just text. The height animation measures \
+                                            whatever you put in it.",
+                                        )
+                                        .child(
+                                            h_flex()
+                                                .gap_4()
+                                                .child(Switch::new("switch1").label("Switch"))
+                                                .child(
+                                                    Checkbox::new("checkbox1")
+                                                        .label("Or a Checkbox"),
+                                                ),
+                                        ),
+                                )
                         })
                         .item(|this| {
                             this.open(self.open_ixs.contains(&2))
                                 .when(self.show_icon, |this| this.icon(IconName::Moon))
-                                .title("This is third accordion")
+                                .title("Is it animated?")
                                 .child(
-                                    "This is the third accordion content. \
-                                It can be any view, like a text view or a button.",
+                                    "Yes. Expanding and collapsing animates the height of \
+                                    the content, and the chevron rotates to follow. \
+                                    Items below move along with it.",
                                 )
                         })
                         .on_toggle_click(cx.listener(|this, open_ixs: &[usize], window, cx| {

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -1,12 +1,25 @@
-use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
-
-use gpui::{
-    AnyElement, App, ElementId, InteractiveElement as _, IntoElement, ParentElement, RenderOnce,
-    Role, SharedString, StatefulInteractiveElement as _, Styled, Window, div,
-    prelude::FluentBuilder as _, rems,
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    rc::Rc,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
-use crate::{ActiveTheme as _, Icon, IconName, Sizable, Size, h_flex, v_flex};
+use gpui::{
+    AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
+    InspectorElementId, InteractiveElement as _, IntoElement, LayoutId, ParentElement, Pixels,
+    RenderOnce, Role, SharedString, StatefulInteractiveElement as _, Style, Styled, Window, div,
+    percentage, prelude::FluentBuilder as _, px, relative, rems, size,
+};
+
+use crate::{
+    ActiveTheme as _, Icon, IconName, Sizable, Size, StyledExt as _, animation::ease_out_cubic,
+    h_flex, v_flex,
+};
+
+/// Duration of the expand/collapse animation.
+const ANIMATION_DURATION: Duration = Duration::from_millis(200);
 
 /// Accordion element.
 #[derive(IntoElement)]
@@ -85,6 +98,7 @@ impl RenderOnce for Accordion {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let open_ixs = Rc::new(RefCell::new(HashSet::new()));
         let is_multiple = self.multiple;
+        let last_ix = self.children.len().saturating_sub(1);
 
         v_flex()
             .id(self.id)
@@ -101,6 +115,7 @@ impl RenderOnce for Accordion {
 
                         accordion
                             .index(ix)
+                            .last(ix == last_ix)
                             .with_size(self.size)
                             .bordered(self.bordered)
                             .disabled(self.disabled)
@@ -134,10 +149,185 @@ impl RenderOnce for Accordion {
     }
 }
 
+/// The content of an [`AccordionItem`], animating its height on toggle.
+///
+/// The content stays in the element tree while closed (clipped to zero height),
+/// so that the collapse can be animated, and so that its natural height is
+/// still measured for the next expand.
+struct AccordionContent {
+    id: ElementId,
+    open: bool,
+    child: AnyElement,
+}
+
+#[derive(Clone, Copy)]
+struct AccordionContentState {
+    /// The `open` of the last frame, to detect a toggle.
+    open: bool,
+    /// The progress at the time the current animation started.
+    from: f32,
+    /// `None` when the content is settled at its target height.
+    started_at: Option<Instant>,
+    /// The natural height measured in the last prepaint.
+    height: Option<Pixels>,
+}
+
+impl AccordionContentState {
+    fn new(open: bool) -> Self {
+        Self {
+            open,
+            from: if open { 1. } else { 0. },
+            started_at: None,
+            height: None,
+        }
+    }
+
+    /// The progress of the animation, from 0. (closed) to 1. (open).
+    ///
+    /// This finishes the animation when the duration has passed, so it takes
+    /// `&mut self`.
+    fn progress(&mut self) -> f32 {
+        let target = if self.open { 1. } else { 0. };
+        let Some(started_at) = self.started_at else {
+            return target;
+        };
+
+        let t = started_at.elapsed().as_secs_f32() / ANIMATION_DURATION.as_secs_f32();
+        if t >= 1. {
+            self.started_at = None;
+            return target;
+        }
+
+        self.from + (target - self.from) * ease_out_cubic(t)
+    }
+}
+
+impl AccordionContent {
+    fn new(id: impl Into<ElementId>, open: bool, child: AnyElement) -> Self {
+        Self {
+            id: id.into(),
+            open,
+            child,
+        }
+    }
+}
+
+impl IntoElement for AccordionContent {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for AccordionContent {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let open = self.open;
+        let (progress, height) = window.with_element_state(
+            global_id.expect("AccordionContent must have an id"),
+            |state: Option<AccordionContentState>, window| {
+                let mut state = state.unwrap_or_else(|| AccordionContentState::new(open));
+
+                if state.open != open {
+                    state.from = state.progress();
+                    state.open = open;
+                    state.started_at = Some(Instant::now());
+                }
+
+                let progress = state.progress();
+                if state.started_at.is_some() {
+                    window.request_animation_frame();
+                }
+
+                ((progress, state.height), state)
+            },
+        );
+
+        let mut style = Style::default();
+        style.size.width = relative(1.).into();
+        match height {
+            // Before the first measure there is nothing to animate to, let the
+            // content lay itself out to get its natural height measured.
+            None if open => {}
+            None => style.size.height = px(0.).into(),
+            Some(height) => style.size.height = (height * progress).into(),
+        }
+
+        (window.request_layout(style, None, cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        global_id: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        // Lay the content out at its natural height, the visible part is the
+        // one clipped by `bounds`.
+        let available = size(
+            AvailableSpace::Definite(bounds.size.width),
+            AvailableSpace::MinContent,
+        );
+        let measured = self.child.layout_as_root(available, window, cx);
+
+        window.with_element_state(
+            global_id.expect("AccordionContent must have an id"),
+            |state: Option<AccordionContentState>, _| {
+                let mut state = state.unwrap_or_else(|| AccordionContentState::new(self.open));
+                state.height = Some(measured.height);
+                ((), state)
+            },
+        );
+
+        // Mask here as well as in paint, to keep the hidden content from
+        // taking mouse events.
+        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+            self.child.prepaint_at(bounds.origin, window, cx);
+        });
+    }
+
+    fn paint(
+        &mut self,
+        _: Option<&GlobalElementId>,
+        _: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _: &mut Self::RequestLayoutState,
+        _: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+            self.child.paint(window, cx);
+        });
+    }
+}
+
 /// An Accordion is a vertically stacked list of items, each of which can be expanded to reveal the content associated with it.
 #[derive(IntoElement)]
 pub struct AccordionItem {
     index: usize,
+    /// The last item does not need a separator under it.
+    last: bool,
     icon: Option<Icon>,
     title: AnyElement,
     children: Vec<AnyElement>,
@@ -153,6 +343,7 @@ impl AccordionItem {
     pub fn new() -> Self {
         Self {
             index: 0,
+            last: false,
             icon: None,
             title: SharedString::default().into_any_element(),
             children: Vec::new(),
@@ -196,6 +387,11 @@ impl AccordionItem {
         self
     }
 
+    fn last(mut self, last: bool) -> Self {
+        self.last = last;
+        self
+    }
+
     fn on_toggle_click(
         mut self,
         on_toggle_click: impl Fn(&bool, &mut Window, &mut App) + 'static,
@@ -231,10 +427,18 @@ impl RenderOnce for AccordionItem {
                 .w_full()
                 .bg(cx.theme().tokens.accordion)
                 .overflow_hidden()
-                .when(self.bordered, |this| {
-                    this.border_1()
-                        .rounded(cx.theme().radius)
-                        .border_color(cx.theme().border)
+                .map(|this| {
+                    if self.bordered {
+                        this.border_1()
+                            .rounded(cx.theme().radius)
+                            .border_color(cx.theme().border)
+                    } else if self.last {
+                        this
+                    } else {
+                        // Without borders the items are separated by a single
+                        // line under each of them, below the content.
+                        this.border_b_1().border_color(cx.theme().border)
+                    }
                 })
                 .text_size(text_size)
                 .child(
@@ -244,22 +448,14 @@ impl RenderOnce for AccordionItem {
                         .aria_expanded(self.open)
                         .justify_between()
                         .gap_3()
+                        .font_medium()
                         .map(|this| match self.size {
-                            Size::XSmall => this.py_0().px_1p5(),
-                            Size::Small => this.py_0p5().px_2(),
-                            Size::Large => this.py_1p5().px_4(),
-                            _ => this.py_1().px_3(),
+                            Size::XSmall => this.py_1().px_2(),
+                            Size::Small => this.py_1p5().px_2p5(),
+                            Size::Large => this.py_3().px_4(),
+                            _ => this.py_2p5().px_3(),
                         })
-                        .when(self.open, |this| {
-                            this.when(self.bordered, |this| {
-                                this.text_color(cx.theme().foreground)
-                                    .border_b_1()
-                                    .border_color(cx.theme().border)
-                            })
-                        })
-                        .when(!self.bordered, |this| {
-                            this.border_b_1().border_color(cx.theme().border)
-                        })
+                        .when(self.open, |this| this.text_color(cx.theme().foreground))
                         .child(
                             h_flex()
                                 .items_center()
@@ -279,13 +475,10 @@ impl RenderOnce for AccordionItem {
                         .when(!self.disabled, |this| {
                             this.hover(|this| this.bg(cx.theme().tokens.accordion_hover))
                                 .child(
-                                    Icon::new(if self.open {
-                                        IconName::ChevronUp
-                                    } else {
-                                        IconName::ChevronDown
-                                    })
-                                    .xsmall()
-                                    .text_color(cx.theme().muted_foreground),
+                                    Icon::new(IconName::ChevronDown)
+                                        .xsmall()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .rotate(percentage(if self.open { 0.5 } else { 0. })),
                                 )
                                 .when_some(self.on_toggle_click, |this, on_toggle_click| {
                                     this.on_click({
@@ -296,18 +489,20 @@ impl RenderOnce for AccordionItem {
                                 })
                         }),
                 )
-                .when(self.open, |this| {
-                    this.child(
-                        div()
-                            .map(|this| match self.size {
-                                Size::XSmall => this.p_1p5(),
-                                Size::Small => this.p_2(),
-                                Size::Large => this.p_4(),
-                                _ => this.p_3(),
-                            })
-                            .children(self.children),
-                    )
-                }),
+                .child(AccordionContent::new(
+                    ("content", self.index),
+                    self.open,
+                    div()
+                        .text_color(cx.theme().muted_foreground)
+                        .map(|this| match self.size {
+                            Size::XSmall => this.px_2().pb_2(),
+                            Size::Small => this.px_2p5().pb_2p5(),
+                            Size::Large => this.px_4().pb_4(),
+                            _ => this.px_3().pb_3(),
+                        })
+                        .children(self.children)
+                        .into_any_element(),
+                )),
         )
     }
 }

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -9,8 +9,8 @@ use std::{
 use gpui::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
     InspectorElementId, InteractiveElement as _, IntoElement, LayoutId, ParentElement, Pixels,
-    RenderOnce, Role, SharedString, StatefulInteractiveElement as _, Style, Styled, Window, div,
-    percentage, prelude::FluentBuilder as _, px, relative, rems, size,
+    RenderOnce, Role, SharedString, StatefulInteractiveElement as _, Style, StyleRefinement,
+    Styled, Window, div, percentage, prelude::FluentBuilder as _, px, relative, rems, size,
 };
 
 use crate::{
@@ -25,6 +25,7 @@ const ANIMATION_DURATION: Duration = Duration::from_millis(200);
 #[derive(IntoElement)]
 pub struct Accordion {
     id: ElementId,
+    style: StyleRefinement,
     multiple: bool,
     size: Size,
     bordered: bool,
@@ -38,6 +39,7 @@ impl Accordion {
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
             id: id.into(),
+            style: StyleRefinement::default(),
             multiple: false,
             size: Size::default(),
             bordered: true,
@@ -94,8 +96,14 @@ impl Sizable for Accordion {
     }
 }
 
+impl Styled for Accordion {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
 impl RenderOnce for Accordion {
-    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let open_ixs = Rc::new(RefCell::new(HashSet::new()));
         let is_multiple = self.multiple;
         let last_ix = self.children.len().saturating_sub(1);
@@ -103,7 +111,15 @@ impl RenderOnce for Accordion {
         v_flex()
             .id(self.id)
             .size_full()
-            .when(self.bordered, |this| this.gap_y_2())
+            // The bordered accordion is a single rounded card, the items are
+            // joined by their separators.
+            .when(self.bordered, |this| {
+                this.border_1()
+                    .border_color(cx.theme().border)
+                    .rounded(cx.theme().radius_lg)
+                    .overflow_hidden()
+            })
+            .refine_style(&self.style)
             .children(
                 self.children
                     .into_iter()
@@ -117,7 +133,6 @@ impl RenderOnce for Accordion {
                             .index(ix)
                             .last(ix == last_ix)
                             .with_size(self.size)
-                            .bordered(self.bordered)
                             .disabled(self.disabled)
                             .on_toggle_click({
                                 let open_ixs = Rc::clone(&open_ixs);
@@ -326,12 +341,15 @@ impl Element for AccordionContent {
 pub struct AccordionItem {
     index: usize,
     last: bool,
+    style: StyleRefinement,
+    hover_style: Option<StyleRefinement>,
+    title_style: StyleRefinement,
+    content_style: StyleRefinement,
     icon: Option<Icon>,
     title: AnyElement,
     children: Vec<AnyElement>,
     open: bool,
     size: Size,
-    bordered: bool,
     disabled: bool,
     on_toggle_click: Option<Arc<dyn Fn(&bool, &mut Window, &mut App)>>,
 }
@@ -342,6 +360,10 @@ impl AccordionItem {
         Self {
             index: 0,
             last: false,
+            style: StyleRefinement::default(),
+            hover_style: None,
+            title_style: StyleRefinement::default(),
+            content_style: StyleRefinement::default(),
             icon: None,
             title: SharedString::default().into_any_element(),
             children: Vec::new(),
@@ -349,7 +371,6 @@ impl AccordionItem {
             disabled: false,
             on_toggle_click: None,
             size: Size::default(),
-            bordered: true,
         }
     }
 
@@ -365,11 +386,6 @@ impl AccordionItem {
         self
     }
 
-    pub fn bordered(mut self, bordered: bool) -> Self {
-        self.bordered = bordered;
-        self
-    }
-
     pub fn open(mut self, open: bool) -> Self {
         self.open = open;
         self
@@ -377,6 +393,28 @@ impl AccordionItem {
 
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Set extra style for the title row.
+    pub fn title_style(mut self, style: StyleRefinement) -> Self {
+        self.title_style = style;
+        self
+    }
+
+    /// Set the style of the title row while the mouse is over it.
+    ///
+    /// There is no hover style by default. The title row is the part that
+    /// toggles the item, so the hover feedback belongs there, not on the
+    /// whole item.
+    pub fn hover(mut self, f: impl FnOnce(StyleRefinement) -> StyleRefinement) -> Self {
+        self.hover_style = Some(f(StyleRefinement::default()));
+        self
+    }
+
+    /// Set extra style for the content below the title.
+    pub fn content_style(mut self, style: StyleRefinement) -> Self {
+        self.content_style = style;
         self
     }
 
@@ -412,6 +450,12 @@ impl Sizable for AccordionItem {
     }
 }
 
+impl Styled for AccordionItem {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
 impl RenderOnce for AccordionItem {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let text_size = match self.size {
@@ -425,19 +469,12 @@ impl RenderOnce for AccordionItem {
                 .w_full()
                 .bg(cx.theme().tokens.accordion)
                 .overflow_hidden()
-                .map(|this| {
-                    if self.bordered {
-                        this.border_1()
-                            .rounded(cx.theme().radius)
-                            .border_color(cx.theme().border)
-                    } else if self.last {
-                        this
-                    } else {
-                        // Separated by a line under each item, below the content.
-                        this.border_b_1().border_color(cx.theme().border)
-                    }
+                // Separated by a line under each item, below the content.
+                .when(!self.last, |this| {
+                    this.border_b_1().border_color(cx.theme().border)
                 })
                 .text_size(text_size)
+                .refine_style(&self.style)
                 .child(
                     h_flex()
                         .id(self.index)
@@ -453,6 +490,7 @@ impl RenderOnce for AccordionItem {
                             _ => this.py_2().px_3(),
                         })
                         .when(self.open, |this| this.text_color(cx.theme().foreground))
+                        .refine_style(&self.title_style)
                         .child(
                             h_flex()
                                 .items_center()
@@ -467,20 +505,25 @@ impl RenderOnce for AccordionItem {
                                 .child(self.title),
                         )
                         .when(!self.disabled, |this| {
-                            this.hover(|this| this.bg(cx.theme().tokens.accordion_hover))
-                                .child(
-                                    Icon::new(IconName::ChevronDown)
-                                        .xsmall()
-                                        .text_color(cx.theme().muted_foreground)
-                                        .rotate(percentage(if self.open { 0.5 } else { 0. })),
-                                )
-                                .when_some(self.on_toggle_click, |this, on_toggle_click| {
+                            this.when_some(self.hover_style, |this, hover_style| {
+                                this.hover(move |this| this.refine_style(&hover_style))
+                            })
+                            .child(
+                                Icon::new(IconName::ChevronDown)
+                                    .xsmall()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .rotate(percentage(if self.open { 0.5 } else { 0. })),
+                            )
+                            .when_some(
+                                self.on_toggle_click,
+                                |this, on_toggle_click| {
                                     this.on_click({
                                         move |_, window, cx| {
                                             on_toggle_click(&!self.open, window, cx);
                                         }
                                     })
-                                })
+                                },
+                            )
                         }),
                 )
                 .child(AccordionContent::new(
@@ -494,6 +537,7 @@ impl RenderOnce for AccordionItem {
                             Size::Large => this.pb_3().px_4(),
                             _ => this.pb_2().px_3(),
                         })
+                        .refine_style(&self.content_style)
                         .children(self.children)
                         .into_any_element(),
                 )),

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -151,9 +151,8 @@ impl RenderOnce for Accordion {
 
 /// The content of an [`AccordionItem`], animating its height on toggle.
 ///
-/// The content stays in the element tree while closed (clipped to zero height),
-/// so that the collapse can be animated, and so that its natural height is
-/// still measured for the next expand.
+/// It stays in the tree while closed, clipped to zero height, to be able to
+/// animate the collapse and to keep its natural height measured.
 struct AccordionContent {
     id: ElementId,
     open: bool,
@@ -162,11 +161,9 @@ struct AccordionContent {
 
 #[derive(Clone, Copy)]
 struct AccordionContentState {
-    /// The `open` of the last frame, to detect a toggle.
     open: bool,
-    /// The progress at the time the current animation started.
+    /// The progress when the current animation started.
     from: f32,
-    /// `None` when the content is settled at its target height.
     started_at: Option<Instant>,
     /// The natural height measured in the last prepaint.
     height: Option<Pixels>,
@@ -182,10 +179,8 @@ impl AccordionContentState {
         }
     }
 
-    /// The progress of the animation, from 0. (closed) to 1. (open).
-    ///
-    /// This finishes the animation when the duration has passed, so it takes
-    /// `&mut self`.
+    /// Progress from 0. (closed) to 1. (open), ending the animation when the
+    /// duration has passed.
     fn progress(&mut self) -> f32 {
         let target = if self.open { 1. } else { 0. };
         let Some(started_at) = self.started_at else {
@@ -263,8 +258,7 @@ impl Element for AccordionContent {
         let mut style = Style::default();
         style.size.width = relative(1.).into();
         match height {
-            // Before the first measure there is nothing to animate to, let the
-            // content lay itself out to get its natural height measured.
+            // Not measured yet, let the content lay itself out.
             None if open => {}
             None => style.size.height = px(0.).into(),
             Some(height) => style.size.height = (height * progress).into(),
@@ -282,25 +276,30 @@ impl Element for AccordionContent {
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
-        // Lay the content out at its natural height, the visible part is the
-        // one clipped by `bounds`.
+        // Lay out at the natural height, `bounds` clips the visible part.
         let available = size(
             AvailableSpace::Definite(bounds.size.width),
             AvailableSpace::MinContent,
         );
         let measured = self.child.layout_as_root(available, window, cx);
 
-        window.with_element_state(
+        let changed = window.with_element_state(
             global_id.expect("AccordionContent must have an id"),
             |state: Option<AccordionContentState>, _| {
                 let mut state = state.unwrap_or_else(|| AccordionContentState::new(self.open));
+                let changed = state.height != Some(measured.height);
                 state.height = Some(measured.height);
-                ((), state)
+                (changed, state)
             },
         );
 
-        // Mask here as well as in paint, to keep the hidden content from
-        // taking mouse events.
+        // The measured height is only used by the next `request_layout`, ask
+        // for that frame, or the new height never gets painted.
+        if changed {
+            window.request_animation_frame();
+        }
+
+        // Masked here too, so the hidden content takes no mouse events.
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             self.child.prepaint_at(bounds.origin, window, cx);
         });
@@ -326,7 +325,6 @@ impl Element for AccordionContent {
 #[derive(IntoElement)]
 pub struct AccordionItem {
     index: usize,
-    /// The last item does not need a separator under it.
     last: bool,
     icon: Option<Icon>,
     title: AnyElement,
@@ -417,9 +415,9 @@ impl Sizable for AccordionItem {
 impl RenderOnce for AccordionItem {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let text_size = match self.size {
-            Size::XSmall => rems(0.875),
-            Size::Small => rems(0.875),
-            _ => rems(1.0),
+            Size::XSmall => rems(0.8125),
+            Size::Large => rems(1.0),
+            _ => rems(0.875),
         };
 
         div().flex_1().child(
@@ -435,8 +433,7 @@ impl RenderOnce for AccordionItem {
                     } else if self.last {
                         this
                     } else {
-                        // Without borders the items are separated by a single
-                        // line under each of them, below the content.
+                        // Separated by a line under each item, below the content.
                         this.border_b_1().border_color(cx.theme().border)
                     }
                 })
@@ -450,10 +447,10 @@ impl RenderOnce for AccordionItem {
                         .gap_3()
                         .font_medium()
                         .map(|this| match self.size {
-                            Size::XSmall => this.py_1().px_2(),
-                            Size::Small => this.py_1p5().px_2p5(),
+                            Size::XSmall => this.py_1().px_1p5(),
+                            Size::Small => this.py_1p5().px_2(),
                             Size::Large => this.py_3().px_4(),
-                            _ => this.py_2p5().px_3(),
+                            _ => this.py_2().px_3(),
                         })
                         .when(self.open, |this| this.text_color(cx.theme().foreground))
                         .child(
@@ -465,10 +462,7 @@ impl RenderOnce for AccordionItem {
                                     _ => this.gap_2(),
                                 })
                                 .when_some(self.icon, |this, icon| {
-                                    this.child(
-                                        icon.with_size(self.size)
-                                            .text_color(cx.theme().muted_foreground),
-                                    )
+                                    this.child(icon.with_size(self.size))
                                 })
                                 .child(self.title),
                         )
@@ -493,12 +487,12 @@ impl RenderOnce for AccordionItem {
                     ("content", self.index),
                     self.open,
                     div()
-                        .text_color(cx.theme().muted_foreground)
+                        // No top padding, the title has its own bottom padding.
                         .map(|this| match self.size {
-                            Size::XSmall => this.px_2().pb_2(),
-                            Size::Small => this.px_2p5().pb_2p5(),
-                            Size::Large => this.px_4().pb_4(),
-                            _ => this.px_3().pb_3(),
+                            Size::XSmall => this.pb_1().px_1p5(),
+                            Size::Small => this.pb_1p5().px_2(),
+                            Size::Large => this.pb_3().px_4(),
+                            _ => this.pb_2().px_3(),
                         })
                         .children(self.children)
                         .into_any_element(),

--- a/crates/ui/src/theme/schema.rs
+++ b/crates/ui/src/theme/schema.rs
@@ -88,9 +88,6 @@ pub struct ThemeConfigColors {
     /// Accordion background color.
     #[serde(rename = "accordion.background")]
     pub accordion: Option<SharedString>,
-    /// Accordion hover background color.
-    #[serde(rename = "accordion.hover.background")]
-    pub accordion_hover: Option<SharedString>,
     /// Default background color.
     #[serde(rename = "background")]
     pub background: Option<SharedString>,
@@ -738,7 +735,6 @@ impl ThemeColor {
         apply_background_color!(accent, fallback = tokens.secondary);
         apply_color!(accent_foreground, fallback = self.foreground);
         apply_background_color!(accordion, fallback = tokens.background);
-        apply_background_color!(accordion_hover, fallback = self.accent.opacity(0.8));
         apply_background_color!(
             group_box,
             fallback = self

--- a/crates/ui/src/theme/theme_color.rs
+++ b/crates/ui/src/theme/theme_color.rs
@@ -63,8 +63,6 @@ pub struct ThemeColor {
     pub accent_foreground: Hsla,
     /// Accordion background color.
     pub accordion: Hsla,
-    /// Accordion hover background color.
-    pub accordion_hover: Hsla,
     /// Default background color.
     pub background: Hsla,
     /// Default border color
@@ -373,7 +371,6 @@ define_theme_tokens! {
     accent,
     accent_foreground,
     accordion,
-    accordion_hover,
     background,
     border,
     button,


### PR DESCRIPTION
## Summary

The accordion content used to appear and disappear in one frame. Now its height animates between 0 and the content height, and the chevron rotates to follow, like the [shadcn accordion](https://ui.shadcn.com/docs/components/base/accordion).

<img width="1039" height="974" alt="image" src="https://github.com/user-attachments/assets/0f73e210-0563-46c9-9d4f-484023238f74" />

## Visual changes

- Chevron rotates 180° instead of swapping `ChevronUp` / `ChevronDown`.
- Bordered: no separator under the title when open.
- Not bordered: the separator moved from under the title to the bottom of the item, so it sits below the content instead of between the title and the content. The last item does not draw one.
- Larger vertical padding on the title, `font_medium` title, and muted content text.

## Story

Wider section and longer content, so the height animation is visible.

## AI Assistance

Written with Claude.