### PR TITLE
story: Redesign the Collapsible story and improve DataTable cells

### DIFF
--- a/crates/story/src/stories/collapsible_story.rs
+++ b/crates/story/src/stories/collapsible_story.rs
@@ -1,26 +1,122 @@
-use gpui::div;
-use gpui::{
-    App, AppContext, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement, Render,
-    Styled, Window, prelude::FluentBuilder as _, px,
-};
+use std::collections::HashSet;
 
-use gpui_component::group_box::{GroupBox, GroupBoxVariants as _};
-use gpui_component::label::Label;
-use gpui_component::tag::Tag;
-use gpui_component::{ActiveTheme, IconName, StyledExt, h_flex};
+use gpui::{
+    App, AppContext, Context, Div, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    ParentElement, Render, Stateful, StatefulInteractiveElement, Styled, Window, div,
+    prelude::FluentBuilder as _, px,
+};
 use gpui_component::{
-    Sizable,
+    ActiveTheme, Icon, IconName, Sizable, StyledExt,
+    avatar::Avatar,
     button::{Button, ButtonVariants},
+    checkbox::Checkbox,
     collapsible::Collapsible,
+    group_box::{GroupBox, GroupBoxVariants as _},
+    h_flex,
+    progress::Progress,
+    tag::Tag,
     v_flex,
 };
 
 use crate::section;
 
