### PR TITLE
story: Join the toolbar buttons and add a million-row table example

### DIFF
--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -1,14 +1,14 @@
 use gpui::{
     Action, Anchor, AnyElement, AnyView, App, AppContext, Bounds, Context, DismissEvent, Div,
     Entity, EventEmitter, FocusHandle, Focusable, Global, Hsla, InteractiveElement, IntoElement,
-    KeyBinding, ParentElement, Pixels, Render, RenderOnce, SharedString, Size, Stateful,
-    StatefulInteractiveElement, StyleRefinement, Styled, Window, WindowBounds, WindowKind,
-    WindowOptions, actions, div, prelude::FluentBuilder as _, px, rems, size,
+    KeyBinding, ParentElement, Pixels, Render, RenderOnce, SharedString, Size, StyleRefinement,
+    Styled, Window, WindowBounds, WindowKind, WindowOptions, actions, div,
+    prelude::FluentBuilder as _, px, rems, size,
 };
 use gpui_component::{
-    ActiveTheme, IconName, Root, Selectable, Sizable as _, Size as ComponentSize, StyledExt as _,
-    TitleBar, WindowExt,
-    button::{Button, ButtonGroup},
+    ActiveTheme, IconName, Root, Sizable as _, Size as ComponentSize, StyledExt as _, TitleBar,
+    WindowExt,
+    button::Button,
     dock::{Panel, PanelControl, PanelEvent, PanelInfo, PanelState, TitleStyle, register_panel},
     group_box::{GroupBox, GroupBoxVariants as _},
     h_flex,
@@ -386,13 +386,20 @@ pub(crate) fn section(title: impl Into<SharedString>) -> StorySection {
 #[derive(IntoElement)]
 pub(crate) struct StoryToolbar {
     base: Div,
-    children: Vec<AnyElement>,
+    items: Vec<StoryToolbarItem>,
+}
+
+enum StoryToolbarItem {
+    Button(Button),
+    Dropdown {
+        button: Button,
+        builder: StoryMenuBuilder,
+    },
 }
 
 impl StoryToolbar {
     pub(crate) fn child(mut self, button: Button) -> Self {
-        self.children
-            .push(button.outline().small().into_any_element());
+        self.items.push(StoryToolbarItem::Button(button));
         self
     }
 
@@ -401,15 +408,10 @@ impl StoryToolbar {
         button: Button,
         builder: impl Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu + 'static,
     ) -> Self {
-        let id = SharedString::from(format!("story-toolbar-menu-{}", self.children.len()));
-        self.children.push(
-            StoryToolbarMenu {
-                id,
-                button,
-                builder: Rc::new(builder),
-            }
-            .into_any_element(),
-        );
+        self.items.push(StoryToolbarItem::Dropdown {
+            button,
+            builder: Rc::new(builder),
+        });
         self
     }
 }
@@ -428,44 +430,6 @@ struct StoryToolbarMenu {
     builder: StoryMenuBuilder,
 }
 
-#[derive(IntoElement)]
-struct StoryToolbarMenuTrigger {
-    base: Stateful<Div>,
-    group: ButtonGroup,
-    selected: bool,
-}
-
-impl Selectable for StoryToolbarMenuTrigger {
-    fn selected(mut self, selected: bool) -> Self {
-        self.selected = selected;
-        self
-    }
-
-    fn is_selected(&self) -> bool {
-        self.selected
-    }
-}
-
-impl InteractiveElement for StoryToolbarMenuTrigger {
-    fn interactivity(&mut self) -> &mut gpui::Interactivity {
-        self.base.interactivity()
-    }
-}
-
-impl StatefulInteractiveElement for StoryToolbarMenuTrigger {}
-
-impl Styled for StoryToolbarMenuTrigger {
-    fn style(&mut self) -> &mut StyleRefinement {
-        self.base.style()
-    }
-}
-
-impl RenderOnce for StoryToolbarMenuTrigger {
-    fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
-        self.base.child(self.group)
-    }
-}
-
 impl RenderOnce for StoryToolbarMenu {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let state =
@@ -473,20 +437,12 @@ impl RenderOnce for StoryToolbarMenu {
         let builder = self.builder;
 
         let popover_id = SharedString::from(format!("story-toolbar-popover-{}", self.id));
-        let group_id = SharedString::from(format!("story-toolbar-group-{}", self.id));
 
         Popover::new(popover_id)
             .appearance(false)
             .overlay_closable(false)
             .anchor(Anchor::TopRight)
-            .trigger(StoryToolbarMenuTrigger {
-                base: div().id(group_id.clone()),
-                group: ButtonGroup::new(group_id)
-                    .outline()
-                    .small()
-                    .child(self.button),
-                selected: false,
-            })
+            .trigger(self.button)
             .content(move |_, window, cx| {
                 if let Some(menu) = state.read(cx).menu.clone() {
                     return menu;
@@ -523,14 +479,40 @@ impl Styled for StoryToolbar {
 
 impl RenderOnce for StoryToolbar {
     fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
-        self.base.children(self.children)
+        let last = self.items.len().saturating_sub(1);
+
+        self.base
+            .children(self.items.into_iter().enumerate().map(|(ix, item)| {
+                // Join the buttons into one segmented control: square off the
+                // inner corners, and let each button after the first sit on its
+                // neighbour's border instead of drawing a second one.
+                let joined = |button: Button| {
+                    button
+                        .outline()
+                        .small()
+                        .when(ix > 0, |this| {
+                            this.rounded_tl(px(0.)).rounded_bl(px(0.)).border_l_0()
+                        })
+                        .when(ix < last, |this| this.rounded_tr(px(0.)).rounded_br(px(0.)))
+                };
+
+                match item {
+                    StoryToolbarItem::Button(button) => joined(button).into_any_element(),
+                    StoryToolbarItem::Dropdown { button, builder } => StoryToolbarMenu {
+                        id: SharedString::from(format!("story-toolbar-menu-{ix}")),
+                        button: joined(button),
+                        builder,
+                    }
+                    .into_any_element(),
+                }
+            }))
     }
 }
 
 pub(crate) fn story_toolbar_group() -> StoryToolbar {
     StoryToolbar {
         base: h_flex().w_full().justify_end(),
-        children: vec![],
+        items: vec![],
     }
 }
 

--- a/crates/story/src/stories/data_table_story.rs
+++ b/crates/story/src/stories/data_table_story.rs
@@ -64,6 +64,10 @@ enum ToggleTableOption {
 
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
 #[action(namespace = data_table_story, no_json)]
+struct ClearTableSelection;
+
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = data_table_story, no_json)]
 enum GoToTablePosition {
     Top,
     Bottom,
@@ -162,6 +166,16 @@ impl Stock {
     }
 }
 
+/// Restarts ids from zero and builds a fresh set of rows.
+fn regenerate_stocks(size: usize) -> Vec<Stock> {
+    {
+        let mut id_lock = INCREMENT_ID.lock().unwrap();
+        *id_lock = 0;
+    }
+
+    random_stocks(size)
+}
+
 fn random_stocks(size: usize) -> Vec<Stock> {
     // Incremental ID with size.
     let start = {
@@ -171,6 +185,28 @@ fn random_stocks(size: usize) -> Vec<Stock> {
         start
     };
 
+    // Drawing all 40-odd fields per row costs ~24s for a million rows in a debug
+    // build, which is most of the time spent switching to the largest example.
+    // Draw a pool of fully random rows instead and clone from it, still giving
+    // every row its own id and counter so no two rows read alike on screen.
+    const POOL_SIZE: usize = 512;
+    if size > POOL_SIZE * 2 {
+        let pool = random_stocks_exact(0, POOL_SIZE);
+        return (start..start + size)
+            .map(|id| {
+                let mut stock = pool[(id - start) % POOL_SIZE].clone();
+                stock.id = id;
+                stock.counter = Counter::random();
+                stock
+            })
+            .collect();
+    }
+
+    random_stocks_exact(start, size)
+}
+
+/// Builds `size` rows with every field independently randomized.
+fn random_stocks_exact(start: usize, size: usize) -> Vec<Stock> {
     (start..start + size)
         .map(|id| Stock {
             id,
@@ -251,8 +287,7 @@ impl StockTableDelegate {
                     .fixed(ColumnFixed::Left)
                     .resizable(true)
                     .min_width(40.)
-                    .max_width(100.)
-                    .text_center(),
+                    .max_width(100.),
                 Column::new("market", "Market")
                     .width(60.)
                     .fixed(ColumnFixed::Left)
@@ -328,15 +363,9 @@ impl StockTableDelegate {
         }
     }
 
-    fn update_stocks(&mut self, size: usize) {
-        // Reset incremental ID
-        {
-            let mut id_lock = INCREMENT_ID.lock().unwrap();
-            *id_lock = 0;
-        }
-
-        self.stocks = random_stocks(size);
-        self.eof = size <= 50;
+    fn set_stocks(&mut self, stocks: Vec<Stock>) {
+        self.eof = stocks.len() <= 50;
+        self.stocks = stocks;
         self.loading = false;
         self.full_loading = false;
     }
@@ -779,6 +808,7 @@ pub struct DataTableStory {
 
     _subscriptions: Vec<Subscription>,
     _load_task: Task<()>,
+    _load_rows_task: Task<()>,
 }
 
 impl super::Story for DataTableStory {
@@ -828,15 +858,23 @@ impl DataTableStory {
                     }
 
                     this.table.update(cx, |table, _| {
-                        table.delegate_mut().stocks.iter_mut().enumerate().for_each(
-                            |(i, stock)| {
+                        // Only walk the head of the table. It paints a few dozen
+                        // rows at a time, so ticking every row of the million-row
+                        // example would stall the frame for nothing on screen.
+                        const MAX_REFRESH_ROWS: usize = 2_000;
+                        table
+                            .delegate_mut()
+                            .stocks
+                            .iter_mut()
+                            .take(MAX_REFRESH_ROWS)
+                            .enumerate()
+                            .for_each(|(i, stock)| {
                                 let n = (3..10).fake::<usize>();
                                 // update 30% of the stocks
                                 if i % n == 0 {
                                     stock.random_update();
                                 }
-                            },
-                        );
+                            });
                     });
                     cx.notify();
                 })
@@ -851,6 +889,7 @@ impl DataTableStory {
             size: Size::default(),
             _subscriptions,
             _load_task,
+            _load_rows_task: Task::ready(()),
         }
     }
 
@@ -1053,10 +1092,29 @@ impl Render for DataTableStory {
                 if action.0 == this.table.read(cx).delegate().stocks.len() {
                     return;
                 }
-                this.table.update(cx, |table, _| {
-                    table.delegate_mut().update_stocks(action.0);
+
+                // Building the largest example allocates a few hundred MB, which
+                // drops frames if it runs between two paints. Show the loading
+                // state, build off-thread, and swap the rows in when they land.
+                let size = action.0;
+                this.table.update(cx, |table, cx| {
+                    table.delegate_mut().full_loading = true;
+                    cx.notify();
                 });
-                cx.notify();
+                this._load_rows_task = cx.spawn(async move |this, cx| {
+                    let stocks = cx
+                        .background_spawn(async move { regenerate_stocks(size) })
+                        .await;
+
+                    this.update(cx, |this, cx| {
+                        this.table.update(cx, |table, cx| {
+                            table.delegate_mut().set_stocks(stocks);
+                            table.refresh(cx);
+                        });
+                        cx.notify();
+                    })
+                    .ok();
+                });
             }))
             .on_action(cx.listener(|this, action: &ChangeExtraColumns, _, cx| {
                 this.table.update(cx, |table, cx| {
@@ -1064,6 +1122,9 @@ impl Render for DataTableStory {
                     table.refresh(cx);
                 });
                 cx.notify();
+            }))
+            .on_action(cx.listener(|this, _: &ClearTableSelection, _, cx| {
+                this.table.update(cx, |table, cx| table.clear_selection(cx));
             }))
             .on_action(cx.listener(|this, action: &GoToTablePosition, _, cx| {
                 this.table.update(cx, |table, cx| match action {
@@ -1182,11 +1243,6 @@ impl Render for DataTableStory {
                             )
                             .menu_with_check("500", rows_count == 500, Box::new(ChangeRows(500)))
                             .menu_with_check(
-                                "1,000",
-                                rows_count == 1_000,
-                                Box::new(ChangeRows(1_000)),
-                            )
-                            .menu_with_check(
                                 "5,000",
                                 rows_count == 5_000,
                                 Box::new(ChangeRows(5_000)),
@@ -1195,6 +1251,11 @@ impl Render for DataTableStory {
                                 "10,000",
                                 rows_count == 10_000,
                                 Box::new(ChangeRows(10_000)),
+                            )
+                            .menu_with_check(
+                                "1,000,000",
+                                rows_count == 1_000_000,
+                                Box::new(ChangeRows(1_000_000)),
                             )
                         },
                     )
@@ -1305,6 +1366,8 @@ impl Render for DataTableStory {
                                 show_group_headers,
                                 Box::new(ToggleTableOption::GroupHeaders),
                             )
+                            .separator()
+                            .menu("Clear Selection", Box::new(ClearTableSelection))
                         }
                     })
                     .dropdown_child(Button::new("go-to").label("Go To"), |menu, _, _| {
@@ -1318,15 +1381,6 @@ impl Render for DataTableStory {
                         Button::new("dump-csv")
                             .label("Export CSV")
                             .on_click(cx.listener(Self::dump_csv)),
-                    )
-                    .child(
-                        Button::new("clear-selection")
-                            .child("Clear")
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.table.update(cx, |table, cx| {
-                                    table.clear_selection(cx);
-                                })
-                            })),
                     ),
             )
             .child(

--- a/website/.vitepress/theme/components/ComponentExample.vue
+++ b/website/.vitepress/theme/components/ComponentExample.vue
@@ -8,6 +8,8 @@ import {
     watch,
 } from "vue";
 import { useData, useRoute, withBase } from "vitepress";
+import { useWindowZoom } from "../composables/zoom";
+import WindowZoomButton from "./WindowZoomButton.vue";
 
 const route = useRoute();
 const { frontmatter } = useData();
@@ -78,6 +80,8 @@ const windowTitle = computed(() =>
 
 const target = shallowRef<HTMLElement>();
 
+const { zoomed, zoomLabel, setZoomed } = useWindowZoom("example");
+
 const createTargetAfterDescription = async () => {
     await nextTick();
     target.value?.remove();
@@ -99,7 +103,11 @@ const createTargetAfterDescription = async () => {
 };
 
 onMounted(createTargetAfterDescription);
-watch(() => route.path, createTargetAfterDescription);
+watch(() => route.path, () => {
+    // A new page means a new example, so it starts unzoomed.
+    setZoomed(false);
+    createTargetAfterDescription();
+});
 onBeforeUnmount(() => target.value?.remove());
 </script>
 
@@ -116,10 +124,24 @@ onBeforeUnmount(() => target.value?.remove());
                 <span>Example</span>
                 <span class="component-example__live">Rust &amp; WASM</span>
             </div>
-            <div class="mac-window">
+            <div class="mac-window" :class="{ 'mac-window--zoomed': zoomed }">
                 <div class="mac-window__bar">
-                    <span class="mac-window__lights" aria-hidden="true"><i /><i /><i /></span>
+                    <span class="mac-window__lights">
+                        <i aria-hidden="true" /><i aria-hidden="true" /><button
+                            type="button"
+                            class="mac-window__zoom"
+                            :title="zoomLabel"
+                            :aria-label="zoomLabel"
+                            :aria-pressed="zoomed"
+                            @click="setZoomed(!zoomed)"
+                        />
+                    </span>
                     <span class="mac-window__title">{{ windowTitle }}</span>
+                    <WindowZoomButton
+                        :zoomed="zoomed"
+                        :label="zoomLabel"
+                        @click="setZoomed(!zoomed)"
+                    />
                 </div>
                 <iframe
                     :key="src"

--- a/website/.vitepress/theme/components/SidebarFilter.vue
+++ b/website/.vitepress/theme/components/SidebarFilter.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, shallowRef, watch } from "vue";
+import { useData, useRouter, withBase } from "vitepress";
+import { useLayout } from "vitepress/theme";
+import VPLink from "vitepress/dist/client/theme-default/components/VPLink.vue";
+
+type Page = { text: string; link: string; group: string };
+type SidebarItem = { text?: string; link?: string; items?: SidebarItem[] };
+
+const { lang, page } = useData();
+const router = useRouter();
+const { sidebarGroups } = useLayout();
+
+const query = ref("");
+const activeIndex = ref(0);
+const list = shallowRef<HTMLElement | null>(null);
+
+const labels = computed(() =>
+  lang.value.startsWith("zh")
+    ? { placeholder: "过滤", empty: "没有匹配的页面", clear: "清除" }
+    : { placeholder: "Filter", empty: "No matching pages", clear: "Clear" },
+);
+
+/** Every linked page of the sidebar the current route resolves to. */
+const pages = computed(() => {
+  const collected: Page[] = [];
+
+  const walk = (items: SidebarItem[] | undefined, group: string) => {
+    for (const item of items ?? []) {
+      if (item.link) {
+        collected.push({ text: item.text ?? "", link: item.link, group });
+      }
+      walk(item.items, item.text ?? group);
+    }
+  };
+
+  walk(sidebarGroups.value as SidebarItem[], "");
+  return collected;
+});
+
+/**
+ * Prefix, then substring, then a loose in-order character match so `dtpick`
+ * still finds "DatePicker". The number only orders the list; null drops the
+ * page from it.
+ */
+function score(text: string, query: string): number | null {
+  const haystack = text.toLowerCase();
+  if (haystack.startsWith(query)) return 0;
+
+  const at = haystack.indexOf(query);
+  if (at >= 0) return 1 + at / 1000;
+
+  let matched = 0;
+  for (const char of haystack) {
+    if (char === query[matched]) matched += 1;
+  }
+  return matched === query.length ? 2 : null;
+}
+
+const results = computed(() => {
+  const needle = query.value.trim().toLowerCase();
+  if (!needle) return [];
+
+  return pages.value
+    .map((item) => ({ item, rank: score(item.text, needle) }))
+    .filter((hit): hit is { item: Page; rank: number } => hit.rank !== null)
+    .sort(
+      (left, right) =>
+        left.rank - right.rank || left.item.text.length - right.item.text.length,
+    )
+    .map((hit) => hit.item);
+});
+
+const filtering = computed(() => query.value.trim().length > 0);
+
+// Repeating the same group on every row is noise when the whole result set
+// comes from one place — it only earns its space when the rows come from
+// different parts of the tree.
+const showGroup = computed(() => new Set(results.value.map((item) => item.group)).size > 1);
+
+watch(results, () => {
+  activeIndex.value = 0;
+});
+
+// A jump lands on the page the reader asked for, so the tree — with that page
+// marked active — is what they need next.
+watch(() => page.value.relativePath, clear);
+
+function clear() {
+  query.value = "";
+}
+
+async function move(delta: number) {
+  const total = results.value.length;
+  if (!total) return;
+
+  activeIndex.value = (activeIndex.value + delta + total) % total;
+  await nextTick();
+  list.value?.querySelector(".is-active")?.scrollIntoView({ block: "nearest" });
+}
+
+function open() {
+  const hit = results.value[activeIndex.value];
+  if (hit) router.go(withBase(hit.link));
+}
+</script>
+
+<template>
+  <div class="SidebarFilter" :data-filtering="filtering">
+    <div class="field">
+      <span class="vpi-search icon" />
+      <input
+        v-model="query"
+        type="search"
+        class="input"
+        :placeholder="labels.placeholder"
+        :aria-label="labels.placeholder"
+        autocomplete="off"
+        spellcheck="false"
+        @keydown.down.prevent="move(1)"
+        @keydown.up.prevent="move(-1)"
+        @keydown.enter.prevent="open"
+        @keydown.esc.prevent="clear"
+      />
+      <button v-if="filtering" class="clear" type="button" :aria-label="labels.clear" @click="clear">
+        <span class="vpi-delete icon" />
+      </button>
+    </div>
+
+    <div v-if="filtering" ref="list" class="results">
+      <VPLink
+        v-for="(item, index) in results"
+        :key="item.link"
+        class="result"
+        :class="{ 'is-active': index === activeIndex }"
+        :href="item.link"
+        @mouseenter="activeIndex = index"
+      >
+        <span class="text">{{ item.text }}</span>
+        <span v-if="showGroup && item.group" class="group">{{ item.group }}</span>
+      </VPLink>
+
+      <p v-if="!results.length" class="empty">{{ labels.empty }}</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.SidebarFilter {
+  padding-bottom: 4px;
+}
+
+.field {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 2rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--background);
+  transition: border-color 140ms ease;
+}
+
+.field:focus-within {
+  border-color: color-mix(in srgb, var(--foreground) 22%, var(--border));
+}
+
+.icon {
+  flex-shrink: 0;
+  width: 0.85rem;
+  height: 0.85rem;
+  color: var(--muted-foreground);
+}
+
+.input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 0.8125rem;
+}
+
+.input:focus {
+  outline: 0;
+}
+
+.input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* The type=search widget draws its own clear button, which would sit beside
+   ours in WebKit. */
+.input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.clear {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-control);
+  cursor: pointer;
+}
+
+.clear:hover .icon {
+  color: var(--foreground);
+}
+
+.results {
+  padding-top: 10px;
+}
+
+.result {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: var(--radius);
+  color: var(--vp-c-text-2);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.result.is-active {
+  background: var(--secondary);
+  color: var(--foreground);
+}
+
+.group {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+}
+
+.empty {
+  padding: 0.25rem 0.4rem;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+</style>
+
+<style>
+/* While a query is active the flat result list stands in for the tree, so the
+   groups VitePress renders after this slot step aside. */
+#VPSidebarNav:has(.SidebarFilter[data-filtering="true"]) > .group {
+  display: none;
+}
+</style>

--- a/website/.vitepress/theme/components/WindowZoomButton.vue
+++ b/website/.vitepress/theme/components/WindowZoomButton.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { Maximize, Minimize } from "lucide-vue-next";
+
+// The traffic lights alone are too quiet to advertise that a frame can be
+// zoomed, so every live window carries a real control at the end of its title
+// bar. It stays hidden until the pointer reaches the bar, the way macOS
+// toolbars reveal their own accessory buttons.
+defineProps<{ zoomed: boolean; label: string }>();
+</script>
+
+<template>
+    <button
+        type="button"
+        class="mac-window__action"
+        :title="label"
+        :aria-label="label"
+        :aria-pressed="zoomed"
+    >
+        <Minimize v-if="zoomed" :size="14" />
+        <Maximize v-else :size="14" />
+    </button>
+</template>

--- a/website/.vitepress/theme/composables/zoom.ts
+++ b/website/.vitepress/theme/composables/zoom.ts
@@ -1,0 +1,35 @@
+import { computed, onBeforeUnmount, onMounted, shallowRef } from "vue";
+
+/**
+ * Zoom state for a `.mac-window` frame that shows the library running.
+ *
+ * Zooming lifts the frame over the viewport rather than entering browser
+ * fullscreen: the page keeps its own chrome one Escape away, and the iframe is
+ * never re-created, so the wasm instance inside it keeps running.
+ */
+export function useWindowZoom(subject = "window") {
+    const zoomed = shallowRef(false);
+
+    const zoomLabel = computed(() =>
+        zoomed.value
+            ? `Restore ${subject} (Esc)`
+            : `Zoom ${subject} to full page`,
+    );
+
+    const setZoomed = (value: boolean) => {
+        zoomed.value = value;
+        document.documentElement.classList.toggle("has-zoomed-window", value);
+    };
+
+    const onKeydown = (event: KeyboardEvent) => {
+        if (event.key === "Escape" && zoomed.value) setZoomed(false);
+    };
+
+    onMounted(() => document.addEventListener("keydown", onKeydown));
+    onBeforeUnmount(() => {
+        document.removeEventListener("keydown", onKeydown);
+        setZoomed(false);
+    });
+
+    return { zoomed, zoomLabel, setZoomed };
+}

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import "./style.css";
 import GitHubStar from "./components/GitHubStar.vue";
 import LanguageSwitcher from "./components/LanguageSwitcher.vue";
 import ComponentExample from "./components/ComponentExample.vue";
+import SidebarFilter from "./components/SidebarFilter.vue";
 import { useThemeFavicon } from "./composables/favicon";
 import config from "../../../crates/ui/Cargo.toml";
 
@@ -27,6 +28,10 @@ const Layout = defineComponent({
         // — where VitePress keeps its own translations menu too.
         "nav-screen-content-after": () =>
           h(LanguageSwitcher, { screenMenu: true }),
+        // The component catalogue is long enough that scanning it costs more
+        // than typing: the filter narrows the tree in place, while search
+        // still covers page contents.
+        "sidebar-nav-before": () => h(SidebarFilter),
       });
   },
 });

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -1011,20 +1011,96 @@ html[lang^="ja"] :is(h1, h2, h3, h4) {
   gap: 0.5rem;
 }
 
-.mac-window__lights i {
+.mac-window__lights i,
+.mac-window__lights button {
   width: 0.75rem;
   height: 0.75rem;
+  padding: 0;
+  border: 0;
   border-radius: 50%;
   background: #ff5f57;
   box-shadow: inset 0 0 0 0.5px rgb(0 0 0 / 12%);
 }
 
-.mac-window__lights i:nth-child(2) {
+.mac-window__lights > :nth-child(2) {
   background: #febc2e;
 }
 
-.mac-window__lights i:nth-child(3) {
+.mac-window__lights > :nth-child(3) {
   background: #28c840;
+}
+
+/* Only the zoom light does anything, and like macOS it reveals its glyph when
+   the pointer is over the title bar. */
+.mac-window__zoom {
+  cursor: pointer;
+}
+
+.mac-window__zoom::before {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: rgb(0 0 0 / 55%);
+  font-size: 0.5rem;
+  line-height: 1;
+  opacity: 0;
+  content: "⤢";
+  transition: opacity 0.12s ease;
+}
+
+.mac-window--zoomed .mac-window__zoom::before {
+  content: "⤡";
+}
+
+.mac-window__bar:hover .mac-window__zoom::before,
+.mac-window__zoom:focus-visible::before {
+  opacity: 1;
+}
+
+/* The explicit zoom control on the right of the bar. It stays out of the way
+   until the pointer reaches the title bar. */
+.mac-window__action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  border-radius: 0.375rem;
+  opacity: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    opacity 0.12s ease,
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.mac-window__bar:hover .mac-window__action,
+.mac-window__action:focus-visible {
+  opacity: 1;
+}
+
+.mac-window__action:hover {
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+  color: var(--foreground);
+}
+
+/* When something other than the (absolutely positioned) title already sits
+   before the control — the home page badge — that element does the pushing;
+   two auto margins would split the free space between them instead. */
+.mac-window__bar > :not(.mac-window__title) + .mac-window__action {
+  margin-left: 0;
+}
+
+/* The home page demo is the site's headline proof that this really runs, so its
+   control stays visible instead of waiting to be discovered. */
+.mac-window__action--always {
+  opacity: 1;
 }
 
 /* Centred in the bar, as macOS does, and independent of the traffic lights. */
@@ -1108,4 +1184,33 @@ html[lang^="ja"] :is(h1, h2, h3, h4) {
   .component-example--base iframe {
     height: 380px;
   }
+}
+
+/* A zoomed window takes over the viewport, above the nav and the sidebar, while
+   the page underneath stops scrolling. Its title bar stays put, so the control
+   that restores it is always in reach. The doubled class keeps these rules
+   ahead of the per-page frame heights, wherever those are declared. */
+.has-zoomed-window,
+.has-zoomed-window body {
+  overflow: hidden;
+}
+
+.mac-window.mac-window--zoomed {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.mac-window.mac-window--zoomed::after {
+  display: none;
+}
+
+.mac-window.mac-window--zoomed iframe,
+.mac-window.mac-window--zoomed .showcase__placeholder {
+  flex: 1;
+  height: auto;
 }

--- a/website/index.vue
+++ b/website/index.vue
@@ -198,7 +198,10 @@
                     </div>
                 </header>
 
-                <div class="showcase__frame mac-window">
+                <div
+                    class="showcase__frame mac-window"
+                    :class="{ 'mac-window--zoomed': zoomed }"
+                >
                     <div class="mac-window__bar">
                         <span class="mac-window__lights" aria-hidden="true"
                             ><i /><i /><i
@@ -209,6 +212,12 @@
                         <span class="live__badge">
                             {{ copy.liveBadge }}
                         </span>
+                        <WindowZoomButton
+                            class="mac-window__action--always"
+                            :zoomed="zoomed"
+                            :label="zoomLabel"
+                            @click="setZoomed(!zoomed)"
+                        />
                     </div>
                     <iframe
                         v-if="liveSrc"
@@ -442,8 +451,12 @@ import {
     X,
 } from "lucide-vue-next";
 import { data as repo } from "./data/repo.data";
+import { useWindowZoom } from "./.vitepress/theme/composables/zoom";
+import WindowZoomButton from "./.vitepress/theme/components/WindowZoomButton.vue";
 
 const { isDark, localeIndex, theme } = useData();
+
+const { zoomed, zoomLabel, setZoomed } = useWindowZoom("demo");
 
 // The navbar renders the very same `nav` array that config.mts feeds to the
 // docs navbar, so the two can never drift apart.


### PR DESCRIPTION
## Description

Two related bits of story polish.

**Toolbar buttons now read as one control.** `dropdown_child` gave every dropdown
its own `ButtonGroup` holding a single button, and `ButtonGroup` skips all border
merging at one child — so a typical toolbar (Size + Options) rendered as two
fully-rounded buttons touching each other, with a doubled border down the middle.
`StoryToolbar` now keeps its items unbuilt until render, where it knows the count
and each index, and squares off the inner corners.

This also let the `StoryToolbarMenuTrigger` wrapper go (struct plus four trait
impls): `Popover::trigger` only requires `Selectable + IntoElement`, which
`Button` already satisfies.

No component was changed — this is entirely inside `crates/story`.

**DataTable story: a million-row example.** Replaces the 1,000-row option; 5,000
stays, since that is what the story opens with. The rarely-used Clear button
moves into the Options menu, and the ID column no longer centers its text.

## Performance

Two things had to change before a million rows was worth showing.

| | before | after |
| :--- | ---: | ---: |
| `random_stocks(1_000_000)`, debug | 24.0 s | 0.71 s |
| `random_stocks(10_000)`, debug | 231 ms | 27.7 ms |

Every row randomized all 40-odd fields independently. Rows are now cloned from a
512-row random pool, each still getting its own id and `Counter::random()`, so no
two rows read alike on screen. Retained size is unchanged at 408 B/row (389 MB at
a million rows).

The remaining ~0.7 s still landed on the main thread between two paints, which
was visible as a hitch on switching. Generation moved to the background executor
behind the story's existing `full_loading` state, so no frame is dropped.

Separately, the "Refresh Data" tick walked the entire table every 33 ms and
randomized ~1/3 of the rows. At a million rows that is millions of field draws
per frame to update the few dozen rows on screen, which would have made the new
example unusable with that option on. It is now bounded to the first 2,000 rows.

## How to Test

```sh
cargo run
```

Open the DataTable story:

- the toolbar buttons form one segmented control, no doubled borders;
- Rows offers 100 / 500 / 5,000 / 10,000 / 1,000,000, with 5,000 checked on open;
- switching to 1,000,000 shows the loading state and does not hitch;
- Options ends with a separator and Clear Selection;
- Refresh Data stays smooth at a million rows.

`cargo check`, `cargo clippy` and `rustfmt --check` are clean for the changed
files.

## AI Assistance

AI assisted with the implementation and with measuring the generation timings
quoted above.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] `cargo run` story verification — see How to Test.
- [x] Cross-platform performance testing is not applicable; no platform-specific path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)