### PR TITLE
input: Track the focused state for every input kind

### DIFF
--- a/crates/base/src/input/editor/lsp/completions.rs
+++ b/crates/base/src/input/editor/lsp/completions.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use gpui::{Context, EntityInputHandler, Pixels, Task, Window, px};
+use gpui::{App, Context, EntityInputHandler, Pixels, Task, Window, px};
 use lsp_types::{
     CompletionContext, CompletionItem, CompletionResponse, InlineCompletionContext,
     InlineCompletionItem, InlineCompletionResponse, InlineCompletionTriggerKind,
@@ -50,7 +50,7 @@ pub trait CompletionProvider {
         offset: usize,
         trigger: CompletionContext,
         window: &mut Window,
-        cx: &mut Context<InputBaseState>,
+        cx: &mut App,
     ) -> Task<Result<CompletionResponse>>;
 
     /// Fetches an inline completion suggestion for the given position.
@@ -73,7 +73,7 @@ pub trait CompletionProvider {
         _offset: usize,
         _trigger: InlineCompletionContext,
         _window: &mut Window,
-        _cx: &mut Context<InputBaseState>,
+        _cx: &mut App,
     ) -> Task<Result<InlineCompletionResponse>> {
         Task::ready(Ok(InlineCompletionResponse::Array(vec![])))
     }
@@ -90,7 +90,7 @@ pub trait CompletionProvider {
         &self,
         _completion_indices: Vec<usize>,
         _completions: Rc<RefCell<Box<[Completion]>>>,
-        _: &mut Context<InputBaseState>,
+        _: &mut App,
     ) -> Task<Result<bool>> {
         Task::ready(Ok(false))
     }
@@ -98,12 +98,7 @@ pub trait CompletionProvider {
     /// Determines if the completion should be triggered based on the given byte offset.
     ///
     /// This is called on the main thread.
-    fn is_completion_trigger(
-        &self,
-        offset: usize,
-        new_text: &str,
-        cx: &mut Context<InputBaseState>,
-    ) -> bool;
+    fn is_completion_trigger(&self, offset: usize, new_text: &str, cx: &mut App) -> bool;
 }
 
 pub(crate) struct InlineCompletion {

--- a/crates/base/src/otp_input.rs
+++ b/crates/base/src/otp_input.rs
@@ -1,6 +1,6 @@
 use crate::{
     StyledExt as _,
-    input::{InputEvent, InputState, blink_cursor::BlinkCursor},
+    input::{InputEvent, blink_cursor::BlinkCursor},
 };
 use gpui::{
     AnyElement, App, AppContext as _, Context, Empty, Entity, EventEmitter, FocusHandle, Focusable,
@@ -15,7 +15,6 @@ pub struct OtpState {
     blink_cursor: Entity<BlinkCursor>,
     masked: bool,
     length: usize,
-    compat_input_state: Entity<InputState>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -23,7 +22,6 @@ impl OtpState {
     pub fn new(length: usize, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         let blink_cursor = cx.new(|_| BlinkCursor::new());
-        let compat_input_state = cx.new(|cx| InputState::new(window, cx));
         let subscriptions = vec![
             cx.observe(&blink_cursor, |_, _, cx| cx.notify()),
             cx.observe_window_activation(window, |this, window, cx| {
@@ -40,7 +38,6 @@ impl OtpState {
             blink_cursor,
             masked: false,
             length,
-            compat_input_state,
             _subscriptions: subscriptions,
         }
     }
@@ -53,13 +50,10 @@ impl OtpState {
     pub fn set_value(
         &mut self,
         value: impl Into<SharedString>,
-        window: &mut Window,
+        _: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.value = value.into();
-        self.compat_input_state.update(cx, |state, cx| {
-            state.set_value(self.value.clone(), window, cx);
-        });
         cx.notify();
     }
 
@@ -77,9 +71,6 @@ impl OtpState {
     }
     pub fn cursor_visible(&self, cx: &App) -> bool {
         self.blink_cursor.read(cx).visible()
-    }
-    pub fn compat_input_state(&self) -> Entity<InputState> {
-        self.compat_input_state.clone()
     }
     pub fn masked(mut self, masked: bool) -> Self {
         self.masked = masked;
@@ -132,10 +123,6 @@ impl OtpState {
         cx.stop_propagation();
         self.blink_cursor.update(cx, |cursor, cx| cursor.pause(cx));
         self.value = value.into();
-        let value = self.value.clone();
-        self.compat_input_state.update(cx, |state, cx| {
-            state.set_value(value, window, cx);
-        });
         if self.value.chars().count() == self.length {
             cx.emit(InputEvent::Change);
         }

--- a/crates/story/examples/editor.rs
+++ b/crates/story/examples/editor.rs
@@ -163,7 +163,7 @@ impl CompletionProvider for ExampleLspStore {
         offset: usize,
         trigger: CompletionContext,
         _: &mut Window,
-        cx: &mut Context<InputBaseState>,
+        cx: &mut App,
     ) -> Task<Result<CompletionResponse>> {
         let trigger_character = trigger.trigger_character.unwrap_or_default();
         if trigger_character.is_empty() {
@@ -221,7 +221,7 @@ impl CompletionProvider for ExampleLspStore {
         offset: usize,
         _trigger: InlineCompletionContext,
         _window: &mut Window,
-        cx: &mut Context<InputBaseState>,
+        cx: &mut App,
     ) -> Task<Result<InlineCompletionResponse>> {
         let rope = rope.clone();
         cx.background_spawn(async move {
@@ -254,12 +254,7 @@ impl CompletionProvider for ExampleLspStore {
         })
     }
 
-    fn is_completion_trigger(
-        &self,
-        _offset: usize,
-        _new_text: &str,
-        _cx: &mut Context<InputBaseState>,
-    ) -> bool {
+    fn is_completion_trigger(&self, _offset: usize, _new_text: &str, _cx: &mut App) -> bool {
         true
     }
 }

--- a/crates/story/src/stories/editor_story.rs
+++ b/crates/story/src/stories/editor_story.rs
@@ -248,7 +248,7 @@ mod syntect_highlighter {
             text: &Rope,
             folding: bool,
             _window: &mut Window,
-            _cx: &mut Context<InputBaseState>,
+            _cx: &mut App,
         ) {
             // `syntect` has no incremental mode, so the whole document is
             // reparsed. Read the rope once and reuse it for folding too.

--- a/crates/story/src/stories/input_story.rs
+++ b/crates/story/src/stories/input_story.rs
@@ -565,7 +565,7 @@ impl Render for InputStory {
                     .overflow_hidden()
                     .child(div().child(format!(
                         "Value: {:?}",
-                        window.focused_input(cx).map(|input| input.read(cx).value())
+                        window.focused_input(cx).map(|input| input.value(cx))
                     ))),
             )
             .child(

--- a/crates/ui/src/input/editor.rs
+++ b/crates/ui/src/input/editor.rs
@@ -3,6 +3,7 @@ use gpui::{
     Window, prelude::FluentBuilder as _,
 };
 
+use super::state::sync_focused_input_registry;
 use super::{EditorState, Input};
 use crate::{RoleOverride, StyledExt as _};
 
@@ -92,6 +93,7 @@ impl Styled for Editor {
 impl RenderOnce for Editor {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         self.state.update(cx, |state, cx| state.prepare(window, cx));
+        sync_focused_input_registry(self.state.clone(), window, cx);
         let base = self.state.read(cx).base_state().clone();
         Input::from_base(&base)
             .appearance(self.appearance)

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -2,12 +2,11 @@ use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AccessibleAction, AnyElement, App, DefiniteLength, Edges, Entity, Focusable, Hsla,
+    AccessibleAction, AnyElement, App, DefiniteLength, Edges, Entity, Hsla,
     InteractiveElement as _, IntoElement, ParentElement as _, Rems, RenderOnce, Role, SharedString,
     StatefulInteractiveElement as _, StyleRefinement, Styled, TextAlign, Window, div, px, relative,
 };
 
-use crate::Root;
 use crate::button::{Button, ButtonVariants as _};
 use crate::input::clear_button;
 use crate::native_menu::NativeMenu;
@@ -19,29 +18,14 @@ use crate::{Sizable, StyleSized};
 use gpui_base::InputBase as BaseInput;
 use rust_i18n::t;
 
-use super::{InputContentType, InputState, sync_native_content_type};
+use super::state::sync_focused_input_registry;
+use super::{AnyInputState, InputContentType, InputState, sync_native_content_type};
 use crate::styled::FocusRingStyleExt as _;
 use gpui_base::input::InputBaseState;
 
 enum InputStateSource {
     Input(Entity<InputState>),
     Base(Entity<InputBaseState>),
-}
-
-pub(super) fn sync_focused_input_registry(
-    focused: bool,
-    state: Entity<InputState>,
-    window: &mut Window,
-    cx: &mut App,
-) {
-    Root::try_update(window, cx, |root, _, cx| {
-        if focused {
-            root.focused_input = Some(state.clone());
-        } else if root.focused_input.as_ref() == Some(&state) {
-            root.focused_input = None;
-        }
-        cx.notify();
-    });
 }
 
 /// Returns `(background, foreground)` colors for input-like components.
@@ -406,12 +390,7 @@ impl RenderOnce for Input {
             InputStateSource::Base(state) => (state.clone(), None),
         };
         if let Some(input) = input_state {
-            sync_focused_input_registry(
-                state.read(cx).focus_handle(cx).is_focused(window),
-                input,
-                window,
-                cx,
-            );
+            sync_focused_input_registry(AnyInputState::Input(input), window, cx);
         }
 
         state.update(cx, |state, cx| {
@@ -948,11 +927,13 @@ mod tests {
 
     #[gpui::test]
     fn focused_input_registry_tracks_focus_and_blur(cx: &mut gpui::TestAppContext) {
-        use crate::WindowExt as _;
+        use crate::{Root, WindowExt as _};
         use gpui::{AppContext as _, Render};
 
         struct Probe {
             input: Entity<InputState>,
+            textarea: Entity<crate::input::TextareaState>,
+            editor: Entity<crate::input::EditorState>,
             otp: Entity<gpui_base::OtpState>,
             other: gpui::FocusHandle,
         }
@@ -961,24 +942,34 @@ mod tests {
                 div()
                     .child(div().track_focus(&self.other))
                     .child(Input::new(&self.input))
+                    .child(crate::input::Textarea::new(&self.textarea))
+                    .child(crate::input::Editor::new(&self.editor))
                     .child(crate::input::OtpInput::new(&self.otp))
             }
         }
 
         cx.update(crate::init);
         let mut input = None;
+        let mut textarea = None;
+        let mut editor = None;
         let mut other_focus = None;
         let mut otp = None;
         let window = cx.update(|cx| {
             cx.open_window(Default::default(), |window, cx| {
                 let state = cx.new(|cx| InputState::new(window, cx));
+                let textarea_state = cx.new(|cx| crate::input::TextareaState::new(window, cx));
+                let editor_state = cx.new(|cx| crate::input::EditorState::new("rust", window, cx));
                 let otp_state = cx.new(|cx| gpui_base::OtpState::new(6, window, cx));
                 input = Some(state.clone());
+                textarea = Some(textarea_state.clone());
+                editor = Some(editor_state.clone());
                 otp = Some(otp_state.clone());
                 let other = cx.focus_handle();
                 other_focus = Some(other.clone());
                 let probe = cx.new(|_| Probe {
                     input: state,
+                    textarea: textarea_state,
+                    editor: editor_state,
                     otp: otp_state,
                     other,
                 });
@@ -987,43 +978,39 @@ mod tests {
             .unwrap()
         });
         let input = input.unwrap();
-        let mut cx = gpui::VisualTestContext::from_window(window.into(), cx);
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        cx.update(|window, cx| input.update(cx, |state, cx| state.focus(window, cx)));
-        cx.run_until_parked();
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        assert_eq!(
-            cx.update(|window, cx| window.focused_input(cx)),
-            Some(input.clone())
-        );
-        cx.update(|window, cx| other_focus.clone().unwrap().focus(window, cx));
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        cx.run_until_parked();
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        assert_eq!(cx.update(|window, cx| window.focused_input(cx)), None);
-
+        let textarea = textarea.unwrap();
+        let editor = editor.unwrap();
         let otp = otp.unwrap();
-        let compat = otp.read_with(&cx, |state, _| state.compat_input_state());
-        cx.update(|window, cx| otp.update(cx, |state, cx| state.focus(window, cx)));
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        assert_eq!(
-            cx.update(|window, cx| window.focused_input(cx)),
-            Some(compat)
-        );
-        cx.update(|window, cx| other_focus.unwrap().focus(window, cx));
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-        assert_eq!(cx.update(|window, cx| window.focused_input(cx)), None);
+        let other_focus = other_focus.unwrap();
+        let mut cx = gpui::VisualTestContext::from_window(window.into(), cx);
+
+        // Focusing each kind of input registers it, and blurring clears it.
+        let cases: Vec<AnyInputState> = vec![
+            input.clone().into(),
+            textarea.clone().into(),
+            editor.clone().into(),
+            otp.clone().into(),
+        ];
+        for expected in cases {
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+            cx.update(|window, cx| expected.focus_handle(cx).focus(window, cx));
+            cx.run_until_parked();
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+            assert_eq!(
+                cx.update(|window, cx| window.focused_input(cx)),
+                Some(expected)
+            );
+
+            cx.update(|window, cx| other_focus.clone().focus(window, cx));
+            cx.run_until_parked();
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+            assert_eq!(cx.update(|window, cx| window.focused_input(cx)), None);
+        }
     }
 }

--- a/crates/ui/src/input/mod.rs
+++ b/crates/ui/src/input/mod.rs
@@ -27,10 +27,12 @@ pub use gpui_base::input::{
     ToggleCodeActions, Undo, WrappingIndent,
 };
 mod editor;
+mod state;
 mod textarea;
 pub use editor::Editor;
 pub use input::*;
 pub use lsp_types::Position;
 pub use number_input::{NumberInput, NumberInputEvent, NumberStep, StepAction};
 pub use otp_input::*;
+pub use state::AnyInputState;
 pub use textarea::Textarea;

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -3,7 +3,8 @@ use gpui::{
     ParentElement as _, RenderOnce, Styled as _, Window, div, prelude::FluentBuilder, px,
 };
 
-use super::input::{input_style, sync_focused_input_registry};
+use super::input::input_style;
+use super::state::sync_focused_input_registry;
 use crate::styled::FocusRingStyleExt as _;
 use crate::{ActiveTheme, Disableable, Icon, IconName, Sizable, Size, h_flex, v_flex};
 use gpui_base::OtpInput as BaseOtpInput;
@@ -72,13 +73,7 @@ impl Sizable for OtpInput {
 }
 impl RenderOnce for OtpInput {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let compat_input = self.state.read(cx).compat_input_state();
-        sync_focused_input_registry(
-            self.state.read(cx).focus_handle(cx).is_focused(window),
-            compat_input,
-            window,
-            cx,
-        );
+        sync_focused_input_registry(self.state.clone(), window, cx);
         let state = self.state.read(cx);
         let blink_show = state.cursor_visible(cx);
         let is_focused = state.focus_handle(cx).is_focused(window);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1,0 +1,124 @@
+use gpui::{App, Entity, FocusHandle, Focusable as _, SharedString, Window};
+use gpui_base::OtpState;
+
+use super::{EditorState, InputState, TextareaState};
+use crate::Root;
+
+/// Any input-like state, regardless of which input element renders it.
+///
+/// [`InputState`], [`TextareaState`], [`EditorState`] and [`OtpState`] are
+/// separate types, so an API that refers to “whatever input is here” takes this
+/// enum instead of one of them. [`crate::WindowExt::focused_input`] returns it.
+///
+/// Use [`Self::as_input`] and friends to get the concrete state back, or
+/// [`Self::value`] and [`Self::focus_handle`] when the kind does not matter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnyInputState {
+    /// A single-line [`crate::input::Input`] state.
+    Input(Entity<InputState>),
+    /// A multi-line [`crate::input::Textarea`] state.
+    Textarea(Entity<TextareaState>),
+    /// A source-code [`crate::input::Editor`] state.
+    Editor(Entity<EditorState>),
+    /// A one-time-code [`crate::input::OtpInput`] state.
+    Otp(Entity<OtpState>),
+}
+
+impl AnyInputState {
+    /// Returns the [`InputState`], if this is an `Input` state.
+    pub fn as_input(&self) -> Option<&Entity<InputState>> {
+        match self {
+            Self::Input(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TextareaState`], if this is a `Textarea` state.
+    pub fn as_textarea(&self) -> Option<&Entity<TextareaState>> {
+        match self {
+            Self::Textarea(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`EditorState`], if this is an `Editor` state.
+    pub fn as_editor(&self) -> Option<&Entity<EditorState>> {
+        match self {
+            Self::Editor(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`OtpState`], if this is an `OtpInput` state.
+    pub fn as_otp(&self) -> Option<&Entity<OtpState>> {
+        match self {
+            Self::Otp(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Returns the value of the input.
+    ///
+    /// A masked input returns its masked value, the same as what is rendered.
+    pub fn value(&self, cx: &App) -> SharedString {
+        match self {
+            Self::Input(state) => state.read(cx).value(),
+            Self::Textarea(state) => state.read(cx).value(),
+            Self::Editor(state) => state.read(cx).value(),
+            Self::Otp(state) => state.read(cx).value().clone(),
+        }
+    }
+
+    /// Returns the focus handle of the input.
+    pub fn focus_handle(&self, cx: &App) -> FocusHandle {
+        match self {
+            Self::Input(state) => state.focus_handle(cx),
+            Self::Textarea(state) => state.focus_handle(cx),
+            Self::Editor(state) => state.focus_handle(cx),
+            Self::Otp(state) => state.focus_handle(cx),
+        }
+    }
+}
+
+impl From<Entity<InputState>> for AnyInputState {
+    fn from(state: Entity<InputState>) -> Self {
+        Self::Input(state)
+    }
+}
+
+impl From<Entity<TextareaState>> for AnyInputState {
+    fn from(state: Entity<TextareaState>) -> Self {
+        Self::Textarea(state)
+    }
+}
+
+impl From<Entity<EditorState>> for AnyInputState {
+    fn from(state: Entity<EditorState>) -> Self {
+        Self::Editor(state)
+    }
+}
+
+impl From<Entity<OtpState>> for AnyInputState {
+    fn from(state: Entity<OtpState>) -> Self {
+        Self::Otp(state)
+    }
+}
+
+/// Registers `state` as the window's focused input while it holds focus, and
+/// unregisters it once focus moves elsewhere.
+pub(super) fn sync_focused_input_registry(
+    state: impl Into<AnyInputState>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let state = state.into();
+    let focused = state.focus_handle(cx).is_focused(window);
+    Root::try_update(window, cx, |root, _, cx| {
+        if focused {
+            root.focused_input = Some(state.clone());
+        } else if root.focused_input.as_ref() == Some(&state) {
+            root.focused_input = None;
+        }
+        cx.notify();
+    });
+}

--- a/crates/ui/src/input/textarea.rs
+++ b/crates/ui/src/input/textarea.rs
@@ -3,6 +3,7 @@ use gpui::{
     Window, prelude::FluentBuilder as _,
 };
 
+use super::state::sync_focused_input_registry;
 use super::{Input, TextareaState};
 use crate::{RoleOverride, StyledExt as _};
 
@@ -92,6 +93,7 @@ impl Styled for Textarea {
 impl RenderOnce for Textarea {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         self.state.update(cx, |state, cx| state.prepare(window, cx));
+        sync_focused_input_registry(self.state.clone(), window, cx);
         let base = self.state.read(cx).base_state().clone();
         Input::from_base(&base)
             .appearance(self.appearance)

--- a/crates/ui/src/inspector.rs
+++ b/crates/ui/src/inspector.rs
@@ -570,7 +570,7 @@ impl CompletionProvider for LspProvider {
         offset: usize,
         _: lsp_types::CompletionContext,
         _: &mut Window,
-        cx: &mut Context<InputBaseState>,
+        cx: &mut App,
     ) -> Task<Result<CompletionResponse>> {
         let mut left_offset = 0;
         while left_offset < 100 {
@@ -627,7 +627,7 @@ impl CompletionProvider for LspProvider {
         })
     }
 
-    fn is_completion_trigger(&self, _: usize, _: &str, _: &mut Context<InputBaseState>) -> bool {
+    fn is_completion_trigger(&self, _: usize, _: &str, _: &mut App) -> bool {
         true
     }
 }

--- a/crates/ui/src/root.rs
+++ b/crates/ui/src/root.rs
@@ -1,7 +1,7 @@
 use crate::{
     ActiveTheme, ElementExt, Placement, StyledExt,
     dialog::{ANIMATION_DURATION, Dialog},
-    input::{Copy, InputState},
+    input::{AnyInputState, Copy},
     native_menu::FallbackMenuOverlay,
     notification::{Notification, NotificationList},
     sheet::Sheet,
@@ -39,7 +39,7 @@ pub struct Root {
     view: AnyView,
     pub(crate) active_sheet: Option<ActiveSheet>,
     pub(crate) active_dialogs: Vec<ActiveDialog>,
-    pub(super) focused_input: Option<Entity<InputState>>,
+    pub(super) focused_input: Option<AnyInputState>,
     pub notification: Entity<NotificationList>,
     pub(crate) tooltip_overlay: Entity<gpui_base::TooltipOverlay>,
     pub(crate) native_menu_overlay: Entity<FallbackMenuOverlay>,

--- a/crates/ui/src/window_ext.rs
+++ b/crates/ui/src/window_ext.rs
@@ -1,7 +1,7 @@
 use crate::{
     Placement, Root,
     dialog::{AlertDialog, Dialog},
-    input::InputState,
+    input::AnyInputState,
     notification::Notification,
     sheet::Sheet,
 };
@@ -77,8 +77,11 @@ pub trait WindowExt: Sized {
     /// Returns number of notifications.
     fn notifications(&mut self, cx: &mut App) -> Rc<Vec<Entity<Notification>>>;
 
-    /// Return current focused Input entity.
-    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>>;
+    /// Return the currently focused input state.
+    ///
+    /// Covers `Input`, `Textarea`, `Editor` and `OtpInput`, use
+    /// [`AnyInputState::as_input`] and friends to get the concrete state.
+    fn focused_input(&mut self, cx: &mut App) -> Option<AnyInputState>;
     /// Returns true if there is a focused Input entity.
     fn has_focused_input(&mut self, cx: &mut App) -> bool;
 
@@ -215,7 +218,7 @@ impl WindowExt for Window {
     }
 
     #[inline]
-    fn focused_input(&mut self, cx: &mut App) -> Option<Entity<InputState>> {
+    fn focused_input(&mut self, cx: &mut App) -> Option<AnyInputState> {
         Root::read(self, cx).focused_input.clone()
     }
 


### PR DESCRIPTION
## Description

Fixes #2711.

`WindowExt::focused_input` returned `Option<Entity<InputState>>`, so after the
Input/Textarea/Editor split there was no way to reach the focused state of
anything but a single-line `Input`.

This adds `AnyInputState`, one enum covering every input state, and returns it
from `focused_input`. Callers match on the kind they need, or read `value` and
`focus_handle` when the kind does not matter.

It also fixes a related gap: `Textarea` and `Editor` render through
`Input::from_base` and were never registered at all, so `has_focused_input` was
always `false` for them. All four kinds now register in their own `render`.

`CompletionProvider` was the only LSP provider trait still taking
`&mut Context<InputBaseState>`; the other five already take `&mut App`. No
implementation used the entity context, so it now matches the rest and no longer
exposes a Base-layer type across the seam.

> AI-generated with Claude Code, reviewed and adjusted by hand.

## Breaking Changes

- `WindowExt::focused_input` returns `AnyInputState` instead of `Entity<InputState>`.

```diff
- let value = window.focused_input(cx).map(|input| input.read(cx).value());
+ let value = window.focused_input(cx).map(|input| input.value(cx));
```

  To get the concrete state back:

```diff
- if let Some(state) = window.focused_input(cx) { /* Entity<InputState> */ }
+ if let Some(state) = window.focused_input(cx).and_then(|i| i.as_input().cloned()) { }
```

- `CompletionProvider` methods take `&mut App` instead of `&mut Context<InputBaseState>`.

```diff
  fn completions(
      &self,
      text: &Rope,
      offset: usize,
      trigger: CompletionContext,
      window: &mut Window,
-     cx: &mut Context<InputBaseState>,
+     cx: &mut App,
  ) -> Task<Result<CompletionResponse>>;
```

  The same applies to `inline_completion`, `resolve_completions` and
  `is_completion_trigger`.

- Removed `OtpState::compat_input_state`. It existed only to feed the old
  focused-input registry, which now tracks `OtpState` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