+/// Keys of the panels, each one tracks its own open state.
+const ORDER: &str = "order";
+const FAQ: &str = "faq";
+const USAGE: &str = "usage";
+const SETTINGS: &str = "settings";
+const API_KEYS: &str = "api-keys";
+const COMPONENTS_DIR: &str = "components-dir";
+const UI_DIR: &str = "ui-dir";
+const PROFILE: &str = "profile";
+
+/// Order details, as (title, value) pairs.
+const ORDER_DETAILS: [(&str, &str); 2] = [
+    ("Shipping address", "100 Market St, San Francisco"),
+    ("Items", "2x Studio Headphones"),
+];
+
+/// The usage breakdown of the billing example, as (label, value) pairs.
+const USAGE_ITEMS: [(&str, &str); 4] = [
+    ("Requests", "$210.84"),
+    ("Active CPU", "$21.95"),
+    ("Events", "$21.20"),
+    ("Storage", "$20.45"),
+];
+
+/// The settings rows, as (key, label) pairs.
+const NOTIFICATIONS: [(&str, &str); 3] = [
+    ("push", "Push notifications"),
+    ("email", "Email notifications"),
+    ("sms", "SMS notifications"),
+];
+
+/// The keys listed by the row actions example, as (name, key) pairs.
+const API_KEY_ROWS: [(&str, &str); 3] = [
+    ("Production", "AUDO230454*242SDIFPPL"),
+    ("Development", "DUILO30454*242SDIFUIP"),
+    ("Staging", "IPPODAS230454*242SDI"),
+];
+
+/// The profile fields, as (icon, label, value) triples.
+const PROFILE_FIELDS: [(IconName, &str, &str); 3] = [
+    (IconName::Inbox, "Last activity", "2 hours ago"),
+    (IconName::Calendar, "Online since", "Today, 9:00 AM"),
+    (IconName::Globe, "Location", "Hong Kong"),
+];
+
+/// A bordered row that frames a piece of summary content.
+fn panel_row(cx: &App) -> Div {
+    h_flex()
+        .px_3()
+        .py_2()
+        .gap_2()
+        .items_center()
+        .rounded(cx.theme().radius_lg)
+        .border_1()
+        .border_color(cx.theme().border)
+        .text_sm()
+}
+
+/// The chevron of a row trigger: pointing right when collapsed, down when open.
+fn chevron(open: bool, cx: &App) -> Icon {
+    Icon::new(if open {
+        IconName::ChevronDown
+    } else {
+        IconName::ChevronRight
+    })
+    .xsmall()
+    .text_color(cx.theme().muted_foreground)
+}
+
+/// A leaf row of the tree example: a file icon and its name.
+fn file_row(name: &'static str, cx: &App) -> impl IntoElement {
+    let accent = cx.theme().accent;
+
+    h_flex()
+        .h_7()
+        .px_2()
+        .gap_2()
+        .items_center()
+        .rounded(cx.theme().radius)
+        .hover(|this| this.bg(accent))
+        .text_sm()
+        // Aligns the name with the folder names, which are preceded by a chevron.
+        .child(div().w_3())
+        .child(
+            Icon::new(IconName::File)
+                .xsmall()
+                .text_color(cx.theme().muted_foreground),
+        )
+        .child(name)
+}
+
 pub struct CollapsibleStory {
     focus_handle: FocusHandle,
-    item1_open: bool,
-    item2_open: bool,
+    /// Keys of the panels that are expanded.
+    open: HashSet<&'static str>,
+    /// Keys of the settings rows that are checked.
+    checked: HashSet<&'static str>,
 }
 
 impl super::Story for CollapsibleStory {
@@ -41,13 +137,442 @@ impl CollapsibleStory {
     pub(crate) fn new(_: &mut Window, cx: &mut App) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
-            item1_open: false,
-            item2_open: false,
+            open: HashSet::from([SETTINGS, API_KEYS, COMPONENTS_DIR, PROFILE]),
+            checked: HashSet::from(["push"]),
         }
     }
 
     pub fn view(window: &mut Window, cx: &mut App) -> Entity<Self> {
         cx.new(|cx| Self::new(window, cx))
+    }
+
+    fn is_open(&self, key: &'static str) -> bool {
+        self.open.contains(key)
+    }
+
+    fn toggle(&mut self, key: &'static str, cx: &mut Context<Self>) {
+        if !self.open.remove(key) {
+            self.open.insert(key);
+        }
+        cx.notify();
+    }
+
+    /// A row that toggles `key` when clicked anywhere along it.
+    fn trigger_row(&self, key: &'static str, cx: &mut Context<Self>) -> Stateful<Div> {
+        h_flex()
+            .id(key)
+            .w_full()
+            .items_center()
+            .on_click(cx.listener(move |this, _, _, cx| this.toggle(key, cx)))
+    }
+
+    /// A folder row of the tree example, the whole row toggles the folder.
+    fn folder_row(
+        &self,
+        key: &'static str,
+        name: &'static str,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let open = self.is_open(key);
+        let accent = cx.theme().accent;
+        let muted_foreground = cx.theme().muted_foreground;
+        let radius = cx.theme().radius;
+
+        self.trigger_row(key, cx)
+            .h_7()
+            .px_2()
+            .gap_2()
+            .rounded(radius)
+            .hover(|this| this.bg(accent))
+            .text_sm()
+            .child(chevron(open, cx))
+            .child(
+                Icon::new(if open {
+                    IconName::FolderOpen
+                } else {
+                    IconName::Folder
+                })
+                .xsmall()
+                .text_color(muted_foreground),
+            )
+            .child(name)
+    }
+
+    /// A trigger beside the title, with a summary row that stays visible.
+    fn render_basic(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let muted_foreground = cx.theme().muted_foreground;
+
+        section("Basic")
+            .description("A trigger beside the title, with a summary that stays visible.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                Collapsible::new()
+                    .w_full()
+                    .gap_2()
+                    .open(self.is_open(ORDER))
+                    .child(
+                        h_flex()
+                            .px_1()
+                            .justify_between()
+                            .items_center()
+                            .gap_4()
+                            .child(div().text_sm().font_semibold().child("Order #4189"))
+                            .child(
+                                Button::new(ORDER)
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::ChevronsUpDown)
+                                    .tooltip("Toggle details")
+                                    .on_click(cx.listener(|this, _, _, cx| this.toggle(ORDER, cx))),
+                            ),
+                    )
+                    .child(
+                        panel_row(cx)
+                            .justify_between()
+                            .bg(cx.theme().muted.opacity(0.3))
+                            .child(div().text_color(muted_foreground).child("Status"))
+                            .child(Tag::success().small().child("Shipped")),
+                    )
+                    .content(
+                        v_flex()
+                            .gap_2()
+                            .children(ORDER_DETAILS.map(|(title, value)| {
+                                panel_row(cx)
+                                    .v_flex()
+                                    .items_start()
+                                    .gap_0()
+                                    .child(div().font_medium().child(title))
+                                    .child(div().text_color(muted_foreground).child(value))
+                            })),
+                    ),
+            )
+    }
+
+    /// The whole row acts as the trigger.
+    fn render_row_trigger(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let muted_foreground = cx.theme().muted_foreground;
+
+        section("Row trigger")
+            .description("The whole row is the trigger, as used by FAQ entries.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                GroupBox::new().outline().w_full().child(
+                    Collapsible::new()
+                        .w_full()
+                        .open(self.is_open(FAQ))
+                        .child(
+                            self.trigger_row(FAQ, cx)
+                                .justify_between()
+                                .gap_2()
+                                .child(div().text_sm().child("How do I reset my password?"))
+                                .child(chevron(self.is_open(FAQ), cx)),
+                        )
+                        .content(div().pt_3().text_sm().text_color(muted_foreground).child(
+                            "Click the Forgot Password link on the sign in page, \
+                                     and we will send you an email with instructions to \
+                                     create a new one.",
+                        )),
+                ),
+            )
+    }
+
+    /// A round trigger sitting on the bottom edge of a card.
+    fn render_bottom_trigger(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let open = self.is_open(USAGE);
+        let muted_foreground = cx.theme().muted_foreground;
+
+        section("Bottom trigger")
+            .description("The trigger sits on the bottom edge of the card it opens.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                div()
+                    .relative()
+                    .w_full()
+                    .child(
+                        GroupBox::new()
+                            .outline()
+                            .w_full()
+                            .title(
+                                h_flex()
+                                    .w_full()
+                                    .justify_between()
+                                    .items_center()
+                                    .child(div().text_sm().child("3 days remaining in cycle"))
+                                    .child(
+                                        Button::new("billing").outline().xsmall().label("Billing"),
+                                    ),
+                            )
+                            .child(
+                                Collapsible::new()
+                                    .w_full()
+                                    .gap_3()
+                                    .open(open)
+                                    .child(
+                                        panel_row(cx)
+                                            .v_flex()
+                                            .items_stretch()
+                                            .gap_2()
+                                            .bg(cx.theme().muted.opacity(0.6))
+                                            .child(
+                                                h_flex()
+                                                    .justify_between()
+                                                    .font_medium()
+                                                    .child("$18.08 / $20")
+                                                    .child("$200"),
+                                            )
+                                            .child(Progress::new(USAGE).value(90.)),
+                                    )
+                                    .content(v_flex().gap_2().children(USAGE_ITEMS.map(
+                                        |(label, value)| {
+                                            h_flex()
+                                                .justify_between()
+                                                .text_xs()
+                                                .font_medium()
+                                                .child(
+                                                    div().text_color(muted_foreground).child(label),
+                                                )
+                                                .child(value)
+                                        },
+                                    ))),
+                            ),
+                    )
+                    .child(
+                        h_flex()
+                            .absolute()
+                            .bottom(px(-12.))
+                            .left_0()
+                            .right_0()
+                            .justify_center()
+                            .child(
+                                Button::new("toggle-usage")
+                                    .outline()
+                                    .xsmall()
+                                    .rounded_full()
+                                    .bg(cx.theme().background)
+                                    .icon(if open {
+                                        IconName::ChevronUp
+                                    } else {
+                                        IconName::ChevronDown
+                                    })
+                                    .tooltip("Toggle details")
+                                    .on_click(cx.listener(|this, _, _, cx| this.toggle(USAGE, cx))),
+                            ),
+                    ),
+            )
+    }
+
+    /// Optional settings held behind a full width trigger.
+    fn render_settings(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let border = cx.theme().border;
+
+        section("Settings")
+            .description("Holds optional controls, keeping the default view short.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                Collapsible::new()
+                    .w_full()
+                    .gap_2()
+                    .open(self.is_open(SETTINGS))
+                    .child(
+                        Button::new(SETTINGS)
+                            .outline()
+                            .w_full()
+                            .justify_start()
+                            .icon(chevron(self.is_open(SETTINGS), cx))
+                            .label("Notification settings")
+                            .on_click(cx.listener(|this, _, _, cx| this.toggle(SETTINGS, cx))),
+                    )
+                    .content(
+                        v_flex()
+                            .w_full()
+                            .rounded(cx.theme().radius_lg)
+                            .border_1()
+                            .border_color(border)
+                            .children(NOTIFICATIONS.into_iter().enumerate().map(
+                                |(ix, (key, label))| {
+                                    h_flex()
+                                        .px_3()
+                                        .py_2()
+                                        .when(ix > 0, |this| this.border_t_1().border_color(border))
+                                        .child(
+                                            Checkbox::new(key)
+                                                .label(label)
+                                                .checked(self.checked.contains(key))
+                                                .on_click(cx.listener(
+                                                    move |this, checked: &bool, _, cx| {
+                                                        if *checked {
+                                                            this.checked.insert(key);
+                                                        } else {
+                                                            this.checked.remove(key);
+                                                        }
+                                                        cx.notify();
+                                                    },
+                                                )),
+                                        )
+                                },
+                            )),
+                    ),
+            )
+    }
+
+    /// A list where the header and every row carry their own action.
+    fn render_row_actions(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let muted = cx.theme().muted;
+        let radius = cx.theme().radius;
+
+        section("Row actions")
+            .description("Actions live beside the trigger, in the header and in every row.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                GroupBox::new().outline().w_full().child(
+                    Collapsible::new()
+                        .w_full()
+                        .gap_3()
+                        .open(self.is_open(API_KEYS))
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .gap_2()
+                                .child(
+                                    self.trigger_row(API_KEYS, cx)
+                                        .flex_1()
+                                        .gap_2()
+                                        .child(chevron(self.is_open(API_KEYS), cx))
+                                        .child(div().text_sm().font_medium().child("API Keys")),
+                                )
+                                .child(
+                                    Button::new("add-key")
+                                        .ghost()
+                                        .xsmall()
+                                        .icon(IconName::Plus)
+                                        .tooltip("Add key"),
+                                ),
+                        )
+                        .content(v_flex().gap_2().children(API_KEY_ROWS.map(|(name, key)| {
+                            h_flex()
+                                .gap_2()
+                                .items_center()
+                                .child(
+                                    h_flex()
+                                        .flex_none()
+                                        .size(px(20.))
+                                        .items_center()
+                                        .justify_center()
+                                        .rounded(radius)
+                                        .bg(muted)
+                                        .child(
+                                            Icon::new(IconName::Asterisk)
+                                                .xsmall()
+                                                .text_color(cx.theme().green),
+                                        ),
+                                )
+                                .child(div().w_20().flex_none().text_xs().child(name))
+                                .child(
+                                    div()
+                                        .flex_1()
+                                        .overflow_hidden()
+                                        .px_2()
+                                        .py(px(2.))
+                                        .rounded(radius)
+                                        .bg(muted)
+                                        .text_xs()
+                                        .child(key),
+                                )
+                                .child(
+                                    Button::new(name)
+                                        .ghost()
+                                        .xsmall()
+                                        .icon(IconName::Ellipsis)
+                                        .tooltip("More"),
+                                )
+                        }))),
+                ),
+            )
+    }
+
+    /// Panels nested inside panels.
+    fn render_tree(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        section("Nested")
+            .description("Panels nest to any depth, here as a file tree.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                GroupBox::new().outline().w_full().child(
+                    v_flex()
+                        .w_full()
+                        .child(
+                            Collapsible::new()
+                                .w_full()
+                                .open(self.is_open(COMPONENTS_DIR))
+                                .child(self.folder_row(COMPONENTS_DIR, "components", cx))
+                                .content(
+                                    v_flex()
+                                        .pl_3()
+                                        .child(
+                                            Collapsible::new()
+                                                .w_full()
+                                                .open(self.is_open(UI_DIR))
+                                                .child(self.folder_row(UI_DIR, "ui", cx))
+                                                .content(
+                                                    v_flex().pl_3().children(
+                                                        ["button.rs", "card.rs", "dialog.rs"]
+                                                            .map(|name| file_row(name, cx)),
+                                                    ),
+                                                ),
+                                        )
+                                        .child(file_row("login_form.rs", cx)),
+                                ),
+                        )
+                        .child(file_row("main.rs", cx)),
+                ),
+            )
+    }
+
+    /// An identity row that stays visible, with the details folded behind it.
+    fn render_profile(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let muted_foreground = cx.theme().muted_foreground;
+
+        section("Profile")
+            .description("Shows who someone is, and their details only on request.")
+            .w(px(360.))
+            .v_flex()
+            .child(
+                GroupBox::new().outline().w_full().child(
+                    Collapsible::new()
+                        .w_full()
+                        .gap_3()
+                        .open(self.is_open(PROFILE))
+                        .child(
+                            self.trigger_row(PROFILE, cx)
+                                .justify_between()
+                                .gap_2()
+                                .child(
+                                    h_flex()
+                                        .gap_2()
+                                        .items_center()
+                                        .child(Avatar::new().name("Jason Lee").xsmall())
+                                        .child(div().text_sm().font_medium().child("@huacnlee")),
+                                )
+                                .child(chevron(self.is_open(PROFILE), cx)),
+                        )
+                        .content(v_flex().gap_2().children(PROFILE_FIELDS.map(
+                            |(icon, label, value)| {
+                                h_flex()
+                                    .gap_2()
+                                    .items_center()
+                                    .text_xs()
+                                    .child(Icon::new(icon).xsmall().text_color(muted_foreground))
+                                    .child(div().text_color(muted_foreground).child(label))
+                                    .child(div().font_medium().child(value))
+                            },
+                        ))),
+                ),
+            )
     }
 }
 
