### PR TITLE
calendar: Fix Calendar styling and FPS monitor layering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ cargo machete
 
 **Note**: Per user configuration, tests do not need to be run.
 
+For pure UI visual or sizing adjustments, do not add automated tests solely to
+assert presentation dimensions. Add tests when the change affects behavior,
+interaction, data flow, or prevents a meaningful regression.
+
 ```bash
 # Run all tests
 cargo test --all

--- a/crates/base/src/calendar.rs
+++ b/crates/base/src/calendar.rs
@@ -500,6 +500,12 @@ impl CalendarItem {
     pub fn item_state(&self) -> CalendarItemState {
         self.state
     }
+
+    /// Remove the default label so a styled facade can provide custom content.
+    pub fn clear_children(mut self) -> Self {
+        self.children.clear();
+        self
+    }
 }
 impl ParentElement for CalendarItem {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
@@ -665,9 +671,12 @@ impl RenderOnce for Calendar {
             for offset in 0..count {
                 let (y, m) = self.state.read(cx).offset_year_month(offset);
                 header = header.child(
-                    div()
-                        .child((self.label)(CalendarItemKind::MonthToggle, m as i32))
-                        .child(y.to_string()),
+                    div().text_sm().font_medium().child(
+                        v_flex()
+                            .items_center()
+                            .child((self.label)(CalendarItemKind::MonthToggle, m as i32))
+                            .child(y.to_string()),
+                    ),
                 );
             }
         }

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -6,8 +6,8 @@ use gpui::{
     prelude::FluentBuilder as _, px, rems, size,
 };
 use gpui_component::{
-    ActiveTheme, IconName, Root, Sizable as _, Size as ComponentSize, StyledExt as _, TitleBar,
-    WindowExt,
+    ActiveTheme, IconName, Root, Sizable as _, Size as ComponentSize, StyledExt as _,
+    TITLE_BAR_HEIGHT, TitleBar, WindowExt,
     button::Button,
     dock::{Panel, PanelControl, PanelEvent, PanelInfo, PanelState, TitleStyle, register_panel},
     group_box::{GroupBox, GroupBoxVariants as _},
@@ -916,16 +916,25 @@ impl Render for StoryRoot {
                             .relative()
                             .flex_1()
                             .overflow_hidden()
-                            .child(self.view.clone())
-                            // Rendered inside the content area rather than the
-                            // window root so the HUD's top right corner clears
-                            // the title bar's own controls.
-                            .when(show_fps, |this| this.child(fps_monitor(window, cx))),
+                            .child(self.view.clone()),
                     )
                     .children(sheet_layer)
                     .children(dialog_layer)
                     .children(notification_layer),
             )
+            .relative()
+            // FPS must be the last sibling so notification/toast layers cannot
+            // paint over the HUD.
+            .when(show_fps, |this| {
+                this.child(
+                    div()
+                        .absolute()
+                        .top(TITLE_BAR_HEIGHT)
+                        .left_0()
+                        .right_0()
+                        .child(fps_monitor(window, cx)),
+                )
+            })
     }
 }
 

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -1,11 +1,11 @@
 use chrono::Weekday;
 use gpui::{
-    App, ElementId, Entity, InteractiveElement, IntoElement, RenderOnce, SharedString,
-    StyleRefinement, Styled, Window, prelude::FluentBuilder as _, px, relative,
+    App, ElementId, Entity, InteractiveElement, IntoElement, ParentElement, RenderOnce,
+    SharedString, StyleRefinement, Styled, Window, prelude::FluentBuilder as _, px, relative,
 };
 use rust_i18n::t;
 
-use crate::{ActiveTheme, Sizable, Size, StyledExt as _};
+use crate::{ActiveTheme, Icon, IconName, Sizable, Size, StyledExt as _};
 
 use gpui_base::{Calendar as BaseCalendar, CalendarItemKind};
 pub use gpui_base::{CalendarEvent, CalendarState, Date, Matcher};
@@ -76,6 +76,7 @@ impl Styled for Calendar {
 impl RenderOnce for Calendar {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let size = self.size;
+        let month_count = self.number_of_months.max(1) as f32;
         BaseCalendar::new(self.id, &self.state)
             .number_of_months(self.number_of_months)
             .first_day_of_week(self.first_day_of_week)
@@ -96,14 +97,38 @@ impl RenderOnce for Calendar {
                 _ => value.to_string().into(),
             })
             .item(move |item, state, _, cx| {
+                let item = match state.kind() {
+                    CalendarItemKind::Previous => item
+                        .clear_children()
+                        .child(Icon::new(IconName::ChevronLeft).size_4()),
+                    CalendarItemKind::Next => item
+                        .clear_children()
+                        .child(Icon::new(IconName::ChevronRight).size_4()),
+                    _ => item,
+                };
                 item.map(|this| match size {
                     Size::Small => this.size_7().rounded(cx.theme().radius / 2.),
                     Size::Large => this.size_10().rounded(cx.theme().radius * 2.),
-                    _ => this.size_9().rounded(cx.theme().radius),
+                    _ => this.size_8().rounded(cx.theme().radius),
                 })
                 .flex()
                 .items_center()
                 .justify_center()
+                .when(state.kind() != CalendarItemKind::Weekday, |this| {
+                    this.text_sm()
+                })
+                .when(state.kind() == CalendarItemKind::Weekday, |this| {
+                    this.text_xs()
+                        .font_normal()
+                        .text_color(cx.theme().muted_foreground)
+                })
+                .when(
+                    matches!(
+                        state.kind(),
+                        CalendarItemKind::MonthToggle | CalendarItemKind::YearToggle
+                    ),
+                    |this| this.text_sm().font_medium(),
+                )
                 .when(
                     matches!(
                         state.kind(),
@@ -111,7 +136,7 @@ impl RenderOnce for Calendar {
                     ),
                     |this| {
                         this.when(state.kind() == CalendarItemKind::Month, |this| {
-                            this.w(relative(0.3))
+                            this.w(relative(0.3)).m_1()
                         })
                         .when(state.kind() == CalendarItemKind::MonthToggle, |this| {
                             this.w_auto().px_2()
@@ -125,26 +150,16 @@ impl RenderOnce for Calendar {
                     ),
                     |this| {
                         this.when(state.kind() == CalendarItemKind::Year, |this| {
-                            this.w(relative(0.2))
+                            this.w(relative(0.16)).m_1()
                         })
                         .when(state.kind() == CalendarItemKind::YearToggle, |this| {
                             this.w_auto().px_2()
                         })
                     },
                 )
-                .when(
-                    matches!(
-                        state.kind(),
-                        CalendarItemKind::Previous | CalendarItemKind::Next
-                    ),
-                    |this| this.text_lg(),
-                )
                 .when(state.is_muted(), |this| {
-                    this.text_color(if state.is_disabled() {
-                        cx.theme().muted_foreground.opacity(0.3)
-                    } else {
-                        cx.theme().muted_foreground
-                    })
+                    this.text_color(cx.theme().muted_foreground)
+                        .when(state.is_disabled(), |this| this.opacity(0.5))
                 })
                 .when(state.is_in_range(), |this| {
                     this.bg(cx.theme().accent)
@@ -156,8 +171,8 @@ impl RenderOnce for Calendar {
                         && state.kind() != CalendarItemKind::Weekday,
                     |this| {
                         this.hover(|this| {
-                            this.bg(cx.theme().tokens.accent)
-                                .text_color(cx.theme().accent_foreground)
+                            this.bg(cx.theme().tokens.secondary_hover)
+                                .text_color(cx.theme().foreground)
                         })
                     },
                 )
@@ -166,7 +181,8 @@ impl RenderOnce for Calendar {
                         .text_color(cx.theme().primary_foreground)
                 })
                 .when(state.is_today() && !state.is_active(), |this| {
-                    this.border_1().border_color(cx.theme().border)
+                    this.bg(cx.theme().accent)
+                        .text_color(cx.theme().accent_foreground)
                 })
                 .into_any_element()
             })
@@ -176,9 +192,9 @@ impl RenderOnce for Calendar {
             .p_3()
             .gap_0p5()
             .map(|this| match size {
-                Size::Small => this.w(px(232.)),
-                Size::Large => this.w(px(316.)),
-                _ => this.w(px(288.)),
+                Size::Small => this.w(px(232.) * month_count),
+                Size::Large => this.w(px(316.) * month_count),
+                _ => this.w(px(288.) * month_count),
             })
             .refine_style(&self.style)
     }
@@ -188,6 +204,7 @@ impl RenderOnce for Calendar {
 mod tests {
     use super::Date;
     use chrono::NaiveDate;
+
     #[test]
     fn date_display_is_stable() {
         assert_eq!(


### PR DESCRIPTION
## Summary

- Align Calendar sizing, typography, spacing, states, and navigation icons with the shadcn-inspired visual language.
- Keep multi-month headings presentational and non-interactive while laying them out cleanly.
- Ensure the FPS monitor renders above toast notifications and below the title bar.

## Validation

- cargo fmt --check
- git diff --check
- cargo check -p gpui-component
