### PR TITLE
dock: Emit `LayoutChanged` after resizing a dock

### DIFF
--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -14,7 +14,7 @@ use crate::{
     resizable::{PANEL_MIN_SIZE, resize_handle},
 };
 
-use super::{DockArea, DockItem, PanelView, TabPanel};
+use super::{DockArea, DockEvent, DockItem, PanelView, TabPanel};
 
 #[derive(Clone)]
 struct ResizePanel;
@@ -376,8 +376,17 @@ impl Dock {
         cx.notify();
     }
 
-    fn done_resizing(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+    fn done_resizing(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.resizing {
+            return;
+        }
         self.resizing = false;
+
+        // Dragging the dock's resize handle finished, bubble a layout change
+        // so subscribers can persist the new dock size.
+        _ = self.dock_area.update(cx, |_, cx| {
+            cx.emit(DockEvent::LayoutChanged);
+        });
     }
 }
 


### PR DESCRIPTION
## Problem

Dragging a dock's resize handle (left/right/bottom dock) never produced any layout event: `Dock::resize` only calls `cx.notify()`, and `Dock::done_resizing` merely cleared the `resizing` flag. As a result, subscribers of `DockEvent::LayoutChanged` (e.g. layout persistence / "layout changed" detection in the host app) were never informed when a dock was resized — unlike dividers inside the center area, which already bubble `ResizablePanelEvent::Resized` → `PanelEvent::LayoutChanged` → `DockEvent::LayoutChanged`.

## Fix

When a resize drag on the dock handle finishes (mouse up), bubble `DockEvent::LayoutChanged` from the `DockArea`, matching the behavior of center-area dividers.

- Guarded by `self.resizing`: the global `MouseUpEvent` handler calls `done_resizing` on every mouse up, and GPUI's 2px drag threshold means a plain click on the handle never sets `resizing`, so no spurious events are emitted.
- Emitting unconditionally after a real drag matches `ResizableState::done_resizing` semantics.

## Verification

- `cargo check -p gpui-component` passes.
- Event chain verified by code inspection against the host app's `DockEvent::LayoutChanged` subscriber (workspace dump + layout-changed marking); end-to-end UI verification pending a dependency bump in the host app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)