@@ -59,127 +584,16 @@ impl Focusable for CollapsibleStory {
 
 impl Render for CollapsibleStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let items = [
-            ["TSLA.US", "$423.00", "+30.25%"],
-            ["NVDA.US", "$312.00", "+12.12%"],
-            ["AAPL.US", "$145.00", "-8.50%"],
-        ];
-
         v_flex()
             .w_full()
             .items_center()
             .gap_6()
-            .child(
-                section("Text")
-                    .description("Reveals supporting text without leaving the current view.")
-                    .w(px(520.))
-                    .v_flex()
-                    .child(
-                    Collapsible::new()
-                        .gap_1()
-                        .open(self.item1_open)
-                        .child(
-                            "A short summary stays visible while the supporting details remain optional.",
-                        )
-                        .content(
-                            "Expanded content can contain text, images, actions, or any other element.",
-                        )
-                        .child(
-                            h_flex().justify_center().child(
-                                Button::new("toggle1")
-                                    .icon(IconName::ChevronDown)
-                                    .label("Show more")
-                                    .when(self.item1_open, |this| {
-                                        this.icon(IconName::ChevronUp).label("Show less")
-                                    })
-                                    .xsmall()
-                                    .link()
-                                    .on_click({
-                                        cx.listener(move |this, _, _, cx| {
-                                            this.item1_open = !this.item1_open;
-                                            cx.notify();
-                                        })
-                                    }),
-                            ),
-                        ),
-                ),
-            )
-            .child(
-                section("Card")
-                    .description("Keeps secondary portfolio details compact until requested.")
-                    .w(px(420.))
-                    .child(
-                    GroupBox::new()
-                        .outline()
-                        .w_full()
-                        .title("Portfolio performance")
-                        .child(
-                            Collapsible::new()
-                                .gap_1()
-                                .open(self.item2_open)
-                                .child(
-                                    h_flex()
-                                        .justify_between()
-                                        .child(
-                                            v_flex().child("Total Return").child(
-                                                h_flex()
-                                                    .gap_1()
-                                                    .child(
-                                                        Label::new("123.5%")
-                                                            .text_2xl()
-                                                            .font_semibold(),
-                                                    )
-                                                    .child(
-                                                        Tag::info()
-                                                            .child("+4.5%")
-                                                            .outline()
-                                                            .rounded_full()
-                                                            .small(),
-                                                    ),
-                                            ),
-                                        )
-                                        .child(
-                                            Button::new("toggle2")
-                                                .small()
-                                                .outline()
-                                                .icon(IconName::ChevronDown)
-                                                .label("Details")
-                                                .when(self.item2_open, |this| {
-                                                    this.icon(IconName::ChevronUp)
-                                                })
-                                                .on_click({
-                                                    cx.listener(move |this, _, _, cx| {
-                                                        this.item2_open = !this.item2_open;
-                                                        cx.notify();
-                                                    })
-                                                }),
-                                        ),
-                                )
-                                .content(v_flex().gap_2().children(items.iter().map(|item| {
-                                    let is_up = item[2].starts_with('+');
-
-                                    h_flex().justify_between().child(item[0]).child(
-                                        h_flex()
-                                            .flex_1()
-                                            .justify_end()
-                                            .gap_4()
-                                            .child(div().w_16().justify_end().child(item[1]))
-                                            .child(
-                                                Label::new(item[2])
-                                                    .text_xs()
-                                                    .w_16()
-                                                    .justify_end()
-                                                    .when(is_up, |this| {
-                                                        this.text_color(cx.theme().green)
-                                                    })
-                                                    .when(!is_up, |this| {
-                                                        this.text_color(cx.theme().red)
-                                                    }),
-                                            ),
-                                    )
-                                }))),
-                        ),
-                ),
-            )
+            .child(self.render_basic(cx))
+            .child(self.render_row_trigger(cx))
+            .child(self.render_bottom_trigger(cx))
+            .child(self.render_settings(cx))
+            .child(self.render_row_actions(cx))
+            .child(self.render_tree(cx))
+            .child(self.render_profile(cx))
     }
 }

