### PR TITLE
text: extend TextView selection on shift-click

### DIFF
--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -143,8 +143,19 @@ impl<E: Element> Element for SelectionScopeMarker<E> {
 pub struct WindowTextSelection {
     pub(crate) anchor: Option<SelectionEndpoint>,
     pub(crate) cursor: Option<SelectionEndpoint>,
+    /// Anchor staged during capture for a Shift+click. Capture still clears the
+    /// visible selection so a component that stops bubble propagation cannot
+    /// leave stale highlights; an unsuppressed bubble handler consumes this to
+    /// extend the selection.
+    pending_extension_anchor: Option<SelectionEndpoint>,
     pub(crate) is_selecting: bool,
     pub(crate) did_hit_text: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SelectionStart {
+    Begin,
+    Extend,
 }
 
 /// A selection endpoint, content-anchored to a TextView.
@@ -374,6 +385,7 @@ impl Root {
         let had_window_selection = self.text_selection.anchor.is_some();
         self.text_selection.anchor = None;
         self.text_selection.cursor = None;
+        self.text_selection.pending_extension_anchor = None;
         self.text_selection.is_selecting = false;
         self.text_selection.did_hit_text = false;
         self.selectable_text_views.retain(|_, (view, _, _)| {
@@ -423,9 +435,10 @@ impl Root {
         }
     }
 
-    pub(crate) fn start_text_selection(
+    fn start_text_selection(
         &mut self,
         position: Point<Pixels>,
+        start: SelectionStart,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -441,18 +454,38 @@ impl Root {
         if endpoint.inside {
             if let Some(view) = endpoint.view.as_ref().and_then(|v| v.upgrade()) {
                 view.update(cx, |state, cx| {
-                    state.is_selecting = true;
                     state.focus_handle.focus(window, cx);
                 });
             }
         }
-        self.text_selection.anchor = Some(endpoint.clone());
+        let extension_anchor = (start == SelectionStart::Extend)
+            .then(|| self.text_selection.pending_extension_anchor.take())
+            .flatten()
+            .filter(|anchor| anchor.resolve(cx).is_some());
+        self.text_selection.pending_extension_anchor = None;
+
+        self.text_selection.anchor = Some(extension_anchor.unwrap_or_else(|| endpoint.clone()));
         self.text_selection.cursor = Some(endpoint);
+        if let Some(view) = self
+            .text_selection
+            .anchor
+            .as_ref()
+            .filter(|endpoint| endpoint.inside)
+            .and_then(|endpoint| endpoint.view.as_ref())
+            .and_then(|view| view.upgrade())
+        {
+            view.update(cx, |state, _| state.is_selecting = true);
+        }
         self.text_selection.did_hit_text = self
             .text_selection
             .anchor
             .as_ref()
-            .is_some_and(|endpoint| endpoint.inside_text);
+            .is_some_and(|endpoint| endpoint.inside_text)
+            || self
+                .text_selection
+                .cursor
+                .as_ref()
+                .is_some_and(|endpoint| endpoint.inside_text);
         self.text_selection.is_selecting = true;
     }
 
@@ -505,6 +538,7 @@ impl Root {
     }
 
     pub(crate) fn end_text_selection(&mut self, cx: &mut Context<Self>) {
+        self.text_selection.pending_extension_anchor = None;
         if !self.text_selection.is_selecting {
             return;
         }
@@ -821,20 +855,35 @@ impl Element for TextSelectionController {
             }
             if phase.capture() {
                 // Reset the suppression flag at the start of every press, then
-                // clear the previous selection (browser behavior), even when an
-                // interactive component consumes the event in the bubble phase.
+                // stage the anchor needed by Shift+click before clearing the
+                // previous selection. Clearing in capture preserves the existing
+                // behavior even when a component stops bubble propagation.
                 GlobalState::reset_text_selection_suppression(cx);
-                Root::update(window, cx, |root, _, cx| root.clear_text_selection(cx));
+                Root::update(window, cx, |root, _, cx| {
+                    let extension_anchor = (event.click_count == 1 && event.modifiers.shift)
+                        .then(|| root.text_selection.anchor.clone())
+                        .flatten();
+                    root.clear_text_selection(cx);
+                    root.text_selection.pending_extension_anchor = extension_anchor;
+                });
             } else if event.click_count == 1 {
                 // Reaching bubble phase means no component stopped propagation.
                 // Components that own their own press (Button, Input, etc.) set
                 // `suppress_text_selection` in their bubble handler; if set, the
                 // press is theirs and must not start a window selection.
                 if GlobalState::is_text_selection_suppressed(cx) {
+                    Root::update(window, cx, |root, _, _| {
+                        root.text_selection.pending_extension_anchor = None;
+                    });
                     return;
                 }
                 Root::update(window, cx, |root, window, cx| {
-                    root.start_text_selection(event.position, window, cx);
+                    let start = if event.modifiers.shift {
+                        SelectionStart::Extend
+                    } else {
+                        SelectionStart::Begin
+                    };
+                    root.start_text_selection(event.position, start, window, cx);
                 });
             }
         });
@@ -1313,6 +1362,138 @@ mod tests {
     fn window_selected_text(cx: &mut VisualTestContext) -> String {
         use crate::WindowExt as _;
         cx.update(|window, cx| window.selected_text(cx))
+    }
+
+    fn click(
+        cx: &mut VisualTestContext,
+        position: gpui::Point<gpui::Pixels>,
+        modifiers: Modifiers,
+    ) {
+        cx.simulate_mouse_down(position, MouseButton::Left, modifiers);
+        cx.simulate_mouse_up(position, MouseButton::Left, modifiers);
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+    }
+
+    fn shift_modifiers() -> Modifiers {
+        Modifiers {
+            shift: true,
+            ..Modifiers::default()
+        }
+    }
+
+    #[gpui::test]
+    fn shift_click_extends_from_previous_plain_click(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        click(cx, point(px(0.), px(15.)), Modifiers::default());
+        click(cx, point(px(300.), px(15.)), shift_modifiers());
+
+        assert_eq!(window_selected_text(cx).trim(), "Hello world");
+    }
+
+    #[gpui::test]
+    fn shift_click_reuses_anchor_for_repeated_extension(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+        let anchor = point(px(0.), px(15.));
+
+        click(cx, anchor, Modifiers::default());
+        click(cx, point(px(300.), px(15.)), shift_modifiers());
+        assert_eq!(window_selected_text(cx).trim(), "Hello world");
+
+        click(cx, anchor, shift_modifiers());
+        assert_eq!(window_selected_text(cx), "");
+    }
+
+    #[gpui::test]
+    fn shift_click_keeps_anchor_when_cursor_crosses_it(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+        let anchor = point(px(20.), px(15.));
+
+        click(cx, anchor, Modifiers::default());
+        click(cx, point(px(300.), px(15.)), shift_modifiers());
+        assert_eq!(window_selected_text(cx).trim(), "llo world");
+
+        click(cx, point(px(0.), px(15.)), shift_modifiers());
+        assert_eq!(window_selected_text(cx).trim(), "He");
+    }
+
+    #[gpui::test]
+    fn shift_drag_keeps_previous_plain_click_as_anchor(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+        let modifiers = shift_modifiers();
+
+        click(cx, point(px(0.), px(15.)), Modifiers::default());
+        cx.simulate_mouse_down(point(px(20.), px(15.)), MouseButton::Left, modifiers);
+        cx.simulate_mouse_move(point(px(300.), px(70.)), Some(MouseButton::Left), modifiers);
+        cx.simulate_mouse_up(point(px(300.), px(70.)), MouseButton::Left, modifiers);
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert_eq!(
+            window_selected_text(cx).trim(),
+            "Hello world\n\nSecond message"
+        );
+    }
+
+    #[gpui::test]
+    fn shift_click_uses_anchor_established_by_latest_plain_click(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+        let start = point(px(0.), px(15.));
+        let end = point(px(300.), px(15.));
+        let new_anchor = point(px(20.), px(15.));
+
+        click(cx, start, Modifiers::default());
+        click(cx, end, shift_modifiers());
+        assert_eq!(window_selected_text(cx).trim(), "Hello world");
+
+        click(cx, new_anchor, Modifiers::default());
+        click(cx, start, shift_modifiers());
+        assert_eq!(window_selected_text(cx).trim(), "He");
+    }
+
+    #[gpui::test]
+    fn shift_click_without_anchor_falls_back_to_plain_click(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        click(cx, point(px(20.), px(15.)), shift_modifiers());
+
+        assert_eq!(window_selected_text(cx), "");
+    }
+
+    #[gpui::test]
+    fn shift_click_extends_across_text_views(cx: &mut TestAppContext) {
+        let (chat, cx) = setup(true, cx);
+
+        click(cx, point(px(0.), px(15.)), Modifiers::default());
+        click(cx, point(px(300.), px(70.)), shift_modifiers());
+
+        let text = window_selected_text(cx);
+        assert!(text.contains("Hello world"), "got: {text:?}");
+        assert!(text.contains("Second message"), "got: {text:?}");
+        let (first_selecting, second_selecting) = cx.update(|_, cx| {
+            let chat = chat.read(cx);
+            (
+                chat.first.read(cx).is_selecting,
+                chat.second.read(cx).is_selecting,
+            )
+        });
+        assert!(!first_selecting);
+        assert!(!second_selecting);
+    }
+
+    #[gpui::test]
+    fn shift_click_on_suppressing_control_clears_text_view_selection(cx: &mut TestAppContext) {
+        let (_, cx) = setup(true, cx);
+
+        drag(cx, point(px(0.), px(15.)), point(px(300.), px(70.)));
+        assert!(!window_selected_text(cx).is_empty());
+
+        click(cx, point(px(20.), px(100.)), shift_modifiers());
+
+        assert_eq!(window_selected_text(cx), "");
     }
 
     #[gpui::test]

--- a/docs/research/2026-08-15-textview-shift-click-selection.md
+++ b/docs/research/2026-08-15-textview-shift-click-selection.md
@@ -1,0 +1,95 @@
+# TextView Shift+click selection research
+
+Date: 2026-08-15
+
+## Decision
+
+Implement `TextView` Shift+click as selection extension around a stable anchor:
+
+- An ordinary single click establishes a new anchor and a coincident cursor.
+- Shift+click keeps that anchor and moves only the cursor to the clicked endpoint.
+- Repeated Shift+click keeps the same anchor. If the cursor crosses the anchor, the visual selection reverses direction; the anchor itself does not move.
+- A Shift+mousedown followed by dragging begins by extending to the pressed endpoint, then continues moving that same cursor endpoint.
+- A later ordinary click starts a new anchor.
+
+This matches both this repository's editable Input/Editor engine and Zed's Editor. Apple explicitly documents Shift-click extension and subsequent Shift-clicks; the precise stable-character-anchor rule is an implementation conclusion from Apple's anchored/non-anchored selection model plus the two concrete editor implementations, rather than a sentence Apple states verbatim.
+
+## Apple/AppKit evidence
+
+Apple's [`NSTextView.selectionGranularity`](https://developer.apple.com/documentation/appkit/nstextview/selectiongranularity) documentation is the most direct behavioral source. It says selection granularity controls how a selection is modified when the user Shift-clicks or drags after a multiple click, and specifically says that **subsequent Shift-clicks** extend a word selection by words. This proves that Shift-click is an extension gesture, repeated Shift-click continues an existing selection, and the initial click count's character/word/line-like granularity survives into later extension gestures.
+
+Apple's archived [Text Editing Programming Guide: Setting Focus and Selection Programmatically](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextEditing/Tasks/SetFocus.html) explains that `NSTextView` repeatedly calls `setSelectedRange(_:affinity:stillSelecting:)` while tracking a user's selection and that the initial click count determines granularity. This supports treating the down-and-drag sequence as updates to one selection rather than unrelated selections.
+
+Apple's current [`NSTextSelection`](https://developer.apple.com/documentation/appkit/nstextselection) model describes affinity in terms of the direction of the selection's **non-anchored edge**, and describes `anchorPositionOffset` relative to the initial tap or click. The latter is a visual line-fragment offset, not itself a character-index selection anchor, so it should not be cited as direct proof of the exact character anchor. Together these APIs nevertheless establish Apple's anchored-edge/non-anchored-edge model.
+
+What Apple documents directly:
+
+- Shift-click modifies/extends a selection.
+- Subsequent Shift-clicks keep extending it.
+- Dragging and Shift-click extension retain the selection granularity established by the initial click count.
+- A selection has anchored and non-anchored edges.
+
+What is inferred rather than stated verbatim in Apple's prose:
+
+- click A, Shift-click B, then Shift-click C keeps A as the exact character anchor;
+- crossing A reverses direction without replacing A;
+- Shift+drag uses precisely the same character anchor.
+
+Those inferred details are strongly corroborated by the local Input/Editor implementation and Zed's Editor below.
+
+## This repository: Input and Editor
+
+`crates/ui/src/input/editor.rs` is only the styled wrapper. Its `RenderOnce` implementation renders the same `Input` element used by the other editable controls (currently lines 112–129). `crates/ui/src/input/state.rs` dispatches Input, Textarea, and Editor to their shared base engine (currently lines 29–148). The actual selection behavior is therefore in `crates/base/src/input/base/state.rs`.
+
+The relevant flow is:
+
+1. [`InputBaseState::on_mouse_down`](../../crates/base/src/input/base/state.rs) (currently lines 1619–1675) converts the pointer to an offset. On a plain click it calls `move_to(offset, None, cx)`; on Shift+click it calls `select_to(offset, cx)` without first resetting the selection.
+2. [`InputBaseState::cursor`](../../crates/base/src/input/base/state.rs) (currently lines 1949–1962) defines the moving end as `selected_range.start` when `selection_reversed`, otherwise `selected_range.end`.
+3. [`InputBaseState::select_to`](../../crates/base/src/input/base/state.rs) (currently lines 2098–2132) changes only that moving end. When it crosses the fixed end, it swaps the normalized range and toggles `selection_reversed`. This preserves the original anchor while allowing selection direction to flip.
+4. [`InputBaseState::on_drag_move`](../../crates/base/src/input/base/state.rs) (currently lines 2291–2329) repeatedly calls the same `select_to`. Consequently Shift+mousedown first extends from the pre-existing anchor, and subsequent movement continues from that anchor.
+
+No dedicated Shift+mouse regression test was found in `crates/base/src/input`; the conclusion above comes directly from the production control flow and state transition logic. This behavior applies equally to this repository's Input, Textarea, and Editor because all three dispatch to the shared engine.
+
+## Current TextView behavior and gap
+
+Window-level TextView selection is stored in `WindowTextSelection` in [`crates/ui/src/text/window_selection.rs`](../../crates/ui/src/text/window_selection.rs) (currently lines 137–179). It already has exactly the needed representation: a separate `anchor`, `cursor`, and `is_selecting` flag. A zero-length click remains represented internally by coincident endpoints even though `resolved_points` returns no visible selection for equal points (currently lines 204–217).
+
+The missing behavior is in the root mouse controller in the same file (currently lines 818–840):
+
+- every left-button mouse-down clears the previous selection unconditionally during capture (lines 822–827), without looking at `event.modifiers.shift`;
+- the bubble phase then calls `start_text_selection`, which assigns **both** `anchor` and `cursor` to the new endpoint (currently lines 426–457).
+
+Thus a plain click already leaves the right latent anchor state, but the next Shift+click destroys it before it can be reused. The existing drag update path already moves only `cursor` (`update_text_selection`, currently lines 459–505), so it is compatible with stable-anchor Shift+drag once selection start distinguishes “begin” from “extend.”
+
+Existing nearby coverage includes plain-click clearing (`mouse_down_clears_previous_selection`, currently lines 1480–1494) and double-click word selection (starting at line 1496), but no Shift+click or Shift+drag test was found.
+
+## Upstream Zed Editor at this repository's pinned revision
+
+`Cargo.lock` pins GPUI's Zed source to commit [`cc053a4a6fa2fd0e8793201ed9099466af1be0b1`](https://github.com/zed-industries/zed/tree/cc053a4a6fa2fd0e8793201ed9099466af1be0b1). The corresponding Editor implementation provides an independent production reference:
+
+- In [`crates/editor/src/element/mouse.rs` lines 723–758](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/editor/src/element/mouse.rs#L723-L758), an unmodified click dispatches `SelectPhase::Begin`, while Shift-only click dispatches `SelectPhase::Extend`.
+- [`SelectPhase`](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/editor/src/editor.rs#L408-L431) explicitly separates `Begin`, `Extend`, `Update`, and `End`.
+- In [`extend_selection`, lines 1190–1253](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/editor/src/selection.rs#L1190-L1253), Zed saves the existing selection tail, begins at the clicked position, then expands the pending selection back to the saved tail and marks it as extending. It also carries forward character/word/line selection mode.
+- Mouse movement dispatches `SelectPhase::Update` in [`mouse.rs` lines 1115–1124](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/editor/src/element/mouse.rs#L1115-L1124), so dragging updates the selection begun or extended on mouse-down.
+
+Zed therefore confirms the same interaction architecture: ordinary click begins; Shift+click extends from the existing tail/anchor; movement updates that pending selection; click count/granularity is retained.
+
+## Recommended TextView implementation boundary
+
+Use the existing `WindowTextSelection.anchor` and `.cursor`; do not add a parallel `last_click_endpoint`. The new behavior should be expressed as two start modes:
+
+- **Begin:** clear old local/window selection, set `anchor = endpoint`, set `cursor = endpoint`.
+- **Extend:** when a usable anchor exists, preserve it and set `cursor = endpoint`; otherwise fall back to Begin. Then set `is_selecting = true`, so a following drag continues to update only the cursor.
+
+The root controller must also preserve existing suppression semantics. A Shift+click owned by Input, Button, or another suppressing component must not accidentally retain a stale TextView selection merely because clearing was skipped during capture. Therefore the implementation should decide clearing after it knows whether the gesture was suppressed, or explicitly clear on the suppressed Shift-click path. It should retain the existing rules for plain click, multiple-click inline selection, selection scopes/modal layers, focus, and blank-space proxy endpoints.
+
+Minimum regression matrix:
+
+1. click A, Shift+click B selects A–B;
+2. click A, Shift+click B, Shift+click C keeps A fixed, both when C remains on the same side and crosses A;
+3. click A, Shift+mousedown B, drag to C selects A–C;
+4. a later plain click D clears the range and establishes D as the next anchor;
+5. Shift+click without a usable prior anchor falls back to a plain click;
+6. cross-TextView extension works with content-anchored endpoints;
+7. Shift+click on a suppressing interactive control clears/does not extend the window TextView selection;
+8. existing double/triple-click granularity and modal selection-scope behavior remain unchanged.

--- a/docs/superpowers/plans/2026-08-15-textview-shift-click-selection.md
+++ b/docs/superpowers/plans/2026-08-15-textview-shift-click-selection.md
@@ -1,0 +1,94 @@
+# TextView Shift+click Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend selectable TextView ranges from the last ordinary click when the user Shift+clicks or Shift+drags.
+
+**Architecture:** Reuse the existing window selection `anchor` as the stable endpoint and `cursor` as the moving endpoint. Distinguish begin from extend only at mouse-down; all later movement continues through the existing cursor-only update path.
+
+**Tech Stack:** Rust, GPUI mouse events, `gpui::test` visual tests.
+
+## Global Constraints
+
+- Ordinary click resets the anchor; Shift+click preserves a usable anchor.
+- Repeated Shift+click and Shift+drag only move the cursor endpoint.
+- Suppressing interactive controls must not retain or extend stale TextView selection.
+- Existing double/triple click, modal scope, proxy endpoint, focus, scrolling, and copy behavior remain unchanged.
+
+---
+
+### Task 1: Shift+click and Shift+drag behavior
+
+**Files:**
+- Modify: `crates/ui/src/text/window_selection.rs`
+- Test: `crates/ui/src/text/window_selection.rs`
+
+**Interfaces:**
+- Consumes: `WindowTextSelection.anchor`, `Root::text_selection_endpoint`, and the existing mouse-move update path.
+- Produces: a begin/extend selection-start API used by `TextSelectionController`.
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Add real pointer-event tests using a helper that emits `MouseDownEvent` and
+`MouseUpEvent` with `Modifiers { shift: true, ..Default::default() }`. Assert
+literal selected strings for click→Shift+click, repeated extension across the
+anchor, Shift+drag, plain-click reset, no-anchor fallback, cross-view extension,
+and a suppressing control.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p gpui-component text::window_selection::tests::shift --lib
+```
+
+Expected: the extension tests fail because capture clears the old endpoints and
+mouse-down assigns both endpoints to the Shift+clicked position.
+
+- [ ] **Step 3: Implement begin versus extend**
+
+Introduce a private mode:
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SelectionStart {
+    Begin,
+    Extend,
+}
+```
+
+Update `Root::start_text_selection` to consume a resolvable event-local anchor
+only for `Extend`, otherwise assign both endpoints. During capture, stage the
+old anchor for Shift+click and then clear selection as before; suppressed or
+stopped events therefore stay cleared, while unsuppressed Shift+clicks consume
+the staged anchor in bubble handling.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p gpui-component text::window_selection::tests::shift --lib
+```
+
+Expected: all Shift-prefixed regression tests pass.
+
+- [ ] **Step 5: Refactor comments and keep focused tests green**
+
+Keep the start-mode branching local to `window_selection.rs`, document why
+suppression is decided in bubble phase, and rerun the focused command.
+
+- [ ] **Step 6: Verify the complete affected package**
+
+Run:
+
+```bash
+cargo test -p gpui-component text::window_selection::tests --lib
+cargo fmt --all -- --check
+cargo check -p gpui-component
+git diff --check
+```
+
+Expected: every command exits successfully with no failures or formatting
+errors.

--- a/docs/superpowers/specs/2026-08-15-textview-shift-click-selection-design.md
+++ b/docs/superpowers/specs/2026-08-15-textview-shift-click-selection-design.md
@@ -1,0 +1,64 @@
+# TextView Shift+click Selection Design
+
+Date: 2026-08-15
+
+## Goal
+
+Make selectable `TextView`s extend a selection from the most recent ordinary
+click when the user Shift+clicks, matching AppKit and the repository's editable
+Input/Editor controls.
+
+## Interaction semantics
+
+- An ordinary single click begins a selection with coincident `anchor` and
+  `cursor` endpoints, so it has no visible highlight but establishes the next
+  extension anchor.
+- Shift+click preserves a usable existing `anchor` and moves only `cursor`.
+- Repeated Shift+click and Shift+drag keep the same anchor. Crossing it reverses
+  the visual direction without replacing it.
+- If no usable anchor exists, Shift+click falls back to an ordinary click.
+- A later ordinary click clears the old range and establishes a new anchor.
+- Double/triple click, modal scope confinement, proxy endpoints, focus, and
+  content-anchored scrolling keep their existing behavior.
+- A mouse gesture owned by a suppressing component such as Input or Button does
+  not begin or extend TextView selection and must not leave a stale highlight.
+
+## Architecture
+
+Keep `WindowTextSelection.anchor` and `cursor` as the only durable endpoint
+state. Add a small begin/extend mode to the controller-to-Root selection-start
+operation. Begin assigns both endpoints. Extend restores the resolvable anchor
+staged for the current mouse event, assigns only the cursor, and otherwise falls
+back to Begin behavior.
+
+Mouse capture continues to reset the per-event suppression flag and clear the
+old selection. Immediately before clearing, a Shift+click temporarily stages the
+old anchor in `pending_extension_anchor`; an unsuppressed bubble handler consumes
+it. This event-local staging is cleared by normal selection clearing and is not
+a parallel click-history model. Keeping the clear in capture means an Input,
+Button, or other component that stops bubble propagation cannot leave stale
+TextView highlights.
+
+Both modes set `is_selecting`, so the existing mouse-move path continues to move
+only the cursor. Endpoint resolution, painting, copying, and autoscroll remain
+unchanged.
+
+## Testing
+
+Add focused visual tests in `crates/ui/src/text/window_selection.rs` for:
+
+- ordinary click followed by Shift+click in one TextView;
+- repeated Shift+click with a stable anchor, including crossing the anchor;
+- Shift+mousedown followed by drag;
+- a later ordinary click resetting the anchor;
+- Shift+click without a prior anchor;
+- extension across TextViews;
+- Shift+click on the suppressing test control clearing stale selection.
+
+Run the focused tests first for the red/green cycle, then the complete
+`window_selection` test target and formatting checks.
+
+## Evidence
+
+The supporting Apple, local Input/Editor, and pinned Zed sources are recorded in
+[`docs/research/2026-08-15-textview-shift-click-selection.md`](../../research/2026-08-15-textview-shift-click-selection.md).


### PR DESCRIPTION
## Summary

- preserve the latest plain-click anchor when extending TextView selection with Shift+click
- support repeated Shift+click, reversed extension, Shift+drag, and cross-TextView selection
- keep suppression and selection lifecycle behavior safe across interactive controls
- document the AppKit, local Editor, and pinned Zed behavior used to choose the design

## Test Plan

- `cargo test -p gpui-component --lib`
- `cargo check -p gpui-component`
- `cargo fmt --all -- --check`
- `git diff --check`