### PR TITLE
base, ui: Close the pub-field seam types behind builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,12 +189,18 @@ Text input system based on Rope data structure:
    mutable temporary element followed by imperative reassignment when the builder API can
    express the same operation.
 7. **No `pub` fields on public data types**: A public struct handed across the
-   `gpui-base`/application seam — a state snapshot, capability set, or option set — keeps
-   its fields private, is constructed with a builder (`new()` plus one chained setter per
-   field), and is read through methods (`is_`/`has_`/`can_` for booleans). Adding a `pub`
-   field is a breaking change; adding one behind a builder is not. Value types whose fields
-   are the definition and cannot grow (`Point`, `Selection`, `Edges`) are exempt. See the
+   `gpui-base`/application seam — a state snapshot, capability set, render context, or
+   option set — keeps its fields private, is constructed with a builder, and is read
+   through methods. Adding a `pub` field is a breaking change; adding one behind a builder
+   is not. Setters and readers must not collide: an all-boolean type names setters after
+   the field and readers `is_`/`has_`/`can_`; a type with non-boolean fields prefixes every
+   setter with `with_` and keeps the field name for readers. Value types whose fields are
+   the definition and cannot grow (`Point`, `Selection`, `Edges`) are exempt. See the
    "Public Data Types Across the Seam" section of `docs/ARCHITECTURE.md`.
+8. **Spell `Context` out**: Name a context type `ComboboxTriggerContext`, never `…Ctx`.
+   `cx` is reserved for GPUI's `App`, `Context<T>`, and `AsyncApp`, so `ctx` for anything
+   else reads as a competing context. A callback receiving both takes the GPUI one as `cx`
+   and names the other after what it holds (`trigger`, `state`).
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,13 @@ Text input system based on Rope data structure:
    conditions with `when`, `when_some`, `when_none`, and `map`; do not split a chain into a
    mutable temporary element followed by imperative reassignment when the builder API can
    express the same operation.
+7. **No `pub` fields on public data types**: A public struct handed across the
+   `gpui-base`/application seam — a state snapshot, capability set, or option set — keeps
+   its fields private, is constructed with a builder (`new()` plus one chained setter per
+   field), and is read through methods (`is_`/`has_`/`can_` for booleans). Adding a `pub`
+   field is a breaking change; adding one behind a builder is not. Value types whose fields
+   are the definition and cannot grow (`Point`, `Selection`, `Edges`) are exempt. See the
+   "Public Data Types Across the Seam" section of `docs/ARCHITECTURE.md`.
 
 ## Code Style
 

