### PR TITLE
input: Add a transaction-based undo manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ For Windows, you can run the following command in PowerShell:
 .\script\install-window.ps1
 ```
 
+### Accessibility-driven UI testing
+
+Use accessibility-driven interaction as the default manual UI testing method
+for focus, keyboard, selection, menu, and input behavior. See
+[Accessibility-driven UI testing](docs/ACCESSIBILITY-UI-TESTING.md) for the
+required Story app launch method, accessibility-tree workflow, and completion
+evidence.
+
 ### Run story
 
 There are a lot of UI test cases in the `crates/story` folder, if you change the existing features you can run the tests to make sure they are working.

--- a/crates/base/src/input/base/change.rs
+++ b/crates/base/src/input/base/change.rs
@@ -8,6 +8,8 @@ pub(super) struct Change {
     pub(crate) old_text: String,
     pub(crate) new_range: Selection,
     pub(crate) new_text: String,
+    pub(crate) selection_before: Selection,
+    pub(crate) selection_after: Selection,
     version: usize,
 }
 
@@ -17,12 +19,16 @@ impl Change {
         old_text: &str,
         new_range: impl Into<Selection>,
         new_text: &str,
+        selection_before: Selection,
+        selection_after: Selection,
     ) -> Self {
         Self {
             old_range: old_range.into(),
             old_text: old_text.to_string(),
             new_range: new_range.into(),
             new_text: new_text.to_string(),
+            selection_before,
+            selection_after,
             version: 0,
         }
     }

--- a/crates/base/src/input/base/movement.rs
+++ b/crates/base/src/input/base/movement.rs
@@ -45,6 +45,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         direction: Option<MoveDirection>,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = offset.clamp(0, self.text.len());
         self.cursor_line_end_affinity = false;
         self.selected_range = (offset..offset).into();

--- a/crates/base/src/input/base/selection.rs
+++ b/crates/base/src/input/base/selection.rs
@@ -16,6 +16,7 @@ impl<M: InputModeKind> InputBaseState<M> {
             return;
         };
 
+        self.undo_manager.break_transaction_coalescing();
         self.selected_range = (range.start..range.end).into();
         self.selected_word_range = Some(self.selected_range);
         cx.notify()
@@ -26,6 +27,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     /// The offset is the UTF-8 offset.
     pub(super) fn select_line(&mut self, offset: usize, _: &mut Window, cx: &mut Context<Self>) {
         let range = TextSelector::line_range(&self.text, offset);
+        self.undo_manager.break_transaction_coalescing();
         self.selected_range = (range.start..range.end).into();
         self.selected_word_range = None;
         cx.notify()

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -28,6 +28,7 @@ use super::{
     kind::InputModeKind,
     mask_pattern::normalize_number_input,
     mode::LayoutMode,
+    undo_manager::{EditIntent, UndoManager},
 };
 use crate::actions::{SelectDown, SelectLeft, SelectRight, SelectUp};
 use crate::input::blink_cursor::CURSOR_WIDTH;
@@ -35,7 +36,7 @@ use crate::input::movement::MoveDirection;
 use crate::input::{
     InputExtras as _, Position, RopeExt as _, Selection, element::RIGHT_MARGIN, layout::LastLayout,
 };
-use crate::{AutoScroll, History, StepAction};
+use crate::{AutoScroll, StepAction};
 
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
 #[action(namespace = input, no_json)]
@@ -285,7 +286,7 @@ pub struct InputBaseState<M: InputModeKind> {
     pub(super) mode: LayoutMode,
     pub(super) text: Rope,
     pub(super) display_map: DisplayMap,
-    pub(super) history: History<Change>,
+    pub(super) undo_manager: UndoManager,
     pub(super) search_session: super::SearchSession,
     pub(super) searchable: bool,
     pub(super) replaceable: bool,
@@ -566,7 +567,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     fn new_in_mode(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle().tab_stop(true);
         let blink_cursor = cx.new(|_| BlinkCursor::new());
-        let history = History::new().group_interval(std::time::Duration::from_secs(1));
+        let undo_manager = UndoManager::new();
 
         let _subscriptions = vec![
             // Observe the blink cursor to repaint the view when it changes.
@@ -601,7 +602,7 @@ impl<M: InputModeKind> InputBaseState<M> {
             scroll_beyond_last_line: None,
             cursor_surrounding_lines: None,
             blink_cursor,
-            history,
+            undo_manager,
             selected_range: Selection::default(),
             selected_word_range: None,
             selection_reversed: false,
@@ -808,17 +809,17 @@ impl<M: InputModeKind> InputBaseState<M> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.history.set_ignoring(true);
+        self.undo_manager.set_ignoring(true);
         self.emit_events = false;
         self.replace_text(value, window, cx);
-        self.history.set_ignoring(false);
+        self.undo_manager.set_ignoring(false);
         self.emit_events = true;
 
         self.reset_selection();
         self.reset_lsp_state();
         self.reset_scroll_to_start();
 
-        self.history.clear();
+        self.undo_manager.clear();
         cx.notify();
     }
 
@@ -867,6 +868,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     ) {
         let text: SharedString = text.into();
         self.with_edits_allowed(|this| {
+            this.undo_manager.pending_intent = Some(EditIntent::Atomic);
             let range_utf16 = this.range_to_utf16(&(this.cursor()..this.cursor()));
             this.replace_text_in_range_silent(Some(range_utf16), &text, window, cx);
             this.selected_range = (this.selected_range.end..this.selected_range.end).into();
@@ -884,6 +886,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     ) {
         let text: SharedString = text.into();
         self.with_edits_allowed(|this| {
+            this.undo_manager.pending_intent = Some(EditIntent::Atomic);
             this.replace_text_in_range_silent(None, &text, window, cx);
             this.selected_range = (this.selected_range.end..this.selected_range.end).into();
         });
@@ -897,6 +900,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     ) {
         let text: SharedString = text.into();
         self.with_edits_allowed(|this| {
+            this.undo_manager.pending_intent = Some(EditIntent::Atomic);
             let range = 0..this.text.chars().map(|c| c.len_utf16()).sum();
             this.replace_text_in_range_silent(Some(range), &text, window, cx);
             this.reset_highlighter(cx);
@@ -1170,10 +1174,12 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
+        self.undo_manager.break_transaction_coalescing();
         self.select_to(self.previous_boundary(self.cursor()), cx);
     }
 
     pub(super) fn select_right(&mut self, _: &SelectRight, _: &mut Window, cx: &mut Context<Self>) {
+        self.undo_manager.break_transaction_coalescing();
         self.select_to(self.next_boundary(self.cursor()), cx);
     }
 
@@ -1181,6 +1187,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         if self.is_single_line() {
             return;
         }
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.start_of_line().saturating_sub(1);
         self.select_to(self.previous_boundary(offset), cx);
     }
@@ -1189,6 +1196,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         if self.is_single_line() {
             return;
         }
+        self.undo_manager.break_transaction_coalescing();
         let offset = (self.end_of_line() + 1).min(self.text.len());
         self.select_to(self.next_boundary(offset), cx);
     }
@@ -1208,6 +1216,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         self.select_to(0, cx);
     }
 
@@ -1217,6 +1226,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let end = self.text.len();
         self.select_to(end, cx);
     }
@@ -1227,6 +1237,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.start_of_line();
         self.select_to(offset, cx);
     }
@@ -1237,6 +1248,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.end_of_line();
         self.select_to(offset, cx);
     }
@@ -1247,6 +1259,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.previous_start_of_word();
         self.select_to(offset, cx);
     }
@@ -1257,6 +1270,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.next_end_of_word();
         self.select_to(offset, cx);
     }
@@ -1408,17 +1422,25 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
-        if self.selected_range.is_empty() {
-            self.select_to(self.previous_boundary(self.cursor()), cx)
-        }
+        let intent = if self.selected_range.is_empty() {
+            self.select_to(self.previous_boundary(self.cursor()), cx);
+            EditIntent::Backspace
+        } else {
+            EditIntent::Atomic
+        };
+        self.undo_manager.pending_intent = Some(intent);
         self.replace_text_in_range(None, "", window, cx);
         self.pause_blink_cursor(cx);
     }
 
     pub(super) fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
-        if self.selected_range.is_empty() {
-            self.select_to(self.next_boundary(self.cursor()), cx)
-        }
+        let intent = if self.selected_range.is_empty() {
+            self.select_to(self.next_boundary(self.cursor()), cx);
+            EditIntent::DeleteForward
+        } else {
+            EditIntent::Atomic
+        };
+        self.undo_manager.pending_intent = Some(intent);
         self.replace_text_in_range(None, "", window, cx);
         self.pause_blink_cursor(cx);
     }
@@ -1548,6 +1570,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         } else {
             // Single line input or submit-on-enter: just emit the event
             // (e.g.: in a dialog to confirm, or a chat textarea to send).
+            self.undo_manager.break_transaction_coalescing();
             cx.propagate();
         }
 
@@ -1622,6 +1645,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.undo_manager.break_transaction_coalescing();
         // Input has its own text selection; suppress the window-level text
         // selection (Root) so it does not start a drag from here.
         crate::global_state::GlobalState::suppress_text_selection(cx);
@@ -1899,19 +1923,29 @@ impl<M: InputModeKind> InputBaseState<M> {
         let selected_text = self.text.slice(self.selected_range).to_string();
         cx.write_to_clipboard(ClipboardItem::new_string(selected_text));
 
+        self.undo_manager.pending_intent = Some(EditIntent::Atomic);
         self.replace_text_in_range_silent(None, "", window, cx);
     }
 
     pub(super) fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(clipboard) = cx.read_from_clipboard() {
             let new_text = clipboard.text().unwrap_or_default();
+            self.undo_manager.pending_intent = Some(EditIntent::Atomic);
             self.replace_text_in_range_silent(None, &new_text, window, cx);
             self.scroll_to(self.cursor(), None, cx);
         }
     }
 
-    fn push_history(&mut self, text: &Rope, range: &Range<usize>, new_text: &str) {
-        if self.history.is_ignoring() {
+    fn push_history(
+        &mut self,
+        text: &Rope,
+        range: &Range<usize>,
+        new_text: &str,
+        requested_intent: Option<EditIntent>,
+        selection_before: Selection,
+        selection_after: Option<Selection>,
+    ) {
+        if self.undo_manager.is_ignoring() {
             return;
         }
 
@@ -1920,30 +1954,63 @@ impl<M: InputModeKind> InputBaseState<M> {
         let old_text = text.slice(range.clone()).to_string();
         let new_range = range.start..range.start + new_text.len();
 
-        self.history
-            .push(Change::new(range, &old_text, new_range, new_text));
+        let intent = requested_intent.unwrap_or_else(|| {
+            if range.is_empty()
+                && old_text.is_empty()
+                && !new_text.is_empty()
+                && !new_text.contains(['\n', '\r'])
+            {
+                EditIntent::Typing
+            } else {
+                EditIntent::Atomic
+            }
+        });
+
+        let selection_before = match intent {
+            EditIntent::Backspace => Selection::new(range.end, range.end),
+            EditIntent::DeleteForward => Selection::new(range.start, range.start),
+            EditIntent::Typing | EditIntent::Atomic => selection_before,
+        };
+        let selection_after =
+            selection_after.unwrap_or_else(|| Selection::new(new_range.end, new_range.end));
+
+        self.undo_manager.record_transaction(
+            Change::new(
+                range,
+                &old_text,
+                new_range,
+                new_text,
+                selection_before,
+                selection_after,
+            ),
+            intent,
+        );
     }
 
     pub(super) fn undo(&mut self, _: &Undo, window: &mut Window, cx: &mut Context<Self>) {
-        self.history.set_ignoring(true);
-        if let Some(changes) = self.history.undo() {
-            for change in changes {
+        self.undo_manager.set_ignoring(true);
+        if let Some(changes) = self.undo_manager.undo() {
+            let selection = changes.last().unwrap().selection_before;
+            for change in &changes {
                 let range_utf16 = self.range_to_utf16(&change.new_range.into());
                 self.replace_text_in_range_silent(Some(range_utf16), &change.old_text, window, cx);
             }
+            self.selected_range = selection;
         }
-        self.history.set_ignoring(false);
+        self.undo_manager.set_ignoring(false);
     }
 
     pub(super) fn redo(&mut self, _: &Redo, window: &mut Window, cx: &mut Context<Self>) {
-        self.history.set_ignoring(true);
-        if let Some(changes) = self.history.redo() {
-            for change in changes {
+        self.undo_manager.set_ignoring(true);
+        if let Some(changes) = self.undo_manager.redo() {
+            let selection = changes.last().unwrap().selection_after;
+            for change in &changes {
                 let range_utf16 = self.range_to_utf16(&change.old_range.into());
                 self.replace_text_in_range_silent(Some(range_utf16), &change.new_text, window, cx);
             }
+            self.selected_range = selection;
         }
-        self.history.set_ignoring(false);
+        self.undo_manager.set_ignoring(false);
     }
 
     /// Get byte offset of the cursor.
@@ -1994,6 +2061,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub fn select_all(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        self.undo_manager.break_transaction_coalescing();
         self.selected_range = (0..self.text.len()).into();
         cx.notify();
     }
@@ -2133,6 +2201,7 @@ impl<M: InputModeKind> InputBaseState<M> {
 
     /// Unselects the currently selected text.
     pub fn unselect(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        self.undo_manager.break_transaction_coalescing();
         let offset = self.cursor();
         self.selected_range = (offset..offset).into();
         cx.notify()
@@ -2227,6 +2296,8 @@ impl<M: InputModeKind> InputBaseState<M> {
         if M::is_context_menu_open(self, cx) {
             return;
         }
+
+        self.undo_manager.break_transaction_coalescing();
 
         // NOTE: Do not cancel select, when blur.
         // Because maybe user want to copy the selected text by AppMenuBar (will take focus handle).
@@ -2567,6 +2638,7 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
 
     fn unmark_text(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
         self.ime_marked_range = None;
+        self.undo_manager.commit_transaction();
     }
 
     /// Replace text in range.
@@ -2580,9 +2652,11 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let requested_intent = self.undo_manager.pending_intent.take();
         if !self.is_editable() {
             return;
         }
+        let selection_before = self.selected_range;
 
         if self.blink_cursor.read(cx).visible() {
             self.pause_blink_cursor(cx);
@@ -2647,11 +2721,24 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
             // A segment-based history entry no longer matches the masked
             // document, record a whole-document change instead, so that
             // undo/redo can restore the text exactly.
-            self.push_history(&old_text, &(0..old_text.len()), &self.text.to_string());
+            self.push_history(
+                &old_text,
+                &(0..old_text.len()),
+                &self.text.to_string(),
+                Some(EditIntent::Atomic),
+                selection_before,
+                Some(Selection::new(new_offset, new_offset)),
+            );
         } else {
-            self.push_history(&old_text, &range, &new_text);
+            self.push_history(
+                &old_text,
+                &range,
+                &new_text,
+                requested_intent,
+                selection_before,
+                None,
+            );
         }
-        self.history.end_grouping();
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
@@ -2700,8 +2787,15 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let requested_intent = self.undo_manager.pending_intent.take();
         if !self.is_editable() {
             return;
+        }
+        let selection_before = self.selected_range;
+
+        let starts_composition = self.ime_marked_range.is_none();
+        if starts_composition {
+            self.undo_manager.begin_transaction();
         }
 
         M::reset_language_features(self);
@@ -2729,6 +2823,9 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
                 && self.is_valid_input(&old_text.to_string(), cx)
             {
                 self.text = old_text;
+                if starts_composition {
+                    self.undo_manager.commit_transaction();
+                }
                 return;
             }
         }
@@ -2776,8 +2873,17 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
         if self.is_multi_line() {
             self.mode.update_auto_grow(&self.display_map);
         }
-        self.history.start_grouping();
-        self.push_history(&old_text, &range, new_text);
+        self.push_history(
+            &old_text,
+            &range,
+            new_text,
+            requested_intent,
+            selection_before,
+            Some(self.selected_range),
+        );
+        if new_text.is_empty() {
+            self.undo_manager.commit_transaction();
+        }
         cx.notify();
     }
 
@@ -3393,13 +3499,515 @@ mod tests {
                 state.replace_text_in_range(None, "5", window, cx);
                 assert_eq!(state.value(), "12,345");
 
-                // The two edits are grouped into one undo step (by the
-                // history group interval). Before the whole-document history
-                // fix, this undo produced a corrupted value like "1,2344".
+                // Each whole-document mask rewrite is an atomic undo step.
+                // Before the whole-document history fix, undo produced a
+                // corrupted value like "1,2344".
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "1,234");
                 state.undo(&Undo, window, cx);
                 assert_eq!(state.value(), "");
                 state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "1,234");
+                state.redo(&Redo, window, cx);
                 assert_eq!(state.value(), "12,345");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_coalesces_adjacent_typing_transactions(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                assert_eq!(state.value(), "ab");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_cursor_movement_splits_typing(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                state.left(&MoveLeft, window, cx);
+                state.replace_text_in_range(None, "x", window, cx);
+                assert_eq!(state.value(), "axb");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "ab");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_splits_backward_and_forward_delete(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("abcd", window, cx);
+                state.set_selected_range(2..2, cx);
+                state.backspace(&Backspace, window, cx);
+                state.delete(&Delete, window, cx);
+                assert_eq!(state.value(), "ad");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "acd");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abcd");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_coalesces_directional_character_deletes(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("abcd", window, cx);
+                state.backspace(&Backspace, window, cx);
+                state.backspace(&Backspace, window, cx);
+                assert_eq!(state.value(), "ab");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abcd");
+                assert_eq!(state.selected_range(), 4..4);
+
+                state.set_value("abcd", window, cx);
+                state.set_selected_range(1..1, cx);
+                state.delete(&Delete, window, cx);
+                state.delete(&Delete, window, cx);
+                assert_eq!(state.value(), "ad");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abcd");
+                assert_eq!(state.selected_range(), 1..1);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_atomic_paste_isolated_from_typing(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            cx.write_to_clipboard(ClipboardItem::new_string("P".to_string()));
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.paste(&Paste, window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                assert_eq!(state.value(), "aPb");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "aP");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "a");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_programmatic_insert_is_atomic(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.insert("P", window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                assert_eq!(state.value(), "aPb");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "aP");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "a");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_selection_round_trip_splits_typing(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                state.select_all(window, cx);
+                state.unselect(window, cx);
+                state.replace_text_in_range(None, "c", window, cx);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "ab");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_enter_is_atomic(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.enter(
+                    &Enter {
+                        secondary: false,
+                        shift: false,
+                    },
+                    window,
+                    cx,
+                );
+                state.replace_text_in_range(None, "b", window, cx);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "a\n");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "a");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_single_line_return_commits_the_typing_session(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                for part in ["a", "b", "c"] {
+                    state.replace_text_in_range(None, part, window, cx);
+                }
+                state.enter(
+                    &Enter {
+                        secondary: false,
+                        shift: false,
+                    },
+                    window,
+                    cx,
+                );
+                for part in ["d", "e", "f"] {
+                    state.replace_text_in_range(None, part, window, cx);
+                }
+                assert_eq!(state.value(), "abcdef");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abc");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_submit_on_enter_commits_the_textarea_session(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state.submit_on_enter(true));
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "before submit", window, cx);
+                state.enter(
+                    &Enter {
+                        secondary: false,
+                        shift: false,
+                    },
+                    window,
+                    cx,
+                );
+                state.replace_text_in_range(None, " after submit", window, cx);
+                assert_eq!(state.value(), "before submit after submit");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "before submit");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_blur_commits_the_typing_session(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "before blur", window, cx);
+                state.on_blur(window, cx);
+                state.on_focus(window, cx);
+                state.replace_text_in_range(None, " after focus", window, cx);
+                assert_eq!(state.value(), "before blur after focus");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "before blur");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_keeps_rapid_lines_in_distinct_transactions(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                let enter = Enter {
+                    secondary: false,
+                    shift: false,
+                };
+                state.replace_text_in_range(None, "a", window, cx);
+                state.enter(&enter, window, cx);
+                state.replace_text_in_range(None, "b", window, cx);
+                state.enter(&enter, window, cx);
+                state.replace_text_in_range(None, "c", window, cx);
+                assert_eq!(state.value(), "a\nb\nc");
+
+                for expected in ["a\nb\n", "a\nb", "a\n", "a", ""] {
+                    state.undo(&Undo, window, cx);
+                    assert_eq!(state.value(), expected);
+                }
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_coalesces_long_unicode_typing_without_a_timer(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+        let parts = [
+            "The ",
+            "quick ",
+            "brown fox, ",
+            "你好，世界 ",
+            "🦀 jumps over 13 lazy dogs.",
+        ];
+        let expected = parts.concat();
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                for part in parts {
+                    state.replace_text_in_range(None, part, window, cx);
+                }
+                assert_eq!(state.value(), expected);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), expected);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_long_multiline_sequence_has_structural_boundaries(
+        cx: &mut TestAppContext,
+    ) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+        let enter = Enter {
+            secondary: false,
+            shift: false,
+        };
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                for (index, line) in [
+                    "first line with punctuation!",
+                    "第二行包含 Unicode 🦀",
+                    "third line has several words",
+                ]
+                .into_iter()
+                .enumerate()
+                {
+                    for chunk in line.split_inclusive(' ') {
+                        state.replace_text_in_range(None, chunk, window, cx);
+                    }
+                    if index < 2 {
+                        state.enter(&enter, window, cx);
+                    }
+                }
+
+                assert_eq!(
+                    state.value(),
+                    "first line with punctuation!\n第二行包含 Unicode 🦀\nthird line has several words"
+                );
+                state.undo(&Undo, window, cx);
+                assert_eq!(
+                    state.value(),
+                    "first line with punctuation!\n第二行包含 Unicode 🦀\n"
+                );
+                state.undo(&Undo, window, cx);
+                assert_eq!(
+                    state.value(),
+                    "first line with punctuation!\n第二行包含 Unicode 🦀"
+                );
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "first line with punctuation!\n");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_cut_and_repeated_pastes_are_distinct_transactions(
+        cx: &mut TestAppContext,
+    ) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "alpha beta gamma", window, cx);
+                state.set_selected_range(6..10, cx);
+                state.cut(&Cut, window, cx);
+                assert_eq!(state.value(), "alpha  gamma");
+
+                state.paste(&Paste, window, cx);
+                state.paste(&Paste, window, cx);
+                assert_eq!(state.value(), "alpha betabeta gamma");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "alpha beta gamma");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "alpha  gamma");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "alpha beta gamma");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_word_and_line_deletes_do_not_coalesce(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("one two three\nfour five", window, cx);
+                state.set_selected_range(13..13, cx);
+                state.delete_previous_word(&DeleteToPreviousWordStart, window, cx);
+                assert_eq!(state.value(), "one two \nfour five");
+                state.delete_to_end_of_line(&DeleteToEndOfLine, window, cx);
+                assert_eq!(state.value(), "one two four five");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "one two \nfour five");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "one two three\nfour five");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_multiline_replacement_is_one_atomic_transaction(cx: &mut TestAppContext) {
+        let input_view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "before", window, cx);
+                state.set_selected_range(0..6, cx);
+                state.replace_text_in_range(None, "line one\nline two\n第三行", window, cx);
+                assert_eq!(state.value(), "line one\nline two\n第三行");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "before");
+                assert_eq!(state.selected_range(), 0..6);
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "line one\nline two\n第三行");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_composition_isolated_from_long_typing(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "prefix ", window, cx);
+                state.replace_and_mark_text_in_range(None, "n", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "ni", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "你", None, window, cx);
+                state.unmark_text(window, cx);
+                state.replace_text_in_range(None, " suffix", window, cx);
+                assert_eq!(state.value(), "prefix 你 suffix");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "prefix 你");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "prefix ");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_selected_replacement_is_atomic(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "abc", window, cx);
+                state.set_selected_range(1..2, cx);
+                state.replace_text_in_range(None, "X", window, cx);
+                state.replace_text_in_range(None, "z", window, cx);
+                assert_eq!(state.value(), "aXzc");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "aXc");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abc");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
             });
         });
     }
@@ -3650,7 +4258,7 @@ mod tests {
                 // Seed with a value and clear history so the baseline is clean.
                 state.set_value("first", window, cx);
                 assert!(
-                    state.history.undos().is_empty(),
+                    !state.undo_manager.has_undos(),
                     "history should be empty after set_value"
                 );
 
@@ -3658,7 +4266,7 @@ mod tests {
                 state.replace_all("second", window, cx);
                 assert_eq!(state.value(), "second");
                 assert!(
-                    !state.history.undos().is_empty(),
+                    state.undo_manager.has_undos(),
                     "replace_all should record an undo step"
                 );
 
@@ -3752,6 +4360,176 @@ mod tests {
                 assert_eq!(state.value(), "你好 sh");
                 assert_eq!(state.selected_range(), 9..9);
                 assert_eq!(state.ime_marked_range, Some((7..9).into()));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_composition_is_one_undo_group(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("a", window, cx);
+                state.replace_and_mark_text_in_range(None, "s", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "sh", None, window, cx);
+                state.replace_text_in_range(None, "是", window, cx);
+                assert_eq!(state.value(), "a是");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "a");
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "a是");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_composition_cancel_leaves_no_entry(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("a", window, cx);
+                state.replace_and_mark_text_in_range(None, "s", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "", None, window, cx);
+
+                assert_eq!(state.value(), "a");
+                assert!(!state.undo_manager.has_undos());
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_selection_restored_by_undo_and_redo(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("abc", window, cx);
+                state.set_selected_range(1..2, cx);
+                state.replace_text_in_range(None, "X", window, cx);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abc");
+                assert_eq!(state.selected_range(), 1..2);
+
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "aXc");
+                assert_eq!(state.selected_range(), 2..2);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_forward_delete_restores_cursor(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("abc", window, cx);
+                state.set_selected_range(1..1, cx);
+                state.delete(&Delete, window, cx);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "abc");
+                assert_eq!(state.selected_range(), 1..1);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_selection_movement_preserves_redo(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "ab", window, cx);
+                state.undo(&Undo, window, cx);
+                state.set_selected_range(0..0, cx);
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "ab");
+
+                state.undo(&Undo, window, cx);
+                state.replace_text_in_range(None, "x", window, cx);
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "x");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_noop_edit_preserves_redo(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "a", window, cx);
+                state.undo(&Undo, window, cx);
+                state.backspace(&Backspace, window, cx);
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "a");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_noop_edit_breaks_coalescing_without_clearing_history(
+        cx: &mut TestAppContext,
+    ) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_text_in_range(None, "alpha", window, cx);
+                state.replace_text_in_range(None, "", window, cx);
+                state.replace_text_in_range(None, "beta", window, cx);
+                assert_eq!(state.value(), "alphabeta");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "alpha");
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_masked_redo_restores_actual_cursor(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| {
+            state.mask_pattern(MaskPattern::Number {
+                separator: Some(','),
+                fraction: None,
+            })
+        });
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("12345", window, cx);
+                state.set_selected_range(2..2, cx);
+                state.replace_text_in_range(None, "9", window, cx);
+                let selection_after_edit = state.selected_range();
+                assert_ne!(selection_after_edit.end, state.value().len());
+
+                state.undo(&Undo, window, cx);
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.selected_range(), selection_after_edit);
             });
         });
     }

--- a/crates/base/src/input/base/undo_manager.rs
+++ b/crates/base/src/input/base/undo_manager.rs
@@ -1,0 +1,263 @@
+use crate::input::change::Change;
+
+const MAX_UNDO_TRANSACTIONS: usize = 1000;
+const MAX_CHANGES_PER_TRANSACTION: usize = 1000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EditIntent {
+    Typing,
+    Backspace,
+    DeleteForward,
+    Atomic,
+}
+
+#[derive(Debug)]
+struct UndoTransaction {
+    intent: EditIntent,
+    changes: Vec<Change>,
+}
+
+/// Coordinates undo and redo as explicit editing transactions.
+///
+/// Each edit first creates a transaction. Compatible adjacent transactions
+/// may then coalesce until an explicit boundary is encountered. Callers that
+/// perform one logical edit through several callbacks (currently IME
+/// composition) bracket those changes with `begin_transaction` and
+/// `commit_transaction`.
+#[derive(Debug)]
+pub(crate) struct UndoManager {
+    undo_transactions: Vec<UndoTransaction>,
+    redo_transactions: Vec<UndoTransaction>,
+    ignoring: bool,
+    transaction_open: bool,
+    pending_change: Option<Change>,
+    pub(crate) pending_intent: Option<EditIntent>,
+    coalescing_boundary: bool,
+}
+
+impl UndoManager {
+    pub(super) fn new() -> Self {
+        Self {
+            undo_transactions: Vec::new(),
+            redo_transactions: Vec::new(),
+            ignoring: false,
+            transaction_open: false,
+            pending_change: None,
+            pending_intent: None,
+            coalescing_boundary: false,
+        }
+    }
+
+    pub(super) fn record_transaction(&mut self, change: Change, intent: EditIntent) {
+        if self.ignoring {
+            return;
+        }
+        if change.old_range == change.new_range && change.old_text == change.new_text {
+            self.break_transaction_coalescing();
+            return;
+        }
+
+        if self.transaction_open {
+            if let Some(pending) = self.pending_change.as_mut() {
+                pending.new_range = change.new_range;
+                pending.new_text = change.new_text;
+                pending.selection_after = change.selection_after;
+            } else {
+                self.pending_change = Some(change);
+            }
+        } else {
+            self.push_transaction(change, intent);
+        }
+    }
+
+    pub(super) fn begin_transaction(&mut self) {
+        if self.transaction_open {
+            return;
+        }
+        self.transaction_open = true;
+        self.pending_change = None;
+    }
+
+    pub(super) fn commit_transaction(&mut self) {
+        if !self.transaction_open {
+            return;
+        }
+        self.transaction_open = false;
+        if let Some(change) = self.pending_change.take()
+            && (change.old_range != change.new_range || change.old_text != change.new_text)
+        {
+            self.push_transaction(change, EditIntent::Atomic);
+        }
+    }
+
+    fn push_transaction(&mut self, change: Change, intent: EditIntent) {
+        self.redo_transactions.clear();
+        let can_coalesce = !self.coalescing_boundary
+            && intent != EditIntent::Atomic
+            && self.undo_transactions.last().is_some_and(|previous| {
+                previous.intent == intent
+                    && previous.changes.len() < MAX_CHANGES_PER_TRANSACTION
+                    && previous
+                        .changes
+                        .last()
+                        .is_some_and(|last| is_adjacent(intent, last, &change))
+            });
+
+        if can_coalesce {
+            self.undo_transactions
+                .last_mut()
+                .expect("coalescing requires a previous transaction")
+                .changes
+                .push(change);
+            return;
+        }
+
+        if self.undo_transactions.len() >= MAX_UNDO_TRANSACTIONS {
+            self.undo_transactions.remove(0);
+        }
+        self.undo_transactions.push(UndoTransaction {
+            intent,
+            changes: vec![change],
+        });
+        self.coalescing_boundary = intent == EditIntent::Atomic;
+    }
+
+    pub(super) fn break_transaction_coalescing(&mut self) {
+        self.commit_transaction();
+        self.coalescing_boundary = true;
+    }
+
+    pub(super) fn is_ignoring(&self) -> bool {
+        self.ignoring
+    }
+
+    pub(super) fn set_ignoring(&mut self, ignoring: bool) {
+        self.ignoring = ignoring;
+        if ignoring {
+            self.commit_transaction();
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.undo_transactions.clear();
+        self.redo_transactions.clear();
+        self.transaction_open = false;
+        self.pending_change = None;
+        self.pending_intent = None;
+        self.coalescing_boundary = false;
+    }
+
+    pub(super) fn undo(&mut self) -> Option<Vec<Change>> {
+        self.commit_transaction();
+        let transaction = self.undo_transactions.pop()?;
+        let changes = transaction.changes.iter().rev().cloned().collect();
+        self.redo_transactions.push(transaction);
+        self.coalescing_boundary = true;
+        Some(changes)
+    }
+
+    pub(super) fn redo(&mut self) -> Option<Vec<Change>> {
+        self.commit_transaction();
+        let transaction = self.redo_transactions.pop()?;
+        let changes = transaction.changes.clone();
+        self.undo_transactions.push(transaction);
+        self.coalescing_boundary = true;
+        Some(changes)
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_undos(&self) -> bool {
+        !self.undo_transactions.is_empty()
+    }
+}
+
+fn is_adjacent(intent: EditIntent, previous: &Change, current: &Change) -> bool {
+    match intent {
+        EditIntent::Typing => {
+            previous.old_range.is_empty()
+                && current.old_range.is_empty()
+                && !previous.new_text.contains(['\n', '\r'])
+                && !current.new_text.contains(['\n', '\r'])
+                && previous.new_range.end == current.old_range.start
+        }
+        EditIntent::Backspace => {
+            previous.new_text.is_empty()
+                && current.new_text.is_empty()
+                && current.old_range.end == previous.old_range.start
+        }
+        EditIntent::DeleteForward => {
+            previous.new_text.is_empty()
+                && current.new_text.is_empty()
+                && current.old_range.start == previous.old_range.start
+        }
+        EditIntent::Atomic => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::Selection;
+
+    fn typing_change(offset: usize, text: &str) -> Change {
+        let end = offset + text.len();
+        Change::new(
+            offset..offset,
+            "",
+            offset..end,
+            text,
+            Selection::new(offset, offset),
+            Selection::new(end, end),
+        )
+    }
+
+    #[test]
+    fn adjacent_typing_transactions_coalesce() {
+        let mut manager = UndoManager::new();
+        manager.record_transaction(typing_change(0, "a"), EditIntent::Typing);
+        manager.record_transaction(typing_change(1, "b"), EditIntent::Typing);
+
+        assert_eq!(manager.undo().unwrap().len(), 2);
+        assert!(manager.undo().is_none());
+    }
+
+    #[test]
+    fn explicit_transaction_collects_multiple_changes() {
+        let mut manager = UndoManager::new();
+        manager.begin_transaction();
+        manager.record_transaction(typing_change(0, "a"), EditIntent::Typing);
+        manager.record_transaction(typing_change(0, "ab"), EditIntent::Typing);
+        manager.commit_transaction();
+
+        let transaction = manager.undo().unwrap();
+        assert_eq!(transaction.len(), 1);
+        assert_eq!(transaction[0].new_text, "ab");
+    }
+
+    #[test]
+    fn limits_the_number_of_retained_transactions() {
+        let mut manager = UndoManager::new();
+
+        for offset in 0..1_100 {
+            manager.record_transaction(typing_change(offset, "a"), EditIntent::Atomic);
+        }
+
+        for _ in 0..MAX_UNDO_TRANSACTIONS {
+            assert!(manager.undo().is_some());
+        }
+        assert!(manager.undo().is_none());
+    }
+
+    #[test]
+    fn splits_a_coalesced_transaction_before_its_change_list_grows_too_large() {
+        let mut manager = UndoManager::new();
+
+        for offset in 0..1_100 {
+            manager.record_transaction(typing_change(offset, "a"), EditIntent::Typing);
+        }
+
+        assert_eq!(manager.undo().unwrap().len(), 100);
+        assert_eq!(manager.undo().unwrap().len(), MAX_CHANGES_PER_TRANSACTION);
+        assert!(manager.undo().is_none());
+    }
+}

--- a/crates/base/src/input/mod.rs
+++ b/crates/base/src/input/mod.rs
@@ -54,6 +54,8 @@ mod selection;
 #[path = "base/state.rs"]
 mod state;
 mod textarea;
+#[path = "base/undo_manager.rs"]
+mod undo_manager;
 
 pub(crate) fn init(cx: &mut App) {
     state::init(cx);

--- a/docs/ACCESSIBILITY-UI-TESTING.md
+++ b/docs/ACCESSIBILITY-UI-TESTING.md
@@ -1,0 +1,75 @@
+# Accessibility-driven UI testing
+
+Use the macOS accessibility tree for interactive UI verification. This is the
+default manual testing method for component behavior that depends on focus,
+keyboard input, selection, menus, or other real window-system state.
+
+## Start the application
+
+Run the Story gallery as a signed macOS application bundle:
+
+```sh
+./script/run-story-macos
+```
+
+Do not use a bare `cargo run` process for accessibility testing. macOS cannot
+reliably address an unbundled executable as an application. The script builds
+`/tmp/GPUIComponentStory.app`, assigns the stable bundle identifier
+`com.longbridge.gpui-component-story`, signs it locally, and starts its binary.
+
+## Drive the accessibility tree
+
+1. Read the complete accessibility tree for
+   `com.longbridge.gpui-component-story`.
+2. Locate controls by role, accessible label, placeholder, and current value.
+3. Prefer actions on accessibility element indexes over screen coordinates.
+4. After every state-changing action, fetch the tree again. Element indexes
+   are snapshots and must not be reused without verifying the current tree.
+5. Assert behavior from semantic properties such as role, enabled/settable
+   state, value, label, focus, selection, and exposed secondary actions.
+6. Use screenshots only when the accessibility tree cannot express a visual
+   requirement. Coordinate input is a fallback, not the default.
+
+The gallery search field can navigate directly to a story. For example, set
+the `Search…` text field to `Input` to expose the Input story controls in the
+tree.
+
+## Keyboard interaction tests
+
+Use real key events after focusing the target through the accessibility tree.
+For an editable component, cover the interaction boundaries relevant to the
+change:
+
+- typing and editing values;
+- focus and keyboard navigation;
+- selection movement and replacement;
+- undo and redo;
+- Backspace versus Forward Delete;
+- paste, cut, Enter, Escape, and other command boundaries;
+- disabled, read-only, and secret-value accessibility behavior.
+
+Read the tree after each checkpoint and assert the control's exposed value.
+For undo history, a representative sequence is:
+
+```text
+type "ab" -> Left -> type "x" -> value "axb"
+Undo                                -> value "ab"
+Undo                                -> empty
+Redo                                -> value "ab"
+```
+
+Also verify that a no-op edit, such as Backspace at offset zero, does not
+destroy an existing redo branch.
+
+## Required completion evidence
+
+For UI-affecting changes, report:
+
+- the app and story tested;
+- the accessibility roles/labels used to find the controls;
+- the input sequence and values observed at each checkpoint;
+- any behavior that required screenshot or coordinate fallback;
+- automated test, formatting, and lint results separately.
+
+Accessibility-driven testing complements Rust tests. It does not replace unit
+or integration coverage for the same state transitions.

--- a/docs/research/undo-manager-design.md
+++ b/docs/research/undo-manager-design.md
@@ -1,0 +1,153 @@
+# Undo Manager Design Research
+
+Research date: 2026-08-15
+
+## Conclusion
+
+The `gpui-base` input history should not keep using the rule “merge every edit that occurs within the same time window.” An undoable operation should first be represented as an explicit **editing transaction**, after which a separate policy decides whether compatible transactions may coalesce. Wall-clock time does not define a boundary; edit intent, spatial continuity, and explicit structural boundaries do.
+
+The recommended model is:
+
+1. Every text mutation first creates a transaction. Adjacent ordinary typing, Backspace, or Forward Delete transactions of the same kind may coalesce.
+2. Coalescing does not use wall-clock time. A pause neither ends nor extends a transaction.
+3. Cursor or selection movement creates no text transaction, but it breaks coalescing. A newline is always an independent structural transaction.
+4. One IME composition produces one undo unit. Intermediate marked-text updates do not create separate history entries.
+5. Any new recorded edit after undo immediately clears the redo branch.
+6. Formatting, auto-indentation, or other commands that produce several changes must explicitly wrap those changes in one transaction.
+7. Both retained transaction count and changes within one coalesced transaction are bounded, preventing either stack layer from growing without limit.
+
+Platform text-input callbacks do not map one-to-one to undo transactions. Several adjacent callbacks may coalesce, an input method may commit several characters in one callback, and one composition may span several callbacks while remaining one explicit transaction.
+
+## Problems in the Previous Implementation
+
+Before this change, [`InputBaseState`](../../crates/base/src/input/base/state.rs) initialized history with `History::new().group_interval(Duration::from_secs(1))`. The generic [`History`](../../crates/base/src/history.rs) implementation only used elapsed time in `inc_version`; unrelated typing, deletion, paste, or replacement operations received the same version whenever they occurred within the configured interval.
+
+Source inspection also identified two independent problems:
+
+- `History::push` did not clear `redos`, so a new edit after undo did not create a new linear history branch.
+- `start_grouping` and `end_grouping` only prevented version increments. They did not express edit intent such as typing, backward deletion, or paste, and could not validate spatial continuity.
+
+Changing one second to 500 milliseconds therefore could not fix the underlying model.
+
+## Primary-Source Comparison
+
+### Browser Input Events Semantics
+
+W3C Input Events Level 2 distinguishes intents including `insertText`, `insertCompositionText`, `insertFromPaste`, `insertReplacementText`, `insertParagraph` / `insertLineBreak`, `deleteContentBackward` / `deleteContentForward`, word- and line-based deletion, and `historyUndo` / `historyRedo`. Platform events therefore expose richer semantics than the time at which text happened to change. [Input Events Level 2: `inputType` table](https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes)
+
+The specification defines `historyUndo` as undoing the previous editing action and `historyRedo` as redoing the previous undone editing action, but it does not prescribe how a browser must divide keystrokes into actions. No universal timing threshold can be derived from the Web specification; the useful part is its intent taxonomy, not unspecified browser grouping behavior. [Input Events Level 2: `inputType` table](https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes)
+
+During IME input, composition events and `insertCompositionText` input events form a sequence with explicit start and end boundaries. The specification also notes that `beforeinput` events within a composition are not cancelable. History should not save every temporary candidate update as ordinary typing. [Input Events Level 2: event order during composition](https://www.w3.org/TR/input-events-2/#events-composition)
+
+Paste has its own `insertFromPaste` intent and event sequence. It should be an independent undo unit rather than merge into nearby typing merely because the events are close in time. [Input Events Level 2: paste event order](https://www.w3.org/TR/input-events-2/#event-order-when-using-insertfrompaste)
+
+### macOS AppKit Text System
+
+`NSTextView` exposes `isCoalescingUndo` and provides `breakUndoCoalescing()` so subsequent typing begins a new undo grouping. The native macOS model is therefore “coalesce successive typing, then break on explicit events,” not fixed time slicing. [Apple `NSTextView`](https://developer.apple.com/documentation/appkit/nstextview); [Apple `breakUndoCoalescing()`](https://developer.apple.com/documentation/appkit/nstextview/breakundocoalescing())
+
+A minimal native `NSTextView` probe confirmed that rapidly typing `abc` is undone in one operation, and a 2.5-second pause does not split it. Inserting after cursor movement creates a new undo item. AppKit also coalesces consecutive Return presses with typing by default and may include deletion immediately following typing in the same item. This design therefore adopts AppKit’s explicit coalescing lifecycle without copying all of its boundary choices. Editor newlines, deletion-direction changes, and structural commands use finer explicit boundaries.
+
+The same probe compared a single-line `NSTextField` with a multiline `NSTextView`. They behave alike for continuous typing, pauses, keyboard movement, and mouse-driven insertion-point changes. Their editing sessions differ: Return commits the single-line field-editor session, and the next edit uses the committed value as its baseline, so Undo returns to that value. In a multiline view, Return is a text mutation and AppKit may coalesce it with surrounding typing. Accordingly, `gpui-base` breaks transaction coalescing on single-line Return, `submit_on_enter`, and blur, while an ordinary multiline Return is an independent structural transaction. It does not copy the `NSTextField` selection behavior that selects the old value when a new editing session begins.
+
+### ProseMirror
+
+ProseMirror defaults `newGroupDelay` to 500 milliseconds, but its documentation states that non-adjacent changes always start a new group. Its `applyTransaction` implementation checks both time and `isAdjacentTo`, so time is only the maximum interval for otherwise adjacent edits. [Official API](https://prosemirror.net/docs/ref/#history.history); [official `applyTransaction` source](https://github.com/ProseMirror/prosemirror-history/blob/445409bc99c88550c2312f5610829ecb25105a5f/src/history.ts#L260-L312)
+
+It also provides `closeHistory(transaction)` to force a boundary and `addToHistory: false` for programmatic transactions that should not enter the undo stack. [Official API](https://prosemirror.net/docs/ref/#history.closeHistory); [official source](https://github.com/ProseMirror/prosemirror-history/blob/445409bc99c88550c2312f5610829ecb25105a5f/src/history.ts#L360-L394)
+
+Transactions with the same composition ID receive special handling so ordinary time and adjacency checks do not split one composition. When a normal new edit enters the done branch, the undone branch is replaced with `Branch.empty`, clearing redo. [Official source](https://github.com/ProseMirror/prosemirror-history/blob/445409bc99c88550c2312f5610829ecb25105a5f/src/history.ts#L277-L287)
+
+### Lexical
+
+Lexical’s default delay is 300 milliseconds, but automatic merging also requires an identical change type, the same editor, and a change within the window. Its change classification distinguishes single-character insertion, Backspace, Forward Delete, composition, and other edits. Non-collapsed selections, incompatible nodes or positions, and complex mutations become `OTHER` and create a new history entry. [Official change-classification source](https://github.com/facebook/lexical/blob/3359e9c6f0cc48d95355b25f42dc5b6eaca4489b/packages/lexical-history/src/index.ts#L105-L205); [official merge and delay source](https://github.com/facebook/lexical/blob/3359e9c6f0cc48d95355b25f42dc5b6eaca4489b/packages/lexical-history/src/index.ts#L251-L375)
+
+Lexical explicitly classifies paste and cut tags as `OTHER`, preventing clipboard operations from merging with typing on either side. It also provides `HISTORY_PUSH_TAG` and `HISTORY_MERGE_TAG` for explicit transaction control. [Official source](https://github.com/facebook/lexical/blob/3359e9c6f0cc48d95355b25f42dc5b6eaca4489b/packages/lexical-history/src/index.ts#L300-L345)
+
+Intermediate composition states do not each create candidate history entries. At composition end, Lexical re-evaluates the pre-composition state, timestamp, and change type so the complete input process is handled as a unit. [Official source](https://github.com/facebook/lexical/blob/3359e9c6f0cc48d95355b25f42dc5b6eaca4489b/packages/lexical-history/src/index.ts#L263-L305)
+
+Lexical clears `redoStack` when it pushes a new history entry. [Official source](https://github.com/facebook/lexical/blob/3359e9c6f0cc48d95355b25f42dc5b6eaca4489b/packages/lexical-history/src/index.ts#L518-L546)
+
+### Slate
+
+Slate’s default rules use no timing window. They merge only strictly continuous `insert_text` operations on the same path and strictly continuous `remove_text` operations in the Backspace direction. Other operations naturally start a new batch. `set_selection` is not itself saved to history, but after cursor movement the next text operation normally cannot satisfy spatial adjacency. [Official source](https://github.com/ianstormtaylor/slate/blob/ec793483ada7f7e21ebc82c2b3aa9ea674605ce3/packages/slate-history/src/with-history.ts#L68-L157)
+
+Slate provides `withNewBatch`, `withoutMerging`, `withMerging`, and `withoutSaving`, demonstrating that explicit transaction boundaries are necessary history controls. [Official documentation](https://docs.slatejs.org/libraries/slate-history/history-editor)
+
+After saving each new operation, Slate assigns `history.redos = []`. Undo and redo move batches inside `withoutSaving` so those operations are not recorded as new edits. [Official source](https://github.com/ianstormtaylor/slate/blob/ec793483ada7f7e21ebc82c2b3aa9ea674605ce3/packages/slate-history/src/with-history.ts#L20-L115)
+
+### CodeMirror 6
+
+CodeMirror defaults `newGroupDelay` to 500 milliseconds, but automatic merging is limited to `input.type*` and `delete*` user events and also requires adjacent change ranges. Paste, structural commands, and other user events are not automatically merged. [Official API](https://codemirror.net/docs/ref/#commands.history); [official source](https://github.com/codemirror/history/blob/3c41743067bc405faa0b9cbe0c81ef1e6f7cd627/src/history.ts#L302-L328)
+
+Selection history is recorded separately. An existing selection event prevents an ordinary change from merging into an earlier change. `isolateHistory("before" | "after" | "full")` establishes an explicit boundary on either side. [Official selection and change-merging source](https://github.com/codemirror/history/blob/3c41743067bc405faa0b9cbe0c81ef1e6f7cd627/src/history.ts#L302-L342); [official explicit-boundary source](https://github.com/codemirror/history/blob/3c41743067bc405faa0b9cbe0c81ef1e6f7cd627/src/history.ts#L10-L16)
+
+`input.type.compose` always merges into the previous event so one composition is not split. Adding a new change constructs `HistoryState(done, none, ...)`, clearing the undone/redo branch. [Official source](https://github.com/codemirror/history/blob/3c41743067bc405faa0b9cbe0c81ef1e6f7cd627/src/history.ts#L314-L328)
+
+## Recommended Rules for `gpui-base`
+
+“Previous item” means the latest transaction that remains eligible for coalescing. Except for operations marked “not recorded,” every real text edit stores the selection before and after the change so undo and redo can restore the insertion point or selection.
+
+| Current operation | May coalesce with previous? | Required conditions | Notes |
+|---|---:|---|---|
+| Ordinary text input at a collapsed selection | Yes | Previous item is ordinary input; insertion positions are strictly adjacent; no explicit boundary occurred | Independent of typing speed, whitespace, punctuation, or language |
+| Single-character Backspace | Yes | Previous item is Backspace; deletion ranges are strictly adjacent to the left | Separate from ordinary input and Forward Delete |
+| Single-character Forward Delete | Yes | Previous item is Forward Delete; deletion occurs at the same logical position | Separate from ordinary input and Backspace |
+| IME marked-text update | Not as an independent item | Keep the composition transaction open | Temporary candidates are not separate committed edits |
+| IME commit | No; creates one item | Snapshot from before composition through final committed result | One composition, one undo operation; subsequent ordinary typing starts separately |
+| Replace a non-empty selection | No | — | The selected range and inserted text form one atomic operation |
+| Paste, cut, or drag-and-drop | No | — | Independent user intent; creates boundaries on both sides |
+| Enter / newline | No | — | A structural intent in textarea/editor; keeps undo granularity stable and predictable |
+| Single-line Return / `submit_on_enter` | Creates no text item, but breaks | — | Commits the current editing session; subsequent input starts another transaction |
+| Blur / refocus | Creates no text item, but breaks | — | Input on opposite sides of blur cannot coalesce; existing history remains intact |
+| Word- or line-based deletion | No | — | One command is one undo unit and does not merge with character deletion |
+| Formatting, auto-indent, or code operation | No, or explicitly merged | Declared by the caller | Derived mutations from one user command should undo atomically |
+| Programmatic replacement such as `replace_all` | No | — | If undoable, it is an independent item; ordinary `set_value` may explicitly reset history |
+| Cursor or selection movement only | Creates no text item | — | Does not clear redo; subsequent input naturally starts a new transaction |
+| Undo / redo | Not recorded as a new edit | — | Moves existing transactions between branches and restores their selections |
+| New edit after undo | No | — | Clears the entire redo branch when the new edit is recorded |
+
+Frameworks do not fully agree on whether newlines may merge with continuous typing. CodeMirror may merge some newlines based on user-event and adjacency rules, while paragraph splitting is a complex structural change in rich-text frameworks. Because `gpui-base` serves Input, Textarea, and Editor, treating explicit Enter as a boundary is simpler and more predictable. This is a product-design decision, not a Web-platform requirement.
+
+## Recommended Data Model
+
+The generic `History<I>` should not use wall-clock time to assign arbitrary items the same version. The Input layer owns grouping decisions because only it knows edit intent, selection state, composition state, and text ranges.
+
+The private `UndoManager` stores:
+
+- private Input undo and redo transaction stacks, leaving the public `History<T>` API and behavior unchanged;
+- an `EditIntent` and one or more `Change` values for each transaction;
+- `transaction_open`, indicating whether an explicit compound transaction is being collected;
+- `pending_change`, aggregating the state from before a compound transaction through its current result;
+- `coalescing_boundary`, indicating that the next item cannot merge with the previous transaction;
+- `selection_before` and `selection_after` on every `Change`.
+
+Recording a new change follows these steps:
+
+1. If the change does not mutate text, do not push it or clear redo.
+2. If an explicit transaction is open, aggregate the change into `pending_change`.
+3. Otherwise, first create a transaction, then compare edit intent, modified ranges, and explicit boundaries. Coalesce compatible transactions; otherwise push a new one.
+4. `break_transaction_coalescing` establishes a boundary without creating an empty undo item or clearing redo.
+5. `commit_transaction` commits explicit compound operations such as IME composition. No time-based open group exists.
+6. Stop coalescing when a transaction reaches the per-transaction change limit, and discard the oldest retained transaction when the stack reaches its outer limit.
+
+Every path that writes a new undo transaction must clear redo. Selection-only movement breaks coalescing but must not clear redo because the document has not created a new history branch.
+
+## Recommended Acceptance Cases
+
+- Rapidly type, or pause while typing, a long single line. One undo removes the continuous input; elapsed time does not change the result.
+- Type several long lines. Each Enter is independent from the text on either side, and undo never crosses a newline boundary.
+- Continue typing after Return in a single-line input or a `submit_on_enter` textarea. The first undo removes only the post-submit input.
+- Blur, refocus, and continue typing. The first undo does not cross the blur boundary.
+- Type `ab`, move the cursor, then type `x`. The first undo removes only `x`.
+- Type, paste immediately, then continue typing. The three segments undo independently.
+- Consecutive Backspace operations may coalesce. Backspace, Forward Delete, and ordinary input never merge with one another.
+- Replace a text selection by typing. The replacement is one undo unit and does not merge with typing on either side.
+- Enter / newline remains independent from typing on both sides.
+- One IME composition containing several marked-text updates requires one undo. Canceling composition leaves no ineffective history item.
+- Undo and redo restore both text and selection. Typing after undo immediately invalidates redo.
+- `replace_all`, mask rewrites, formatting, and other compound mutations undo atomically without range corruption.
+- Selection movement that does not enter history preserves redo; a real new text edit clears it.
+
+## Final Decision
+
+Use a transaction-first model. Every edit first forms a transaction; compatible, spatially continuous ordinary typing or same-direction deletion may coalesce. Composition and other compound operations use an explicit lifecycle. Cursor movement and structural commands explicitly break coalescing, and wall-clock time never defines a boundary. This preserves the familiar feel of continuous macOS typing while giving newlines, clipboard operations, replacements, and command deletion stable boundaries.


### PR DESCRIPTION
## Summary

- implement transaction-first input history with explicit begin/commit and coalescing boundaries
- coalesce adjacent same-kind typing and directional deletes without a time threshold, while isolating cursor/selection movement, newlines, paste, cut, command deletes, replacements, and programmatic edits
- model editing-session boundaries: blur and non-inserting Return (`Input` / `submit_on_enter`) break coalescing, while multiline Return is an independent structural transaction
- preserve exact selections across undo/redo, keep IME composition atomic, preserve redo across no-op edits, and clear redo only for real new edits
- document the macOS accessibility-driven UI testing workflow and native AppKit behavior research

## Test Plan

- native AppKit comparison of `NSTextField` and `NSTextView`: rapid typing, 2.5s pause, mouse/keyboard cursor changes, Return, focus sessions, multiline input, and deletion
- signed Story Input and Editor via macOS accessibility tree: long multiline input, newline boundaries, single-line Return sessions, cut, paste, and repeated Backspace
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p gpui-base input_history -- --nocapture` (29 history scenarios)
- `cargo test -p gpui-base`
- `cargo clippy -p gpui-base --all-targets -- --deny warnings`