### PR TITLE
input: Draw the NumberInput frame around the whole control

### DIFF
--- a/crates/story/src/stories/button_story.rs
+++ b/crates/story/src/stories/button_story.rs
@@ -90,7 +90,7 @@ impl Render for ButtonStory {
             .color(cx.theme().magenta)
             .foreground(cx.theme().magenta)
             .hover(cx.theme().magenta.opacity(0.1))
-            .active(cx.theme().magenta);
+            .active(cx.theme().magenta.opacity(0.2));
 
         v_flex()
             .on_action(

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -850,7 +850,7 @@ impl ButtonVariant {
             }
             Self::Link => cx.theme().link,
             Self::Text => cx.theme().foreground.opacity(0.9),
-            Self::Custom(colors) => colors.color,
+            Self::Custom(colors) => colors.foreground,
         }
     }
 
@@ -979,12 +979,7 @@ impl ButtonVariant {
                     cx.theme().tokens.button_info_hover.into()
                 }
             }
-            Self::Custom(colors) => if outline {
-                colors.color.mix_oklab(cx.theme().transparent, 0.2)
-            } else {
-                colors.color.mix_oklab(cx.theme().transparent, 0.3)
-            }
-            .into(),
+            Self::Custom(colors) => colors.hover.into(),
             Self::Ghost => if cx.theme().mode.is_dark() {
                 cx.theme().secondary.lighten(0.1).opacity(0.8)
             } else {
@@ -1071,7 +1066,7 @@ impl ButtonVariant {
                     cx.theme().tokens.button_info_active.into()
                 }
             }
-            Self::Custom(colors) => colors.color.mix_oklab(cx.theme().transparent, 0.4).into(),
+            Self::Custom(colors) => colors.active.into(),
             Self::Link => cx.theme().transparent.into(),
             Self::Text => cx.theme().transparent.into(),
         };

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::theme::ActiveTheme;
 use gpui::Corners;
 use gpui::Window;