--- a/crates/base/examples/showcase/components/calendar.rs
+++ b/crates/base/examples/showcase/components/calendar.rs
@@ -9,7 +9,7 @@ impl BaseShowcase {
             .border_1()
             .border_color(rgb(0xd4d4d4))
             .item(|item, state, _, _| {
-                match state.kind {
+                match state.kind() {
                     CalendarItemKind::Previous | CalendarItemKind::Next => item
                         .size_7()
                         .flex()
@@ -37,14 +37,14 @@ impl BaseShowcase {
                         .items_center()
                         .justify_center()
                         .text_xs()
-                        .when(state.muted, |s| s.text_color(rgb(0xa3a3a3)))
-                        .when(state.today && !state.active, |s| {
+                        .when(state.is_muted(), |s| s.text_color(rgb(0xa3a3a3)))
+                        .when(state.is_today() && !state.is_active(), |s| {
                             s.border_1().border_color(rgb(0xd4d4d4))
                         })
-                        .when(state.active, |s| {
+                        .when(state.is_active(), |s| {
                             s.bg(rgb(0x171717)).text_color(rgb(0xffffff))
                         })
-                        .when(!state.disabled && !state.active, |s| {
+                        .when(!state.is_disabled() && !state.is_active(), |s| {
                             s.hover(|s| s.bg(rgb(0xf5f5f5)))
                         }),
                     CalendarItemKind::Month | CalendarItemKind::Year => item
@@ -54,10 +54,10 @@ impl BaseShowcase {
                         .items_center()
                         .justify_center()
                         .text_xs()
-                        .when(state.active, |s| {
+                        .when(state.is_active(), |s| {
                             s.bg(rgb(0x171717)).text_color(rgb(0xffffff))
                         })
-                        .when(!state.active, |s| s.hover(|s| s.bg(rgb(0xf5f5f5)))),
+                        .when(!state.is_active(), |s| s.hover(|s| s.bg(rgb(0xf5f5f5)))),
                 }
                 .into_any_element()
             })

--- a/crates/base/src/calendar.rs
+++ b/crates/base/src/calendar.rs
@@ -400,14 +400,83 @@ pub enum CalendarItemKind {
 
 /// State exposed to a calendar item slot. Applications may use it solely to
 /// decorate the unstyled primitive; all interaction remains owned by base.
+///
+/// The fields are private and reached through the methods below, so that a new
+/// one can be added without breaking the item slots.
 #[derive(Clone, Copy, Debug)]
 pub struct CalendarItemState {
-    pub kind: CalendarItemKind,
-    pub active: bool,
-    pub in_range: bool,
-    pub muted: bool,
-    pub disabled: bool,
-    pub today: bool,
+    kind: CalendarItemKind,
+    active: bool,
+    in_range: bool,
+    muted: bool,
+    disabled: bool,
+    today: bool,
+}
+
+impl CalendarItemState {
+    /// Create a state for `kind`, with every flag off.
+    pub fn new(kind: CalendarItemKind) -> Self {
+        Self {
+            kind,
+            active: false,
+            in_range: false,
+            muted: false,
+            disabled: false,
+            today: false,
+        }
+    }
+
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    /// Set whether the item is between the two ends of a range selection.
+    pub fn in_range(mut self, in_range: bool) -> Self {
+        self.in_range = in_range;
+        self
+    }
+
+    /// Set whether the item is shown as secondary, e.g.: a weekday header or a
+    /// day that belongs to the neighboring month.
+    pub fn muted(mut self, muted: bool) -> Self {
+        self.muted = muted;
+        self
+    }
+
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn today(mut self, today: bool) -> Self {
+        self.today = today;
+        self
+    }
+
+    pub fn kind(&self) -> CalendarItemKind {
+        self.kind
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn is_in_range(&self) -> bool {
+        self.in_range
+    }
+
+    pub fn is_muted(&self) -> bool {
+        self.muted
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    pub fn is_today(&self) -> bool {
+        self.today
+    }
 }
 
 /// An unstyled, pre-wired calendar item passed to the item slot.
@@ -521,7 +590,7 @@ impl Calendar {
         window: &mut Window,
         cx: &mut App,
     ) -> AnyElement {
-        let label = (self.label)(state.kind, value);
+        let label = (self.label)(state.kind(), value);
         (self.item)(CalendarItem::new(id, state).child(label), state, window, cx)
     }
 }
@@ -538,17 +607,11 @@ impl RenderOnce for Calendar {
             .update(cx, |s, cx| s.set_number_of_months(count, window, cx));
         let view = self.state.read(cx).view();
         let mut header = h_flex().items_center().justify_between().child({
-            let st = CalendarItemState {
-                kind: CalendarItemKind::Previous,
-                active: false,
-                in_range: false,
-                muted: false,
-                disabled: view.is_month()
-                    || (view.is_year() && !self.state.read(cx).has_prev_year_page()),
-                today: false,
-            };
-            let mut item = CalendarItem::new("calendar-prev", st).child((self.label)(st.kind, 0));
-            if !st.disabled {
+            let st = CalendarItemState::new(CalendarItemKind::Previous).disabled(
+                view.is_month() || (view.is_year() && !self.state.read(cx).has_prev_year_page()),
+            );
+            let mut item = CalendarItem::new("calendar-prev", st).child((self.label)(st.kind(), 0));
+            if !st.is_disabled() {
                 let entity = self.state.clone();
                 item = item.on_click(move |_, _window, cx| {
                     entity.update(cx, |s, cx| {
@@ -572,14 +635,7 @@ impl RenderOnce for Calendar {
                 (CalendarItemKind::MonthToggle, month, view.is_month()),
                 (CalendarItemKind::YearToggle, year, view.is_year()),
             ] {
-                let st = CalendarItemState {
-                    kind,
-                    active,
-                    in_range: false,
-                    muted: false,
-                    disabled: false,
-                    today: false,
-                };
+                let st = CalendarItemState::new(kind).active(active);
                 let entity = self.state.clone();
                 let mut item = CalendarItem::new(format!("calendar-{kind:?}"), st)
                     .child((self.label)(kind, value));
@@ -616,17 +672,11 @@ impl RenderOnce for Calendar {
             }
         }
         header = header.child({
-            let st = CalendarItemState {
-                kind: CalendarItemKind::Next,
-                active: false,
-                in_range: false,
-                muted: false,
-                disabled: view.is_month()
-                    || (view.is_year() && !self.state.read(cx).has_next_year_page()),
-                today: false,
-            };
-            let mut item = CalendarItem::new("calendar-next", st).child((self.label)(st.kind, 0));
-            if !st.disabled {
+            let st = CalendarItemState::new(CalendarItemKind::Next).disabled(
+                view.is_month() || (view.is_year() && !self.state.read(cx).has_next_year_page()),
+            );
+            let mut item = CalendarItem::new("calendar-next", st).child((self.label)(st.kind(), 0));
+            if !st.is_disabled() {
                 let entity = self.state.clone();
                 item = item.on_click(move |_, _, cx| {
                     entity.update(cx, |s, cx| {
@@ -653,14 +703,9 @@ impl RenderOnce for Calendar {
                 let weeks = days_in_month(year, month_number, self.first_day_of_week);
                 let mut month = h_flex().flex_wrap();
                 for weekday in 0..7 {
-                    let st = CalendarItemState {
-                        kind: CalendarItemKind::Weekday,
-                        active: false,
-                        in_range: false,
-                        muted: true,
-                        disabled: true,
-                        today: false,
-                    };
+                    let st = CalendarItemState::new(CalendarItemKind::Weekday)
+                        .muted(true)
+                        .disabled(true);
                     month = month.child(self.render_item(
                         format!("weekday-{offset}-{weekday}"),
                         st,
@@ -675,18 +720,16 @@ impl RenderOnce for Calendar {
                         let s = self.state.read(cx);
                         let (_, m) = s.offset_year_month(offset);
                         let disabled = s.disabled_matcher_ref().is_some_and(|x| x.matched(&date));
-                        CalendarItemState {
-                            kind: CalendarItemKind::Day,
-                            active: s.date().is_active(&date),
-                            in_range: s.date().is_in_range(&date),
-                            muted: date.month() != m || disabled,
-                            disabled,
-                            today: date == s.today(),
-                        }
+                        CalendarItemState::new(CalendarItemKind::Day)
+                            .active(s.date().is_active(&date))
+                            .in_range(s.date().is_in_range(&date))
+                            .muted(date.month() != m || disabled)
+                            .disabled(disabled)
+                            .today(date == s.today())
                     };
                     let mut item = CalendarItem::new(format!("calendar-{date}-{offset}"), st)
-                        .child((self.label)(st.kind, date.day() as i32));
-                    if !st.disabled {
+                        .child((self.label)(st.kind(), date.day() as i32));
+                    if !st.is_disabled() {
                         let entity = self.state.clone();
                         item = item.on_click(move |_, _, cx| {
                             entity.update(cx, |s, cx| {
@@ -701,17 +744,10 @@ impl RenderOnce for Calendar {
         } else if view.is_month() {
             let current = self.state.read(cx).current_month();
             for month in 1..=12u8 {
-                let st = CalendarItemState {
-                    kind: CalendarItemKind::Month,
-                    active: month == current,
-                    in_range: false,
-                    muted: false,
-                    disabled: false,
-                    today: false,
-                };
+                let st = CalendarItemState::new(CalendarItemKind::Month).active(month == current);
                 let entity = self.state.clone();
                 let item = CalendarItem::new(format!("calendar-month-{month}"), st)
-                    .child((self.label)(st.kind, month as i32))
+                    .child((self.label)(st.kind(), month as i32))
                     .on_click(move |_, _, cx| {
                         entity.update(cx, |s, cx| {
                             s.select_month(month);
@@ -724,17 +760,10 @@ impl RenderOnce for Calendar {
             let current = self.state.read(cx).current_year();
             let years = self.state.read(cx).years_on_page().to_vec();
             for year in years {
-                let st = CalendarItemState {
-                    kind: CalendarItemKind::Year,
-                    active: year == current,
-                    in_range: false,
-                    muted: false,
-                    disabled: false,
-                    today: false,
-                };
+                let st = CalendarItemState::new(CalendarItemKind::Year).active(year == current);
                 let entity = self.state.clone();
                 let item = CalendarItem::new(format!("calendar-year-{year}"), st)
-                    .child((self.label)(st.kind, year))
+                    .child((self.label)(st.kind(), year))
                     .on_click(move |_, _, cx| {
                         entity.update(cx, |s, cx| {
                             s.select_year(year);

--- a/crates/base/src/input/base/mod.rs
+++ b/crates/base/src/input/base/mod.rs
@@ -5,14 +5,99 @@ use gpui::{
     Styled, Window, div, prelude::FluentBuilder as _,
 };
 
+/// What the input can offer to its context menu, at the moment it is opened.
+///
+/// Built by the input and read by the menu, the fields are private and reached
+/// through the methods below, so that a new capability can be added without
+/// breaking the menu builders.
+///
+/// ```
+/// use gpui_base::input::InputContextMenuCapabilities;
+///
+/// let capabilities = InputContextMenuCapabilities::new()
+///     .code_editor(true)
+///     .selection(true);
+///
+/// assert!(capabilities.is_editable());
+/// assert!(capabilities.has_selection());
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InputContextMenuCapabilities {
-    pub disabled: bool,
-    pub readonly: bool,
-    pub code_editor: bool,
-    pub selection: bool,
-    pub go_to_definition: bool,
-    pub code_actions: bool,
+    disabled: bool,
+    readonly: bool,
+    code_editor: bool,
+    selection: bool,
+    go_to_definition: bool,
+    code_actions: bool,
+}
+
+impl InputContextMenuCapabilities {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn readonly(mut self, readonly: bool) -> Self {
+        self.readonly = readonly;
+        self
+    }
+
+    pub fn code_editor(mut self, code_editor: bool) -> Self {
+        self.code_editor = code_editor;
+        self
+    }
+
+    /// Set whether the input has a non-empty selection.
+    pub fn selection(mut self, selection: bool) -> Self {
+        self.selection = selection;
+        self
+    }
+
+    pub fn go_to_definition(mut self, go_to_definition: bool) -> Self {
+        self.go_to_definition = go_to_definition;
+        self
+    }
+
+    pub fn code_actions(mut self, code_actions: bool) -> Self {
+        self.code_actions = code_actions;
+        self
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    pub fn is_readonly(&self) -> bool {
+        self.readonly
+    }
+
+    /// Returns true if the user is allowed to change the text.
+    ///
+    /// The items that write to the input (Cut, Paste, Code Actions) belong to
+    /// this, the reading ones (Copy, Go to Definition) do not.
+    pub fn is_editable(&self) -> bool {
+        !self.disabled && !self.readonly
+    }
+
+    pub fn is_code_editor(&self) -> bool {
+        self.code_editor
+    }
+
+    pub fn has_selection(&self) -> bool {
+        self.selection
+    }
+
+    pub fn can_go_to_definition(&self) -> bool {
+        self.go_to_definition
+    }
+
+    pub fn has_code_actions(&self) -> bool {
+        self.code_actions
+    }
 }
 
 /// The foundational input frame.

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -397,27 +397,75 @@ pub struct InputBaseState {
 }
 
 /// Read-only styling data exposed to presentation facades.
+///
+/// The fields are private and read through the methods below, so that a new
+/// one can be added without breaking the facades.
 #[derive(Clone)]
 pub struct InputPresentation {
-    pub focus_handle: FocusHandle,
-    pub disabled: bool,
-    pub readonly: bool,
-    pub loading: bool,
-    pub masked: bool,
-    pub multi_line: bool,
-    pub code_editor: bool,
-    pub text_align: TextAlign,
-    pub placeholder: SharedString,
-    pub value: String,
-    pub mask_placeholder: Option<String>,
+    focus_handle: FocusHandle,
+    disabled: bool,
+    readonly: bool,
+    loading: bool,
+    masked: bool,
+    multi_line: bool,
+    code_editor: bool,
+    text_align: TextAlign,
+    placeholder: SharedString,
+    value: String,
+    mask_placeholder: Option<String>,
 }
 
 impl InputPresentation {
+    pub fn focus_handle(&self) -> &FocusHandle {
+        &self.focus_handle
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    pub fn is_readonly(&self) -> bool {
+        self.readonly
+    }
+
     /// Returns true if the user is allowed to change the text.
     ///
     /// See also: [`InputBaseState::is_editable`].
     pub fn is_editable(&self) -> bool {
         !self.disabled && !self.readonly
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.loading
+    }
+
+    pub fn is_masked(&self) -> bool {
+        self.masked
+    }
+
+    pub fn is_multi_line(&self) -> bool {
+        self.multi_line
+    }
+
+    pub fn is_code_editor(&self) -> bool {
+        self.code_editor
+    }
+
+    pub fn text_align(&self) -> TextAlign {
+        self.text_align
+    }
+
+    pub fn placeholder(&self) -> &SharedString {
+        &self.placeholder
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// The placeholder derived from the mask pattern, e.g.: `(___) ___-____`.
+    pub fn mask_placeholder(&self) -> Option<&str> {
+        self.mask_placeholder.as_deref()
     }
 }
 
@@ -459,14 +507,13 @@ impl InputBaseState {
     }
 
     pub fn context_menu_capabilities(&self) -> InputContextMenuCapabilities {
-        InputContextMenuCapabilities {
-            disabled: self.disabled,
-            readonly: self.readonly,
-            code_editor: self.mode.is_code_editor(),
-            selection: !self.selected_range.is_empty(),
-            go_to_definition: self.lsp.definition_provider.is_some(),
-            code_actions: !self.lsp.code_action_providers.is_empty(),
-        }
+        InputContextMenuCapabilities::new()
+            .disabled(self.disabled)
+            .readonly(self.readonly)
+            .code_editor(self.mode.is_code_editor())
+            .selection(!self.selected_range.is_empty())
+            .go_to_definition(self.lsp.definition_provider.is_some())
+            .code_actions(!self.lsp.code_action_providers.is_empty())
     }
 
     pub fn set_text_align(&mut self, text_align: TextAlign, cx: &mut Context<Self>) {

--- a/crates/story/src/stories/combobox_story.rs
+++ b/crates/story/src/stories/combobox_story.rs
@@ -569,8 +569,8 @@ impl Render for ComboboxStory {
                         Combobox::new(&self.with_icon)
                             .placeholder("Select industry category")
                             .search_placeholder("Search…")
-                            .render_trigger(|ctx, _, cx| {
-                                let (icon, title) = match &ctx.selection {
+                            .render_trigger(|trigger, _, cx| {
+                                let (icon, title) = match trigger.selection() {
                                     [] => (None, None),
                                     [(_index, item)] => {
                                         (Some(item.icon.clone()), Some(item.title().clone()))
@@ -601,13 +601,13 @@ impl Render for ComboboxStory {
                                             .overflow_hidden()
                                             .truncate()
                                             .when_some(title, |this, title| this.child(title))
-                                            .when(ctx.selection.is_empty(), |this| {
+                                            .when(trigger.selection().is_empty(), |this| {
                                                 this.text_color(cx.theme().muted_foreground)
                                                     .child("Select industry category")
                                             }),
                                     )
                                     .child(
-                                        Caret::new(ctx.size)
+                                        Caret::new(trigger.size())
                                             .text_color(cx.theme().muted_foreground),
                                     )
                                     .into_any_element()
@@ -656,8 +656,8 @@ impl Render for ComboboxStory {
                         Combobox::new(&self.custom_trigger)
                             .placeholder("Select framework")
                             .search_placeholder("Search…")
-                            .render_trigger(|ctx, _, cx| {
-                                let title = match &ctx.selection {
+                            .render_trigger(|trigger, _, cx| {
+                                let title = match trigger.selection() {
                                     [] => None,
                                     [(_index, item)] => Some(item.title().clone()),
                                     items => {
@@ -691,16 +691,17 @@ impl Render for ComboboxStory {
                                                         .child(title),
                                                 )
                                             })
-                                            .when(ctx.selection.is_empty(), |this| {
+                                            .when(trigger.selection().is_empty(), |this| {
                                                 this.text_color(cx.theme().muted_foreground).child(
-                                                    ctx.placeholder
+                                                    trigger
+                                                        .placeholder()
                                                         .cloned()
                                                         .unwrap_or_else(|| "Select...".into()),
                                                 )
                                             }),
                                     )
                                     .child(
-                                        Caret::new(ctx.size)
+                                        Caret::new(trigger.size())
                                             .text_color(cx.theme().muted_foreground),
                                     )
                                     .into_any_element()
@@ -716,8 +717,8 @@ impl Render for ComboboxStory {
                         Combobox::new(&self.multi_badges)
                             .placeholder("Select frameworks")
                             .search_placeholder("Search…")
-                            .render_trigger(move |ctx, _, cx| {
-                                let items = ctx.selection;
+                            .render_trigger(move |trigger, _, cx| {
+                                let items = trigger.selection();
 
                                 if items.is_empty() {
                                     return div()
@@ -783,7 +784,7 @@ impl Render for ComboboxStory {
                                     )
                                     .child(
                                         div().flex_shrink_0().child(
-                                            Caret::new(ctx.size)
+                                            Caret::new(trigger.size())
                                                 .text_color(cx.theme().muted_foreground),
                                         ),
                                     )
@@ -833,10 +834,10 @@ impl Render for ComboboxStory {
                         Combobox::new(&self.multi_expand)
                             .placeholder("Select frameworks")
                             .search_placeholder("Search…")
-                            .render_trigger(|ctx, _, cx| {
+                            .render_trigger(|trigger, _, cx| {
                                 const MAX_SHOWN: usize = 2;
 
-                                if ctx.selection.is_empty() {
+                                if trigger.selection().is_empty() {
                                     return div()
                                         .text_color(cx.theme().muted_foreground)
                                         .child("Select frameworks")
@@ -847,7 +848,7 @@ impl Render for ComboboxStory {
                                     .w_full()
                                     .flex_wrap()
                                     .gap_1()
-                                    .children(ctx.selection.iter().take(MAX_SHOWN).map(
+                                    .children(trigger.selection().iter().take(MAX_SHOWN).map(
                                         |(_index, item)| {
                                             div()
                                                 .rounded_sm()
@@ -858,8 +859,8 @@ impl Render for ComboboxStory {
                                                 .child(*item)
                                         },
                                     ))
-                                    .when(ctx.selection.len() > MAX_SHOWN, |this| {
-                                        let hidden = ctx.selection.len() - MAX_SHOWN;
+                                    .when(trigger.selection().len() > MAX_SHOWN, |this| {
+                                        let hidden = trigger.selection().len() - MAX_SHOWN;
                                         this.child(
                                             div()
                                                 .rounded_sm()
@@ -884,8 +885,8 @@ impl Render for ComboboxStory {
                         Combobox::new(&self.multi_count)
                             .placeholder("Select frameworks")
                             .search_placeholder("Search…")
-                            .render_trigger(|ctx, _, cx| {
-                                let count = ctx.selection.len();
+                            .render_trigger(|trigger, _, cx| {
+                                let count = trigger.selection().len();
 
                                 if count == 0 {
                                     return div()

--- a/crates/story/src/stories/settings_story.rs
+++ b/crates/story/src/stories/settings_story.rs
@@ -88,7 +88,7 @@ impl SettingFieldElement for OpenURLSettingField {
         Button::new("open-url")
             .outline()
             .label(self.label.clone())
-            .with_size(options.size)
+            .with_size(options.size())
             .on_click(move |_, _window, cx| {
                 cx.open_url(url.as_str());
             })
@@ -346,14 +346,14 @@ impl SettingsStory {
                                 .flex_wrap()
                                 .gap_3()
                                 .child("View source, report issues, and follow project updates.")
-                                .when(options.disabled, |this| this.opacity(0.5))
+                                .when(options.is_disabled(), |this| this.opacity(0.5))
                                 .child(
                                     Button::new("action")
                                         .icon(IconName::Globe)
                                         .label("Repository...")
                                         .outline()
-                                        .with_size(options.size)
-                                        .disabled(options.disabled)
+                                        .with_size(options.size())
+                                        .disabled(options.is_disabled())
                                         .on_click(|_, _, cx| {
                                             cx.open_url(
                                                 "https://github.com/longbridge/gpui-component",
@@ -372,7 +372,7 @@ impl SettingsStory {
                                     .children(["Comfortable", "Compact"].map(|value| {
                                         Button::new(value)
                                             .label(value)
-                                            .with_size(options.size)
+                                            .with_size(options.size())
                                             .map(|this| {
                                                 if current == value {
                                                     this.primary()
@@ -502,7 +502,7 @@ impl SettingsStory {
                                 Button::new("open-url")
                                     .outline()
                                     .label("Website...")
-                                    .with_size(options.size)
+                                    .with_size(options.size())
                                     .on_click(|_, _window, cx| {
                                         cx.open_url("https://longbridge.github.io/gpui-component/");
                                     })

--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -23,15 +23,42 @@ use crate::{
 };
 use gpui_base::{Combobox as BaseCombobox, GlobalState};
 
-// MARK: ComboboxTriggerCtx
+// MARK: ComboboxTriggerContext
 
 /// Context passed to the `render_trigger` closure on [`Combobox`].
-pub struct ComboboxTriggerCtx<'a, D: SearchableListDelegate + 'static> {
-    pub selection: &'a [(IndexPath, D::Item)],
-    pub placeholder: Option<&'a SharedString>,
-    pub open: bool,
-    pub disabled: bool,
-    pub size: Size,
+///
+/// The fields are private and reached through the methods below, so that a new
+/// one can be added without breaking the trigger renderers.
+pub struct ComboboxTriggerContext<'a, D: SearchableListDelegate + 'static> {
+    selection: &'a [(IndexPath, D::Item)],
+    placeholder: Option<&'a SharedString>,
+    open: bool,
+    disabled: bool,
+    size: Size,
+}
+
+impl<'a, D: SearchableListDelegate + 'static> ComboboxTriggerContext<'a, D> {
+    /// The items currently selected, empty when the combobox has no value.
+    pub fn selection(&self) -> &'a [(IndexPath, D::Item)] {
+        self.selection
+    }
+
+    pub fn placeholder(&self) -> Option<&'a SharedString> {
+        self.placeholder
+    }
+
+    /// Whether the dropdown list is showing.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    pub fn size(&self) -> Size {
+        self.size
+    }
 }
 
 // MARK: ComboboxChange
@@ -87,8 +114,9 @@ where
     searchable: bool,
     trigger_icon: Option<Icon>,
     check_icon: Option<Icon>,
-    render_trigger:
-        Option<Box<dyn Fn(&ComboboxTriggerCtx<D>, &mut Window, &mut App) -> AnyElement + 'static>>,
+    render_trigger: Option<
+        Box<dyn Fn(&ComboboxTriggerContext<D>, &mut Window, &mut App) -> AnyElement + 'static>,
+    >,
     footer: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyElement + 'static>>,
 }
 
@@ -573,7 +601,7 @@ where
         let has_custom_trigger = self.render_trigger.is_some();
 
         let trigger_body = if let Some(render_trigger) = &self.render_trigger {
-            let ctx = ComboboxTriggerCtx {
+            let trigger = ComboboxTriggerContext {
                 selection,
                 placeholder,
                 open,
@@ -581,7 +609,7 @@ where
                 size,
             };
 
-            render_trigger(&ctx, window, cx)
+            render_trigger(&trigger, window, cx)
         } else {
             self.default_trigger_body(window, cx)
         };
@@ -703,8 +731,9 @@ where
     id: ElementId,
     state: Entity<ComboboxState<D>>,
     options: ComboboxOptions,
-    render_trigger:
-        Option<Box<dyn Fn(&ComboboxTriggerCtx<D>, &mut Window, &mut App) -> AnyElement + 'static>>,
+    render_trigger: Option<
+        Box<dyn Fn(&ComboboxTriggerContext<D>, &mut Window, &mut App) -> AnyElement + 'static>,
+    >,
     footer: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyElement + 'static>>,
     empty: Option<Box<dyn Fn(&mut Window, &App) -> AnyElement + 'static>>,
 }
@@ -793,10 +822,10 @@ where
     /// Override the entire trigger element.
     pub fn render_trigger<E: IntoElement + 'static>(
         mut self,
-        f: impl Fn(&ComboboxTriggerCtx<D>, &mut Window, &mut App) -> E + 'static,
+        f: impl Fn(&ComboboxTriggerContext<D>, &mut Window, &mut App) -> E + 'static,
     ) -> Self {
-        self.render_trigger = Some(Box::new(move |ctx, window, cx| {
-            f(ctx, window, cx).into_any_element()
+        self.render_trigger = Some(Box::new(move |trigger, window, cx| {
+            f(trigger, window, cx).into_any_element()
         }));
         self
     }

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -257,7 +257,7 @@ impl Input {
     }
 
     fn render_toggle_mask_button(state: &Entity<InputBaseState>, cx: &App) -> impl IntoElement {
-        let masked = state.read(cx).presentation().masked;
+        let masked = state.read(cx).presentation().is_masked();
         Button::new("toggle-mask")
             .icon(if masked {
                 IconName::Eye
@@ -436,7 +436,7 @@ impl RenderOnce for Input {
                         .into_any_element()
                 })),
             });
-            state.set_editor_paddings(if state.presentation().multi_line {
+            state.set_editor_paddings(if state.presentation().is_multi_line() {
                 Edges {
                     top: self.size.input_py(),
                     right: self.size.input_px(),
@@ -454,33 +454,33 @@ impl RenderOnce for Input {
                 let menu = if let Some(custom) = custom.as_ref() {
                     custom(NativeMenu::new(), window, cx)
                 } else {
-                    let enabled = !capabilities.disabled;
+                    let enabled = !capabilities.is_disabled();
                     // A read-only input can still navigate the code, it only
                     // rejects the items that would change the text.
-                    let editable = enabled && !capabilities.readonly;
+                    let editable = enabled && !capabilities.is_readonly();
                     let mut menu = NativeMenu::new();
-                    if capabilities.code_editor {
+                    if capabilities.is_code_editor() {
                         menu = menu
                             .menu_with_disabled(
                                 t!("Input.Go to Definition"),
-                                !(enabled && capabilities.go_to_definition),
+                                !(enabled && capabilities.can_go_to_definition()),
                                 Box::new(gpui_base::input::GoToDefinition),
                             )
                             .menu_with_disabled(
                                 t!("Input.Show Code Actions"),
-                                !(editable && capabilities.code_actions),
+                                !(editable && capabilities.has_code_actions()),
                                 Box::new(gpui_base::input::ToggleCodeActions),
                             )
                             .separator();
                     }
                     menu.menu_with_disabled(
                         t!("Input.Cut"),
-                        !(editable && capabilities.selection),
+                        !(editable && capabilities.has_selection()),
                         Box::new(gpui_base::input::Cut),
                     )
                     .menu_with_disabled(
                         t!("Input.Copy"),
-                        !capabilities.selection,
+                        !capabilities.has_selection(),
                         Box::new(gpui_base::input::Copy),
                     )
                     .menu_with_disabled(
@@ -502,15 +502,15 @@ impl RenderOnce for Input {
         let presentation = state.read(cx).presentation();
         let content_type = self.content_type;
         let disabled = self.disabled;
-        let is_multi_line = presentation.multi_line;
+        let is_multi_line = presentation.is_multi_line();
         let accessibility_role = Self::accessibility_role(is_multi_line, content_type, self.role);
         let accessibility_state = state.clone();
         // Materializing the whole rope is only observable through the
         // accessibility tree, so skip it when no client is listening.
         let accessibility_value = (window.is_a11y_active()
-            && Self::exposes_accessibility_value(presentation.masked, content_type))
-        .then(|| presentation.value.clone());
-        let focused = presentation.focus_handle.is_focused(window) && !presentation.disabled;
+            && Self::exposes_accessibility_value(presentation.is_masked(), content_type))
+        .then(|| presentation.value().to_owned());
+        let focused = presentation.focus_handle().is_focused(window) && !presentation.is_disabled();
         if focused {
             sync_native_content_type(window, content_type, presentation.is_editable());
         }
@@ -521,13 +521,13 @@ impl RenderOnce for Input {
             _ => px(6.),
         };
 
-        let (bg, _) = input_style(presentation.disabled, cx);
-        let bg = if presentation.code_editor {
+        let (bg, _) = input_style(presentation.is_disabled(), cx);
+        let bg = if presentation.is_code_editor() {
             cx.theme().editor_background()
         } else {
             bg
         };
-        let bg = if presentation.disabled {
+        let bg = if presentation.is_disabled() {
             bg.opacity(0.5)
         } else {
             bg
@@ -536,17 +536,16 @@ impl RenderOnce for Input {
         let suffix = self.suffix;
         let show_clear_button = self.cleanable
             && presentation.is_editable()
-            && !presentation.loading
-            && !presentation.value.is_empty()
-            && !presentation.multi_line;
+            && !presentation.is_loading()
+            && !presentation.value().is_empty()
+            && !presentation.is_multi_line();
         let has_suffix =
-            suffix.is_some() || presentation.loading || self.mask_toggle || show_clear_button;
+            suffix.is_some() || presentation.is_loading() || self.mask_toggle || show_clear_button;
 
-        let placeholder = Some(presentation.placeholder.clone()).filter(|p| !p.is_empty());
+        let placeholder = Some(presentation.placeholder().clone()).filter(|p| !p.is_empty());
 
         // Don't use a mask-derived placeholder ("(___)___-___") as an aria_label fallback.
-        let placeholder_is_mask =
-            presentation.mask_placeholder.as_deref() == placeholder.as_deref();
+        let placeholder_is_mask = presentation.mask_placeholder() == placeholder.as_deref();
 
         let aria_label = match self.aria_label {
             Some(label) => Some(label),
@@ -586,7 +585,7 @@ impl RenderOnce for Input {
             .input_h(self.size)
             .input_text_size(self.size)
             .items_center()
-            .when(presentation.multi_line, |this| {
+            .when(presentation.is_multi_line(), |this| {
                 this.h_auto()
                     .when_some(self.height, |this, height| this.h(height))
             })
@@ -602,13 +601,15 @@ impl RenderOnce for Input {
             .refine_style(&self.style)
             .children(prefix.map(|p| {
                 div()
-                    .when(presentation.disabled, |this| this.opacity(0.5))
+                    .when(presentation.is_disabled(), |this| this.opacity(0.5))
                     .child(p)
             }))
-            .when(presentation.multi_line, |this| {
+            .when(presentation.is_multi_line(), |this| {
                 this.child(Self::render_editor(&state, overlays.search, window))
             })
-            .when(!presentation.multi_line, |this| this.child(state.clone()))
+            .when(!presentation.is_multi_line(), |this| {
+                this.child(state.clone())
+            })
             .when(has_suffix, |this| {
                 this.pr(self.size.input_px()).child(
                     h_flex()
@@ -616,8 +617,8 @@ impl RenderOnce for Input {
                         .gap(gap_x)
                         .items_center()
                         .cursor_default()
-                        .when(presentation.disabled, |this| this.opacity(0.5))
-                        .when(presentation.loading, |this| {
+                        .when(presentation.is_disabled(), |this| this.opacity(0.5))
+                        .when(presentation.is_loading(), |this| {
                             this.child(Spinner::new().color(cx.theme().muted_foreground))
                         })
                         .when(self.mask_toggle, |this| {

--- a/crates/ui/src/setting/fields/bool.rs
+++ b/crates/ui/src/setting/fields/bool.rs
@@ -38,8 +38,8 @@ impl SettingFieldRender for BoolField {
             .child(if self.use_switch {
                 Switch::new("check")
                     .checked(checked)
-                    .disabled(options.disabled)
-                    .with_size(options.size)
+                    .disabled(options.is_disabled())
+                    .with_size(options.size())
                     .on_click(move |checked: &bool, _, cx: &mut App| {
                         set_value(*checked, cx);
                     })
@@ -47,8 +47,8 @@ impl SettingFieldRender for BoolField {
             } else {
                 Checkbox::new("check")
                     .checked(checked)
-                    .disabled(options.disabled)
-                    .with_size(options.size)
+                    .disabled(options.is_disabled())
+                    .with_size(options.size())
                     .on_click(move |checked: &bool, _, cx: &mut App| {
                         set_value(*checked, cx);
                     })

--- a/crates/ui/src/setting/fields/dropdown.rs
+++ b/crates/ui/src/setting/fields/dropdown.rs
@@ -58,12 +58,12 @@ where
             .unwrap_or_else(|| old_value.clone().into());
 
         Button::new("btn")
-            .when(options.layout.is_vertical(), |this| this.w_full())
+            .when(options.layout().is_vertical(), |this| this.w_full())
             .label(old_label)
             .dropdown_caret(true)
             .outline()
-            .disabled(options.disabled)
-            .with_size(options.size)
+            .disabled(options.is_disabled())
+            .with_size(options.size())
             .refine_style(style)
             .dropdown_menu_with_anchor(Anchor::TopRight, move |menu, _, _| {
                 let set_value = set_value.clone();

--- a/crates/ui/src/setting/fields/number.rs
+++ b/crates/ui/src/setting/fields/number.rs
@@ -69,7 +69,9 @@ impl SettingFieldRender for NumberField {
         let state_entity = window.use_keyed_state(
             SharedString::from(format!(
                 "number-state-{}-{}-{}",
-                options.page_ix, options.group_ix, options.item_ix
+                options.page_ix(),
+                options.group_ix(),
+                options.item_ix()
             )),
             cx,
             |window, cx| {
@@ -156,10 +158,10 @@ impl SettingFieldRender for NumberField {
         let state = state_entity.read(cx);
 
         NumberInput::new(&state.input)
-            .disabled(options.disabled)
-            .with_size(options.size)
+            .disabled(options.is_disabled())
+            .with_size(options.size())
             .map(|this| {
-                if options.layout.is_horizontal() {
+                if options.layout().is_horizontal() {
                     this.w_32()
                 } else {
                     this.w_full()

--- a/crates/ui/src/setting/fields/string.rs
+++ b/crates/ui/src/setting/fields/string.rs
@@ -50,7 +50,9 @@ where
         let state_entity = window.use_keyed_state(
             SharedString::from(format!(
                 "string-state-{}-{}-{}",
-                options.page_ix, options.group_ix, options.item_ix
+                options.page_ix(),
+                options.group_ix(),
+                options.item_ix()
             )),
             cx,
             {
@@ -87,10 +89,10 @@ where
         let state = state_entity.read(cx);
 
         Input::new(&state.input)
-            .disabled(options.disabled)
-            .with_size(options.size)
+            .disabled(options.is_disabled())
+            .with_size(options.size())
             .map(|this| {
-                if options.layout.is_horizontal() {
+                if options.layout().is_horizontal() {
                     this.w_64()
                 } else {
                     this.w_full()

--- a/crates/ui/src/setting/group.rs
+++ b/crates/ui/src/setting/group.rs
@@ -82,8 +82,8 @@ impl SettingGroup {
         cx: &mut App,
     ) -> impl IntoElement {
         GroupBox::new()
-            .id(SharedString::from(format!("group-{}", options.group_ix)))
-            .with_variant(options.group_variant)
+            .id(SharedString::from(format!("group-{}", options.group_ix())))
+            .with_variant(options.group_variant())
             .when_some(self.title.clone(), |this, title| {
                 this.title(v_flex().gap_1().child(title).when_some(
                     self.description.clone(),
@@ -99,14 +99,10 @@ impl SettingGroup {
             .gap_4()
             .children(self.items.iter().enumerate().filter_map(|(item_ix, item)| {
                 if item.is_match(&query, cx) {
-                    Some(item.clone().render_item(
-                        &RenderOptions {
-                            item_ix,
-                            ..*options
-                        },
-                        window,
-                        cx,
-                    ))
+                    Some(
+                        item.clone()
+                            .render_item(&options.with_item_ix(item_ix), window, cx),
+                    )
                 } else {
                     None
                 }

--- a/crates/ui/src/setting/item.rs
+++ b/crates/ui/src/setting/item.rs
@@ -253,7 +253,7 @@ impl SettingItem {
         cx: &mut App,
     ) -> Stateful<Div> {
         div()
-            .id(SharedString::from(format!("item-{}", options.item_ix)))
+            .id(SharedString::from(format!("item-{}", options.item_ix())))
             .w_full()
             .child(match self {
                 SettingItem::Item {
@@ -264,7 +264,7 @@ impl SettingItem {
                     field,
                     ..
                 } => {
-                    let layout = if options.layout.is_vertical() {
+                    let layout = if options.layout().is_vertical() {
                         Axis::Vertical
                     } else {
                         layout
@@ -305,11 +305,7 @@ impl SettingItem {
                         )
                         .child(div().id("field").child(Self::render_field(
                             field,
-                            RenderOptions {
-                                layout,
-                                disabled,
-                                ..*options
-                            },
+                            options.with_layout(layout).with_disabled(disabled),
                             window,
                             cx,
                         )))
@@ -320,14 +316,7 @@ impl SettingItem {
                 } => div()
                     .w_full()
                     .when(disabled, |this| this.opacity(0.5))
-                    .child((render)(
-                        &RenderOptions {
-                            disabled,
-                            ..*options
-                        },
-                        window,
-                        cx,
-                    ))
+                    .child((render)(&options.with_disabled(disabled), window, cx))
                     .into_any_element(),
             })
     }

--- a/crates/ui/src/setting/page.rs
+++ b/crates/ui/src/setting/page.rs
@@ -218,11 +218,7 @@ impl SettingPage {
                                     .py_4()
                                     .render(
                                         &query,
-                                        &RenderOptions {
-                                            page_ix: ix,
-                                            group_ix,
-                                            ..options
-                                        },
+                                        &options.with_page_ix(ix).with_group_ix(group_ix),
                                         window,
                                         cx,
                                     )

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -253,15 +253,106 @@ pub(super) struct SettingsState {
 }
 
 /// Options for rendering setting item.
+///
+/// The fields are private and reached through the methods below, so that a new
+/// one can be added without breaking the item renderers. The setters take
+/// `self` by value, so a nested renderer narrows a copy of its parent options:
+///
+/// ```ignore
+/// item.render_item(&options.with_item_ix(item_ix), window, cx)
+/// ```
 #[derive(Clone, Copy)]
 pub struct RenderOptions {
-    pub page_ix: usize,
-    pub group_ix: usize,
-    pub item_ix: usize,
-    pub size: Size,
-    pub group_variant: GroupBoxVariant,
-    pub layout: Axis,
-    pub disabled: bool,
+    page_ix: usize,
+    group_ix: usize,
+    item_ix: usize,
+    size: Size,
+    group_variant: GroupBoxVariant,
+    layout: Axis,
+    disabled: bool,
+}
+
+impl RenderOptions {
+    pub fn new() -> Self {
+        Self {
+            page_ix: 0,
+            group_ix: 0,
+            item_ix: 0,
+            size: Size::default(),
+            group_variant: GroupBoxVariant::default(),
+            layout: Axis::Horizontal,
+            disabled: false,
+        }
+    }
+
+    pub fn with_page_ix(mut self, page_ix: usize) -> Self {
+        self.page_ix = page_ix;
+        self
+    }
+
+    pub fn with_group_ix(mut self, group_ix: usize) -> Self {
+        self.group_ix = group_ix;
+        self
+    }
+
+    pub fn with_item_ix(mut self, item_ix: usize) -> Self {
+        self.item_ix = item_ix;
+        self
+    }
+
+    pub fn with_size(mut self, size: Size) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub fn with_group_variant(mut self, group_variant: GroupBoxVariant) -> Self {
+        self.group_variant = group_variant;
+        self
+    }
+
+    pub fn with_layout(mut self, layout: Axis) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn page_ix(&self) -> usize {
+        self.page_ix
+    }
+
+    pub fn group_ix(&self) -> usize {
+        self.group_ix
+    }
+
+    pub fn item_ix(&self) -> usize {
+        self.item_ix
+    }
+
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
+    pub fn group_variant(&self) -> GroupBoxVariant {
+        self.group_variant
+    }
+
+    pub fn layout(&self) -> Axis {
+        self.layout
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -288,15 +379,9 @@ impl RenderOnce for Settings {
 
         let query = state.read(cx).search_input.read(cx).value();
         let filtered_pages = self.filtered_pages(&query, cx);
-        let options = RenderOptions {
-            page_ix: 0,
-            group_ix: 0,
-            item_ix: 0,
-            size: self.size,
-            group_variant: self.group_variant,
-            layout: Axis::Horizontal,
-            disabled: false,
-        };
+        let options = RenderOptions::new()
+            .with_size(self.size)
+            .with_group_variant(self.group_variant);
         let sidebar_size_range = self.sidebar_size_range.clone();
         let sidebar = self
             .render_sidebar(&state, &filtered_pages, window, cx)
@@ -311,14 +396,11 @@ impl RenderOnce for Settings {
             )
             .child(
                 resizable_panel().child(container_query(move |size, window, cx| {
-                    let options = RenderOptions {
-                        layout: if size.width <= STACKED_LAYOUT_MAX_WIDTH {
-                            Axis::Vertical
-                        } else {
-                            Axis::Horizontal
-                        },
-                        ..options
-                    };
+                    let options = options.with_layout(if size.width <= STACKED_LAYOUT_MAX_WIDTH {
+                        Axis::Vertical
+                    } else {
+                        Axis::Horizontal
+                    });
                     self.render_active_page(&state, &filtered_pages, &options, window, cx)
                 })),
             )

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -106,52 +106,54 @@ impl RenderOnce for Calendar {
                 .justify_center()
                 .when(
                     matches!(
-                        state.kind,
+                        state.kind(),
                         CalendarItemKind::Month | CalendarItemKind::MonthToggle
                     ),
                     |this| {
-                        this.when(state.kind == CalendarItemKind::Month, |this| {
+                        this.when(state.kind() == CalendarItemKind::Month, |this| {
                             this.w(relative(0.3))
                         })
-                        .when(state.kind == CalendarItemKind::MonthToggle, |this| {
+                        .when(state.kind() == CalendarItemKind::MonthToggle, |this| {
                             this.w_auto().px_2()
                         })
                     },
                 )
                 .when(
                     matches!(
-                        state.kind,
+                        state.kind(),
                         CalendarItemKind::Year | CalendarItemKind::YearToggle
                     ),
                     |this| {
-                        this.when(state.kind == CalendarItemKind::Year, |this| {
+                        this.when(state.kind() == CalendarItemKind::Year, |this| {
                             this.w(relative(0.2))
                         })
-                        .when(state.kind == CalendarItemKind::YearToggle, |this| {
+                        .when(state.kind() == CalendarItemKind::YearToggle, |this| {
                             this.w_auto().px_2()
                         })
                     },
                 )
                 .when(
                     matches!(
-                        state.kind,
+                        state.kind(),
                         CalendarItemKind::Previous | CalendarItemKind::Next
                     ),
                     |this| this.text_lg(),
                 )
-                .when(state.muted, |this| {
-                    this.text_color(if state.disabled {
+                .when(state.is_muted(), |this| {
+                    this.text_color(if state.is_disabled() {
                         cx.theme().muted_foreground.opacity(0.3)
                     } else {
                         cx.theme().muted_foreground
                     })
                 })
-                .when(state.in_range, |this| {
+                .when(state.is_in_range(), |this| {
                     this.bg(cx.theme().accent)
                         .text_color(cx.theme().accent_foreground)
                 })
                 .when(
-                    !state.active && !state.disabled && state.kind != CalendarItemKind::Weekday,
+                    !state.is_active()
+                        && !state.is_disabled()
+                        && state.kind() != CalendarItemKind::Weekday,
                     |this| {
                         this.hover(|this| {
                             this.bg(cx.theme().tokens.accent)
@@ -159,11 +161,11 @@ impl RenderOnce for Calendar {
                         })
                     },
                 )
-                .when(state.active, |this| {
+                .when(state.is_active(), |this| {
                     this.bg(cx.theme().tokens.primary)
                         .text_color(cx.theme().primary_foreground)
                 })
-                .when(state.today && !state.active, |this| {
+                .when(state.is_today() && !state.is_active(), |this| {
                     this.border_1().border_color(cx.theme().border)
                 })
                 .into_any_element()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,6 +191,54 @@ Compound and stateful modules expose explicit presentation seams:
 - style refinements for internal virtualized containers;
 - presentation snapshots such as `InputPresentation`.
 
+## Public Data Types Across the Seam
+
+A public struct that crosses the base/application seam must not expose `pub`
+fields. Every field a caller can name is a field that cannot be added later:
+adding one breaks any struct literal, and removing or renaming one breaks every
+reader. The seam types are the ones that grow the most, because each new
+capability of a control shows up as another flag in the state it hands out.
+
+The shape to use instead:
+
+- private fields;
+- a builder for construction — `new()` plus one chained setter per field, named
+  after the field;
+- a reader per field, named `is_`/`has_`/`can_` for booleans and after the field
+  otherwise, so the reader never collides with the setter.
+
+A type that is only ever built inside its own module — `InputPresentation` is
+built by `InputBaseState::presentation` and nowhere else — needs the private
+fields and the readers, but not a public builder. Private fields already close
+the breaking-change hole, and a public builder there would hand out a
+construction path the seam does not want. Such a type reads its non-boolean
+fields under the plain field name, which is why it cannot also carry
+field-named setters.
+
+```rust
+let capabilities = InputContextMenuCapabilities::new()
+    .code_editor(true)
+    .selection(true);
+
+if capabilities.is_editable() && capabilities.has_selection() { /* ... */ }
+```
+
+Derived answers belong on the type rather than at each call site. When several
+readers are always combined the same way — `!disabled && !readonly` — publish
+that combination as its own reader (`is_editable`) so the rule has one
+definition and new inputs to it stay invisible to callers.
+
+This applies to state snapshots (`InputPresentation`, `CalendarItemState`),
+capability sets (`InputContextMenuCapabilities`), and option sets. It does not
+apply to value types whose fields *are* the definition and cannot grow, such as
+`Point`, `Selection`, `Edges`, `IndexPath`, or `FoldRange`, nor to types that
+mirror an external schema, such as the LSP `Diagnostic`.
+
+Design-token records (`ColorTokens`, `RadiusTokens`, and the rest of
+`theme_tokens`) still carry `pub` fields. They have the same growth problem, and
+converting them is tracked separately because every theme in `gpui-component`
+constructs them.
+
 ## Input, Textarea, and Editor Architecture
 
 Text editing is intentionally deeper than the semantic elements, but callers do
@@ -408,5 +456,8 @@ Changes to `gpui-base` should preserve these invariants:
 10. One scroll handle represents one logical viewport.
 11. Platform differences are isolated behind explicit adapters or conditional
     implementations.
-12. Long-lived architectural facts belong here; progress logs and temporary
+12. Public types that cross the seam keep their fields private, are built with a
+    builder, and are read through methods, so a new field is not a breaking
+    change.
+13. Long-lived architectural facts belong here; progress logs and temporary
     reviews belong in issues and pull requests.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,10 +202,25 @@ capability of a control shows up as another flag in the state it hands out.
 The shape to use instead:
 
 - private fields;
-- a builder for construction — `new()` plus one chained setter per field, named
-  after the field;
-- a reader per field, named `is_`/`has_`/`can_` for booleans and after the field
-  otherwise, so the reader never collides with the setter.
+- a builder for construction — `new()` plus one chained setter per field;
+- a reader per field.
+
+Setters and readers must not collide, which decides the naming:
+
+- a type whose fields are all boolean names its setters after the field and its
+  readers `is_`/`has_`/`can_`, matching how elements read — `CalendarItemState`,
+  `InputContextMenuCapabilities`;
+- a type carrying non-boolean fields prefixes every setter with `with_`, so the
+  readers keep the plain field name — `RenderOptions::with_item_ix` against
+  `RenderOptions::item_ix`. This follows `Sizable::with_size`.
+
+A `with_`-style setter that takes `self` by value also replaces functional
+update syntax, which stops compiling once the fields are private:
+
+```rust
+// was: RenderOptions { item_ix, ..*options }
+item.render_item(&options.with_item_ix(item_ix), window, cx)
+```
 
 A type that is only ever built inside its own module — `InputPresentation` is
 built by `InputBaseState::presentation` and nowhere else — needs the private
@@ -228,8 +243,15 @@ readers are always combined the same way — `!disabled && !readonly` — publis
 that combination as its own reader (`is_editable`) so the rule has one
 definition and new inputs to it stay invisible to callers.
 
+Name such a type in full: `ComboboxTriggerContext`, never `…Ctx`. In a GPUI
+codebase `cx` is reserved for `App`, `Context<T>`, and `AsyncApp`, so an
+abbreviated `ctx` for anything else reads as a second, competing context. A
+callback that receives both takes the GPUI one as `cx` and gives the other a
+name describing what it holds.
+
 This applies to state snapshots (`InputPresentation`, `CalendarItemState`),
-capability sets (`InputContextMenuCapabilities`), and option sets. It does not
+capability sets (`InputContextMenuCapabilities`), render contexts
+(`ComboboxTriggerContext`), and option sets (`RenderOptions`). It does not
 apply to value types whose fields *are* the definition and cannot grow, such as
 `Point`, `Selection`, `Edges`, `IndexPath`, or `FoldRange`, nor to types that
 mirror an external schema, such as the LSP `Diagnostic`.

--- a/docs/READONLY-NAMING-RESEARCH.md
+++ b/docs/READONLY-NAMING-RESEARCH.md
@@ -1,0 +1,61 @@
+# `readonly` / `readOnly` / `read_only` API 命名调研
+
+调研日期：2026-08-14
+
+## 结论
+
+建议 `gpui-component` **继续使用 `readonly`**，包括：
+
+```rust
+Input::new(state).readonly(true);
+state.set_readonly(true, cx);
+```
+
+理由：
+
+1. Rust 公共标识符必须使用 `snake_case`，但这并不意味着每个自然语言复合词都必须拆开。Rust 标准库本身已经把该概念拼作 [`Permissions::readonly()`](https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.readonly) 和 [`Permissions::set_readonly()`](https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.set_readonly)。因此 `readonly` / `set_readonly` 都符合 Rust 的实际先例。
+2. HTML 和多个声明式框架把它视为一个稳定的术语：标记层使用 `readonly`，JavaScript、Dart、Kotlin API 使用 `readOnly`。在 Rust 中转成小写后自然就是 `readonly`。
+3. 当前项目已经公开或内部使用 `readonly`, `set_readonly` 与 `.readonly(true)`；改为 `read_only` 会制造迁移成本，却没有得到跨生态惯例或 Rust 标准库先例的支持。
+
+建议在代码标识符中使用 `readonly`，在英文文档叙述中使用形容词 `read-only`。不建议新增 `read_only` 别名。
+
+## 调研范围与判定方法
+
+这里只记录规范、项目官方文档或项目官方源码。对 Vue、Svelte 这类直接渲染原生元素的框架，需要把其“原生 HTML attribute 透传/书写规则”和 HTML 规范一起看；这不是框架另行定义的组件 prop。
+
+| 生态 | 面向使用者的拼写 | 一手资料与判定 |
+|---|---|---|
+| HTML 标记 | `readonly` | HTML Standard 将输入控件的布尔 content attribute 定义为 [`readonly`](https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly)，示例为 `<input readonly>`。 |
+| DOM | `readOnly` | 同一规范的 [`HTMLInputElement`](https://html.spec.whatwg.org/multipage/input.html#htmlinputelement) IDL 定义 `attribute boolean readOnly`；因此 JavaScript 写 `input.readOnly = true`。这说明标记拼写和编程语言属性拼写本来就不同。 |
+| React DOM | `readOnly` | React 官方 [`<input>` reference](https://react.dev/reference/react-dom/components/input) 把 `readOnly` 列为布尔 prop，并示例 `<input value={something} readOnly={true} />`。 |
+| Vue | 原生元素上为 `readonly` | Vue 官方说明模板 attribute 的基本写法和 `v-bind` 缩写（[`Attribute Bindings`](https://vuejs.org/guide/essentials/template-syntax.html#attribute-bindings)）。用于原生 `<input>` 时，attribute 本身由 HTML Standard 定义为 [`readonly`](https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly)，所以静态写 `readonly`，动态写 `:readonly="flag"`；不是 `read_only`。 |
+| Angular | HTML/模板为 `readonly`；Signals Forms API 为 `readonly(...)` | 原生 attribute 仍是 HTML 的 [`readonly`](https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly)。Angular 官方 Signals Forms 文档使用 [`readonly(schemaPath.username)`](https://angular.dev/guide/forms/signals/field-state-management#readonly-fields)，字段状态访问为 `readonly()`，并说明 `formField` 会自动绑定 `readonly` attribute。 |
+| Svelte | 原生元素上为 `readonly` | Svelte 官方 [`Attributes`](https://svelte.dev/docs/svelte/basic-markup#Attributes) 说明元素 attribute 可按 HTML 方式书写，也可用表达式赋值。结合 HTML Standard 的 [`readonly`](https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly)，写法是 `readonly` 或 `readonly={flag}`；不是 `read_only`。 |
+| Flutter | `readOnly` | Flutter 官方 [`TextField.readOnly`](https://api.flutter.dev/flutter/material/TextField/readOnly.html) 声明为 `final bool readOnly`；构造参数也是 `TextField(readOnly: true)`。 |
+| Jetpack Compose | `readOnly` | AndroidX 官方 `TextField.kt` 源码的 [`TextField` 参数](https://github.com/androidx/androidx/blob/androidx-main/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TextField.kt) 是 `readOnly: Boolean = false`，KDoc 也以 `readOnly` 描述只读状态。 |
+| SwiftUI | 没有同名的通用 `TextField` 参数 | Apple 官方 [`TextField`](https://developer.apple.com/documentation/swiftui/textfield) 把它定义为可编辑文本接口，公开 initializer 中没有 `readOnly` / `read_only` 参数。Apple 的 [`EditMode`](https://developer.apple.com/documentation/swiftui/editmode) 示例在非编辑状态改为展示 `Text`；官方教程也展示对 `TextField` 使用 [`.disabled(...)`](https://developer.apple.com/tutorials/swiftui/working-with-ui-controls)。`disabled` 会禁用交互，并不等同于 Web 中“仍可聚焦/选择”的 readonly 语义。 |
+| egui | 没有同名 builder；用 `interactive` 或只读 buffer 表达 | egui 官方 API 文档说明 [`TextEdit::interactive(false)`](https://docs.rs/egui/latest/egui/widgets/text_edit/struct.TextEdit.html#method.interactive) 会禁止用户选择文本；若要“可选择但不可编辑”，[`TextEdit`](https://docs.rs/egui/latest/egui/widgets/text_edit/struct.TextEdit.html) 文档建议传入 `&mut &str`。它没有为该语义选择 `readonly` 或 `read_only`。 |
+| iced | 没有同名属性；通过是否提供编辑消息表达 | iced 官方 [`TextInput::on_input`](https://docs.rs/iced/latest/iced/widget/struct.TextInput.html#method.on_input) 文档说明，不调用该方法会产生 disabled `TextInput`。它没有独立的 readonly 命名，因此不能作为 `read_only` 的先例。 |
+| Slint | Slint DSL 为 `read-only` | Slint 官方 [`LineEdit`](https://docs.slint.dev/latest/docs/slint/reference/std-widgets/views/lineedit/#read-only) 定义 `read-only: bool`，语义是仍可选择和复制但不能编辑。Slint 标识符采用 kebab-case，不能直接推导 Rust API 应写成 `read_only`。 |
+
+## 跨生态规律
+
+可归纳为三层命名：
+
+- 标记或 DSL：HTML/Vue/Svelte/Angular 使用 `readonly`，Slint 使用其 DSL 风格的 `read-only`。
+- camelCase 语言 API：DOM、React、Flutter、Jetpack Compose 使用 `readOnly`。
+- Rust：被调查的 UI 库没有形成统一属性名；真正相关的 Rust 标准库先例明确采用 `readonly()`。
+
+因此，“Rust 一律把 `readOnly` 机械转换成 `read_only`”并不是可靠规则。Rust API Guidelines 的 [C-CASE](https://rust-lang.github.io/api-guidelines/naming.html#c-case) 要求函数和方法使用 `snake_case`；`readonly` 本身不含大写字母，也没有违反该规则，而标准库先例进一步消除了歧义。
+
+## 对 `gpui-component` 的具体建议
+
+| 场景 | 推荐 | 不推荐 |
+|---|---|---|
+| Builder 方法 | `readonly(bool)` | `read_only(bool)` |
+| 状态 setter | `set_readonly(bool, cx)` | `set_read_only(bool, cx)` |
+| 字段/能力标志 | `readonly: bool` | `read_only: bool` |
+| 英文说明文字 | “read-only input/mode” | “readonly input/mode” |
+| 与 DOM 交互的 JavaScript | `node.readOnly` | `node.readonly`, `node.read_only` |
+
+如果未来需要表达“当前内容能否被编辑”而非一个 HTML 式模式，也可以单独考虑正向命名 `editable` / `is_editable`。这属于不同的 API 设计，不应与 `readonly` / `read_only` 的拼写迁移混在一起。


### PR DESCRIPTION
A public struct with `pub` fields cannot grow. Adding a field breaks every struct literal, so each new capability of a control turns into a breaking change to the state it hands out. Adding `readonly` in #2705 hit this twice.

A full sweep of `crates/base` and `crates/ui` found **100 structs with `pub` fields**. Most are exempt for good reasons; this PR closes the ones that are not, and records the rule so the next one does not reopen it.

## Closed here

| Type | Role | Shape |
| --- | --- | --- |
| `InputContextMenuCapabilities` | capability set, passed to the menu builder | builder + readers |
| `CalendarItemState` | state snapshot, passed to the item slot | builder + readers |
| `ComboboxTriggerCtx` → `ComboboxTriggerContext` | render context, passed to `render_trigger` | private fields + readers |
| `RenderOptions` (setting) | option set, threaded through the item renderers | `with_`-prefixed builder + readers |
| `InputPresentation` | state snapshot, built only by `InputBaseState` | private fields + readers |

`RenderOptions` is threaded down four nesting levels with functional update syntax, which stops compiling once fields are private. A `with_`-setter taking `self` by value replaces it exactly, and reads better.

`InputPresentation` gets no public builder. It is built by `InputBaseState::presentation` and nowhere else, so private fields already close the hole, and a public builder would hand out a construction path the seam does not want.

`is_editable()` (`!disabled && !readonly`) is published on both capability types, so the "may the user write" rule has one definition instead of being re-derived at each call site.

## The rules

`docs/ARCHITECTURE.md` gains a **Public Data Types Across the Seam** section and a design invariant; `CLAUDE.md` gains two matching principles.

**Encapsulation.** A public struct crossing the seam keeps private fields, is built with a builder, and is read through methods. Setters and readers must not collide, which decides the naming:

- all-boolean types name setters after the field and readers `is_`/`has_`/`can_`, matching how elements read;
- types with non-boolean fields prefix every setter with `with_`, keeping the plain field name for readers — following `Sizable::with_size`.

**Naming.** Spell `Context` out — `ComboboxTriggerContext`, never `…Ctx`. In a GPUI codebase `cx` is reserved for `App`, `Context<T>`, and `AsyncApp`, so an abbreviated `ctx` for anything else reads as a second, competing context. A callback receiving both takes the GPUI one as `cx` and names the other after what it holds (`trigger`).

## Exempt, and why

- **Value types** whose fields *are* the definition and cannot grow: `Point`, `Selection`, `Edges`, `IndexPath`, `FoldRange`, `Span`, `SelectIndex`, and the plot geometry (`StackPoint`, `SankeyLink`, `ArcData`).
- **Serde schemas** where fields are the on-disk contract and growth is handled by `#[serde(default)]`: `DockAreaState`, `PanelState`, `ThemeConfig`, `Semantic*Config`.
- **Mirrors of external schemas**: the LSP `Diagnostic`, tree-sitter's `InputEdit`, the markdown AST nodes.
- **GPUI action structs**: `Confirm`, `Enter`.

## Still open, deliberately

Two groups are left for follow-ups, because the right fix differs and the blast radius is larger:

1. **Token records** — `ThemeColor` (139 fields), `ThemeConfigColors` (128), `SyntaxColors` (41), `ColorTokens` (17), and the rest of `theme_tokens`. A builder with 139 setters is not the answer; these want `#[non_exhaustive]` with a construction path, and every theme in `gpui-component` constructs them.
2. **Internal state exposed as `pub`** — `TableState` (11 pub fields), `Lsp` (8), `SearchSession` (7), `InputBaseState.lsp`, `CalendarState.focus_handle`, `Root.notification`, `NativeMenu.items`. These are a *stronger* problem than a future breaking change: callers can currently violate invariants the type maintains. The fix is tightening visibility, not adding a builder.

Also unconverted, lower priority: `InputEditorStyle` (12 fields), `Column` (12), `ToastMotion`, `ToastOptions`, `ToastAdvance`, `ListSettings`, `NotificationSettings`, `TextViewStyle`, `TooltipState`.

## Breaking Changes

### `InputContextMenuCapabilities`

- Fields are read through methods.

```diff
- capabilities.disabled
- capabilities.selection
- capabilities.go_to_definition
- capabilities.code_actions
+ capabilities.is_disabled()
+ capabilities.has_selection()
+ capabilities.can_go_to_definition()
+ capabilities.has_code_actions()
```

- Built with `new()` instead of a struct literal.
  > `is_editable()` is `!disabled && !readonly`. Use it for the items that write: Cut, Paste, Show Code Actions.

```diff
- InputContextMenuCapabilities { code_editor: true, selection: true, ..Default::default() }
+ InputContextMenuCapabilities::new().code_editor(true).selection(true)
```

### `InputPresentation`

- Fields are read through methods.

```diff
- presentation.multi_line
- presentation.disabled
- presentation.focus_handle
- presentation.placeholder.clone()
- presentation.value.clone()
+ presentation.is_multi_line()
+ presentation.is_disabled()
+ presentation.focus_handle()
+ presentation.placeholder().clone()
+ presentation.value().to_owned()
```

### `CalendarItemState`

- Fields are read through methods.

```diff
- state.kind
- state.active
- state.today
+ state.kind()
+ state.is_active()
+ state.is_today()
```

- Built with `new(kind)` instead of a struct literal.
  > Every flag defaults to off, so only the ones actually set need naming.

```diff
- CalendarItemState { kind: CalendarItemKind::Month, active: month == current, in_range: false, muted: false, disabled: false, today: false }
+ CalendarItemState::new(CalendarItemKind::Month).active(month == current)
```

### `ComboboxTriggerCtx` → `ComboboxTriggerContext`

- Renamed to spell `Context` out.

```diff
- use gpui_component::combobox::ComboboxTriggerCtx;
+ use gpui_component::combobox::ComboboxTriggerContext;
```

- Fields are read through methods.
  > Name the closure parameter after what it holds, so `cx` stays the GPUI context.

```diff
- combobox.render_trigger(|ctx, window, cx| Caret::new(ctx.size).into_any_element())
+ combobox.render_trigger(|trigger, window, cx| Caret::new(trigger.size()).into_any_element())
```

```diff
- ctx.selection
- ctx.placeholder
- ctx.open
- ctx.disabled
+ trigger.selection()
+ trigger.placeholder()
+ trigger.is_open()
+ trigger.is_disabled()
```

### `RenderOptions` (setting)

- Fields are read through methods.

```diff
- options.page_ix
- options.group_ix
- options.item_ix
- options.size
- options.layout
- options.disabled
+ options.page_ix()
+ options.group_ix()
+ options.item_ix()
+ options.size()
+ options.layout()
+ options.is_disabled()
```

- Narrowed with `with_` setters instead of functional update syntax.
  > The setters take `self` by value, so a nested renderer gets its own copy.

```diff
- item.render_item(&RenderOptions { item_ix, ..*options }, window, cx)
+ item.render_item(&options.with_item_ix(item_ix), window, cx)
```

## Testing

`cargo clippy --workspace --all-targets` clean, `cargo test --workspace` green, `typos` clean.

---

Written with Claude Code, reviewed and adjusted by hand.
