### PR TITLE
input: Split themed styles out of StyledExt, and publish the focus ring

### DIFF
--- a/crates/base/src/styled.rs
+++ b/crates/base/src/styled.rs
@@ -31,8 +31,6 @@ impl From<Option<Role>> for RoleOverride {
     }
 }
 
-use crate::theme::ActiveTheme as _;
-
 pub fn h_flex() -> Div {
     div().h_flex()
 }
@@ -161,16 +159,6 @@ pub trait StyledExt: Styled + Sized {
     font_weight!(font_bold, BOLD);
     font_weight!(font_extrabold, EXTRA_BOLD);
     font_weight!(font_black, BLACK);
-
-    fn popover_style(self, cx: &App) -> Self {
-        let tokens = cx.theme().tokens;
-        self.bg(tokens.colors.surface)
-            .text_color(tokens.colors.surface_foreground)
-            .border_1()
-            .border_color(tokens.colors.border)
-            .shadow_lg()
-            .rounded(tokens.radius.md)
-    }
 
     fn corner_radii(self, radius: Corners<Pixels>) -> Self {
         self.rounded_tl(radius.top_left)

--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{
     ActiveTheme, Colorize as _, Disableable, Icon, RoleOverride, Selectable, Sizable, Size,
     StyleSized, StyledExt,
@@ -13,7 +13,7 @@ use gpui::{
     AnyElement, App, Background, ClickEvent, Corners, Edges, ElementId, Hsla, InteractiveElement,
     Interactivity, IntoElement, MouseButton, ParentElement, Pixels, RenderOnce, Role, SharedString,
     StatefulInteractiveElement as _, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder as _, px, relative, transparent_white,
+    prelude::FluentBuilder as _, relative, transparent_white,
 };
 
 #[derive(Default, Clone, Copy)]
@@ -717,7 +717,9 @@ impl RenderOnce for Button {
                 this
             }
         })
-        .draw_focus_ring(is_focused && self.focus_ring_enabled, px(0.), window, cx)
+        .when(is_focused && self.focus_ring_enabled, |this| {
+            this.focus_ring_style(window, cx)
+        })
     }
 }
 
