### PR TITLE
input: Avoid rescanning long lines for diagnostic positions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ lsp-types = { version = "0.97.0", features = ["proposed"] }
 notify = "7.0.0"
 raw-window-handle = "0.6.2"
 ropey = { version = "=2.0.0-beta.1", features = [
+    "metric_chars",
     "metric_lines_lf",
     "metric_utf16",
 ] }

--- a/crates/base/src/input/base/rope_ext.rs
+++ b/crates/base/src/input/base/rope_ext.rs
@@ -329,12 +329,9 @@ impl RopeExt for Rope {
 
     fn position_to_offset(&self, pos: &Position) -> usize {
         let line = self.slice_line(pos.line as usize);
+        // Clamp out-of-range columns, then use Ropey's index to avoid rescanning long lines.
         self.line_start_offset(pos.line as usize)
-            + line
-                .chars()
-                .take(pos.character as usize)
-                .map(|c| c.len_utf8())
-                .sum::<usize>()
+            + line.char_to_byte_idx((pos.character as usize).min(line.len_chars()))
     }
 
     fn offset_to_position(&self, offset: usize) -> Position {
@@ -551,6 +548,10 @@ mod tests {
         assert_eq!(
             rope.position_to_offset(&Position::new(1, 1)),
             "a 中文🎉 test\nR".len()
+        );
+        assert_eq!(
+            rope.position_to_offset(&Position::new(0, u32::MAX)),
+            "a 中文🎉 test".len()
         );
 
         assert_eq!(


### PR DESCRIPTION
Closes #2710

## Description

Replace the linear character scan in `RopeExt::position_to_offset` with
Ropey's indexed character-to-byte conversion.

The previous implementation iterated from the beginning of a line for each
diagnostic range endpoint. Applying many diagnostics near the end of a long
line therefore took `O(number of diagnostics * line length)` work on the
synchronous update path.

This change enables Ropey's `metric_chars` feature and uses
`RopeSlice::char_to_byte_idx` to resolve the requested column. The column is
clamped to `line.len_chars()` first, preserving the existing behavior for
positions beyond the end of a line.

No marker limits, asynchronous processing, or unrelated position semantics are
changed.

## Performance

The same release-mode reproduction used 1,000 diagnostics whose start and end
positions were beyond the end of a 1,000,000-character ASCII line:

| | Before | After |
| --- | ---: | ---: |
| Elapsed time | 4,937.835 ms | 0.729 ms |
| Three-second deadline | Timed out (`124`) | Completed (`0`) |
| Stored diagnostics | 1,000 | 1,000 |

For comparison, after the change the same document and diagnostic count with
column `1` took 0.667 ms. Large valid or out-of-range columns no longer cause a
full line scan for each range endpoint.

## How to Test

Run the complete `gpui-base` library test suite:

```console
cargo test -p gpui-base --lib --locked
```

Result: 267 passed, 0 failed.

Check formatting and whitespace:

```console
cargo fmt --all -- --check
git diff --check
```

The existing Unicode position assertions continue to pass, and an additional
assertion verifies that `u32::MAX` as a column still resolves to the end of the
line.

## AI Assistance

Codex was used to analyze the performance issue, identify Ropey's indexed
character metric API, implement the change, add the regression assertion, and
draft this description. The resulting diff was reviewed by the contributor and
validated with the tests listed above before submission.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] Passed `cargo test -p gpui-base --lib --locked`.
- [x] Passed `cargo fmt --all -- --check` and `git diff --check`.
- [x] Story testing is not applicable because this change does not modify rendering or interaction behavior.
- [x] Cross-platform performance testing is not applicable because the change uses platform-independent Ropey indexing.
