### PR TITLE
ci: Ignore `syntect` in the WASM example machete check

### DIFF
--- a/crates/base/examples/wasm/Cargo.toml
+++ b/crates/base/examples/wasm/Cargo.toml
@@ -22,6 +22,6 @@ wasm-bindgen = "=0.2.121"
 workspace = true
 
 # The shared showcase is included with `#[path]`, which cargo-machete cannot
-# follow when detecting its `gpui_base` imports.
+# follow when detecting its `gpui_base` and `syntect` imports.
 [package.metadata.cargo-machete]
-ignored = ["gpui-base"]
+ignored = ["gpui-base", "syntect"]


### PR DESCRIPTION
## Summary

`cargo machete` on `main` fails with `syntect` reported as unused in
`gpui-base-examples-wasm`.

The dependency is used, but only from `crates/base/examples/showcase/syntect_highlighter.rs`,
which the WASM example pulls in with `#[path = "../../showcase/mod.rs"]`.
cargo-machete only scans the crate's own directory, so it cannot follow that
path — this is the same reason `gpui-base` is already in the ignore list.

## Test Plan

- `cargo machete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)