### PR TITLE
input: Clip selection ranges to UTF-8 boundaries

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -2244,10 +2244,17 @@ impl InputBaseState {
     }
 
     /// Set the selected range using UTF-8 byte offsets.
+    ///
+    /// Non-empty ranges expand to character boundaries. Empty ranges remain empty and are
+    /// clipped to the preceding character boundary.
     pub fn set_selected_range(&mut self, range: Range<usize>, cx: &mut Context<Self>) {
-        let len = self.text.len();
-        let start = range.start.min(len);
-        let end = range.end.min(len);
+        let end_bias = if range.start == range.end {
+            Bias::Left
+        } else {
+            Bias::Right
+        };
+        let start = self.text.clip_offset(range.start, Bias::Left);
+        let end = self.text.clip_offset(range.end, end_bias);
 
         self.move_to(start, None, cx);
         self.selection_reversed = false;
@@ -3851,6 +3858,24 @@ mod tests {
                 // clamped + collapsed
                 s.set_selected_range(100..100, cx);
                 assert_eq!(s.selected_range(), 11..11);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_set_selected_range_clips_to_utf8_boundaries(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state.default_value("éx"));
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_selected_range(0..1, cx);
+                assert_eq!(state.selected_range(), 0..2);
+                state.copy(&Copy, window, cx);
+
+                state.set_selected_range(1..1, cx);
+                assert_eq!(state.selected_range(), 0..0);
             });
         });
     }


### PR DESCRIPTION
Closes #2699

## Description

`InputBaseState::set_selected_range` previously clamped offsets only to the text byte length. An offset inside a multi-byte UTF-8 character could therefore be stored in `selected_range`. Copying or cutting that selection later passed the invalid range to `Rope::slice` and panicked the application.

This change clips non-empty selection ranges outward to valid character boundaries before storing them. Empty ranges remain collapsed and are clipped to the preceding character boundary.

The patch is intentionally limited to the public selection setter and a regression test for the reported crash path. Internal cursor movement and selection helpers are unchanged.

## Screenshot

Not applicable. The change fixes non-visual selection state validation and a process panic.

## How to Test

```bash
cargo fmt --all -- --check
cargo test -p gpui-base
```

The regression test uses the text `"éx"` and selection `0..1`, where byte offset `1` is inside `é`. It verifies that the range becomes `0..2` and that the existing Copy action completes without panicking. It also verifies that an empty `1..1` range remains empty after clipping.

The original native Wayland GUI reproduction was also rerun after the patch. The focused Copy action completed without a panic, and the normalized selection was reported as `0..2`.

## AI Assistance

AI assisted with the implementation, regression test, native reproduction, and PR draft. The contributor reviewed the generated changes and test evidence before submission.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI-generated code is accurate.
- [x] Passed `cargo test -p gpui-base` (264 unit tests and 1 integration test).
- [x] Passed a native `cargo run` GPUI reproduction for the affected Copy action on Linux Wayland.
- [x] The change is not platform-specific; no platform-specific behavior was modified.