--- a/crates/story/src/stories/data_table_story.rs
+++ b/crates/story/src/stories/data_table_story.rs
@@ -6,7 +6,7 @@ use std::{
 
 use fake::Fake;
 use gpui::{
-    Action, AnyElement, App, AppContext, ClickEvent, Context, Div, Entity, Focusable,
+    Action, AnyElement, App, AppContext, ClickEvent, Context, Div, Entity, Focusable, Hsla,
     InteractiveElement, IntoElement, ParentElement, Render, SharedString, Stateful,
     StatefulInteractiveElement, Styled, Subscription, Task, TextAlign, Window, div,
     prelude::FluentBuilder as _, px,
@@ -146,24 +146,52 @@ struct Stock {
 }
 
 impl Stock {
+    /// Ticks the quote, keeping the fields consistent with the new price.
     fn random_update(&mut self) {
-        self.price = (-300.0..999.999).fake::<f64>();
-        self.change = (-0.1..5.0).fake::<f64>();
         self.change_percent = (-0.1..0.1).fake::<f64>();
-        self.volume = (-300.0..999.999).fake::<f64>();
-        self.turnover = (-300.0..999.999).fake::<f64>();
-        self.market_cap = (-1000.0..9999.999).fake::<f64>();
-        self.ttm = (-1000.0..9999.999).fake::<f64>();
+        self.price = (5.0..999.0).fake::<f64>();
+        self.change = self.price * self.change_percent;
+        self.prev_close = self.price - self.change;
+        self.volume = (1e4..5e8).fake::<f64>();
+        self.turnover = (1e5..9e9).fake::<f64>();
+        self.market_cap = self.price * self.shares as f64;
+        self.ttm = (5.0..80.0).fake::<f64>();
         self.five_mins_ranking = self.five_mins_ranking * (1.0 + (-0.2..0.2).fake::<f64>());
-        self.bid = self.price * (1.0 + (-0.2..0.2).fake::<f64>());
-        self.bid_volume = (100.0..1000.0).fake::<f64>();
-        self.ask = self.price * (1.0 + (-0.2..0.2).fake::<f64>());
-        self.ask_volume = (100.0..1000.0).fake::<f64>();
-        self.bid_ask_ratio = self.bid / self.ask;
-        self.volume_ratio = self.volume / self.turnover;
-        self.high = self.price * (1.0 + (0.0..1.5).fake::<f64>());
-        self.low = self.price * (1.0 + (-1.5..0.0).fake::<f64>());
+        self.bid = self.price * (1.0 - (0.0..0.01).fake::<f64>());
+        self.bid_volume = (100.0..5e4).fake::<f64>();
+        self.ask = self.price * (1.0 + (0.0..0.01).fake::<f64>());
+        self.ask_volume = (100.0..5e4).fake::<f64>();
+        self.bid_ask_ratio = self.bid_volume / self.ask_volume;
+        self.volume_ratio = (0.0..3.0).fake::<f64>();
+        self.high = self.price * (1.0 + (0.0..0.08).fake::<f64>());
+        self.low = self.price * (1.0 - (0.0..0.08).fake::<f64>());
     }
+}
+
+/// Returns the (foreground, background) colors for a change value.
+///
+/// A rise is green and a fall is red, both taken from the theme. Unchanged
+/// values keep the default cell colors.
+fn change_colors(val: f64, cx: &App) -> Option<(Hsla, Hsla)> {
+    if val > 0. {
+        Some((cx.theme().green, cx.theme().green_light))
+    } else if val < 0. {
+        Some((cx.theme().red, cx.theme().red_light))
+    } else {
+        None
+    }
+}
+
+/// Formats a large number with a compact unit, e.g. `1.24B`, so wide columns
+/// stay readable.
+fn compact(val: f64) -> String {
+    const UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "K")];
+
+    UNITS
+        .into_iter()
+        .find(|(scale, _)| val.abs() >= *scale)
+        .map(|(scale, unit)| format!("{:.2}{unit}", val / scale))
+        .unwrap_or_else(|| format!("{val:.2}"))
 }
 
 /// Restarts ids from zero and builds a fresh set of rows.
@@ -205,53 +233,65 @@ fn random_stocks(size: usize) -> Vec<Stock> {
     random_stocks_exact(start, size)
 }
 
