### PR TITLE
text: Prevent implicit local image access

### DIFF
--- a/crates/ui/src/text/inline_flow.rs
+++ b/crates/ui/src/text/inline_flow.rs
@@ -5,10 +5,10 @@ use std::{
 
 use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, DefiniteLength, Element, ElementId,
-    GlobalElementId, HighlightStyle, InspectorElementId, InteractiveElement as _, IntoElement,
-    LayoutId, LineFragment as WrapLineFragment, ObjectFit, Pixels, ShapedLine, SharedString,
-    SharedUri, Size, StatefulInteractiveElement as _, Styled, StyledImage as _, TextRun, TextStyle,
-    WhiteSpace, Window, img, point, prelude::FluentBuilder as _, px, relative, size,
+    GlobalElementId, HighlightStyle, ImageSource, InspectorElementId, InteractiveElement as _,
+    IntoElement, LayoutId, LineFragment as WrapLineFragment, ObjectFit, Pixels, ShapedLine,
+    SharedString, Size, StatefulInteractiveElement as _, Styled, StyledImage as _, TextRun,
+    TextStyle, WhiteSpace, Window, img, point, prelude::FluentBuilder as _, px, relative, size,
 };
 
 use crate::{
@@ -20,7 +20,6 @@ use crate::{
 use super::{
     inline::{Inline, InlineState},
     node::LinkMark,
-    utils::image_source,
 };
 
 const IMAGE_LEN: usize = 1;
@@ -39,7 +38,7 @@ pub(super) enum InlineFlowItem {
         highlights: Vec<(Range<usize>, HighlightStyle)>,
     },
     Image {
-        url: SharedUri,
+        source: ImageSource,
         link: Option<LinkMark>,
         title: String,
         width: Option<DefiniteLength>,
@@ -83,7 +82,7 @@ enum MeasureItem {
         highlights: Vec<(Range<usize>, HighlightStyle)>,
     },
     Image {
-        url: SharedUri,
+        source: ImageSource,
         width: Option<DefiniteLength>,
         height: Option<DefiniteLength>,
     },
@@ -120,13 +119,13 @@ impl InlineFlow {
 
     fn image_element(
         ix: usize,
-        url: &SharedUri,
+        source: &ImageSource,
         link: &Option<LinkMark>,
         title: &str,
         size: Size<Pixels>,
         link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     ) -> AnyElement {
-        img(image_source(url))
+        img(source.clone())
             .id(ix)
             .object_fit(ObjectFit::Contain)
             .max_w(relative(1.))
@@ -199,9 +198,13 @@ impl Element for InlineFlow {
             .iter()
             .enumerate()
             .map(|(ix, item)| match item {
-                MeasureItem::Image { url, width, height } => Some(measure_image_size(
+                MeasureItem::Image {
+                    source,
+                    width,
+                    height,
+                } => Some(measure_image_size(
                     ix,
-                    url,
+                    source,
                     *width,
                     *height,
                     line_height,
@@ -310,14 +313,17 @@ impl Element for InlineFlow {
                     size: fragment_size,
                 } => {
                     let InlineFlowItem::Image {
-                        url, link, title, ..
+                        source,
+                        link,
+                        title,
+                        ..
                     } = &self.items[item_ix]
                     else {
                         continue;
                     };
                     let mut element = Self::image_element(
                         elements.len(),
-                        url,
+                        source,
                         link,
                         title.as_str(),
                         fragment_size,
@@ -371,9 +377,12 @@ impl From<&InlineFlowItem> for MeasureItem {
                 highlights: highlights.clone(),
             },
             InlineFlowItem::Image {
-                url, width, height, ..
+                source,
+                width,
+                height,
+                ..
             } => MeasureItem::Image {
-                url: url.clone(),
+                source: source.clone(),
                 width: *width,
                 height: *height,
             },
@@ -606,7 +615,7 @@ fn line_ranges(
 #[allow(clippy::too_many_arguments)]
 fn measure_image_size(
     ix: usize,
-    url: &SharedUri,
+    source: &ImageSource,
     width: Option<DefiniteLength>,
     height: Option<DefiniteLength>,
     line_height: Pixels,
@@ -617,20 +626,20 @@ fn measure_image_size(
     let intrinsic_size = if width.is_some() && height.is_some() {
         None
     } else {
-        intrinsic_image_size(ix, url, width, height, window, cx)
+        intrinsic_image_size(ix, source, width, height, window, cx)
     };
     image_size(width, height, intrinsic_size, line_height, rem_size)
 }
 
 fn intrinsic_image_size(
     ix: usize,
-    url: &SharedUri,
+    source: &ImageSource,
     width: Option<DefiniteLength>,
     height: Option<DefiniteLength>,
     window: &mut Window,
     cx: &mut App,
 ) -> Option<Size<Pixels>> {
-    let mut element = img(image_source(url))
+    let mut element = img(source.clone())
         .id(ix)
         .object_fit(ObjectFit::Contain)
         .max_w(relative(1.))

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -20,7 +20,8 @@ use crate::{
     input::{InputEdit, Point, RopeExt as _},
     scroll::horizontal_scroll_area,
     text::{
-        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, MarkdownNode,
+        CodeBlockActionsFn, ImageSourceResolverFn, LinkClickHandlerFn, MarkdownExtensions,
+        MarkdownNode,
         document::NodeRenderOptions,
         inline::{Inline, InlineState},
         inline_flow::{InlineFlow, InlineFlowItem},
@@ -1280,6 +1281,7 @@ pub(crate) struct NodeContext {
     pub(crate) style: TextViewStyle,
     pub(crate) code_block_actions: Option<Arc<CodeBlockActionsFn>>,
     pub(crate) link_click_handler: Option<Arc<LinkClickHandlerFn>>,
+    pub(crate) image_source_resolver: Option<Arc<ImageSourceResolverFn>>,
     pub(crate) markdown_extensions: Arc<MarkdownExtensions>,
 }
 
@@ -1292,8 +1294,8 @@ impl NodeContext {
 impl PartialEq for NodeContext {
     fn eq(&self, other: &Self) -> bool {
         self.link_refs == other.link_refs && self.style == other.style
-        // Note: code_block_actions and markdown_extensions are intentionally
-        // not compared (closures can't be compared)
+        // Note: callback fields and markdown_extensions are intentionally not
+        // compared (closures can't be compared)
     }
 }
 
@@ -1341,44 +1343,47 @@ impl Paragraph {
                 }
                 let link_click_handler = node_cx.link_click_handler.clone();
                 child_nodes.push(
-                    img(image_source(&image.url))
-                        .id(ix)
-                        .object_fit(ObjectFit::Contain)
-                        .max_w(relative(1.))
-                        .when_some(image.width, |this, width| this.w(width))
-                        .when_some(image.link.clone(), |this, link| {
-                            let title = image.title();
-                            let link_click_handler = link_click_handler.clone();
-                            let aux_link = link.clone();
-                            let aux_link_click_handler = link_click_handler.clone();
-                            this.cursor_pointer()
-                                .tooltip(move |window, cx| {
-                                    Tooltip::new(title.clone()).build(window, cx)
-                                })
-                                .on_click(move |event, window, cx| {
-                                    window.end_text_selection(cx);
-                                    cx.stop_propagation();
-                                    handle_link_click(
-                                        &link_click_handler,
-                                        link.url.clone(),
-                                        event.clone(),
-                                        window,
-                                        cx,
-                                    );
-                                })
-                                .on_aux_click(move |event, window, cx| {
-                                    window.end_text_selection(cx);
-                                    cx.stop_propagation();
-                                    handle_link_click(
-                                        &aux_link_click_handler,
-                                        aux_link.url.clone(),
-                                        event.clone(),
-                                        window,
-                                        cx,
-                                    );
-                                })
-                        })
-                        .into_any_element(),
+                    img(image_source(
+                        &image.url,
+                        node_cx.image_source_resolver.as_ref(),
+                    ))
+                    .id(ix)
+                    .object_fit(ObjectFit::Contain)
+                    .max_w(relative(1.))
+                    .when_some(image.width, |this, width| this.w(width))
+                    .when_some(image.link.clone(), |this, link| {
+                        let title = image.title();
+                        let link_click_handler = link_click_handler.clone();
+                        let aux_link = link.clone();
+                        let aux_link_click_handler = link_click_handler.clone();
+                        this.cursor_pointer()
+                            .tooltip(move |window, cx| {
+                                Tooltip::new(title.clone()).build(window, cx)
+                            })
+                            .on_click(move |event, window, cx| {
+                                window.end_text_selection(cx);
+                                cx.stop_propagation();
+                                handle_link_click(
+                                    &link_click_handler,
+                                    link.url.clone(),
+                                    event.clone(),
+                                    window,
+                                    cx,
+                                );
+                            })
+                            .on_aux_click(move |event, window, cx| {
+                                window.end_text_selection(cx);
+                                cx.stop_propagation();
+                                handle_link_click(
+                                    &aux_link_click_handler,
+                                    aux_link.url.clone(),
+                                    event.clone(),
+                                    window,
+                                    cx,
+                                );
+                            })
+                    })
+                    .into_any_element(),
                 );
 
                 text.clear();
@@ -1496,7 +1501,7 @@ impl Paragraph {
                 }
 
                 items.push(InlineFlowItem::Image {
-                    url: image.url.clone(),
+                    source: image_source(&image.url, node_cx.image_source_resolver.as_ref()),
                     link: image.link.clone(),
                     title: image.title(),
                     width: image.width,

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -13,7 +13,8 @@ use crate::{
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
-        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, TextViewStyle,
+        CodeBlockActionsFn, ImageSourceResolverFn, LinkClickHandlerFn, MarkdownExtensions,
+        TextViewStyle,
         document::ParsedDocument,
         format,
         node::{self, NodeContext},
@@ -78,6 +79,7 @@ pub struct TextViewState {
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
     pub(super) link_click_handler: Option<std::sync::Arc<LinkClickHandlerFn>>,
+    pub(super) image_source_resolver: Option<std::sync::Arc<ImageSourceResolverFn>>,
     pub(super) markdown_extensions: Arc<MarkdownExtensions>,
 
     pub(super) is_selecting: bool,
@@ -165,6 +167,7 @@ impl TextViewState {
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
             link_click_handler: None,
+            image_source_resolver: None,
             markdown_extensions: Arc::default(),
             is_selecting: false,
             auto_scroll: AutoScroll::default(),
@@ -544,6 +547,7 @@ impl Render for TextViewState {
 
         node_cx.code_block_actions = self.code_block_actions.clone();
         node_cx.link_click_handler = self.link_click_handler.clone();
+        node_cx.image_source_resolver = self.image_source_resolver.clone();
         node_cx.markdown_extensions = self.markdown_extensions.clone();
         node_cx.style = self.text_view_style.clone();
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, Bounds, ClickEvent, Element, ElementId, Entity, GlobalElementId, Hitbox,
-    HitboxBehavior, InspectorElementId, InteractiveElement, IntoElement, LayoutId, MouseButton,
-    ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
+    HitboxBehavior, ImageSource, InspectorElementId, InteractiveElement, IntoElement, LayoutId,
+    MouseButton, ParentElement, Pixels, SharedString, SharedUri, StyleRefinement, Styled, Window,
+    div,
 };
 
 use crate::StyledExt;
@@ -21,6 +22,8 @@ pub(crate) type CodeBlockActionsFn =
 
 pub(crate) type LinkClickHandlerFn =
     dyn Fn(&SharedString, &ClickEvent, &mut Window, &mut App) + Send + Sync;
+
+pub(crate) type ImageSourceResolverFn = dyn Fn(&SharedUri) -> ImageSource + Send + Sync;
 
 pub(crate) fn handle_link_click(
     handler: &Option<Arc<LinkClickHandlerFn>>,
@@ -71,6 +74,7 @@ pub struct TextView {
     scrollable: bool,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
     link_click_handler: Option<Arc<LinkClickHandlerFn>>,
+    image_source_resolver: Option<Arc<ImageSourceResolverFn>>,
     markdown_extensions: Arc<MarkdownExtensions>,
 }
 
@@ -112,6 +116,7 @@ impl TextView {
             scrollable: false,
             code_block_actions: None,
             link_click_handler: None,
+            image_source_resolver: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -130,6 +135,7 @@ impl TextView {
             scrollable: false,
             code_block_actions: None,
             link_click_handler: None,
+            image_source_resolver: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -148,6 +154,7 @@ impl TextView {
             scrollable: false,
             code_block_actions: None,
             link_click_handler: None,
+            image_source_resolver: None,
             markdown_extensions: Arc::default(),
         }
     }
@@ -214,6 +221,20 @@ impl TextView {
         F: Fn(&SharedString, &ClickEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.link_click_handler = Some(Arc::new(handler));
+        self
+    }
+
+    /// Resolve document image URLs to custom image sources.
+    ///
+    /// By default, image URLs remain URI resources and are never interpreted as
+    /// filesystem paths. The resolver receives document-controlled values, so
+    /// it should only return path-backed sources for trusted content or after
+    /// enforcing an appropriate path policy.
+    pub fn image_source_resolver<F>(mut self, resolver: F) -> Self
+    where
+        F: Fn(&SharedUri) -> ImageSource + Send + Sync + 'static,
+    {
+        self.image_source_resolver = Some(Arc::new(resolver));
         self
     }
 
@@ -331,6 +352,7 @@ impl Element for TextView {
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
             state.link_click_handler = self.link_click_handler.clone();
+            state.image_source_resolver = self.image_source_resolver.clone();
             state.set_markdown_extensions(self.markdown_extensions.clone(), cx);
             state.selectable = self.selectable;
             state.selection_format = self.selection_format;
@@ -409,12 +431,19 @@ impl Element for TextView {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
     use super::{TextView, TextViewPlugin};
     use crate::text::TextViewState;
     use gpui::{
-        AppContext as _, ClickEvent, Context, Entity, InteractiveElement as _, IntoElement,
-        Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render,
-        SharedString, Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
+        AppContext as _, ClickEvent, Context, Entity, ImageSource, InteractiveElement as _,
+        IntoElement, Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _,
+        Render, SharedString, SharedUri, Styled as _, TestAppContext, VisualTestContext, Window,
+        div, point, px,
     };
 
     struct TextViewTestRoot {
@@ -456,6 +485,10 @@ mod tests {
         text_view: Entity<TextViewState>,
     }
 
+    struct ImageSourceResolverTestRoot {
+        resolver_called: Arc<AtomicBool>,
+    }
+
     impl InlineImageTextViewTestRoot {
         fn new(cx: &mut Context<Self>) -> Self {
             let text_view = cx.new(|cx| {
@@ -473,6 +506,23 @@ mod tests {
             div()
                 .w(px(420.))
                 .child(TextView::new(&self.text_view).selectable(true))
+        }
+    }
+
+    impl Render for ImageSourceResolverTestRoot {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let called = self.resolver_called.clone();
+            div().w(px(420.)).child(
+                TextView::markdown(
+                    "image-source-resolver",
+                    "Before ![image](trusted/image.svg) after",
+                )
+                .image_source_resolver(move |url| {
+                    assert_eq!(url.as_ref(), "trusted/image.svg");
+                    called.store(true, Ordering::SeqCst);
+                    url.clone().into()
+                }),
+            )
         }
     }
 
@@ -513,6 +563,48 @@ mod tests {
             inline_bounds[1].left() - inline_bounds[0].right() < px(40.),
             "unloaded inline image fallback should stay generic and compact"
         );
+    }
+
+    #[gpui::test]
+    fn image_source_resolver_is_an_explicit_opt_in(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let resolver_called = Arc::new(AtomicBool::new(false));
+        let called = resolver_called.clone();
+        let (_, cx) = cx.add_window_view(move |_, _| ImageSourceResolverTestRoot {
+            resolver_called: called,
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        assert!(resolver_called.load(Ordering::SeqCst));
+    }
+
+    #[gpui::test]
+    fn document_image_paths_are_not_cached_as_filesystem_resources(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../website/public/logo.svg");
+        let url = path.to_string_lossy().to_string();
+        let markdown = format!("![poc]({url})");
+        let (_, cx) = cx.add_window_view(|_, cx| TextViewTestRoot::new(&markdown, cx));
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.run_until_parked();
+
+        let uri: SharedUri = url.clone().into();
+        let uri_source: ImageSource = uri.into();
+        let path_source: ImageSource = path.into();
+        cx.update(|_, cx| {
+            assert!(uri_source.is_asset_cached(cx));
+            assert!(!path_source.is_asset_cached(cx));
+        });
     }
 
     #[gpui::test]

--- a/crates/ui/src/text/utils.rs
+++ b/crates/ui/src/text/utils.rs
@@ -1,6 +1,8 @@
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use gpui::{ImageSource, SharedUri};
+
+use super::text_view::ImageSourceResolverFn;
 
 const NUMBERED_PREFIXES_1: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const NUMBERED_PREFIXES_2: &str = "abcdefghijklmnopqrstuvwxyz";
@@ -38,75 +40,61 @@ pub(super) fn list_item_prefix(ix: usize, ordered: bool, depth: usize) -> String
     }
 }
 
-/// Converts an image URL from a document into an [`ImageSource`].
+/// Resolves an image URL from a document into an [`ImageSource`].
 ///
-/// URLs with a scheme (e.g. `https:`, `data:`) load as remote resources, while
-/// `file://` URLs and plain paths load from the filesystem. Relative paths
-/// resolve against the process working directory. A single-letter scheme is
-/// treated as a Windows drive letter.
-pub(super) fn image_source(url: &SharedUri) -> ImageSource {
-    let url_str = url.as_ref();
-    if let Some(path) = url_str.strip_prefix("file://") {
-        return PathBuf::from(path).into();
-    }
-
-    let has_scheme = url_str.split_once(':').is_some_and(|(scheme, _)| {
-        scheme.len() > 1
-            && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
-            && scheme
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
-    });
-
-    if has_scheme {
-        url.clone().into()
-    } else {
-        PathBuf::from(url_str).into()
-    }
+/// Document-controlled strings remain URI resources by default. Callers may
+/// explicitly provide a resolver for trusted content or a constrained local
+/// resource policy.
+pub(super) fn image_source(
+    url: &SharedUri,
+    resolver: Option<&Arc<ImageSourceResolverFn>>,
+) -> ImageSource {
+    resolver.map_or_else(|| url.clone().into(), |resolver| resolver(url))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, sync::Arc};
+    use std::{path::PathBuf, sync::Arc};
 
     use gpui::{ImageSource, Resource};
 
-    use crate::text::utils::{image_source, list_item_prefix};
+    use crate::text::{
+        text_view::ImageSourceResolverFn,
+        utils::{image_source, list_item_prefix},
+    };
 
     #[test]
-    fn test_image_source() {
-        fn source(url: &str) -> Resource {
-            match image_source(&url.to_string().into()) {
+    fn document_images_default_to_uri_resources() {
+        fn source(url: &str, resolver: Option<&Arc<ImageSourceResolverFn>>) -> Resource {
+            match image_source(&url.to_string().into(), resolver) {
                 ImageSource::Resource(resource) => resource,
                 _ => panic!("expected a resource for {url:?}"),
             }
         }
         fn assert_uri(url: &str) {
-            match source(url) {
+            match source(url, None) {
                 Resource::Uri(uri) => assert_eq!(uri.as_ref(), url),
                 other => panic!("expected Uri for {url:?}, got {other:?}"),
-            }
-        }
-        fn assert_path(url: &str, expected: &str) {
-            match source(url) {
-                Resource::Path(path) => assert_eq!(path, Arc::from(Path::new(expected))),
-                other => panic!("expected Path for {url:?}, got {other:?}"),
             }
         }
 
         assert_uri("https://example.com/logo.png");
         assert_uri("http://example.com/logo.png");
         assert_uri("data:image/png;base64,iVBORw0KGgo=");
+        assert_uri("website/public/logo.svg");
+        assert_uri("./images/a.png");
+        assert_uri("../images/a.png");
+        assert_uri("/absolute/path/logo.svg");
+        assert_uri("file:///absolute/path/logo.svg");
+        assert_uri(r"C:\images\logo.png");
+        assert_uri("docs/a:b.png");
 
-        assert_path("website/public/logo.svg", "website/public/logo.svg");
-        assert_path("./images/a.png", "./images/a.png");
-        assert_path("../images/a.png", "../images/a.png");
-        assert_path("/absolute/path/logo.svg", "/absolute/path/logo.svg");
-        assert_path("file:///absolute/path/logo.svg", "/absolute/path/logo.svg");
-        // A single-letter scheme is a Windows drive letter, not a URL scheme.
-        assert_path(r"C:\images\logo.png", r"C:\images\logo.png");
-        // A colon inside a path segment does not make it a URL.
-        assert_path("docs/a:b.png", "docs/a:b.png");
+        let resolver: Arc<ImageSourceResolverFn> =
+            Arc::new(|url| PathBuf::from(url.as_ref()).into());
+        match source("trusted/image.svg", Some(&resolver)) {
+            Resource::Path(path) => assert_eq!(path.as_ref(), PathBuf::from("trusted/image.svg")),
+            other => panic!("expected an explicitly resolved Path, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep Markdown and HTML image strings as URI resources by default instead of implicitly converting local-looking values into filesystem paths.
- Add an explicit `TextView::image_source_resolver` opt-in for trusted documents or caller-defined constrained resource policies.
- Resolve inline images once and reuse the same `ImageSource` for intrinsic measurement and rendering.
- Add helper-level and end-to-end TextView regression coverage for local-looking image sources and the explicit resolver path.

## Why

Commit `99313ee` made `file://`, absolute, relative, and Windows-style document image strings become `Resource::Path`. Since TextView renders Markdown/HTML supplied by sources including LSP hover and completion documentation, those strings could cause GPUI to execute `fs::read` on document-selected local paths.

This change restores the safe trust boundary by default while preserving an explicit escape hatch for applications rendering trusted local documents.

Fixes #2733.

## User impact

Untrusted TextView content can no longer implicitly read local files through image tags. Applications that intentionally render local images must now supply an `image_source_resolver` and are responsible for applying an appropriate trust or path-confinement policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gpui-component` — 385 unit tests and all compatibility tests passed
- `cargo clippy -p gpui-component --all-targets --no-deps -- -D warnings`
- `strace` regression check confirmed the local image path is no longer opened by the default TextView rendering path

Running Clippy with dependency linting enabled is currently blocked by two pre-existing `clippy::nonminimal_bool` warnings in `crates/base/src/calendar.rs:131` on upstream `main`; the changed `gpui-component` crate passes with `--no-deps`.
