### PR TITLE
chart: Avoid quadratic Sankey topology computation

### DIFF
--- a/crates/ui/src/plot/shape/sankey.rs
+++ b/crates/ui/src/plot/shape/sankey.rs
@@ -290,8 +290,7 @@ impl Sankey {
 
         compute_node_links(&mut graph);
         compute_node_values(&mut graph);
-        compute_node_ranks(&mut graph, true)?;
-        compute_node_ranks(&mut graph, false)?;
+        compute_node_ranks(&mut graph)?;
         self.compute_node_layers(&mut graph);
 
         Ok(graph)
@@ -667,59 +666,53 @@ fn compute_node_values(graph: &mut SankeyGraph) {
     }
 }
 
-/// Assign longest-path ranks in topological order.
-///
-/// `forward` walks source links to their targets and writes `depth`;
-/// otherwise it walks target links to their sources and writes `height`.
-fn compute_node_ranks(graph: &mut SankeyGraph, forward: bool) -> Result<(), SankeyError> {
+/// Assign the longest-path `depth` (from any source) and `height` (to any
+/// sink) from a single topological ordering. A node left unordered means its
+/// incoming links never resolved, i.e. a cycle.
+fn compute_node_ranks(graph: &mut SankeyGraph) -> Result<(), SankeyError> {
     let n = graph.nodes.len();
-    let mut degree: Vec<usize> = graph
+    let mut incoming: Vec<usize> = graph
         .nodes
         .iter()
-        .map(|node| {
-            if forward {
-                node.target_links.len()
-            } else {
-                node.source_links.len()
-            }
-        })
+        .map(|node| node.target_links.len())
         .collect();
-    let mut ranks = vec![0; n];
-    let mut pending: Vec<usize> = (0..n).filter(|&index| degree[index] == 0).collect();
-    let mut visited = 0;
+    // Doubles as the traversal queue and, once drained, the topological order.
+    let mut order: Vec<usize> = (0..n).filter(|&index| incoming[index] == 0).collect();
 
-    while let Some(index) = pending.pop() {
+    // Ranks live in their own arrays rather than in the nodes: the traversal
+    // hops between them by index, and the node struct is an order of magnitude
+    // wider than a `usize`.
+    let mut depths = vec![0usize; n];
+    let mut visited = 0;
+    while visited < order.len() {
+        let index = order[visited];
         visited += 1;
-        let next_rank = ranks[index] + 1;
-        let node = &graph.nodes[index];
-        let links = if forward {
-            &node.source_links
-        } else {
-            &node.target_links
-        };
-        for &link in links {
-            let neighbor = if forward {
-                graph.links[link].target
-            } else {
-                graph.links[link].source
-            };
-            ranks[neighbor] = ranks[neighbor].max(next_rank);
-            degree[neighbor] -= 1;
-            if degree[neighbor] == 0 {
-                pending.push(neighbor);
+        let depth = depths[index] + 1;
+        for &link in &graph.nodes[index].source_links {
+            let target = graph.links[link].target;
+            depths[target] = depths[target].max(depth);
+            incoming[target] -= 1;
+            if incoming[target] == 0 {
+                order.push(target);
             }
         }
     }
-
-    if visited != n {
+    if order.len() != n {
         return Err(SankeyError::CircularLink);
     }
-    for (node, rank) in graph.nodes.iter_mut().zip(ranks) {
-        if forward {
-            node.depth = rank;
-        } else {
-            node.height = rank;
+
+    // Walking the order backwards means every target's height is already final
+    // when its sources are visited.
+    let mut heights = vec![0usize; n];
+    for &index in order.iter().rev() {
+        for &link in &graph.nodes[index].source_links {
+            heights[index] = heights[index].max(heights[graph.links[link].target] + 1);
         }
+    }
+
+    for (node, (depth, height)) in graph.nodes.iter_mut().zip(depths.into_iter().zip(heights)) {
+        node.depth = depth;
+        node.height = height;
     }
     Ok(())
 }

--- a/crates/ui/src/plot/shape/sankey.rs
+++ b/crates/ui/src/plot/shape/sankey.rs
@@ -667,43 +667,59 @@ fn compute_node_values(graph: &mut SankeyGraph) {
     }
 }
 
-/// Assign topological ranks by BFS waves; later waves overwrite, yielding the
-/// longest-path rank. More waves than nodes means a cycle.
+/// Assign longest-path ranks in topological order.
 ///
 /// `forward` walks source links to their targets and writes `depth`;
 /// otherwise it walks target links to their sources and writes `height`.
 fn compute_node_ranks(graph: &mut SankeyGraph, forward: bool) -> Result<(), SankeyError> {
     let n = graph.nodes.len();
-    let mut current: Vec<usize> = (0..n).collect();
-    let mut x = 0;
-    while !current.is_empty() {
-        let mut next = vec![false; n];
-        for &index in &current {
-            let node = &graph.nodes[index];
-            let links = if forward {
-                &node.source_links
-            } else {
-                &node.target_links
-            };
-            for &link in links {
-                let neighbor = if forward {
-                    graph.links[link].target
-                } else {
-                    graph.links[link].source
-                };
-                next[neighbor] = true;
-            }
+    let mut degree: Vec<usize> = graph
+        .nodes
+        .iter()
+        .map(|node| {
             if forward {
-                graph.nodes[index].depth = x;
+                node.target_links.len()
             } else {
-                graph.nodes[index].height = x;
+                node.source_links.len()
+            }
+        })
+        .collect();
+    let mut ranks = vec![0; n];
+    let mut pending: Vec<usize> = (0..n).filter(|&index| degree[index] == 0).collect();
+    let mut visited = 0;
+
+    while let Some(index) = pending.pop() {
+        visited += 1;
+        let next_rank = ranks[index] + 1;
+        let node = &graph.nodes[index];
+        let links = if forward {
+            &node.source_links
+        } else {
+            &node.target_links
+        };
+        for &link in links {
+            let neighbor = if forward {
+                graph.links[link].target
+            } else {
+                graph.links[link].source
+            };
+            ranks[neighbor] = ranks[neighbor].max(next_rank);
+            degree[neighbor] -= 1;
+            if degree[neighbor] == 0 {
+                pending.push(neighbor);
             }
         }
-        x += 1;
-        if x > n {
-            return Err(SankeyError::CircularLink);
+    }
+
+    if visited != n {
+        return Err(SankeyError::CircularLink);
+    }
+    for (node, rank) in graph.nodes.iter_mut().zip(ranks) {
+        if forward {
+            node.depth = rank;
+        } else {
+            node.height = rank;
         }
-        current = (0..n).filter(|&index| next[index]).collect();
     }
     Ok(())
 }
@@ -1030,6 +1046,18 @@ mod tests {
         for (a, b) in completed.links.iter().zip(&graph.links) {
             assert_eq!((a.y0, a.y1, a.width), (b.y0, b.y1, b.width));
         }
+    }
+
+    #[test]
+    fn test_sankey_topology_large_chain() {
+        const NODE_COUNT: usize = 50_000;
+        let links: Vec<SankeyLink> = (0..NODE_COUNT - 1)
+            .map(|source| SankeyLink::new(source, source + 1, 1.))
+            .collect();
+        let graph = Sankey::new().topology(NODE_COUNT, &links).unwrap();
+
+        assert_eq!(graph.nodes[0].height, NODE_COUNT - 1);
+        assert_eq!(graph.nodes[NODE_COUNT - 1].depth, NODE_COUNT - 1);
     }
 
     #[test]


### PR DESCRIPTION
# Title

chart: Avoid quadratic Sankey topology computation

# Body

Closes #2681

## Description

`Sankey::topology` previously computed node ranks in repeated waves. Each wave allocated an `N`-element boolean vector and scanned all node indices to build the next frontier. A valid chain of `N` nodes therefore required `O(N^2)` work for both the forward and backward rank passes, blocking the UI while the chart was painted.

This change replaces that loop with a degree-based topological traversal. Each node and link is processed once per direction, reducing rank computation to `O(V + E)` while preserving the existing longest-path `depth` and `height` values and circular-link detection.

The public API and chart rendering flow are unchanged.

## Screenshot

| Before | After |
| ------ | ----- |
| <img width="1972" height="1262" alt="sankey-pre-fix-reproduction" src="https://github.com/user-attachments/assets/3b97270e-b056-429e-831e-8beadc935842" /> | <img width="1972" height="1262" alt="sankey-post-fix-verification" src="https://github.com/user-attachments/assets/0c88a56a-3c47-45bf-b248-c921ce0d8a6e" /> |

With the same optimized PoC against the checked-in `sankey.rs`:

- Before: a valid 50,000-node chain exceeded the 5-second timeout (`exit_code=124`).
- After: the same chain completed in 5 ms (`exit_code=0`); a same-size shallow star completed in 4 ms.

## How to Test

```sh
cargo test --locked --offline --all
cargo clippy -p gpui-component --lib -- --deny warnings
cargo run -p gpui-component-story -- Chart
```

The automated test suite includes a 50,000-node chain regression case for `Sankey::topology`.

For the manual story check, open the Chart story and scroll to the `Sankey Chart - TSLA` examples.

## AI Assistance

AI assisted with the implementation, regression test, and PR draft. The contributor reviewed the generated changes and test evidence before submission.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Not platform-specific; no platform-specific rendering path was changed.