-/// Builds `size` rows with every field independently randomized.
+/// Builds `size` rows of randomized quotes.
+///
+/// The fields of one row hang together the way a real quote does: the change is
+/// the percentage applied to the price, the previous close sits a change away
+/// from it, and the bid, ask, open, high and low stay within a day's range of
+/// it. A table of unrelated numbers reads as noise.
 fn random_stocks_exact(start: usize, size: usize) -> Vec<Stock> {
     (start..start + size)
-        .map(|id| Stock {
-            id,
-            counter: Counter::random(),
-            change: (-100.0..100.0).fake(),
-            change_percent: (-0.1..0.1).fake(),
-            volume: (0.0..1000.0).fake(),
-            turnover: (0.0..1000.0).fake(),
-            market_cap: (0.0..1000.0).fake(),
-            ttm: (0.0..1000.0).fake(),
-            five_mins_ranking: (0.0..1000.0).fake(),
-            th60_days_ranking: (0.0..1000.0).fake(),
-            year_change_percent: (-1.0..1.0).fake(),
-            bid: (0.0..1000.0).fake(),
-            bid_volume: (0.0..1000.0).fake(),
-            ask: (0.0..1000.0).fake(),
-            ask_volume: (0.0..1000.0).fake(),
-            open: (0.0..1000.0).fake(),
-            prev_close: (0.0..1000.0).fake(),
-            high: (0.0..1000.0).fake(),
-            low: (0.0..1000.0).fake(),
-            turnover_rate: (0.0..1.0).fake(),
-            rise_rate: (0.0..1.0).fake(),
-            amplitude: (0.0..1000.0).fake(),
-            pe_status: (0.0..1000.0).fake(),
-            pb_status: (0.0..1000.0).fake(),
-            volume_ratio: (0.0..1.0).fake(),
-            bid_ask_ratio: (0.0..1.0).fake(),
-            latest_pre_close: (0.0..1000.0).fake(),
-            latest_post_close: (0.0..1000.0).fake(),
-            pre_market_cap: (0.0..1000.0).fake(),
-            pre_market_percent: (-1.0..1.0).fake(),
-            pre_market_change: (-100.0..100.0).fake(),
-            post_market_cap: (0.0..1000.0).fake(),
-            post_market_percent: (-1.0..1.0).fake(),
-            post_market_change: (-100.0..100.0).fake(),
-            float_cap: (0.0..1000.0).fake(),
-            shares: (100000..9999999).fake(),
-            shares_float: (100000..9999999).fake(),
-            day_5_ranking: (0.0..1000.0).fake(),
-            day_10_ranking: (0.0..1000.0).fake(),
-            day_30_ranking: (0.0..1000.0).fake(),
-            day_120_ranking: (0.0..1000.0).fake(),
-            day_250_ranking: (0.0..1000.0).fake(),
-            ..Default::default()
+        .map(|id| {
+            let price = (5.0..999.0).fake::<f64>();
+            let change_percent = (-0.1..0.1).fake::<f64>();
+            let change = price * change_percent;
+            let shares = (1_000_000..9_999_999_999i64).fake::<i64>();
+
+            Stock {
+                id,
+                counter: Counter::random(),
+                price,
+                change,
+                change_percent,
+                volume: (1e4..5e8).fake(),
+                turnover: (1e5..9e9).fake(),
+                market_cap: price * shares as f64,
+                ttm: (5.0..80.0).fake(),
+                five_mins_ranking: (0.0..1000.0).fake(),
+                th60_days_ranking: (0.0..1000.0).fake(),
+                year_change_percent: (-1.0..1.0).fake(),
+                bid: price * (1.0 - (0.0..0.01).fake::<f64>()),
+                bid_volume: (100.0..5e4).fake(),
+                ask: price * (1.0 + (0.0..0.01).fake::<f64>()),
+                ask_volume: (100.0..5e4).fake(),
+                open: price * (1.0 + (-0.05..0.05).fake::<f64>()),
+                prev_close: price - change,
+                high: price * (1.0 + (0.0..0.08).fake::<f64>()),
+                low: price * (1.0 - (0.0..0.08).fake::<f64>()),
+                turnover_rate: (0.0..0.2).fake(),
+                rise_rate: (0.0..1.0).fake(),
+                amplitude: (0.0..0.15).fake(),
+                pe_status: (5.0..60.0).fake(),
+                pb_status: (0.5..12.0).fake(),
+                volume_ratio: (0.0..3.0).fake(),
+                bid_ask_ratio: (0.0..3.0).fake(),
+                latest_pre_close: price * (1.0 + (-0.03..0.03).fake::<f64>()),
+                latest_post_close: price * (1.0 + (-0.03..0.03).fake::<f64>()),
+                pre_market_cap: price * shares as f64,
+                pre_market_percent: (-0.05..0.05).fake(),
+                pre_market_change: price * (-0.05..0.05).fake::<f64>(),
+                post_market_cap: price * shares as f64,
+                post_market_percent: (-0.05..0.05).fake(),
+                post_market_change: price * (-0.05..0.05).fake::<f64>(),
+                float_cap: price * shares as f64 * (0.3..1.0).fake::<f64>(),
+                shares,
+                shares_float: (shares as f64 * (0.3..1.0).fake::<f64>()) as i64,
+                day_5_ranking: (0.0..1000.0).fake(),
+                day_10_ranking: (0.0..1000.0).fake(),
+                day_30_ranking: (0.0..1000.0).fake(),
+                day_120_ranking: (0.0..1000.0).fake(),
+                day_250_ranking: (0.0..1000.0).fake(),
+            }
         })
         .collect()
 }
@@ -370,53 +410,45 @@ impl StockTableDelegate {
         self.full_loading = false;
     }
 
-    fn render_percent(&self, col: &Column, val: f64, cx: &mut App) -> AnyElement {
-        let right_num = ((val - val.floor()) * 1000.).floor() as i32;
-
+    /// The frame shared by the value cells: it fills the row and follows the
+    /// column alignment.
+    ///
+    /// Columns that carry their own padding (`Column::p_0`) leave it to the cell,
+    /// so the frame supplies it for them.
+    fn value_cell(&self, col: &Column) -> Div {
         div()
             .h_full()
-            .table_cell_size(self.size)
-            .when(col.align == TextAlign::Right, |this| {
-                this.h_flex().justify_end()
+            .h_flex()
+            .items_center()
+            .when(col.paddings.is_some(), |this| {
+                this.table_cell_size(self.size)
             })
-            .map(|this| {
-                if right_num % 3 == 0 {
-                    this.text_color(cx.theme().red)
-                        .bg(cx.theme().red_light.alpha(0.05))
-                } else if right_num % 3 == 1 {
-                    this.text_color(cx.theme().green)
-                        .bg(cx.theme().green_light.alpha(0.05))
-                } else {
-                    this
-                }
+            .when(col.align == TextAlign::Right, |this| this.justify_end())
+    }
+
+    /// A plain number, already formatted by the caller.
+    fn render_number(&self, col: &Column, text: String) -> AnyElement {
+        self.value_cell(col).child(text).into_any_element()
+    }
+
+    /// A percentage, tinted over the whole cell as ticker tables do.
+    fn render_percent(&self, col: &Column, val: f64, cx: &mut App) -> AnyElement {
+        self.value_cell(col)
+            .when_some(change_colors(val, cx), |this, (foreground, background)| {
+                this.text_color(foreground).bg(background.alpha(0.05))
             })
-            .child(format!("{:.2}%", val * 100.))
+            .child(format!("{:+.2}%", val * 100.))
             .into_any_element()
     }
 
-    fn render_value_cell(&self, col: &Column, val: f64, cx: &mut App) -> AnyElement {
-        let this = div()
-            .h_full()
-            .table_cell_size(self.size)
-            .child(format!("{:.3}", val));
-        // Val is a 0.0 .. n.0
-        // 30% to red, 30% to green, others to default
-        let right_num = ((val - val.floor()) * 1000.).floor() as i32;
-
-        let this = if right_num % 3 == 0 {
-            this.text_color(cx.theme().red)
-                .bg(cx.theme().red_light.alpha(0.05))
-        } else if right_num % 3 == 1 {
-            this.text_color(cx.theme().green)
-                .bg(cx.theme().green_light.alpha(0.05))
-        } else {
-            this
-        };
-
-        this.when(col.align == TextAlign::Right, |this| {
-            this.h_flex().justify_end()
-        })
-        .into_any_element()
+    /// A signed change, colored by its direction.
+    fn render_change(&self, col: &Column, val: f64, cx: &mut App) -> AnyElement {
+        self.value_cell(col)
+            .when_some(change_colors(val, cx), |this, (foreground, _)| {
+                this.text_color(foreground)
+            })
+            .child(format!("{val:+.2}"))
+            .into_any_element()
     }
 }
 
@@ -553,11 +585,14 @@ impl TableDelegate for StockTableDelegate {
         };
 
         match col.key.as_ref() {
-            "id" => div()
+            "id" => self
+                .value_cell(&col)
+                .text_color(cx.theme().muted_foreground)
+                .when(col.align == TextAlign::Center, |this| this.justify_center())
                 .child(stock.id.to_string())
-                .when(col.align == TextAlign::Center, |this| this.text_center())
                 .into_any_element(),
-            "market" => div()
+            "market" => self
+                .value_cell(&col)
                 .map(|this| {
                     if stock.counter.market == "US" {
                         this.text_color(cx.theme().blue)
@@ -567,79 +602,75 @@ impl TableDelegate for StockTableDelegate {
                 })
                 .child(stock.counter.market.clone())
                 .into_any_element(),
-            "symbol" => stock.counter.symbol_code().into_any_element(),
-            "name" => stock.counter.name.clone().into_any_element(),
-            "price" => self.render_value_cell(&col, stock.price, cx),
-            "change" => self.render_value_cell(&col, stock.change, cx),
+            "symbol" => self
+                .value_cell(&col)
+                .font_medium()
+                .child(stock.counter.symbol_code())
+                .into_any_element(),
+            "name" => self
+                .value_cell(&col)
+                .child(stock.counter.name.clone())
+                .into_any_element(),
+            "price" => self
+                .value_cell(&col)
+                .font_semibold()
+                .child(format!("{:.2}", stock.price))
+                .into_any_element(),
+            "change" => self.render_change(&col, stock.change, cx),
             "change_percent" => self.render_percent(&col, stock.change_percent, cx),
-            "volume" => self.render_value_cell(&col, stock.volume, cx),
-            "turnover" => self.render_value_cell(&col, stock.turnover, cx),
-            "market_cap" => self.render_value_cell(&col, stock.market_cap, cx),
-            "ttm" => self.render_value_cell(&col, stock.ttm, cx),
-            "five_mins_ranking" => self.render_value_cell(&col, stock.five_mins_ranking, cx),
-            "th60_days_ranking" => stock
-                .th60_days_ranking
-                .floor()
-                .to_string()
-                .into_any_element(),
+            "volume" => self.render_number(&col, compact(stock.volume)),
+            "turnover" => self.render_number(&col, compact(stock.turnover)),
+            "market_cap" => self.render_number(&col, compact(stock.market_cap)),
+            "ttm" => self.render_number(&col, compact(stock.ttm)),
+            "five_mins_ranking" => {
+                self.render_number(&col, format!("{:.0}", stock.five_mins_ranking))
+            }
+            "th60_days_ranking" => {
+                self.render_number(&col, format!("{:.0}", stock.th60_days_ranking))
+            }
             "year_change_percent" => self.render_percent(&col, stock.year_change_percent, cx),
-            "bid" => self.render_value_cell(&col, stock.bid, cx),
-            "bid_volume" => self.render_value_cell(&col, stock.bid_volume, cx),
-            "ask" => self.render_value_cell(&col, stock.ask, cx),
-            "ask_volume" => self.render_value_cell(&col, stock.ask_volume, cx),
-            "open" => self.render_value_cell(&col, stock.open, cx),
-            "prev_close" => self.render_value_cell(&col, stock.prev_close, cx),
-            "high" => self.render_value_cell(&col, stock.high, cx),
-            "low" => self.render_value_cell(&col, stock.low, cx),
-            "turnover_rate" => (stock.turnover_rate * 100.0)
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "rise_rate" => (stock.rise_rate * 100.0)
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "amplitude" => (stock.amplitude * 100.0)
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "pe_status" => stock.pe_status.floor().to_string().into_any_element(),
-            "pb_status" => stock.pb_status.floor().to_string().into_any_element(),
-            "volume_ratio" => self.render_value_cell(&col, stock.volume_ratio, cx),
-            "bid_ask_ratio" => self.render_value_cell(&col, stock.bid_ask_ratio, cx),
-            "latest_pre_close" => stock
-                .latest_pre_close
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "latest_post_close" => stock
-                .latest_post_close
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "pre_market_cap" => stock.pre_market_cap.floor().to_string().into_any_element(),
+            "bid" => self.render_number(&col, format!("{:.2}", stock.bid)),
+            "bid_volume" => self.render_number(&col, compact(stock.bid_volume)),
+            "ask" => self.render_number(&col, format!("{:.2}", stock.ask)),
+            "ask_volume" => self.render_number(&col, compact(stock.ask_volume)),
+            "open" => self.render_number(&col, format!("{:.2}", stock.open)),
+            "prev_close" => self.render_number(&col, format!("{:.2}", stock.prev_close)),
+            "high" => self.render_number(&col, format!("{:.2}", stock.high)),
+            "low" => self.render_number(&col, format!("{:.2}", stock.low)),
+            "turnover_rate" => {
+                self.render_number(&col, format!("{:.2}%", stock.turnover_rate * 100.))
+            }
+            "rise_rate" => self.render_number(&col, format!("{:.2}%", stock.rise_rate * 100.)),
+            "amplitude" => self.render_number(&col, format!("{:.2}%", stock.amplitude * 100.)),
+            "pe_status" => self.render_number(&col, format!("{:.2}", stock.pe_status)),
+            "pb_status" => self.render_number(&col, format!("{:.2}", stock.pb_status)),
+            "volume_ratio" => self.render_number(&col, format!("{:.2}", stock.volume_ratio)),
+            "bid_ask_ratio" => self.render_number(&col, format!("{:.2}", stock.bid_ask_ratio)),
+            "latest_pre_close" => {
+                self.render_number(&col, format!("{:.2}", stock.latest_pre_close))
+            }
+            "latest_post_close" => {
+                self.render_number(&col, format!("{:.2}", stock.latest_post_close))
+            }
+            "pre_market_cap" => self.render_number(&col, compact(stock.pre_market_cap)),
             "pre_market_percent" => self.render_percent(&col, stock.pre_market_percent, cx),
-            "pre_market_change" => stock
-                .pre_market_change
-                .floor()
-                .to_string()
-                .into_any_element(),
-            "post_market_cap" => stock.post_market_cap.floor().to_string().into_any_element(),
+            "pre_market_change" => self.render_change(&col, stock.pre_market_change, cx),
+            "post_market_cap" => self.render_number(&col, compact(stock.post_market_cap)),
             "post_market_percent" => self.render_percent(&col, stock.post_market_percent, cx),
-            "post_market_change" => stock
-                .post_market_change
-                .floor()
-                .to_string()
+            "post_market_change" => self.render_change(&col, stock.post_market_change, cx),
+            "float_cap" => self.render_number(&col, compact(stock.float_cap)),
+            "shares" => self.render_number(&col, compact(stock.shares as f64)),
+            "shares_float" => self.render_number(&col, compact(stock.shares_float as f64)),
+            "day_5_ranking" => self.render_number(&col, format!("{:.0}", stock.day_5_ranking)),
+            "day_10_ranking" => self.render_number(&col, format!("{:.0}", stock.day_10_ranking)),
+            "day_30_ranking" => self.render_number(&col, format!("{:.0}", stock.day_30_ranking)),
+            "day_120_ranking" => self.render_number(&col, format!("{:.0}", stock.day_120_ranking)),
+            "day_250_ranking" => self.render_number(&col, format!("{:.0}", stock.day_250_ranking)),
+            _ => self
+                .value_cell(&col)
+                .text_color(cx.theme().muted_foreground)
+                .child("--")
                 .into_any_element(),
-            "float_cap" => stock.float_cap.floor().to_string().into_any_element(),
-            "shares" => stock.shares.to_string().into_any_element(),
-            "shares_float" => stock.shares_float.to_string().into_any_element(),
-            "day_5_ranking" => stock.day_5_ranking.floor().to_string().into_any_element(),
-            "day_10_ranking" => stock.day_10_ranking.floor().to_string().into_any_element(),
-            "day_30_ranking" => stock.day_30_ranking.floor().to_string().into_any_element(),
-            "day_120_ranking" => stock.day_120_ranking.floor().to_string().into_any_element(),
-            "day_250_ranking" => stock.day_250_ranking.floor().to_string().into_any_element(),
-            _ => "--".to_string().into_any_element(),
         }
     }
 

--- a/crates/story/src/stories/data_table_story.rs
+++ b/crates/story/src/stories/data_table_story.rs
@@ -93,8 +93,16 @@ impl Counter {
         ALL_COUNTERS[ix].clone()
     }
 
+    /// The symbol carrying its market, e.g. `AAPL.US`.
+    ///
+    /// Hong Kong symbols already ship the suffix (`0700.HK`), so appending the
+    /// market again would read `0700.HK.HK`.
     fn symbol_code(&self) -> SharedString {
-        format!("{}.{}", self.symbol, self.market).into()
+        if self.symbol.contains('.') {
+            self.symbol.clone()
+        } else {
+            format!("{}.{}", self.symbol, self.market).into()
+        }
     }
 }
 
@@ -152,8 +160,8 @@ impl Stock {
         self.price = (5.0..999.0).fake::<f64>();
         self.change = self.price * self.change_percent;
         self.prev_close = self.price - self.change;
-        self.volume = (1e4..5e8).fake::<f64>();
-        self.turnover = (1e5..9e9).fake::<f64>();
+        self.volume = (1e4..5e7).fake::<f64>();
+        self.turnover = self.volume * self.price;
         self.market_cap = self.price * self.shares as f64;
         self.ttm = (5.0..80.0).fake::<f64>();
         self.five_mins_ranking = self.five_mins_ranking * (1.0 + (-0.2..0.2).fake::<f64>());
@@ -185,7 +193,7 @@ fn change_colors(val: f64, cx: &App) -> Option<(Hsla, Hsla)> {
 /// Formats a large number with a compact unit, e.g. `1.24B`, so wide columns
 /// stay readable.
 fn compact(val: f64) -> String {
-    const UNITS: [(f64, &str); 3] = [(1e9, "B"), (1e6, "M"), (1e3, "K")];
+    const UNITS: [(f64, &str); 4] = [(1e12, "T"), (1e9, "B"), (1e6, "M"), (1e3, "K")];
 
     UNITS
         .into_iter()
@@ -245,7 +253,8 @@ fn random_stocks_exact(start: usize, size: usize) -> Vec<Stock> {
             let price = (5.0..999.0).fake::<f64>();
             let change_percent = (-0.1..0.1).fake::<f64>();
             let change = price * change_percent;
-            let shares = (1_000_000..9_999_999_999i64).fake::<i64>();
+            let shares = (1_000_000..3_000_000_000i64).fake::<i64>();
+            let volume = (1e4..5e7).fake::<f64>();
 
             Stock {
                 id,
@@ -253,8 +262,8 @@ fn random_stocks_exact(start: usize, size: usize) -> Vec<Stock> {
                 price,
                 change,
                 change_percent,
-                volume: (1e4..5e8).fake(),
-                turnover: (1e5..9e9).fake(),
+                volume,
+                turnover: volume * price,
                 market_cap: price * shares as f64,
                 ttm: (5.0..80.0).fake(),
                 five_mins_ranking: (0.0..1000.0).fake(),
@@ -347,15 +356,15 @@ impl StockTableDelegate {
                     .sortable()
                     .text_right()
                     .p_0(),
-                Column::new("volume", "Volume").p_0(),
-                Column::new("turnover", "Turnover").p_0(),
-                Column::new("market_cap", "Market Cap").p_0(),
-                Column::new("ttm", "TTM").p_0(),
+                Column::new("volume", "Volume").text_right().p_0(),
+                Column::new("turnover", "Turnover").text_right().p_0(),
+                Column::new("market_cap", "Market Cap").text_right().p_0(),
+                Column::new("ttm", "TTM").text_right().p_0(),
                 Column::new("five_mins_ranking", "5m Ranking")
                     .text_right()
                     .p_0(),
-                Column::new("th60_days_ranking", "60d Ranking"),
-                Column::new("year_change_percent", "Year Chg%"),
+                Column::new("th60_days_ranking", "60d Ranking").text_right(),
+                Column::new("year_change_percent", "Year Chg%").text_right(),
                 Column::new("bid", "Bid").text_right().p_0(),
                 Column::new("bid_volume", "Bid Vol").text_right().p_0(),
                 Column::new("ask", "Ask").text_right().p_0(),
@@ -364,33 +373,33 @@ impl StockTableDelegate {
                 Column::new("prev_close", "Prev Close").text_right().p_0(),
                 Column::new("high", "High").text_right().p_0(),
                 Column::new("low", "Low").text_right().p_0(),
-                Column::new("turnover_rate", "Turnover Rate"),
-                Column::new("rise_rate", "Rise Rate"),
-                Column::new("amplitude", "Amplitude"),
-                Column::new("pe_status", "P/E"),
-                Column::new("pb_status", "P/B"),
+                Column::new("turnover_rate", "Turnover Rate").text_right(),
+                Column::new("rise_rate", "Rise Rate").text_right(),
+                Column::new("amplitude", "Amplitude").text_right(),
+                Column::new("pe_status", "P/E").text_right(),
+                Column::new("pb_status", "P/B").text_right(),
                 Column::new("volume_ratio", "Volume Ratio")
                     .text_right()
                     .p_0(),
                 Column::new("bid_ask_ratio", "Bid Ask Ratio")
                     .text_right()
                     .p_0(),
-                Column::new("latest_pre_close", "Latest Pre Close"),
-                Column::new("latest_post_close", "Latest Post Close"),
-                Column::new("pre_market_cap", "Pre Mkt Cap"),
-                Column::new("pre_market_percent", "Pre Mkt%"),
-                Column::new("pre_market_change", "Pre Mkt Chg"),
-                Column::new("post_market_cap", "Post Mkt Cap"),
-                Column::new("post_market_percent", "Post Mkt%"),
-                Column::new("post_market_change", "Post Mkt Chg"),
-                Column::new("float_cap", "Float Cap"),
-                Column::new("shares", "Shares"),
-                Column::new("shares_float", "Float Shares"),
-                Column::new("day_5_ranking", "5d Ranking"),
-                Column::new("day_10_ranking", "10d Ranking"),
-                Column::new("day_30_ranking", "30d Ranking"),
-                Column::new("day_120_ranking", "120d Ranking"),
-                Column::new("day_250_ranking", "250d Ranking"),
+                Column::new("latest_pre_close", "Latest Pre Close").text_right(),
+                Column::new("latest_post_close", "Latest Post Close").text_right(),
+                Column::new("pre_market_cap", "Pre Mkt Cap").text_right(),
+                Column::new("pre_market_percent", "Pre Mkt%").text_right(),
+                Column::new("pre_market_change", "Pre Mkt Chg").text_right(),
+                Column::new("post_market_cap", "Post Mkt Cap").text_right(),
+                Column::new("post_market_percent", "Post Mkt%").text_right(),
+                Column::new("post_market_change", "Post Mkt Chg").text_right(),
+                Column::new("float_cap", "Float Cap").text_right(),
+                Column::new("shares", "Shares").text_right(),
+                Column::new("shares_float", "Float Shares").text_right(),
+                Column::new("day_5_ranking", "5d Ranking").text_right(),
+                Column::new("day_10_ranking", "10d Ranking").text_right(),
+                Column::new("day_30_ranking", "30d Ranking").text_right(),
+                Column::new("day_120_ranking", "120d Ranking").text_right(),
+                Column::new("day_250_ranking", "250d Ranking").text_right(),
             ],
             extra_columns_count: 0,
             loading: false,
@@ -474,15 +483,35 @@ impl TableDelegate for StockTableDelegate {
         if !self.show_group_headers {
             return None;
         }
+        // Both rows must span every column, and the lower row subdivides the
+        // upper one, so each group lines up with the columns it names.
+        let trailing = self.columns_count(cx) - self.columns.len();
+
         Some(vec![
             vec![
                 ColumnGroup {
-                    label: "Stock Info".into(),
+                    label: "Stock".into(),
                     span: 4,
                 },
                 ColumnGroup {
-                    label: "Price & Change".into(),
-                    span: 3,
+                    label: "Market Data".into(),
+                    span: 10,
+                },
+                ColumnGroup {
+                    label: "Quotes".into(),
+                    span: 8,
+                },
+                ColumnGroup {
+                    label: "Stats".into(),
+                    span: 7,
+                },
+                ColumnGroup {
+                    label: "Extended Hours".into(),
+                    span: 8,
+                },
+                ColumnGroup {
+                    label: "Shares & Rankings".into(),
+                    span: 8 + trailing,
                 },
             ],
             vec![
@@ -491,16 +520,48 @@ impl TableDelegate for StockTableDelegate {
                     span: 4,
                 },
                 ColumnGroup {
-                    label: "Stock Info".into(),
-                    span: 7,
+                    label: "Price & Change".into(),
+                    span: 3,
                 },
                 ColumnGroup {
-                    label: "Ranking & Stats".into(),
-                    span: 14,
+                    label: "Turnover".into(),
+                    span: 4,
                 },
                 ColumnGroup {
-                    label: "Market Data".into(),
-                    span: self.columns_count(cx) - 25,
+                    label: "Momentum".into(),
+                    span: 3,
+                },
+                ColumnGroup {
+                    label: "Order Book".into(),
+                    span: 4,
+                },
+                ColumnGroup {
+                    label: "Session".into(),
+                    span: 4,
+                },
+                ColumnGroup {
+                    label: "Activity".into(),
+                    span: 3,
+                },
+                ColumnGroup {
+                    label: "Valuation".into(),
+                    span: 2,
+                },
+                ColumnGroup {
+                    label: "Ratios".into(),
+                    span: 2,
+                },
+                ColumnGroup {
+                    label: "Pre & Post Market".into(),
+                    span: 8,
+                },
+                ColumnGroup {
+                    label: "Shares".into(),
+                    span: 3,
+                },
+                ColumnGroup {
+                    label: "Rankings".into(),
+                    span: 5 + trailing,
                 },
             ],
         ])
@@ -514,8 +575,9 @@ impl TableDelegate for StockTableDelegate {
         let col = self.column(col_ix, cx);
 
         div()
-            .child(col.name.clone())
-            .when(col_ix >= 3 && col_ix <= 10, |this| {
+            // Same rule as the cells: supply the padding only for the columns
+            // that dropped their own, so a header lines up with its column.
+            .when(col.paddings.is_some(), |this| {
                 this.table_cell_size(self.size)
             })
             .when(col.align == TextAlign::Center, |this| {
@@ -524,6 +586,7 @@ impl TableDelegate for StockTableDelegate {
             .when(col.align == TextAlign::Right, |this| {
                 this.h_flex().w_full().justify_end()
             })
+            .child(col.name.clone())
     }
 
     fn context_menu(
@@ -609,7 +672,7 @@ impl TableDelegate for StockTableDelegate {
                 .into_any_element(),
             "name" => self
                 .value_cell(&col)
-                .child(stock.counter.name.clone())
+                .child(div().truncate().child(stock.counter.name.clone()))
                 .into_any_element(),
             "price" => self
                 .value_cell(&col)


### PR DESCRIPTION
Reworks two stories so they show the components the way they are actually used, taking the [ReUI](https://reui.io) examples as the reference.

## Collapsible

The story had two examples. It now has seven, one per pattern the component gets used for:

- **Basic** — a trigger beside the title, with a summary row that stays visible
- **Row trigger** — the whole row toggles, as FAQ entries do
- **Bottom trigger** — a round trigger sitting on the bottom edge of the card it opens
- **Settings** — optional controls behind a full width trigger
- **Row actions** — actions beside the trigger, in the header and in every row
- **Nested** — panels nested as a file tree
- **Profile** — an identity row with its details folded behind it

Each panel tracks its own open state by key, so the story no longer needs one field per panel.

## DataTable

The cells said very little: most of them printed a bare `floor()`ed number, and the red/green tint was hander out by `right_num % 3`, which has nothing to do with the value.

- Rise/fall colors now follow the sign, and only on the columns that carry a direction (Chg, Chg%, Year Chg%, pre/post market)
- Volume, turnover and the caps use a compact unit (`1.24B`), rate columns carry their `%`, the rest share one decimal precision
- The row data is self-consistent: change is the percentage applied to the price, previous close sits a change away from it, bid/ask/open/high/low stay within a day's range, and magnitudes sit in realistic ranges
- `price` was never assigned, so that column read `0.00` for every row — fixed

Both stories only touch `crates/story`, so there is no public API change.

## Test plan

- `cargo run -p gpui-component-story -- Collapsible` — every panel opens and closes, nested folders included
- `cargo run -p gpui-component-story -- DataTable` — colors track the sign, Options › Refresh Data keeps the rows consistent
- `cargo clippy -p gpui-component-story` and `cargo fmt --check` are clean

Parts of this PR were written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
