### PR TITLE
input: Add readonly mode for Input, Textarea and Editor

### DIFF
--- a/crates/base/src/input/base/mod.rs
+++ b/crates/base/src/input/base/mod.rs
@@ -8,6 +8,7 @@ use gpui::{
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InputContextMenuCapabilities {
     pub disabled: bool,
+    pub readonly: bool,
     pub code_editor: bool,
     pub selection: bool,
     pub go_to_definition: bool,

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -301,6 +301,7 @@ pub struct InputBaseState {
     pub(super) last_selected_range: Option<Selection>,
     pub(super) selecting: bool,
     pub(crate) disabled: bool,
+    pub(crate) readonly: bool,
     pub(crate) text_align: TextAlign,
     pub(super) masked: bool,
     pub(super) clean_on_escape: bool,
@@ -400,6 +401,7 @@ pub struct InputBaseState {
 pub struct InputPresentation {
     pub focus_handle: FocusHandle,
     pub disabled: bool,
+    pub readonly: bool,
     pub loading: bool,
     pub masked: bool,
     pub multi_line: bool,
@@ -408,6 +410,15 @@ pub struct InputPresentation {
     pub placeholder: SharedString,
     pub value: String,
     pub mask_placeholder: Option<String>,
+}
+
+impl InputPresentation {
+    /// Returns true if the user is allowed to change the text.
+    ///
+    /// See also: [`InputBaseState::is_editable`].
+    pub fn is_editable(&self) -> bool {
+        !self.disabled && !self.readonly
+    }
 }
 
 impl EventEmitter<InputEvent> for InputBaseState {}
@@ -435,6 +446,7 @@ impl InputBaseState {
         InputPresentation {
             focus_handle: self.focus_handle.clone(),
             disabled: self.disabled,
+            readonly: self.readonly,
             loading: self.loading,
             masked: self.masked,
             multi_line: self.mode.is_multi_line(),
@@ -449,6 +461,7 @@ impl InputBaseState {
     pub fn context_menu_capabilities(&self) -> InputContextMenuCapabilities {
         InputContextMenuCapabilities {
             disabled: self.disabled,
+            readonly: self.readonly,
             code_editor: self.mode.is_code_editor(),
             selection: !self.selected_range.is_empty(),
             go_to_definition: self.lsp.definition_provider.is_some(),
@@ -522,6 +535,7 @@ impl InputBaseState {
             input_bounds: Bounds::default(),
             selecting: false,
             disabled: false,
+            readonly: false,
             text_align: TextAlign::Left,
             masked: false,
             clean_on_escape: false,
@@ -921,6 +935,17 @@ impl InputBaseState {
         cx.notify();
     }
 
+    /// Perform `f` with the user-facing edit restrictions lifted.
+    ///
+    /// The `disabled` and `readonly` modes only reject the changes made by the
+    /// user, the programmatic APIs must always be able to update the text.
+    fn with_edits_allowed(&mut self, f: impl FnOnce(&mut Self)) {
+        let (was_disabled, was_readonly) = (self.disabled, self.readonly);
+        (self.disabled, self.readonly) = (false, false);
+        f(self);
+        (self.disabled, self.readonly) = (was_disabled, was_readonly);
+    }
+
     /// Insert text at the current cursor position.
     ///
     /// And the cursor will be moved to the end of inserted text.
@@ -930,13 +955,12 @@ impl InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let was_disabled = self.disabled;
-        self.disabled = false;
         let text: SharedString = text.into();
-        let range_utf16 = self.range_to_utf16(&(self.cursor()..self.cursor()));
-        self.replace_text_in_range_silent(Some(range_utf16), &text, window, cx);
-        self.selected_range = (self.selected_range.end..self.selected_range.end).into();
-        self.disabled = was_disabled;
+        self.with_edits_allowed(|this| {
+            let range_utf16 = this.range_to_utf16(&(this.cursor()..this.cursor()));
+            this.replace_text_in_range_silent(Some(range_utf16), &text, window, cx);
+            this.selected_range = (this.selected_range.end..this.selected_range.end).into();
+        });
     }
 
     /// Replace text at the current cursor position.
@@ -948,12 +972,11 @@ impl InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let was_disabled = self.disabled;
-        self.disabled = false;
         let text: SharedString = text.into();
-        self.replace_text_in_range_silent(None, &text, window, cx);
-        self.selected_range = (self.selected_range.end..self.selected_range.end).into();
-        self.disabled = was_disabled;
+        self.with_edits_allowed(|this| {
+            this.replace_text_in_range_silent(None, &text, window, cx);
+            this.selected_range = (this.selected_range.end..this.selected_range.end).into();
+        });
     }
 
     fn replace_text(
@@ -962,13 +985,12 @@ impl InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let was_disabled = self.disabled;
-        self.disabled = false;
         let text: SharedString = text.into();
-        let range = 0..self.text.chars().map(|c| c.len_utf16()).sum();
-        self.replace_text_in_range_silent(Some(range), &text, window, cx);
-        self.reset_highlighter(cx);
-        self.disabled = was_disabled;
+        self.with_edits_allowed(|this| {
+            let range = 0..this.text.chars().map(|c| c.len_utf16()).sum();
+            this.replace_text_in_range_silent(Some(range), &text, window, cx);
+            this.reset_highlighter(cx);
+        });
     }
 
     fn reset_selection(&mut self) {
@@ -1016,6 +1038,39 @@ impl InputBaseState {
 
         self.disabled = disabled;
         cx.notify();
+    }
+
+    /// Set with read-only mode.
+    ///
+    /// Unlike [`Self::disabled`], a read-only input keeps the normal appearance,
+    /// focus, cursor, selection and copy behavior, it only rejects any change
+    /// of the text made by the user.
+    ///
+    /// See also: [`Self::set_readonly`].
+    #[allow(unused)]
+    pub(crate) fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    pub fn set_readonly(&mut self, readonly: bool, cx: &mut Context<Self>) {
+        if self.readonly == readonly {
+            return;
+        }
+
+        self.readonly = readonly;
+        if readonly {
+            self.search_session.replace_mode = false;
+        }
+        cx.notify();
+    }
+
+    /// Returns true if the user is allowed to change the text.
+    ///
+    /// This is false when the input is `disabled` or `readonly`, the programmatic
+    /// APIs (e.g.: [`Self::set_value`], [`Self::insert`]) are not limited by this.
+    pub fn is_editable(&self) -> bool {
+        !self.disabled && !self.readonly
     }
 
     /// Set with password masked state.
@@ -2823,7 +2878,7 @@ impl EntityInputHandler for InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.disabled {
+        if !self.is_editable() {
             return;
         }
 
@@ -2939,7 +2994,7 @@ impl EntityInputHandler for InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.disabled {
+        if !self.is_editable() {
             return;
         }
 
@@ -3129,7 +3184,7 @@ impl Render for InputBaseState {
             .id("input-state")
             .key_context(CONTEXT)
             .track_focus(&self.focus_handle)
-            .when(!self.disabled, |this| {
+            .when(self.is_editable(), |this| {
                 this.on_action(window.listener_for(&entity, InputBaseState::backspace))
                     .on_action(window.listener_for(&entity, InputBaseState::delete))
                     .on_action(
@@ -3305,6 +3360,64 @@ mod tests {
             })
         });
         assert_eq!(calls.get(), 1);
+    }
+
+    #[gpui::test]
+    fn test_readonly_rejects_user_edits_only(cx: &mut TestAppContext) {
+        let input_view = InputView::new(cx);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("hello", window, cx);
+                state.set_readonly(true, cx);
+            });
+        });
+
+        cx.update(|_, cx| {
+            input.read_with(cx, |state, _| {
+                assert!(!state.is_editable());
+                assert!(!state.is_replaceable());
+            });
+        });
+
+        // Typing (and IME) goes through the input handler, it must be rejected.
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, " world", window, cx);
+                state.replace_and_mark_text_in_range(None, "あ", None, window, cx);
+            });
+        });
+        cx.update(|_, cx| {
+            input.read_with(cx, |state, _| assert_eq!(state.value(), "hello"));
+        });
+
+        // The programmatic APIs are not limited by the readonly mode.
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.insert(" world", window, cx);
+                state.set_value("changed", window, cx);
+            });
+        });
+        cx.update(|_, cx| {
+            input.read_with(cx, |state, _| assert_eq!(state.value(), "changed"));
+        });
+
+        // And the user can edit again after leaving the readonly mode.
+        // The caret is at the start, because `set_value` has reset the selection.
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_readonly(false, cx);
+                state.replace_text_in_range(None, "!", window, cx);
+            });
+        });
+        cx.update(|_, cx| {
+            input.read_with(cx, |state, _| {
+                assert!(state.is_editable());
+                assert_eq!(state.value(), "!changed");
+            });
+        });
     }
 
     /// Regression test: `scroll_to` at end-of-buffer must produce a deferred

