### PR TITLE
editor: Ignore empty or inverted document color ranges

### DIFF
--- a/crates/base/src/input/editor/lsp/document_colors.rs
+++ b/crates/base/src/input/editor/lsp/document_colors.rs
@@ -111,14 +111,27 @@ mod tests {
     use lsp_types::{Position, Range as LspRange};
 
     #[test]
-    fn test_document_colors_for_range_ignores_inverted_ranges() {
+    fn test_document_colors_for_range_ignores_empty_and_inverted_ranges() {
         let text = Rope::from_str("01234567890123456789");
         let mut lsp = Lsp::default();
-        lsp.document_colors.push((
-            LspRange::new(Position::new(0, 10), Position::new(0, 5)),
-            gpui::red(),
-        ));
+        lsp.document_colors.extend([
+            (
+                LspRange::new(Position::new(0, 10), Position::new(0, 5)),
+                gpui::red(),
+            ),
+            (
+                LspRange::new(Position::new(0, 10), Position::new(0, 10)),
+                gpui::green(),
+            ),
+            (
+                LspRange::new(Position::new(0, 5), Position::new(0, 10)),
+                gpui::blue(),
+            ),
+        ]);
 
-        assert!(lsp.document_colors_for_range(&text, &(0..0)).is_empty());
+        assert_eq!(
+            lsp.document_colors_for_range(&text, &(0..0)),
+            vec![(5..10, gpui::blue())]
+        );
     }
 }

--- a/crates/base/src/input/editor/lsp/document_colors.rs
+++ b/crates/base/src/input/editor/lsp/document_colors.rs
@@ -24,7 +24,8 @@ pub trait DocumentColorProvider {
 impl Lsp {
     /// Get document colors that intersect with the visible range (0-based row).
     ///
-    /// Returns byte ranges and colors.
+    /// Returns non-empty byte ranges and colors. Ranges that become empty or
+    /// inverted after position conversion are ignored.
     pub(crate) fn document_colors_for_range(
         &self,
         text: &Rope,
@@ -41,6 +42,9 @@ impl Lsp {
 
                 let start = text.position_to_offset(&range.start);
                 let end = text.position_to_offset(&range.end);
+                if start >= end {
+                    return None;
+                }
 
                 Some((start..end, *color))
             })
@@ -98,5 +102,23 @@ impl Lsp {
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::{Position, Range as LspRange};
+
+    #[test]
+    fn test_document_colors_for_range_ignores_inverted_ranges() {
+        let text = Rope::from_str("01234567890123456789");
+        let mut lsp = Lsp::default();
+        lsp.document_colors.push((
+            LspRange::new(Position::new(0, 10), Position::new(0, 5)),
+            gpui::red(),
+        ));
+
+        assert!(lsp.document_colors_for_range(&text, &(0..0)).is_empty());
     }
 }


### PR DESCRIPTION
Closes #2718

## Description

Ignore LSP document color ranges whose converted byte offsets are empty or
inverted before passing them to the render-time text-run splitter.

`document_colors_for_range` previously returned `start..end` without checking
that the converted offsets formed a non-empty range. An empty or inverted range
could cause `split_runs_by_bg_segments` to emit `TextRun` lengths whose total
exceeded the shaped substring length. Text backends expect those runs to
partition the substring, so malformed document-color responses could reach a
backend-dependent panic or rendering failure.

This change discards ranges when `start >= end` after position conversion and
documents that behavior. Valid document color ranges are unchanged.

The implementation and PR draft were generated with AI assistance. The changes
were reviewed and tested with the repository's Rust test suite.

## How to Test

```console
cargo fmt --check
git diff --check
cargo test -p gpui-base
cargo run -p gpui-component-story --example editor
```

The new regression test verifies that an inverted `10..5` document color range
is ignored. The full `gpui-base` test suite passes with 269 tests.

The complete Editor story was also run on Linux with temporary provider
responses for an inverted `10..5` range and an empty `10..10` range. Both were
observed being rejected after position conversion, and the UI remained in its
event loop without a panic until the bounded test timeout. The temporary input
injection and diagnostic logging were removed after the test.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific).
