### PR TITLE
text: Break inline flow at hard newlines

### DIFF
--- a/crates/ui/src/text/inline_flow.rs
+++ b/crates/ui/src/text/inline_flow.rs
@@ -522,44 +522,81 @@ fn line_ranges(
     window: &mut Window,
 ) -> Vec<Range<usize>> {
     let total_len = items.iter().map(MeasureItem::len).sum::<usize>();
+    let mut hard_lines = Vec::new();
+    let mut line_start = 0;
+    let mut item_start = 0;
+
+    for item in items {
+        if let MeasureItem::Text { text, .. } = item {
+            for (newline, _) in text.match_indices('\n') {
+                let newline = item_start + newline;
+                hard_lines.push(line_start..newline);
+                line_start = newline + 1;
+            }
+        }
+        item_start += item.len();
+    }
+    hard_lines.push(line_start..total_len);
+
     let Some(wrap_width) = wrap_width else {
-        return std::iter::once(0..total_len).collect();
+        return hard_lines;
     };
     let rem_size = window.rem_size();
-
-    let wrap_fragments = items
-        .iter()
-        .enumerate()
-        .map(|(ix, item)| match item {
-            MeasureItem::Text { text, .. } => WrapLineFragment::text(text),
-            MeasureItem::Image { .. } => WrapLineFragment::element(
-                image_sizes[ix]
-                    .expect("image size should be measured before wrapping")
-                    .width,
-                IMAGE_LEN,
-            ),
-        })
-        .collect::<Vec<_>>();
     let font_size = text_style.font_size.to_pixels(rem_size);
     let mut wrapper = window
         .text_system()
         .line_wrapper(text_style.font(), font_size);
-    let boundaries = wrapper
-        .wrap_line(&wrap_fragments, wrap_width)
-        .map(|boundary| boundary.ix.min(total_len))
-        .collect::<Vec<_>>();
-    let mut ranges = Vec::with_capacity(boundaries.len() + 1);
-    let mut start = 0;
+    let mut ranges = Vec::new();
 
-    for end in boundaries {
-        if start < end {
-            ranges.push(start..end);
+    for hard_line in hard_lines {
+        let mut item_start = 0;
+        let wrap_fragments = items
+            .iter()
+            .enumerate()
+            .filter_map(|(ix, item)| {
+                let item_end = item_start + item.len();
+                let fragment = if item_end <= hard_line.start || item_start >= hard_line.end {
+                    None
+                } else {
+                    match item {
+                        MeasureItem::Text { text, .. } => {
+                            let start = hard_line.start.max(item_start) - item_start;
+                            let end = hard_line.end.min(item_end) - item_start;
+                            (start < end).then(|| WrapLineFragment::text(&text[start..end]))
+                        }
+                        MeasureItem::Image { .. } => (hard_line.start <= item_start
+                            && item_end <= hard_line.end)
+                            .then(|| {
+                                WrapLineFragment::element(
+                                    image_sizes[ix]
+                                        .expect("image size should be measured before wrapping")
+                                        .width,
+                                    IMAGE_LEN,
+                                )
+                            }),
+                    }
+                };
+                item_start = item_end;
+                fragment
+            })
+            .collect::<Vec<_>>();
+
+        let boundaries = wrapper
+            .wrap_line(&wrap_fragments, wrap_width)
+            .map(|boundary| hard_line.start + boundary.ix.min(hard_line.len()))
+            .collect::<Vec<_>>();
+        let mut start = hard_line.start;
+
+        for end in boundaries {
+            if start < end {
+                ranges.push(start..end);
+            }
+            start = end;
         }
-        start = end;
-    }
 
-    if start < total_len {
-        ranges.push(start..total_len);
+        if start < hard_line.end || hard_line.is_empty() {
+            ranges.push(start..hard_line.end);
+        }
     }
 
     ranges

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -516,6 +516,23 @@ mod tests {
     }
 
     #[gpui::test]
+    fn inline_html_image_after_newline_does_not_panic(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, cx| {
+            TextViewTestRoot::new(
+                "Hi\n[<img src=\"https://example.com/image.svg\">](https://google.com/)",
+                cx,
+            )
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    #[gpui::test]
     fn list_item_renders_fenced_code_block_at_document_width(cx: &mut TestAppContext) {
         struct ListItemBlockRoot;
 


### PR DESCRIPTION
Closes #2673

## Description

Fix a panic when a Markdown paragraph contains a newline before an inline HTML image, for example:

```markdown
Hi
[<img src="whatever">](https://google.com/)
```

`InlineFlow` previously passed a text range containing a hard line break to GPUI's single-line text shaper. GPUI's line wrapper skips `\n` during width calculation but does not split the range, so the newline later reached `shape_line`, which rejects multiline input and panicked.

This change splits inline-flow content at hard newlines first, then applies soft wrapping to each hard line independently. It also adds a regression test using the issue's Markdown structure.

AI assistance: Codex assisted with root-cause analysis, implementation, testing, and PR wording. The final changes were reviewed and tested manually.

## Before / After

The same Markdown was tested in the Markdown Editor before and after this change:

```markdown
Hi
[<img src="https://github.githubassets.com/favicons/favicon.svg">](https://google.com/)
```

### Before

The application panics while laying out the Markdown because a newline reaches the text shaper:

<img width="1947" height="344" alt="Before: the Markdown example panics with text argument should not contain newlines" src="https://github.com/user-attachments/assets/947e1614-1445-44b6-a11c-527a73bd2087" />

### After

The Markdown renders successfully, with the linked inline image appearing on the line after `Hi`:

<img width="2727" height="1617" alt="After: the Markdown Editor renders the text and linked inline image" src="https://github.com/user-attachments/assets/69f0bcef-c11a-4e5b-b7aa-268cebd5ab17" />

## How to Test

```bash
cargo test -p gpui-component inline_html_image_after_newline_does_not_panic
cargo test -p gpui-component
cargo fmt --package gpui-component -- --check
```

Results:

- Regression test passes.
- All 407 `gpui-component` tests pass.
- Formatting check passes.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI-generated code is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [x] Platform-specific performance testing is not applicable to this fix.
