### PR TITLE
Add a `test-support` feature that skips native-window integrations

### DIFF
--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -15,6 +15,15 @@ edition.workspace = true
 doctest = false
 
 [features]
+# Skip the platform integrations that need a real OS window.
+#
+# Every `ns_view` helper below is already written as `window_handle(window).ok()?`, so a
+# window without a native handle is an expected case. gpui's `TestWindow` answers that
+# call with `unimplemented!()` rather than `Err`, so the `.ok()?` never runs and any
+# downstream test that builds a `Root` or focuses an `Input` panics on macOS. `not(test)`
+# cannot help: it is not set when this crate is compiled as a dependency of someone
+# else's test binary. Named after gpui's own feature of the same purpose.
+test-support = []
 decimal = ["dep:rust_decimal"]
 inspector = ["gpui_macros/inspector", "gpui/inspector"]
 tree-sitter = ["dep:tree-sitter", "dep:tree-sitter-json"]

--- a/crates/ui/src/input/native.rs
+++ b/crates/ui/src/input/native.rs
@@ -48,6 +48,11 @@ mod macos {
     }
 
     fn ns_view(window: &Window) -> Option<&AnyObject> {
+        // gpui's `TestWindow` panics here instead of returning the `Err` that the
+        // `.ok()?` below is written for. See the `test-support` feature.
+        if cfg!(feature = "test-support") {
+            return None;
+        }
         let handle = HasWindowHandle::window_handle(window).ok()?;
         let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
             return None;

--- a/crates/ui/src/macos_accessibility.rs
+++ b/crates/ui/src/macos_accessibility.rs
@@ -40,6 +40,11 @@ extern "C" fn hit_test_forwarder(this: &NSWindow, _cmd: Sel, point: NSPoint) -> 
 }
 
 fn ns_view(window: &Window) -> Option<&NSView> {
+    // gpui's `TestWindow` panics here instead of returning the `Err` that the
+    // `.ok()?` below is written for. See the `test-support` feature.
+    if cfg!(feature = "test-support") {
+        return None;
+    }
     let handle = HasWindowHandle::window_handle(window).ok()?;
     let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
         return None;

--- a/crates/ui/src/native_menu/macos.rs
+++ b/crates/ui/src/native_menu/macos.rs
@@ -202,6 +202,11 @@ fn ns_image_for_icon(
 
 /// Extract the AppKit `NSView` pointer from the window's raw handle.
 fn ns_view_ptr(window: &Window) -> Option<usize> {
+    // gpui's `TestWindow` panics here instead of returning the `Err` that the
+    // `.ok()?` below is written for. See the `test-support` feature.
+    if cfg!(feature = "test-support") {
+        return None;
+    }
     let handle = HasWindowHandle::window_handle(window).ok()?;
     let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
         return None;

--- a/crates/ui/src/native_menu/windows.rs
+++ b/crates/ui/src/native_menu/windows.rs
@@ -393,6 +393,11 @@ unsafe fn stream_from_bytes(bytes: &[u8]) -> Option<windows::Win32::System::Com:
 
 /// Extract the Win32 `HWND` (as an `isize`) from the window's raw handle.
 fn hwnd_ptr(window: &Window) -> Option<isize> {
+    // gpui's `TestWindow` panics here instead of returning the `Err` that the
+    // `.ok()?` below is written for. See the `test-support` feature.
+    if cfg!(feature = "test-support") {
+        return None;
+    }
     let handle = HasWindowHandle::window_handle(window).ok()?;
     let RawWindowHandle::Win32(handle) = handle.as_raw() else {
         return None;


### PR DESCRIPTION
## Description

Four helpers reach for the platform's `NSView`/`HWND` through `HasWindowHandle::window_handle(window).ok()?`, so a window with no native handle is already an expected case at every one of them:

- `macos_accessibility::ns_view`
- `input::native::macos::ns_view`
- `native_menu::macos::ns_view_ptr`
- `native_menu::windows::hwnd_ptr`

gpui's `TestWindow` answers that call with `unimplemented!("Test Windows are not backed by a real platform window")` rather than an `Err`, so the `.ok()?` never runs and the call panics instead.

Two of those helpers sit on paths that any UI test crosses:

- `Root::new` installs the accessibility hook
- `Input::render` calls `sync_native_content_type` whenever the input is focused

So a downstream crate whose tests build a `Root`, or render a focused `Input`, panics on macOS. Measured on one application: **329 of 2225 tests**, all from those two entry points.

`Root::new` already guards its hook with `#[cfg(all(target_os = "macos", not(test)))]`, which suggests this was known. That guard cannot help a dependent, though: `test` is not set when this crate is compiled as a dependency of *someone else's* test binary. This crate's own tests do build `Root` (`root.rs`, `input/state.rs`, `text/text_view.rs`) and are unaffected, because there `cfg(test)` is set.

This PR adds a `test-support` feature that makes all four helpers return `None` before asking for the handle. It is named after gpui's own feature of the same purpose, and consumers enable it the same way — as a **dev-dependency** feature, so it never reaches a release build and the accessibility hook stays live in production:

```toml
[dev-dependencies]
gpui-component = { version = "...", features = ["test-support"] }
```

### The alternative, which would be better

The root cause is in gpui, not here. If `TestWindow::window_handle` returned `Err(HandleError::NotSupported)` instead of panicking, every `.ok()?` in this crate would behave as already written, with no feature and no downstream opt-in. Filed as zed-industries/zed#62510.

This change does not preclude that one — if the gpui fix lands, this feature becomes a no-op and can be dropped. I raised it here as well because it unblocks consumers on the current gpui without waiting on that.

## Screenshot

No visual change: the feature is off by default, and with it off the behaviour is byte-for-byte what it was.

## How to Test

`cargo test -p gpui-component` on this branch: **412 passed, 0 failed**. The existing suite is unaffected, since the feature is off by default and this crate's own tests were already fine under `cfg(test)`.

To see the bug it fixes, from a *dependent* crate on macOS:

1. Depend on `gpui-component` (git) and on `gpui` with `test-support` in dev-dependencies.
2. Write a `#[gpui::test]` that opens a window through `TestAppContext` and builds a `Root`, or renders a focused `Input`.
3. `cargo test` — panics on `main` with `not implemented: Test Windows are not backed by a real platform window`; passes with `features = ["test-support"]` on this branch.

Verified downstream on a 2225-test workspace: 329 failures to 0, with the shipped binary unchanged.

Platforms: developed and tested on **macOS 26.6, arm64**. The Windows helper (`native_menu::windows`) takes the same one-line guard for consistency but I have no Windows machine to test on; it is compile-only there. Linux is untouched — none of the four helpers exist on it.

## AI Assistance

Per CONTRIBUTING: this was written with AI assistance and reviewed and tested by hand. The failure was diagnosed from a backtrace, the fix verified downstream (329 failing tests to 0), and this crate's own suite (412 tests) run against this branch. The change is five lines of guard plus a feature declaration; I understand and stand behind each one, and I am happy to rework the approach if you would prefer the problem solved differently.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes. — ran `cargo test -p gpui-component` instead; the story gallery needs a display and this change is invisible to it (feature off by default).
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — macOS tested; Windows compile-only; Linux unaffected. See above.