@@ -1209,7 +1211,7 @@ impl ButtonVariant {
 mod tests {
     use super::*;
     use crate::IconName;
-    use gpui::{linear_color_stop, linear_gradient};
+    use gpui::{linear_color_stop, linear_gradient, px};
 
     #[gpui::test]
     fn disabled_legacy_button_keeps_existing_pointer_blocking(cx: &mut gpui::TestAppContext) {

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,10 +1,10 @@
 use std::{rc::Rc, time::Duration};
 
-use crate::styled::FocusRingStyleExt as _;
 use crate::{
-    ActiveTheme, Disableable, IconName, RoleOverride, Selectable, Sizable, Size, StyledExt as _,
-    icon::IconNamed, text::Text, tooltip::ComponentTooltip, v_flex,
+    ActiveTheme, Disableable, IconName, RoleOverride, Selectable, Sizable, Size, icon::IconNamed,
+    text::Text, tooltip::ComponentTooltip, v_flex,
 };
+use crate::{StyledExt as _, ThemeStyled as _};
 use gpui::{
     Animation, AnimationExt, AnyElement, App, ElementId, InteractiveElement, IntoElement,
     MouseButton, ParentElement, RenderOnce, SharedString, StatefulInteractiveElement,
@@ -269,7 +269,9 @@ impl RenderOnce for Checkbox {
                 _ => this,
             })
             .rounded(cx.theme().radius * 0.5)
-            .draw_focus_ring(is_focused && self.focus_ring_enabled, px(2.), window, cx)
+            .when(is_focused && self.focus_ring_enabled, |this| {
+                this.focus_ring_style(window, cx)
+            })
             .refine_style(&self.style)
             .child(
                 CheckboxIndicator::new()

--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -10,7 +10,7 @@ use rust_i18n::t;
 
 pub use crate::select::Caret;
 
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{
     ActiveTheme, Disableable, ElementExt as _, Icon, IconName, IndexPath, Sizable, Size,
     StyleSized, StyledExt, h_flex,
@@ -995,13 +995,11 @@ fn render_trigger_container(
         .input_text_size(size)
         .refine_style(style)
         .when(outline_visible && appearance, |this| {
-            this.focused_border(cx)
+            this.border_1().border_color(cx.theme().ring)
         })
-        .draw_focus_ring(
+        .when(
             outline_visible && appearance && focus_ring_enabled,
-            px(0.),
-            window,
-            cx,
+            |this| this.focus_ring_style(window, cx),
         )
         .when(allow_open, |this| {
             this.when_some(toggle_handler, |this, handler| this.on_click(handler))

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -20,7 +20,7 @@ use rust_i18n::t;
 
 use super::state::{TextInputState, sync_focused_input_registry};
 use super::{InputContentType, InputState, sync_native_content_type};
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 
 fn accessibility_role(
     is_multi_line: bool,
@@ -585,11 +585,9 @@ impl RenderOnce for Input {
             .items_center()
             .gap(gap_x)
             .refine_style(&self.style)
-            .draw_focus_ring(
+            .when(
                 focused && self.appearance && self.bordered && self.focus_bordered,
-                px(0.),
-                window,
-                cx,
+                |this| this.focus_ring_style(window, cx),
             )
             .children(prefix.map(|p| {
                 div()

--- a/crates/ui/src/input/number_input.rs
+++ b/crates/ui/src/input/number_input.rs
@@ -11,7 +11,7 @@ use gpui::{
 use crate::{Disableable, Icon, IconName, Sizable, Size, StyleSized as _, StyledExt as _};
 
 use super::{Input, InputState, input::input_style};
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use gpui_base::NumberInput as BaseNumberInput;
 pub use gpui_base::{NumberInputEvent, NumberStep, StepAction};
 use rust_i18n::t;
@@ -196,16 +196,16 @@ impl RenderOnce for NumberInput {
                 this.bg(bg)
                     .border_1()
                     .border_color(border_color)
-                    .when(focused, |this| this.focused_border(cx))
+                    .when(focused, |this| {
+                        this.border_1().border_color(cx.theme().ring)
+                    })
             })
             .refine_style(&self.style)
             .when(self.disabled, |this| this.opacity(0.5))
             .child(content)
-            .draw_focus_ring(
+            .when(
                 focused && self.appearance && self.focus_ring_enabled,
-                px(0.),
-                window,
-                cx,
+                |this| this.focus_ring_style(window, cx),
             )
     }
 }

--- a/crates/ui/src/input/otp_input.rs
+++ b/crates/ui/src/input/otp_input.rs
@@ -5,7 +5,7 @@ use gpui::{
 
 use super::input::input_style;
 use super::state::sync_focused_input_registry;
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{ActiveTheme, Disableable, Icon, IconName, Sizable, Size, h_flex, v_flex};
 use gpui_base::OtpInput as BaseOtpInput;
 pub use gpui_base::OtpState;
@@ -130,7 +130,7 @@ impl RenderOnce for OtpInput {
                         Size::Large => this.w_11().h_11(),
                         Size::Size(px) => this.w(px).h(px),
                     })
-                    .draw_focus_ring(focus_visible, px(0.), window, cx)
+                    .when(focus_visible, |this| this.focus_ring_style(window, cx))
                     .on_mouse_down(MouseButton::Left, {
                         let state = self.state.clone();
                         move |_, window, cx| state.read(cx).focus_handle(cx).focus(window, cx)

--- a/crates/ui/src/input/popovers/hover_popover.rs
+++ b/crates/ui/src/input/popovers/hover_popover.rs
@@ -8,7 +8,7 @@ use gpui::{
 };
 
 use crate::{
-    StyledExt,
+    StyledExt, ThemeStyled as _,
     input::{EditorState, popovers::render_markdown},
 };
 

--- a/crates/ui/src/input/popovers/mod.rs
+++ b/crates/ui/src/input/popovers/mod.rs
@@ -14,7 +14,7 @@ use gpui::{
 };
 
 use crate::{
-    ActiveTheme, StyledExt as _,
+    ActiveTheme, ThemeStyled as _,
     text::{TextView, TextViewStyle},
 };
 

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -1,9 +1,10 @@
+use crate::ThemeStyled as _;
 use crate::actions::{Cancel, Confirm, SelectDown, SelectUp};
 use crate::actions::{SelectLeft, SelectRight};
 use crate::menu::menu_item::MenuItemElement;
 use crate::scroll::ScrollableElement;
 use crate::{ActiveTheme, ElementExt, Icon, IconName, Sizable as _, h_flex, v_flex};
-use crate::{Side, Size, StyledExt, kbd::Kbd};
+use crate::{Side, Size, kbd::Kbd};
 use gpui::{
     Action, Anchor, AnyElement, App, AppContext, Bounds, Context, DismissEvent, Edges, Entity,
     EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding,

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -3,6 +3,7 @@ use gpui::{
     SharedString, Size, StyleRefinement, Styled, Window, deferred, div, prelude::FluentBuilder, px,
 };
 
+use crate::ThemeStyled as _;
 use crate::{ActiveTheme, Colorize, StyledExt, h_flex, v_flex};
 
 #[derive(Default)]

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -5,6 +5,7 @@ use gpui::{
 };
 use std::rc::Rc;
 
+use crate::ThemeStyled as _;
 use crate::{Selectable, StyledExt as _, v_flex};
 use gpui_base::Popover as BasePopover;
 pub use gpui_base::PopoverState;

--- a/crates/ui/src/radio.rs
+++ b/crates/ui/src/radio.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{
     ActiveTheme, AxisExt, Sizable, Size, StyledExt, checkbox::checkbox_check_icon, h_flex,
     text::Text, tooltip::ComponentTooltip, v_flex,
@@ -8,7 +8,7 @@ use crate::{
 use gpui::{
     AnyElement, App, Axis, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce,
     SharedString, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder, px, relative, rems,
+    prelude::FluentBuilder, relative, rems,
 };
 use gpui_base::{Radio as BaseRadio, RadioGroup as BaseRadioGroup};
 
@@ -182,7 +182,9 @@ impl RenderOnce for Radio {
             .items_start()
             .line_height(relative(1.))
             .rounded(cx.theme().radius * 0.5)
-            .draw_focus_ring(is_focused && self.focus_ring_enabled, px(2.), window, cx)
+            .when(is_focused && self.focus_ring_enabled, |this| {
+                this.focus_ring_style(window, cx)
+            })
             .map(|this| match self.size {
                 Size::XSmall => this.text_xs(),
                 Size::Small => this.text_sm(),

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -6,7 +6,7 @@ use gpui::{
 };
 use rust_i18n::t;
 
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{
     ActiveTheme, Disableable, ElementExt as _, Icon, IconName, IndexPath, Sizable, Size,
     StyleSized, StyledExt,
@@ -493,13 +493,11 @@ where
                     .input_text_size(self.state.size)
                     .refine_style(&self.state.style)
                     .when(outline_visible && self.state.appearance, |this| {
-                        this.focused_border(cx)
+                        this.border_1().border_color(cx.theme().ring)
                     })
-                    .draw_focus_ring(
+                    .when(
                         outline_visible && self.state.appearance && self.focus_ring_enabled,
-                        px(0.),
-                        window,
-                        cx,
+                        |this| this.focus_ring_style(window, cx),
                     )
                     .when(allow_open, |this| {
                         this.on_click(cx.listener(Self::toggle_menu))

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -8,22 +8,44 @@ use crate::ActiveTheme as _;
 const FOCUS_RING_WIDTH: Pixels = px(3.);
 const FOCUS_RING_OPACITY: f32 = 0.5;
 
-pub(crate) trait FocusRingStyleExt<T: ParentElement + Styled + Sized> {
-    fn focused_border(self, cx: &App) -> Self;
+/// Finished styles that read the theme.
+///
+/// Separate from [`StyledExt`], which holds neutral helpers that make no
+/// visual decisions. Everything here does: it reaches into the theme and
+/// produces a specific look, which is why it belongs above the base layer.
+pub trait ThemeStyled: Styled + Sized {
+    /// Give this element the focus appearance the framework's own controls
+    /// use: its border tinted with the focus colour, and the ring outside it.
+    ///
+    /// Calling this turns the ring on; gate it with `when` for the conditions
+    /// that decide whether the control shows one at all — its focus state,
+    /// [`FocusableExt::focus_ring`], appearance, and so on.
+    ///
+    /// The ring sits outside the element's border, so an ancestor that clips
+    /// its content will cut it off — leave it a few pixels of room, or don't
+    /// clip.
+    fn focus_ring_style(self, window: &Window, cx: &App) -> Self
+    where
+        Self: ParentElement;
 
-    fn draw_focus_ring(self, visible: bool, margin: Pixels, window: &Window, cx: &App) -> Self;
+    /// Give this element the surface, border, shadow and radius of a popover.
+    fn popover_style(self, cx: &App) -> Self;
 }
 
-impl<T: ParentElement + Styled + Sized> FocusRingStyleExt<T> for T {
-    fn focused_border(self, cx: &App) -> Self {
-        self.border_1().border_color(cx.theme().ring)
-    }
-
-    fn draw_focus_ring(mut self, visible: bool, margin: Pixels, window: &Window, cx: &App) -> Self {
-        if !visible {
-            return self;
-        }
-
+impl<T: Styled + Sized> ThemeStyled for T {
+    /// Draw the focus ring the framework's own controls use.
+    ///
+    /// Calling this turns the ring on; gate it with `when` for the conditions
+    /// that decide whether the control shows one at all — its focus state,
+    /// [`crate::FocusableExt::focus_ring`], appearance, and so on.
+    ///
+    /// The ring sits outside the element's border, so an ancestor that clips
+    /// its content will cut it off — leave it a few pixels of room, or don't
+    /// clip.
+    fn focus_ring_style(mut self, window: &Window, cx: &App) -> Self
+    where
+        Self: ParentElement,
+    {
         let rem_size = window.rem_size();
         let style = self.style();
         let border_widths = Edges::<Pixels> {
@@ -76,9 +98,9 @@ impl<T: ParentElement + Styled + Sized> FocusRingStyleExt<T> for T {
         ring_style.corner_radii.top_right = Some(radius.top_right.into());
         ring_style.corner_radii.bottom_left = Some(radius.bottom_left.into());
         ring_style.corner_radii.bottom_right = Some(radius.bottom_right.into());
-        let inset = FOCUS_RING_WIDTH + margin;
+        let inset = FOCUS_RING_WIDTH;
 
-        self.child(
+        self.border_color(cx.theme().ring).child(
             div()
                 .flex_none()
                 .absolute()
@@ -90,5 +112,15 @@ impl<T: ParentElement + Styled + Sized> FocusRingStyleExt<T> for T {
                 .border_color(cx.theme().ring.alpha(FOCUS_RING_OPACITY))
                 .refine_style(&ring_style),
         )
+    }
+
+    fn popover_style(self, cx: &App) -> Self {
+        let theme = cx.theme();
+        self.bg(theme.popover)
+            .text_color(theme.popover_foreground)
+            .border_1()
+            .border_color(theme.border)
+            .shadow_lg()
+            .rounded(theme.radius)
     }
 }

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -9,7 +9,7 @@ use gpui::{
 };
 use rust_i18n::t;
 
-use crate::styled::FocusRingStyleExt as _;
+use crate::ThemeStyled as _;
 use crate::{
     ActiveTheme, Disableable, Icon, IconName, Sizable, Size, StyleSized as _, StyledExt as _,
     actions::{Cancel, Confirm},
@@ -432,13 +432,13 @@ impl RenderOnce for DatePicker {
                             .border_1()
                             .border_color(cx.theme().input)
                             .rounded(cx.theme().radius)
-                            .when(is_focused, |this| this.focused_border(cx))
+                            .when(is_focused, |this| {
+                                this.border_1().border_color(cx.theme().ring)
+                            })
                     })
-                    .draw_focus_ring(
+                    .when(
                         is_focused && self.appearance && !self.disabled && self.focus_ring_enabled,
-                        px(0.),
-                        window,
-                        cx,
+                        |this| this.focus_ring_style(window, cx),
                     )
                     .input_text_size(self.size)
                     .input_size(self.size)


### PR DESCRIPTION
## Description

An application building a control that should sit alongside `Input` or `Select`
had no way to draw the same focus ring — the helper was `pub(crate)`, so the
only option was re-deriving the width, colour and geometry by eye.

`StyledExt` in `gpui-base` was the wrong home for it. That trait holds neutral
helpers — `h_flex`, `refine_style`, `corner_radii` — that make no visual
decisions, which is what lets it live in the base layer. Two of its methods did
not fit: the focus ring and `popover_style` both read `cx.theme()` and produce a
specific look.

They move into `ThemeStyled` in `gpui-component`, where deciding what things
look like is the job, and are named alike:

```rust
use gpui_component::ThemeStyled as _;

div()
    .border_1()
    .border_color(cx.theme().input)
    .when(focused, |this| this.focus_ring_style(window, cx))

div().popover_style(cx)
```

`StyledExt` no longer mentions `cx.theme()` anywhere, so the base layer is
visually unopinionated in fact and not just in intent.

`focus_ring_style` gives the whole focus appearance, not half of it: the border
tinted with the focus colour **and** the ring outside it. The framework's own
controls do both — `Input` tints through its focused style and then draws the
ring — so a caller drawing only the ring would not match them.

### The ring's API changes with the move

**The offset is gone.** It was `px(0.)` at seven of the nine call sites;
checkbox and radio passed `px(2.)` and now sit at zero like the rest.

**`visible` is a `when` at the call site.** Calling the method means the ring is
on, which reads the way the rest of the builder API does, and keeps
`FocusableExt::focus_ring` — the component-level switch — as one of the
conditions rather than something the ring has to reach into:

```diff
- .draw_focus_ring(is_focused && self.focus_ring_enabled, px(0.), window, cx)
+ .when(is_focused && self.focus_ring_enabled, |this| {
+     this.focus_ring_style(window, cx)
+ })
```

That matters because the conditions differ per control — `appearance`,
`bordered`, `!disabled` and the focus state all take part — and they belong
where they are known.

`focus_ring_style` also stays clear of `FocusableExt::focus_ring`, the
component-level switch. `Button` satisfies both traits, so a shared name would
make `Button::new(..).focus_ring(false)` ambiguous for anyone importing both.

### Known limitation

The ring is an absolutely positioned child offset outwards, so an ancestor that
clips its content cuts it off — the same behaviour as CSS `outline` under
`overflow: hidden`. Now documented on the method: containers holding focusable
controls need a few pixels of room, or no clipping.

> AI-generated with Claude Code, reviewed and adjusted by hand.

## Breaking Changes

- `popover_style` moved from `StyledExt` to `ThemeStyled`. Both are exported
  from `gpui_component`, so this is an import change — but keep `StyledExt`
  where the same file also uses its neutral helpers.

```diff
- use gpui_component::{ActiveTheme, StyledExt, h_flex, v_flex};
+ use gpui_component::{ActiveTheme, ThemeStyled, h_flex, v_flex};
  div().popover_style(cx)
```

```diff
  // a file using both
- use gpui_component::{ActiveTheme, Sizable, StyledExt, WindowExt};
+ use gpui_component::{ActiveTheme, Sizable, StyledExt, ThemeStyled, WindowExt};
  div().popover_style(cx).child(div().font_semibold())
```

Checked against a downstream application: four call sites, three needing only
the swap and one needing both traits.

- The focus ring helper was `pub(crate)` and shipped one day ago, so nothing
  downstream can be relying on it. Listed for completeness.

```diff
- element.draw_focus_ring(visible, px(0.), window, cx)
+ element.when(visible, |this| this.focus_ring_style(window, cx))

- element.focused_border(cx)
+ element.border_1().border_color(cx.theme().ring)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