-use gpui::{AnyElement, App, Context, Edges, Entity, EventEmitter, FocusHandle, Focusable};
+use gpui::{AnyElement, App, Context, Entity, EventEmitter, FocusHandle, Focusable, px};
 use gpui::{
     InteractiveElement, IntoElement, KeyBinding, ParentElement, RenderOnce, Role, SharedString,
     StatefulInteractiveElement as _, StyleRefinement, Styled, TextAlign, actions,
@@ -12,11 +12,11 @@ use gpui::{
 
 use crate::{
     Disableable, IconName, Sizable, Size, StyledExt as _,
-    button::{Button, ButtonVariants as _},
+    button::{Button, ButtonCustomVariant, ButtonVariants as _},
     h_flex,
 };
 
-use super::{Input, InputState, MaskPattern};
+use super::{Input, InputState, MaskPattern, input::input_style};
 
 actions!(number_input, [Increment, Decrement]);
 
@@ -298,6 +298,25 @@ impl RenderOnce for NumberInput {
         }
 
         let numeric_value = self.state.read(cx).value().parse::<f64>().ok();
+        let focused = self.state.read(cx).focus_handle.is_focused(window) && !self.disabled;
+        let (bg, _) = input_style(self.disabled, cx);
+        let border_color = if self.disabled {
+            cx.theme().input.opacity(0.5)
+        } else {
+            cx.theme().input
+        };
+        // Transparent like a ghost button, but tinted to the frame on hover.
+        let button_variant = ButtonCustomVariant::new(cx)
+            .foreground(cx.theme().secondary_foreground)
+            .hover(cx.theme().input.opacity(0.4))
+            .active(cx.theme().input.opacity(0.6));
+        // The buttons sit inside the 1px frame, so their corners are a pixel
+        // tighter than the frame's, or they paint over its inner curve.
+        let button_radius = if self.appearance {
+            (cx.theme().radius - px(1.)).max(px(0.))
+        } else {
+            cx.theme().radius
+        };
 
         h_flex()
             .id(("number-input", self.state.entity_id()))
@@ -308,34 +327,31 @@ impl RenderOnce for NumberInput {
             .on_action(window.listener_for(&self.state, InputState::on_action_decrement))
             .flex_1()
             .rounded(cx.theme().radius)
+            // The buttons are ghost, so the frame around the whole control is
+            // drawn here instead of by each of its parts.
+            .when(self.appearance, |this| {
+                this.bg(bg)
+                    .border_1()
+                    .border_color(border_color)
+                    .when(focused, |this| this.focused_border(cx))
+            })
             .refine_style(&self.style)
             .when(self.disabled, |this| this.opacity(0.5))
             .child(
                 Button::new("minus")
-                    .map(|this| {
-                        if self.appearance {
-                            this.outline()
-                        } else {
-                            this.ghost()
-                        }
-                    })
+                    .custom(button_variant)
+                    .rounded(button_radius)
                     .with_size(self.size)
                     .icon(IconName::Minus)
                     .compact()
                     .tab_stop(false)
                     .disabled(self.disabled)
-                    .border_color(cx.theme().input)
+                    // Only the outer corners are rounded, to follow the frame.
                     .border_corners(Corners {
                         top_left: true,
                         top_right: false,
                         bottom_right: false,
                         bottom_left: true,
-                    })
-                    .border_edges(Edges {
-                        top: self.appearance,
-                        right: false,
-                        bottom: self.appearance,
-                        left: self.appearance,
                     })
                     .on_click({
                         let state = self.state.clone();
@@ -346,7 +362,7 @@ impl RenderOnce for NumberInput {
             )
             .child(
                 Input::new(&self.state)
-                    .appearance(self.appearance)
+                    .appearance(false)
                     .with_size(self.size)
                     .disabled(self.disabled)
                     .gap_0()
@@ -357,30 +373,18 @@ impl RenderOnce for NumberInput {
             )
             .child(
                 Button::new("plus")
-                    .map(|this| {
-                        if self.appearance {
-                            this.outline()
-                        } else {
-                            this.ghost()
-                        }
-                    })
+                    .custom(button_variant)
+                    .rounded(button_radius)
                     .with_size(self.size)
                     .icon(IconName::Plus)
                     .compact()
                     .tab_stop(false)
                     .disabled(self.disabled)
-                    .border_color(cx.theme().input)
                     .border_corners(Corners {
                         top_left: false,
                         top_right: true,
                         bottom_right: true,
                         bottom_left: false,
-                    })
-                    .border_edges(Edges {
-                        top: self.appearance,
-                        right: self.appearance,
-                        bottom: self.appearance,
-                        left: false,
                     })
                     .on_click({
                         let state = self.state.clone();


### PR DESCRIPTION
## Summary

The `-` and `+` buttons each drew a part of the frame around `NumberInput`, together with the `Input` in the middle. Draw it once, around the whole control, and leave the buttons transparent.

- The `h_flex` gets the background, the border and the focus ring, `Input` is now `appearance(false)`.
- The buttons drop `border_edges` / `border_color` and use a custom variant that is transparent, tinted to `input.opacity(0.4)` on hover.
- Their corners are `radius - 1px`, since they sit inside the 1px frame, and only the outer two are rounded, so they follow the frame instead of painting over its inner curve.

<img width="1056" height="838" alt="image" src="https://github.com/user-attachments/assets/5d54e3b9-53e0-427e-98f1-15ec611178d7" />

## `ButtonCustomVariant`

Three of its fields were never read, the states were all derived from `color` instead:

| Field | Before | Now |
|---|---|---|
| `foreground` | unused, the foreground was `color` | the foreground |
| `hover` | unused, hover was `color` mixed 30% | the hover background |
| `active` | only used when selected, active was `color` mixed 40% | the active background |

The custom buttons in the Button story set `color` and `foreground` to the same value, so their foreground is unchanged; their hover now uses the `magenta.opacity(0.1)` they already asked for.

## Test plan

- [x] `cargo clippy -p gpui-component -p gpui-component-story --all-targets`
- [ ] NumberInput story: the frame is one rounded box in every size, the focus ring is on the whole control, `-` / `+` hover fills the corner cleanly, and `Without appearance` has no frame.
- [ ] Button story: the custom buttons still read the same, hover is the lighter magenta.

## AI Assistance

Written with Claude.