### PR TITLE
theme: Let an application turn the focus ring off

### DIFF
--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -17,6 +17,10 @@ pub trait ThemeStyled: Styled + Sized {
     /// Give this element the focus appearance the framework's own controls
     /// use: its border tinted with the focus colour, and the ring outside it.
     ///
+    /// The ring is dropped when [`crate::Theme::focus_ring`] is off, leaving
+    /// the tinted border — an application whose layout clips its containers can
+    /// turn it off rather than finding room for the ring in each of them.
+    ///
     /// Calling this turns the ring on; gate it with `when` for the conditions
     /// that decide whether the control shows one at all — its focus state,
     /// [`FocusableExt::focus_ring`], appearance, and so on.
@@ -46,6 +50,13 @@ impl<T: Styled + Sized> ThemeStyled for T {
     where
         Self: ParentElement,
     {
+        // The ring is painted outside the border, so a clipping ancestor cuts
+        // it off. An application whose layout clips heavily turns it off in the
+        // theme and keeps the tinted border, which takes no space.
+        if !cx.theme().focus_ring {
+            return self.border_color(cx.theme().ring);
+        }
+
         let rem_size = window.rem_size();
         let style = self.style();
         let border_widths = Edges::<Pixels> {

--- a/crates/ui/src/theme/mod.rs
+++ b/crates/ui/src/theme/mod.rs
@@ -44,6 +44,10 @@ impl ActiveTheme for App {
     }
 }
 
+fn default_true() -> bool {
+    true
+}
+
 /// The global theme configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Theme {
@@ -78,6 +82,14 @@ pub struct Theme {
     /// Radius for the large elements, e.g.: Dialog, Notification border radius.
     pub radius_lg: Pixels,
     pub shadow: bool,
+    /// Whether focused controls draw a ring outside their border, default true.
+    ///
+    /// The ring is painted outside the element, so any ancestor that clips its
+    /// content will cut it off. An application whose layout clips heavily can
+    /// turn it off here: focused controls then show only their tinted border,
+    /// which costs no space and cannot be clipped.
+    #[serde(default = "default_true")]
+    pub focus_ring: bool,
     pub transparent: Hsla,
     /// Show the scrollbar mode, default: Scrolling
     #[serde(alias = "scrollbar_show")]
@@ -447,6 +459,7 @@ impl From<&ThemeColor> for Theme {
             radius: px(6.),
             radius_lg: px(8.),
             shadow: true,
+            focus_ring: true,
             scrollbar_mode: ScrollbarMode::default(),
             notification: NotificationSettings::default(),
             tile_grid_size: px(8.),


### PR DESCRIPTION
## Description

The focus ring is painted outside the element's border, so any ancestor that
clips its content cuts it off — the same as CSS `outline` under
`overflow: hidden`.

That is fine when a layout has room for it, and awkward when it does not. In a
dense application the ring gets clipped by a scrolling toolbar, then by a
collapsing panel, then by whatever region comes next; each one is found only by
noticing a ring with a flat edge, and fixed by rebalancing that container's
padding. Adding a control to a clipping region silently reopens the question.

Give the theme a switch, alongside `shadow`:

```rust
Theme::global_mut(cx).focus_ring = false;
```

Off, a focused control shows its tinted border and nothing else — no space to
reserve, nothing to clip:

```rust
fn focus_ring_style(mut self, window: &Window, cx: &App) -> Self {
    if !cx.theme().focus_ring {
        return self.border_color(cx.theme().ring);
    }
    // …ring as before
}
```

Default stays `true`, so nothing changes unless an application asks for it.
`#[serde(default)]` keeps existing theme files loading.

Found while moving a downstream application onto #2726: it clips in enough
places that reserving room container by container was going to be an ongoing
tax, and the tinted border alone reads well there.

> AI-generated with Claude Code, reviewed and adjusted by hand.