--- a/crates/base/src/input/editor/search.rs
+++ b/crates/base/src/input/editor/search.rs
@@ -62,7 +62,8 @@ impl InputBaseState {
         if !self.searchable {
             return;
         }
-        self.search_session.open(replace_mode, self.replaceable);
+        self.search_session
+            .open(replace_mode, self.is_replaceable());
         let selected = self.selected_text().to_string();
         if !selected.is_empty() {
             self.search_session.query = selected;
@@ -88,12 +89,16 @@ impl InputBaseState {
 
     #[doc(hidden)]
     pub fn set_search_replace_mode(&mut self, replace_mode: bool, cx: &mut Context<Self>) {
-        self.search_session.replace_mode = replace_mode && self.replaceable;
+        self.search_session.replace_mode = replace_mode && self.is_replaceable();
         cx.notify();
     }
 
+    /// Returns true if the search panel can replace the matches.
+    ///
+    /// This is false when the input is not `replaceable`, or when it is
+    /// `disabled` or `readonly`.
     pub fn is_replaceable(&self) -> bool {
-        self.replaceable
+        self.replaceable && self.is_editable()
     }
 
     pub fn set_search_query(
@@ -136,7 +141,7 @@ impl InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if !self.replaceable {
+        if !self.is_replaceable() {
             return false;
         }
         let matcher = &mut self.search_session.matcher;
@@ -167,7 +172,7 @@ impl InputBaseState {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> usize {
-        if !self.replaceable {
+        if !self.is_replaceable() {
             return 0;
         }
         let ranges = self.search_session.matcher.matched_ranges();

--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -77,7 +77,7 @@ pub struct Example {
     soft_wrap: bool,
     show_whitespaces: bool,
     folding: bool,
-    disabled: bool,
+    readonly: bool,
     scroll_beyond_last_line: Option<usize>,
     cursor_surrounding_lines: Option<usize>,
     lsp_store: ExampleLspStore,
@@ -744,7 +744,7 @@ impl Example {
             soft_wrap: false,
             show_whitespaces: false,
             folding: true,
-            disabled: false,
+            readonly: false,
             scroll_beyond_last_line: None,
             cursor_surrounding_lines: None,
             lsp_store,
@@ -1046,14 +1046,14 @@ impl Example {
             }))
     }
 
-    fn render_disabled_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
-        Button::new("disabled")
+    fn render_readonly_button(&self, _: &mut Window, cx: &mut Context<Self>) -> Button {
+        Button::new("readonly")
             .ghost()
             .xsmall()
-            .when(self.disabled, |this| this.icon(IconName::Check))
-            .label("Disabled")
+            .when(self.readonly, |this| this.icon(IconName::Check))
+            .label("Read only")
             .on_click(cx.listener(|this, _, _window, cx| {
-                this.disabled = !this.disabled;
+                this.readonly = !this.readonly;
                 cx.notify();
             }))
     }
@@ -1167,7 +1167,7 @@ impl Render for Example {
                             )
                             .child(
                                 Input::from_base(&self.editor)
-                                    .disabled(self.disabled)
+                                    .readonly(self.readonly)
                                     .bordered(false)
                                     .p_0()
                                     .h_full()
@@ -1184,7 +1184,7 @@ impl Render for Example {
                             .left(self.render_show_whitespaces_button(window, cx))
                             .left(self.render_indent_guides_button(window, cx))
                             .left(self.render_folding_button(window, cx))
-                            .left(self.render_disabled_button(window, cx))
+                            .left(self.render_readonly_button(window, cx))
                             .left(self.render_scroll_beyond_last_line_button(window, cx))
                             .left(self.render_cursor_surrounding_lines_button(window, cx))
                             .right(self.render_go_to_line_button(window, cx)),

--- a/crates/story/src/stories/editor_story.rs
+++ b/crates/story/src/stories/editor_story.rs
@@ -3,7 +3,7 @@ use gpui::{
     Styled, Window, div,
 };
 
-use gpui_component::{ActiveTheme, input::*, tab::TabBar, v_flex};
+use gpui_component::{ActiveTheme, h_flex, input::*, switch::Switch, tab::TabBar, v_flex};
 
 const EXAMPLE_CODE: &str = include_str!("./editor_preview.rs");
 
@@ -12,6 +12,7 @@ pub struct EditorStory {
     decorations_state: Entity<EditorState>,
     _decorations: TextDecorationCollection,
     active_tab: usize,
+    readonly: bool,
 }
 impl super::Story for EditorStory {
     fn title() -> &'static str {
@@ -127,6 +128,7 @@ impl EditorStory {
             decorations_state,
             _decorations: decorations,
             active_tab: 0,
+            readonly: false,
         }
     }
 }
@@ -137,27 +139,42 @@ impl Render for EditorStory {
             .size_full()
             .gap_3()
             .child(
-                TabBar::new("editor-story-tabs")
-                    .w_64()
-                    .underline()
-                    .selected_index(self.active_tab)
-                    .on_click(cx.listener(|this, selected: &usize, _, cx| {
-                        this.active_tab = *selected;
-                        cx.notify();
-                    }))
-                    .child("Code")
-                    .child("Decorations"),
+                h_flex()
+                    .justify_between()
+                    .child(
+                        TabBar::new("editor-story-tabs")
+                            .w_64()
+                            .underline()
+                            .selected_index(self.active_tab)
+                            .on_click(cx.listener(|this, selected: &usize, _, cx| {
+                                this.active_tab = *selected;
+                                cx.notify();
+                            }))
+                            .child("Code")
+                            .child("Decorations"),
+                    )
+                    .child(
+                        Switch::new("editor-read-only")
+                            .label("Read only")
+                            .checked(self.readonly)
+                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                this.readonly = *checked;
+                                cx.notify();
+                            })),
+                    ),
             )
             .child(div().min_h_0().flex_1().child(if self.active_tab == 0 {
                 Editor::new(&self.editor_state)
                     .font_family(cx.theme().mono_font_family.clone())
                     .text_size(cx.theme().mono_font_size)
+                    .readonly(self.readonly)
                     .size_full()
                     .into_any_element()
             } else {
                 Editor::new(&self.decorations_state)
                     .font_family(cx.theme().mono_font_family.clone())
                     .text_size(cx.theme().mono_font_size)
+                    .readonly(self.readonly)
                     .size_full()
                     .into_any_element()
             }))

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -16,6 +16,7 @@ pub struct InputStory {
     input_text_right: Entity<InputState>,
     mask_input: Entity<InputState>,
     disabled_input: Entity<InputState>,
+    readonly_input: Entity<InputState>,
     prefix_input1: Entity<InputState>,
     suffix_input1: Entity<InputState>,
     both_input1: Entity<InputState>,
@@ -264,6 +265,8 @@ impl InputStory {
             mask_input,
             disabled_input: cx
                 .new(|cx| InputState::new(window, cx).default_value("This is disabled input")),
+            readonly_input: cx
+                .new(|cx| InputState::new(window, cx).default_value("This is read-only input")),
             small_input: cx.new(|cx| {
                 InputState::new(window, cx)
                     .validate(|s, _| s.parse::<f32>().is_ok())
@@ -394,12 +397,17 @@ impl Render for InputStory {
             )
             .child(
                 section("States")
-                    .description("Disabled and revealable password inputs.")
+                    .description("Disabled, read-only and revealable password inputs.")
                     .w_128()
                     .child(
                         Input::new(&self.disabled_input)
                             .with_size(self.size)
                             .disabled(true),
+                    )
+                    .child(
+                        Input::new(&self.readonly_input)
+                            .with_size(self.size)
+                            .readonly(true),
                     )
                     .child(
                         Input::new(&self.mask_input)

--- a/crates/ui/src/input/content_type.rs
+++ b/crates/ui/src/input/content_type.rs
@@ -149,12 +149,17 @@ impl InputContentType {
     }
 }
 
+/// Tells the OS what the focused input is used for, to let the autofill offer
+/// the matched value.
+///
+/// The `editable` is false when the input is `disabled` or `readonly`, in that
+/// case the autofill has nothing to fill in, so the content type is not synced.
 pub(super) fn sync_native_content_type(
     window: &mut Window,
     content_type: Option<InputContentType>,
-    disabled: bool,
+    editable: bool,
 ) {
-    if disabled {
+    if !editable {
         return;
     }
 

--- a/crates/ui/src/input/editor.rs
+++ b/crates/ui/src/input/editor.rs
@@ -15,6 +15,7 @@ pub struct Editor {
     appearance: bool,
     bordered: bool,
     disabled: bool,
+    readonly: bool,
     tab_index: isize,
     role: RoleOverride,
     aria_label: Option<SharedString>,
@@ -29,6 +30,7 @@ impl Editor {
             appearance: true,
             bordered: true,
             disabled: false,
+            readonly: false,
             tab_index: 0,
             role: RoleOverride::default(),
             aria_label: None,
@@ -52,6 +54,16 @@ impl Editor {
 
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Set the editor to read-only, default is `false`.
+    ///
+    /// Unlike [`Self::disabled`], a read-only editor keeps the normal appearance
+    /// and still can be focused, selected and copied, it only rejects the changes
+    /// made by the user.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
         self
     }
 
@@ -86,6 +98,7 @@ impl RenderOnce for Editor {
             .bordered(self.bordered)
             .focus_bordered(false)
             .disabled(self.disabled)
+            .readonly(self.readonly)
             .tab_index(self.tab_index)
             .role(self.role)
             .when_some(self.height, |this, height| this.h(height))

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -68,6 +68,7 @@ pub struct Input {
     cleanable: bool,
     mask_toggle: bool,
     disabled: bool,
+    readonly: bool,
     bordered: bool,
     focus_bordered: bool,
     tab_index: isize,
@@ -129,6 +130,7 @@ impl Input {
             cleanable: false,
             mask_toggle: false,
             disabled: false,
+            readonly: false,
             bordered: true,
             focus_bordered: true,
             tab_index: 0,
@@ -224,6 +226,16 @@ impl Input {
     /// Set to disable the input field.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Set the input field to read-only, default is `false`.
+    ///
+    /// Unlike [`Self::disabled`], a read-only input keeps the normal appearance
+    /// and still can be focused, selected and copied, it only rejects the changes
+    /// made by the user.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
         self
     }
 
@@ -435,6 +447,7 @@ impl RenderOnce for Input {
                 Edges::default()
             });
             state.set_disabled(self.disabled, cx);
+            state.set_readonly(self.readonly, cx);
             state.set_text_align(text_align, cx);
             let custom = self.context_menu_builder.clone();
             state.on_context_menu(Rc::new(move |_, capabilities, position, window, cx| {
@@ -442,6 +455,9 @@ impl RenderOnce for Input {
                     custom(NativeMenu::new(), window, cx)
                 } else {
                     let enabled = !capabilities.disabled;
+                    // A read-only input can still navigate the code, it only
+                    // rejects the items that would change the text.
+                    let editable = enabled && !capabilities.readonly;
                     let mut menu = NativeMenu::new();
                     if capabilities.code_editor {
                         menu = menu
@@ -452,14 +468,14 @@ impl RenderOnce for Input {
                             )
                             .menu_with_disabled(
                                 t!("Input.Show Code Actions"),
-                                !(enabled && capabilities.code_actions),
+                                !(editable && capabilities.code_actions),
                                 Box::new(gpui_base::input::ToggleCodeActions),
                             )
                             .separator();
                     }
                     menu.menu_with_disabled(
                         t!("Input.Cut"),
-                        !(enabled && capabilities.selection),
+                        !(editable && capabilities.selection),
                         Box::new(gpui_base::input::Cut),
                     )
                     .menu_with_disabled(
@@ -469,7 +485,7 @@ impl RenderOnce for Input {
                     )
                     .menu_with_disabled(
                         t!("Input.Paste"),
-                        !(enabled && cx.read_from_clipboard().is_some()),
+                        !(editable && cx.read_from_clipboard().is_some()),
                         Box::new(gpui_base::input::Paste),
                     )
                     .separator()
@@ -496,7 +512,7 @@ impl RenderOnce for Input {
         .then(|| presentation.value.clone());
         let focused = presentation.focus_handle.is_focused(window) && !presentation.disabled;
         if focused {
-            sync_native_content_type(window, content_type, presentation.disabled);
+            sync_native_content_type(window, content_type, presentation.is_editable());
         }
 
         let gap_x = match self.size {
@@ -519,7 +535,7 @@ impl RenderOnce for Input {
         let prefix = self.prefix;
         let suffix = self.suffix;
         let show_clear_button = self.cleanable
-            && !presentation.disabled
+            && presentation.is_editable()
             && !presentation.loading
             && !presentation.value.is_empty()
             && !presentation.multi_line;

--- a/crates/ui/src/input/textarea.rs
+++ b/crates/ui/src/input/textarea.rs
@@ -15,6 +15,7 @@ pub struct Textarea {
     appearance: bool,
     bordered: bool,
     disabled: bool,
+    readonly: bool,
     tab_index: isize,
     role: RoleOverride,
     aria_label: Option<SharedString>,
@@ -29,6 +30,7 @@ impl Textarea {
             appearance: true,
             bordered: true,
             disabled: false,
+            readonly: false,
             tab_index: 0,
             role: RoleOverride::default(),
             aria_label: None,
@@ -52,6 +54,16 @@ impl Textarea {
 
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Set the textarea to read-only, default is `false`.
+    ///
+    /// Unlike [`Self::disabled`], a read-only textarea keeps the normal appearance
+    /// and still can be focused, selected and copied, it only rejects the changes
+    /// made by the user.
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
         self
     }
 
@@ -85,6 +97,7 @@ impl RenderOnce for Textarea {
             .appearance(self.appearance)
             .bordered(self.bordered)
             .disabled(self.disabled)
+            .readonly(self.readonly)
             .tab_index(self.tab_index)
             .role(self.role)
             .when_some(self.height, |this, height| this.h(height))

--- a/website/docs/components/editor.md
+++ b/website/docs/components/editor.md
@@ -83,7 +83,17 @@ Editor::new(&editor)
     .h(px(480.))
     .bordered(true)
     .disabled(false)
+    .readonly(false)
     .aria_label("Rust source")
+```
+
+Use `readonly` to preview a file without allowing changes. Unlike `disabled`,
+a read-only editor keeps the normal appearance and still can be focused,
+selected, copied and searched, it only rejects the changes made by the user.
+The programmatic APIs such as `set_value` keep working.
+
+```rust
+Editor::new(&editor).readonly(true)
 ```
 
 Editor focus does not add the single-line Input focus-border treatment. The

--- a/website/docs/components/input.md
+++ b/website/docs/components/input.md
@@ -106,6 +106,15 @@ Input::new(&input).small()
 Input::new(&input).disabled(true)
 ```
 
+### Read-only Input
+
+Unlike `disabled`, a read-only input keeps the normal appearance and still can
+be focused, selected and copied, it only rejects the changes made by the user.
+
+```rust
+Input::new(&input).readonly(true)
+```
+
 ### Clean on ESC
 
 ```rust

--- a/website/docs/components/textarea.md
+++ b/website/docs/components/textarea.md
@@ -68,8 +68,13 @@ Textarea::new(&notes)
     .h(px(160.))
     .bordered(true)
     .disabled(false)
+    .readonly(false)
     .aria_label("Notes")
 ```
+
+Unlike `disabled`, a read-only textarea keeps the normal appearance and still
+can be focused, selected and copied, it only rejects the changes made by the
+user.
 
 `Textarea` deliberately does not expose Input-only adornments such as `prefix`,
 `suffix`, mask toggle, or the clear button. Compose related actions beside the

--- a/website/zh-CN/docs/components/editor.md
+++ b/website/zh-CN/docs/components/editor.md
@@ -73,7 +73,14 @@ Editor::new(&editor)
     .h(px(480.))
     .bordered(true)
     .disabled(false)
+    .readonly(false)
     .aria_label("Rust 源代码")
+```
+
+预览文件但不允许修改时使用 `readonly`。与 `disabled` 不同，只读编辑器保持正常外观，仍然可以聚焦、选中、复制和搜索，只是拒绝用户对内容的修改。`set_value` 等程序调用不受影响。
+
+```rust
+Editor::new(&editor).readonly(true)
 ```
 
 Editor 聚焦时不会应用单行 Input 的焦点边框效果。gutter、当前行背景和滚动条会作为同一个编辑器表面对齐绘制。

--- a/website/zh-CN/docs/components/input.md
+++ b/website/zh-CN/docs/components/input.md
@@ -101,6 +101,14 @@ Input::new(&input).small()
 Input::new(&input).disabled(true)
 ```
 
+### 只读态
+
+与 `disabled` 不同，只读输入框保持正常外观，仍然可以聚焦、选中和复制，只是拒绝用户对内容的修改。
+
+```rust
+Input::new(&input).readonly(true)
+```
+
 ### 按 ESC 清空
 
 ```rust

--- a/website/zh-CN/docs/components/textarea.md
+++ b/website/zh-CN/docs/components/textarea.md
@@ -66,7 +66,10 @@ Textarea::new(&notes)
     .h(px(160.))
     .bordered(true)
     .disabled(false)
+    .readonly(false)
     .aria_label("备注")
 ```
+
+与 `disabled` 不同，只读 Textarea 保持正常外观，仍然可以聚焦、选中和复制，只是拒绝用户对内容的修改。
 
 `Textarea` 不提供只适用于单行 Input 的前后缀、密码显示切换和清除按钮；相关操作应组合在 Textarea 外部。


### PR DESCRIPTION
Fixes #2702

A read-only editor previously had to use `disabled`, which dims the whole editor with `opacity(0.5)`. That is not what a file preview (e.g.: a Git application) should look like.

`readonly` keeps the normal appearance and only rejects the changes made by the user. The name follows the HTML `readonly` attribute.

```rust
Editor::new(&state).readonly(true)
Textarea::new(&state).readonly(true)
Input::new(&state).readonly(true)
```

## What a read-only input keeps

| | `disabled` | `readonly` |
| --- | --- | --- |
| Normal colors (no `opacity(0.5)`) | ✗ | ✓ |
| Focus, caret, selection | ✗ | ✓ |
| Copy, Select All | ✗ | ✓ |
| Search (`Find`) | ✓ | ✓ |
| Go to Definition, hover | ✗ | ✓ |
| Replace, Cut, Paste, Code Actions | ✗ | ✗ |
| Typing, IME, undo/redo, indent | ✗ | ✗ |
| `set_value`, `insert`, `replace` | ✓ | ✓ |

## Implementation

- `InputBaseState` gets a `readonly` field, `set_readonly()`, and a single `is_editable()` predicate (`!disabled && !readonly`) that all the write paths now go through: `replace_text_in_range`, `replace_and_mark_text_in_range` (IME), and the edit action registration.
- The scattered "temporarily clear `disabled`" blocks in `insert` / `replace` / `replace_text` are folded into `with_edits_allowed()`, so a programmatic write is never blocked by either mode.
- `is_replaceable()` becomes `replaceable && is_editable()`, so the search panel offers find-only in read-only mode.
- The context menu disables Cut / Paste / Show Code Actions, but keeps Copy and Go to Definition — the two a code preview needs.
- The clear button is hidden, and the OS autofill content type is no longer synced for a read-only input.

## Testing

`crates/story/examples/editor.rs` — the status bar toggle at the bottom is now `Read only` instead of `Disabled`. The Editor story has a `Read only` switch, and the Input story shows a read-only field beside the disabled one.

Added `test_readonly_rejects_user_edits_only`: user input (including IME) is rejected, programmatic writes still apply, and editing resumes after leaving the mode.

---

Written with Claude Code, reviewed and adjusted by hand.
