### PR TITLE
text: Keep document image sources URI-backed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="website/public/logo.svg" width="112" alt="GPUI Component logo" />
+  <img src="https://raw.githubusercontent.com/longbridge/gpui-component/main/website/public/logo.svg" width="112" alt="GPUI Component logo" />
   <br>
   <strong>GPUI Component</strong>
 </p>

--- a/crates/ui/src/text/utils.rs
+++ b/crates/ui/src/text/utils.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use gpui::{ImageSource, SharedUri};
 
 const NUMBERED_PREFIXES_1: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -38,37 +36,17 @@ pub(super) fn list_item_prefix(ix: usize, ordered: bool, depth: usize) -> String
     }
 }
 
-/// Converts an image URL from a document into an [`ImageSource`].
+/// Converts a document image URL into an [`ImageSource`] without granting
+/// implicit filesystem access.
 ///
-/// URLs with a scheme (e.g. `https:`, `data:`) load as remote resources, while
-/// `file://` URLs and plain paths load from the filesystem. Relative paths
-/// resolve against the process working directory. A single-letter scheme is
-/// treated as a Windows drive letter.
+/// Document-provided values remain URI-backed, including `file://` and
+/// scheme-less strings.
 pub(super) fn image_source(url: &SharedUri) -> ImageSource {
-    let url_str = url.as_ref();
-    if let Some(path) = url_str.strip_prefix("file://") {
-        return PathBuf::from(path).into();
-    }
-
-    let has_scheme = url_str.split_once(':').is_some_and(|(scheme, _)| {
-        scheme.len() > 1
-            && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
-            && scheme
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
-    });
-
-    if has_scheme {
-        url.clone().into()
-    } else {
-        PathBuf::from(url_str).into()
-    }
+    url.clone().into()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, sync::Arc};
-
     use gpui::{ImageSource, Resource};
 
     use crate::text::utils::{image_source, list_item_prefix};
@@ -87,26 +65,17 @@ mod tests {
                 other => panic!("expected Uri for {url:?}, got {other:?}"),
             }
         }
-        fn assert_path(url: &str, expected: &str) {
-            match source(url) {
-                Resource::Path(path) => assert_eq!(path, Arc::from(Path::new(expected))),
-                other => panic!("expected Path for {url:?}, got {other:?}"),
-            }
-        }
-
         assert_uri("https://example.com/logo.png");
         assert_uri("http://example.com/logo.png");
         assert_uri("data:image/png;base64,iVBORw0KGgo=");
 
-        assert_path("website/public/logo.svg", "website/public/logo.svg");
-        assert_path("./images/a.png", "./images/a.png");
-        assert_path("../images/a.png", "../images/a.png");
-        assert_path("/absolute/path/logo.svg", "/absolute/path/logo.svg");
-        assert_path("file:///absolute/path/logo.svg", "/absolute/path/logo.svg");
-        // A single-letter scheme is a Windows drive letter, not a URL scheme.
-        assert_path(r"C:\images\logo.png", r"C:\images\logo.png");
-        // A colon inside a path segment does not make it a URL.
-        assert_path("docs/a:b.png", "docs/a:b.png");
+        assert_uri("website/public/logo.svg");
+        assert_uri("./images/a.png");
+        assert_uri("../images/a.png");
+        assert_uri("/absolute/path/logo.svg");
+        assert_uri("file:///absolute/path/logo.svg");
+        assert_uri(r"C:\images\logo.png");
+        assert_uri("docs/a:b.png");
     }
 
     #[test]


### PR DESCRIPTION
<!-- PR title: text: Keep document image sources URI-backed -->

Closes #2733

## Description

Keep image sources originating from `TextView` documents URI-backed instead of
implicitly converting `file://` and scheme-less strings into `Resource::Path`.

The previous conversion allowed Markdown and HTML content, including LSP hover
and completion documentation, to trigger reads of attacker-selected local
filesystem paths.

Inline images, block images, and intrinsic-size measurement already share the
`image_source` helper, so this change is confined to that conversion and its
existing unit test. Relative paths, absolute paths, Windows paths, and
`file://` values are now all kept as `Resource::Uri`.

This intentionally removes implicit local-filesystem image loading from generic
`TextView` content. As a result, relative images such as
`website/public/logo.svg` in the Story Gallery README will no longer load as
local files. Supporting trusted local document resources requires a separate,
explicit API; base-directory confinement, path normalization, file-size
limits, and other resource-policy changes are outside the scope of this patch.

## How to Test

The following checks pass:

```console
cargo test -p gpui-component text::utils::tests::test_image_source -- --nocapture
cargo fmt --all -- --check
cargo test -p gpui-component
```

The updated `test_image_source` verifies that remote URLs, data URLs, relative
paths (including `..` traversal), Unix absolute paths, Windows paths, paths
containing colons, and `file://` values all remain `Resource::Uri`.

Manual runtime verification was also performed on Linux with the existing
`markdown_table` example and a Markdown document containing:

```markdown
![poc](/tmp/textview-local-read-poc.svg)
```

Under `strace`, the vulnerable implementation opened the referenced SVG:

```text
openat(AT_FDCWD, "/tmp/textview-local-read-poc.svg", O_RDONLY|O_CLOEXEC) = 28
```

With this patch, the example opened the injected Markdown document but did not
issue any `open` or `openat` call for the referenced SVG.

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI-generated code is accurate.
- [x] Passed `cargo run` for story tests related to the changes. The Story
  Gallery starts successfully; the README relative image is no longer loaded
  from the local filesystem, as documented above.
- [x] This change is not platform-specific.
