### PR TITLE
dock: Add `DockItem::is_empty`

### DIFF
--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -392,6 +392,43 @@ impl DockItem {
         }
     }
 
+    /// Whether this dock item currently holds no visible panel.
+    ///
+    /// Walks the live panel entities, not `items`: [`Self::add_panel`] only
+    /// pushes into them, nothing ever removes, and splitting does not touch
+    /// them at all.
+    ///
+    /// A container is empty when every child is, so a fresh one is empty. A
+    /// leaf counts as empty while it is hidden, matching the render path, which
+    /// skips panels whose [`Panel::visible`] is `false`.
+    pub fn is_empty(&self, cx: &App) -> bool {
+        fn is_empty(panel: &Arc<dyn PanelView>, cx: &App) -> bool {
+            let view = panel.view();
+
+            if let Ok(stack) = view.clone().downcast::<StackPanel>() {
+                return stack
+                    .read(cx)
+                    .panels
+                    .iter()
+                    .all(|panel| is_empty(panel, cx));
+            }
+            if let Ok(tabs) = view.clone().downcast::<TabPanel>() {
+                return tabs.read(cx).panels.iter().all(|panel| is_empty(panel, cx));
+            }
+            if let Ok(tiles) = view.downcast::<Tiles>() {
+                return tiles
+                    .read(cx)
+                    .panels()
+                    .iter()
+                    .all(|item| is_empty(&item.panel, cx));
+            }
+
+            !panel.visible(cx)
+        }
+
+        is_empty(&self.view(), cx)
+    }
+
     /// Find existing panel in the dock item.
     pub fn find_panel(&self, panel: Arc<dyn PanelView>) -> Option<Arc<dyn PanelView>> {
         match self {
@@ -642,32 +679,12 @@ impl DockArea {
         &self.center
     }
 
-    /// Whether the center area currently holds no panel.
+    /// Whether the center area currently holds no visible panel.
     ///
-    /// Walks the live panel entities; the [`DockItem`] tree is only rebuilt by
-    /// [`Self::load`] and [`Self::set_center`], so it goes stale.
+    /// See [`DockItem::is_empty`]. Ask a dock the same question with
+    /// [`Dock::panel`].
     pub fn is_center_empty(&self, cx: &App) -> bool {
-        fn is_empty(panel: &Arc<dyn PanelView>, cx: &App) -> bool {
-            let view = panel.view();
-
-            if let Ok(stack) = view.clone().downcast::<StackPanel>() {
-                return stack
-                    .read(cx)
-                    .panels
-                    .iter()
-                    .all(|panel| is_empty(panel, cx));
-            }
-            if let Ok(tabs) = view.clone().downcast::<TabPanel>() {
-                return tabs.read(cx).panels.is_empty();
-            }
-            if let Ok(tiles) = view.downcast::<Tiles>() {
-                return tiles.read(cx).panels().is_empty();
-            }
-
-            false
-        }
-
-        is_empty(&self.center.view(), cx)
+        self.center.is_empty(cx)
     }
 
     /// Return the left dock item.

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -642,6 +642,34 @@ impl DockArea {
         &self.center
     }
 
+    /// Whether the center area currently holds no panel.
+    ///
+    /// Walks the live panel entities; the [`DockItem`] tree is only rebuilt by
+    /// [`Self::load`] and [`Self::set_center`], so it goes stale.
+    pub fn is_center_empty(&self, cx: &App) -> bool {
+        fn is_empty(panel: &Arc<dyn PanelView>, cx: &App) -> bool {
+            let view = panel.view();
+
+            if let Ok(stack) = view.clone().downcast::<StackPanel>() {
+                return stack
+                    .read(cx)
+                    .panels
+                    .iter()
+                    .all(|panel| is_empty(panel, cx));
+            }
+            if let Ok(tabs) = view.clone().downcast::<TabPanel>() {
+                return tabs.read(cx).panels.is_empty();
+            }
+            if let Ok(tiles) = view.downcast::<Tiles>() {
+                return tiles.read(cx).panels().is_empty();
+            }
+
+            false
+        }
+
+        is_empty(&self.center.view(), cx)
+    }
+
     /// Return the left dock item.
     pub fn left_dock(&self) -> Option<&Entity<Dock>> {
         self.left_dock.as_ref()

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -1504,7 +1504,10 @@ mod tests {
     use gpui::{TestAppContext, VisualTestContext, WindowHandle};
 
     use super::*;
-    use crate::{Root, Theme, dock::DockItem};
+    use crate::{
+        Root, Theme,
+        dock::{DockItem, TileMeta},
+    };
 
     #[test]
     fn drop_placeholder_bounds_cover_each_target_placement() {
@@ -1605,11 +1608,16 @@ mod tests {
         name: &'static str,
         focus_handle: FocusHandle,
         log: Log,
+        visible: bool,
     }
 
     impl Panel for TestPanel {
         fn panel_name(&self) -> &'static str {
             "TestPanel"
+        }
+
+        fn visible(&self, _: &App) -> bool {
+            self.visible
         }
 
         fn set_active(&mut self, active: bool, _: &mut Window, _: &mut Context<Self>) {
@@ -1662,6 +1670,7 @@ mod tests {
             name,
             focus_handle: cx.focus_handle(),
             log,
+            visible: true,
         })
     }
 
@@ -1780,6 +1789,80 @@ mod tests {
         cx.run_until_parked();
 
         assert!(!cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+    }
+
+    /// Rendering skips invisible panels, so a centre holding only hidden ones
+    /// draws nothing and counts as empty.
+    #[gpui::test]
+    fn center_holding_only_hidden_panels_is_empty(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        let (item, tab_panel, panels) = build_tabs(&fixture, &["A", "B"], None, &mut cx);
+        cx.update(|window, cx| {
+            fixture
+                .dock_area
+                .update(cx, |area, cx| area.set_center(item, window, cx))
+        });
+        cx.run_until_parked();
+        assert!(!cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+
+        cx.update(|_, cx| {
+            for panel in &panels {
+                panel.update(cx, |panel, _| panel.visible = false);
+            }
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.read(|cx| tab_panel.read(cx).panels.len()),
+            2,
+            "hiding a panel does not remove it from the tab group"
+        );
+        assert!(cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+    }
+
+    /// A `TabPanel` inside `Tiles` has no parent `StackPanel` to remove itself
+    /// from, so emptying it leaves the tile behind and the walk has to recurse.
+    #[gpui::test]
+    fn center_holding_only_empty_tiles_is_empty(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        let (tabs, tab_panel, panels) = build_tabs(&fixture, &["A"], None, &mut cx);
+        let weak_dock_area = fixture.dock_area.downgrade();
+        cx.update(|window, cx| {
+            let tiles = DockItem::tiles(
+                vec![tabs],
+                vec![TileMeta::default()],
+                &weak_dock_area,
+                window,
+                cx,
+            );
+            fixture
+                .dock_area
+                .update(cx, |area, cx| area.set_center(tiles, window, cx))
+        });
+        cx.run_until_parked();
+        assert!(!cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+
+        for panel in panels {
+            cx.update(|window, cx| {
+                tab_panel.update(cx, |tab_panel, cx| {
+                    tab_panel.remove_panel(Arc::new(panel.clone()), window, cx)
+                })
+            });
+        }
+        cx.run_until_parked();
+
+        let tiles = cx.read(|cx| {
+            let DockItem::Tiles { view, .. } = fixture.dock_area.read(cx).center() else {
+                unreachable!("the centre is a Tiles item");
+            };
+            view.read(cx).panels().len()
+        });
+        assert_eq!(tiles, 1, "the emptied TabPanel is still listed as a tile");
+        assert!(cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
     }
 
     #[gpui::test]

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -1703,6 +1703,86 @@ mod tests {
     }
 
     #[gpui::test]
+    fn fresh_center_is_empty(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        assert!(
+            cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)),
+            "DockArea::new starts with an empty StackPanel centre"
+        );
+    }
+
+    #[gpui::test]
+    fn center_holding_a_tab_group_is_not_empty(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        let (item, _, _) = build_tabs(&fixture, &["A", "B"], None, &mut cx);
+        cx.update(|window, cx| {
+            fixture
+                .dock_area
+                .update(cx, |area, cx| area.set_center(item, window, cx))
+        });
+        cx.run_until_parked();
+
+        assert!(!cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+    }
+
+    /// The `DockItem` tree still lists the tab group here, so anything reading
+    /// `DockItem::Split { items }` would report non-empty.
+    #[gpui::test]
+    fn center_is_empty_again_once_every_panel_is_removed(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        let (item, tab_panel, panels) = build_tabs(&fixture, &["A", "B"], None, &mut cx);
+        cx.update(|window, cx| {
+            fixture
+                .dock_area
+                .update(cx, |area, cx| area.set_center(item, window, cx))
+        });
+        cx.run_until_parked();
+
+        for panel in panels {
+            cx.update(|window, cx| {
+                tab_panel.update(cx, |tab_panel, cx| {
+                    tab_panel.remove_panel(Arc::new(panel.clone()), window, cx)
+                })
+            });
+        }
+        cx.run_until_parked();
+
+        assert!(cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+    }
+
+    #[gpui::test]
+    fn center_is_not_empty_after_adding_to_a_tab_group(cx: &mut TestAppContext) {
+        let fixture = setup(cx);
+        let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);
+
+        let (item, tab_panel, _) = build_tabs(&fixture, &[], None, &mut cx);
+        cx.update(|window, cx| {
+            fixture
+                .dock_area
+                .update(cx, |area, cx| area.set_center(item, window, cx))
+        });
+        cx.run_until_parked();
+        assert!(cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+
+        let log = fixture.log.clone();
+        cx.update(|window, cx| {
+            let panel = test_panel("A", &log, cx);
+            tab_panel.update(cx, |tab_panel, cx| {
+                tab_panel.add_panel(Arc::new(panel), window, cx)
+            });
+        });
+        cx.run_until_parked();
+
+        assert!(!cx.read(|cx| fixture.dock_area.read(cx).is_center_empty(cx)));
+    }
+
+    #[gpui::test]
     fn single_panel_group_receives_initial_active(cx: &mut TestAppContext) {
         let fixture = setup(cx);
         let mut cx = VisualTestContext::from_window(fixture.window.into(), cx);


### PR DESCRIPTION
## Description

Hosts that want to render something when a layout holds no panel — a placeholder, a different background — currently have no way to ask.

`DockItem::items` looks like the answer, but it is stale in both directions: `add_panel` only pushes into them, `remove_panel` takes `&self` so it cannot remove, and splitting never touches them. `dump` does walk the live tree, but it builds the whole serialisable state, and a panel's `dump` may read host state the caller is already holding.

So `DockItem::is_empty` walks the live panels and answers only that one question. A container is empty when every child is (`all` over no children is `true`, so a fresh one is empty). A leaf is empty while it is hidden, which is what rendering already assumes: `StackPanel` draws each child as `.visible(panel.visible(cx))` and `TabPanel::visible` counts only visible panels, so a group holding nothing but hidden panels draws nothing and should not read as full.

`Tiles` recurses for the same reason its children outlive their contents: a `TabPanel` in a tile has no parent `StackPanel` to remove itself from, so emptying it leaves the tile behind.

The method lives on `DockItem`, so a dock can be asked the same question through `Dock::panel()`. `DockArea::is_center_empty` wraps it for the centre — named that way because a `DockArea` also has three docks, and an inherent `is_empty` would shadow the extension traits downstream already define under that name.

## How to Test

```sh
cargo test -p gpui-component dock::   # 34 passed
cargo check --workspace
cargo clippy -p gpui-component --all-targets
cargo fmt --check
```

Six of those tests cover the walk:

- a fresh `DockArea` reports empty
- a centre holding a tab group does not
- after removing every panel it reports empty again — the `DockItem` tree still lists the tab group here, so anything reading `items` would get this wrong
- adding a panel to an empty tab group flips it back
- a centre whose panels are all hidden reports empty
- a centre holding a single emptied tile reports empty

The last two also assert that the panels and the tile are still in place, so they cannot quietly become no-ops if `TabPanel` or `Tiles` later learns to drop its empty children. Both fail if the matching arm stops recursing.

`cargo check --workspace --all-targets` does not run here: upstream `gpui`'s test target fails to build with `can't find crate for sum_tree`, which `cargo check -p gpui --all-targets` reproduces on its own.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes — see Screenshot above.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)

AI assistance: written with Claude Code. The empty/hidden semantics and the API placement were reviewed and adjusted by hand.
